### PR TITLE
v0.3.1 release infrastructure: CI, CHANGELOG, completions, release binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
+
+jobs:
+  test:
+    name: test + lint + fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Cache Cargo build
+        uses: Swatinem/rust-cache@v2
+
+      - name: cargo fmt --all -- --check
+        run: cargo fmt --all -- --check
+
+      - name: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+      - name: cargo test --workspace --features pitboss-core/test-support
+        run: cargo test --workspace --features pitboss-core/test-support
+
+      - name: Smoke part 1 (offline, no API calls)
+        run: |
+          cargo build --release -p pitboss-cli
+          export PITBOSS="$(pwd)/target/release/pitboss"
+          bash scripts/smoke-part1.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: build + upload (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            archive: tar.gz
+          # Add macos-latest / aarch64-apple-darwin / x86_64-apple-darwin
+          # when ready. For now Linux x86_64 is the floor.
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache Cargo build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build release binaries
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          cargo build --release --target "$TARGET" \
+            -p pitboss-cli -p pitboss-tui
+
+      - name: Package
+        env:
+          TARGET: ${{ matrix.target }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          mkdir -p dist
+          cp "target/${TARGET}/release/pitboss" \
+             "target/${TARGET}/release/pitboss-tui" \
+             dist/
+          cd dist
+          tar czf "pitboss-${REF_NAME}-${TARGET}.tar.gz" pitboss pitboss-tui
+
+      - name: Upload to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/pitboss-*.tar.gz
+          generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,120 @@
+# Changelog
+
+All notable changes to Pitboss are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This project uses [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+## [0.3.0] — 2026-04-17
+
+### Added
+- Hierarchical dispatch mode: a lead `claude` subprocess dynamically spawns
+  workers via MCP tool calls over a unix socket. Six tools:
+  `spawn_worker`, `worker_status`, `wait_for_worker`, `wait_for_any`,
+  `list_workers`, `cancel_worker`.
+- House rules for hierarchical runs: `max_workers` (<=16), `budget_usd` with
+  reservation accounting + per-worker model tracking, `lead_timeout_secs`.
+- `pitboss mcp-bridge <socket>` subcommand — stdio<->unix-socket proxy that
+  bridges Claude's MCP client to the pitboss MCP server. Auto-launched by
+  the lead's generated `--mcp-config`.
+- TUI annotations: `[LEAD] <id>` prefix on lead tiles, `<- <lead-id>` on
+  worker tiles, `— N workers spawned` status-bar counter, dynamic-worker
+  discovery from summary.jsonl + filesystem.
+- `parent_task_id: Option<String>` on `TaskRecord` with backward-compatible
+  JSON deserialization.
+- SQLite migrations: `parent_task_id` column + `shire_version` ->
+  `pitboss_version` column rename, both idempotent via `pragma_table_info`.
+- `pitboss resume` now works for hierarchical runs — re-dispatches the lead
+  with `--resume <session-id>`; workers are not individually resumed.
+- `pitboss validate` prints a hierarchical summary when a `[[lead]]` section
+  is present.
+
+### Changed
+- **Rebrand**: crates renamed (`mosaic-core` -> `pitboss-core`, `shire-cli`
+  -> `pitboss-cli`, `mosaic-tui` -> `pitboss-tui`); binaries renamed
+  (`shire` -> `pitboss`, `mosaic` -> `pitboss-tui`); default runs dir now
+  `~/.local/share/pitboss/runs/`; env vars under `PITBOSS_*`; MCP server
+  name and tool prefix are `pitboss` / `mcp__pitboss__*`; README rewritten
+  with a pit-boss-at-a-casino aesthetic.
+- `truncate_preview` in `pitboss-core/src/session/handle.rs` now iterates
+  by character instead of byte-slicing, so multi-byte UTF-8 (emoji) in
+  claude output no longer panics the parser.
+
+### Fixed
+- Budget-guard TOCTOU: burst spawning used to bypass `budget_usd` because
+  the guard only checked `spent_usd`. Now reserves the estimated cost at
+  spawn time and releases it on completion.
+- Budget estimator used to hardcode Haiku rates when pricing historical
+  workers, undercounting Sonnet/Opus runs. Each worker's actual model is
+  now tracked and used for both historical and fallback estimates.
+
+## [0.2.2] — 2026-04-17
+
+### Added
+- `pitboss diff <run-a> <run-b>` subcommand: side-by-side run comparison
+  with totals, per-task metrics, only-in-A / only-in-B sections, and
+  `--json` output for scripting. Useful as a before/after tool with
+  `pitboss resume`.
+
+### Changed
+- Moved `prices` module from the TUI crate to core so both binaries
+  (pitboss + pitboss-tui) can compute cost from `TokenUsage`.
+
+### Fixed
+- Non-TTY progress table now emits exactly one line per completed task
+  instead of repeating the last-registered task's row on every state
+  change. Three regression tests lock the fix.
+
+## [0.2.1] — 2026-04-17
+
+### Added
+- Run picker in the TUI (`o` to switch between runs without relaunching).
+- SQLite session store alongside the existing JSON file store
+  (`rusqlite` with bundled sqlite; `runs` + `task_records` tables with
+  full init/append/finalize/load round-trip).
+- `pitboss resume <run-id>` for flat-mode runs (reuses
+  `claude_session_id` via `--resume <id>` in spawn args).
+- View-only snap-in mode: press Enter on a running tile to enter a
+  full-screen log view with scrolling.
+- Cost estimation per tile (price-table lookup per model).
+- Wall-clock run timer in the status bar.
+
+## [0.2.0] — 2026-04-17
+
+### Added
+- TUI (`pitboss-tui`, then `mosaic`): tile grid of task state, live log
+  tailing (stream-json parsed), 500 ms polling, read-only observation.
+  Keybindings `h/j/k/l`, `L`, `r`, `?`, `q`; non-interactive `list` and
+  `screenshot` subcommands.
+- Stats bar with tokens + duration; per-task stderr routed to
+  `stderr.log`.
+
+### Fixed
+- Dispatcher now calls `store.append_record` on each task completion
+  (spec §5.3 invariant was silently violated in v0.1). Regression test
+  added.
+- `--verbose` wired into claude spawn args so stream-json output flows
+  correctly.
+- `summary.jsonl` persistence restored.
+
+## [0.1.0] — 2026-04-16
+
+### Added
+- Headless dispatcher (`pitboss`, then `shire`) reading a TOML manifest
+  and fanning out `claude` subprocesses under a concurrency cap.
+- Per-task git worktree isolation.
+- Stream-JSON parser for Claude output with token/cost accounting.
+- Structured run artifacts: manifest snapshot, resolved config,
+  summary.json, summary.jsonl, per-task logs.
+- Graceful Ctrl-C handling: single SIGINT drains running tasks; second
+  SIGINT terminates.
+- Part 1 offline smoke test harness (`scripts/smoke-part1.sh`, 10 tests).
+
+[Unreleased]: https://github.com/SDS-Mode/pitboss/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/SDS-Mode/pitboss/compare/v0.2.2...v0.3.0
+[0.2.2]: https://github.com/SDS-Mode/pitboss/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/SDS-Mode/pitboss/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/SDS-Mode/pitboss/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/SDS-Mode/pitboss/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1130,6 +1139,7 @@ dependencies = [
  "atty",
  "chrono",
  "clap",
+ "clap_complete",
  "fake-mcp-client",
  "git2",
  "libc",
@@ -1173,6 +1183,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "clap_complete",
  "crossterm",
  "pitboss-core",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ tracing            = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter","fmt"] }
 async-trait        = "0.1"
 clap               = { version = "4", features = ["derive"] }
+clap_complete      = "4"
 shellexpand        = "3"
 atty               = "0.2"
 tempfile           = "3"

--- a/crates/pitboss-cli/Cargo.toml
+++ b/crates/pitboss-cli/Cargo.toml
@@ -30,6 +30,7 @@ serde              = { workspace = true }
 serde_json         = { workspace = true }
 toml               = { workspace = true }
 clap               = { workspace = true }
+clap_complete      = { workspace = true }
 anyhow             = { workspace = true }
 tracing            = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/pitboss-cli/src/cli.rs
+++ b/crates/pitboss-cli/src/cli.rs
@@ -60,4 +60,35 @@ pub enum Command {
         /// Path to the pitboss MCP unix socket to bridge stdio to.
         socket: PathBuf,
     },
+    /// Print shell completion script for the given shell (bash, zsh, fish,
+    /// elvish, powershell) to stdout.
+    Completions {
+        #[arg(value_enum)]
+        shell: clap_complete::Shell,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn completions_bash_contains_pitboss_name() {
+        // Smoke test: generate bash completions and confirm the output
+        // references the binary name. We're not validating the script
+        // content, just that the subcommand plumbing is wired correctly.
+        use clap::CommandFactory;
+        let mut cmd = Cli::command();
+        let mut buf = Vec::new();
+        clap_complete::generate(clap_complete::Shell::Bash, &mut cmd, "pitboss", &mut buf);
+        let s = String::from_utf8(buf).unwrap();
+        assert!(
+            s.contains("pitboss"),
+            "output should reference the binary name"
+        );
+        assert!(
+            s.contains("complete"),
+            "output should look like a completion script"
+        );
+    }
 }

--- a/crates/pitboss-cli/src/main.rs
+++ b/crates/pitboss-cli/src/main.rs
@@ -31,6 +31,12 @@ fn main() -> Result<()> {
         Command::McpBridge { socket } => {
             run_mcp_bridge(&socket);
         }
+        Command::Completions { shell } => {
+            use clap::CommandFactory;
+            let mut cmd = cli::Cli::command();
+            clap_complete::generate(shell, &mut cmd, "pitboss", &mut std::io::stdout());
+            std::process::exit(0);
+        }
     }
 }
 

--- a/crates/pitboss-tui/Cargo.toml
+++ b/crates/pitboss-tui/Cargo.toml
@@ -15,6 +15,7 @@ ratatui      = { workspace = true }
 crossterm    = { workspace = true }
 anyhow       = { workspace = true }
 clap         = { workspace = true }
+clap_complete = { workspace = true }
 serde        = { workspace = true }
 serde_json   = { workspace = true }
 chrono       = { workspace = true }

--- a/crates/pitboss-tui/src/main.rs
+++ b/crates/pitboss-tui/src/main.rs
@@ -54,6 +54,12 @@ enum Commands {
         #[arg(long, default_value_t = 30)]
         rows: u16,
     },
+    /// Print shell completion script for the given shell (bash, zsh, fish,
+    /// elvish, powershell) to stdout.
+    Completions {
+        #[arg(value_enum)]
+        shell: clap_complete::Shell,
+    },
     /// Open a specific run by UUID or directory name.
     #[command(external_subcommand)]
     Run(Vec<String>),
@@ -74,6 +80,12 @@ fn main() -> Result<()> {
         }
         Some(Commands::Screenshot { run, cols, rows }) => {
             cmd_screenshot(run.as_deref(), cols, rows)
+        }
+        Some(Commands::Completions { shell }) => {
+            use clap::CommandFactory;
+            let mut cmd = Cli::command();
+            clap_complete::generate(shell, &mut cmd, "pitboss-tui", &mut std::io::stdout());
+            Ok(())
         }
         Some(Commands::Run(args)) => {
             if args.is_empty() {
@@ -320,5 +332,35 @@ fn build_one_shot_snapshot(run_dir: &std::path::Path) -> crate::state::AppSnapsh
         focus_log: Vec::new(),
         failed_count,
         run_started_at,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Cli;
+
+    #[test]
+    fn completions_bash_contains_binary_name() {
+        // Smoke test: generate bash completions for pitboss-tui and confirm
+        // the output references the binary name. We're not validating the
+        // script content, just that the subcommand plumbing is wired up.
+        use clap::CommandFactory;
+        let mut cmd = Cli::command();
+        let mut buf = Vec::new();
+        clap_complete::generate(
+            clap_complete::Shell::Bash,
+            &mut cmd,
+            "pitboss-tui",
+            &mut buf,
+        );
+        let s = String::from_utf8(buf).unwrap();
+        assert!(
+            s.contains("pitboss-tui"),
+            "output should reference the binary name"
+        );
+        assert!(
+            s.contains("complete"),
+            "output should look like a completion script"
+        );
     }
 }

--- a/crates/pitboss-tui/src/runs.rs
+++ b/crates/pitboss-tui/src/runs.rs
@@ -47,7 +47,7 @@ pub fn collect_run_entries(base: &Path) -> Vec<RunEntry> {
         .collect();
 
     // Newest first.
-    entries.sort_by(|a, b| b.mtime.cmp(&a.mtime));
+    entries.sort_by_key(|e| std::cmp::Reverse(e.mtime));
     entries
 }
 

--- a/crates/pitboss-tui/src/watcher.rs
+++ b/crates/pitboss-tui/src/watcher.rs
@@ -214,7 +214,7 @@ fn collect_dynamic_ids(
         .collect();
     if let Ok(entries) = std::fs::read_dir(tasks_dir) {
         for entry in entries.flatten() {
-            if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            if entry.file_type().is_ok_and(|t| t.is_dir()) {
                 if let Some(name) = entry.file_name().to_str() {
                     let name = name.to_string();
                     if !static_ids.iter().any(|s| s == &name) && !ids.iter().any(|s| s == &name) {


### PR DESCRIPTION
## Summary
- GitHub Actions CI on every PR: fmt + clippy + test + offline smoke
- CHANGELOG.md covering v0.1.0..v0.3.0
- `pitboss completions <shell>` and `pitboss-tui completions <shell>`
- Release workflow to build + upload binaries on `v*` tag push

## Test plan
- [ ] CI run on this PR passes
- [ ] `pitboss completions bash` prints a valid bash completion script
- [ ] `pitboss-tui completions zsh` prints a valid zsh completion script