### PR TITLE
v0.3.2 TUI perf: interruptible watcher + seek-based log tail

### DIFF
--- a/crates/pitboss-tui/src/watcher.rs
+++ b/crates/pitboss-tui/src/watcher.rs
@@ -1,7 +1,7 @@
 //! Background watcher thread — polls the run directory every 500ms and
 //! emits `AppSnapshot` updates via an mpsc channel.
 
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::time::Duration;
@@ -15,6 +15,10 @@ use crate::state::{AppSnapshot, TileState, TileStatus};
 const POLL_INTERVAL_MS: u64 = 500;
 /// Number of parsed focus-pane lines to keep.
 const TAIL_LINES: usize = 40;
+/// Maximum bytes to read off the end of a log file when tailing. Chosen so
+/// that even a verbose stream-json run has >> `TAIL_LINES` rendered events
+/// within this window, without re-parsing multi-megabyte logs every poll.
+const TAIL_BYTES: u64 = 256 * 1024;
 /// A task is considered "running" if its log was modified within this many seconds.
 const RUNNING_FRESHNESS_SECS: u64 = 5;
 
@@ -62,7 +66,7 @@ pub fn watch(
         let mut focused_id: Option<String> = None;
 
         loop {
-            // Drain focus updates (non-blocking).
+            // Drain any pending focus updates (non-blocking).
             while let Ok(id) = focus_rx.try_recv() {
                 focused_id = Some(id);
             }
@@ -73,7 +77,14 @@ pub fn watch(
                 break;
             }
 
-            std::thread::sleep(Duration::from_millis(POLL_INTERVAL_MS));
+            // Wait up to POLL_INTERVAL_MS for the next tick, OR wake early
+            // when the user changes focus so the new tile's log tails
+            // without an up-to-half-second delay.
+            match focus_rx.recv_timeout(Duration::from_millis(POLL_INTERVAL_MS)) {
+                Ok(id) => focused_id = Some(id),
+                Err(mpsc::RecvTimeoutError::Timeout) => {}
+                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            }
         }
     });
 }
@@ -347,12 +358,32 @@ fn log_freshness_secs(path: &Path) -> Option<u64> {
 /// as human-readable text, while noisy/unknown events are silently skipped.
 /// Returns an empty vec if the file is missing or unreadable.
 fn tail_log(path: &Path, n: usize) -> Vec<String> {
-    let Ok(file) = std::fs::File::open(path) else {
+    let Ok(mut file) = std::fs::File::open(path) else {
         return Vec::new();
     };
+    let Ok(meta) = file.metadata() else {
+        return Vec::new();
+    };
+    let file_size = meta.len();
+
+    // Seek to the last TAIL_BYTES of the file. If the file is smaller than
+    // that, read from the beginning. When we seek mid-file we drop the first
+    // line — it's almost certainly partial (we landed inside an existing
+    // stream-json record).
+    let start = file_size.saturating_sub(TAIL_BYTES);
+    let seeked_partial = start > 0;
+    if seeked_partial && file.seek(SeekFrom::Start(start)).is_err() {
+        return Vec::new();
+    }
+
     let reader = BufReader::new(file);
+    let mut lines = reader.lines().map_while(Result::ok);
+    if seeked_partial {
+        let _ = lines.next();
+    }
+
     let mut rendered: Vec<String> = Vec::new();
-    for raw_line in reader.lines().map_while(Result::ok) {
+    for raw_line in lines {
         let trimmed = raw_line.trim();
         if trimmed.is_empty() {
             continue;
@@ -647,5 +678,75 @@ mod tests {
         );
         let live_tile = snap.tasks.iter().find(|t| t.id == "worker-live").unwrap();
         assert_eq!(live_tile.parent_task_id.as_deref(), Some("lead"));
+    }
+
+    #[test]
+    fn tail_log_small_file_returns_all_events() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("stdout.log");
+        let body = [
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"first"}]}}"#,
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"second"}]}}"#,
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"third"}]}}"#,
+        ]
+        .join("\n");
+        std::fs::write(&path, body).unwrap();
+
+        let out = tail_log(&path, 40);
+        assert_eq!(out.len(), 3, "expected 3 events, got {out:?}");
+        assert!(out[0].contains("first"));
+        assert!(out[2].contains("third"));
+    }
+
+    #[test]
+    fn tail_log_large_file_returns_tail_and_drops_partial_first_line() {
+        use std::fmt::Write;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("stdout.log");
+
+        // Build >TAIL_BYTES of events. Each line here is ~100 bytes; 3000
+        // lines puts us solidly past the 256 KiB window.
+        let mut body = String::new();
+        for i in 0..3000 {
+            writeln!(
+                &mut body,
+                r#"{{"type":"assistant","message":{{"content":[{{"type":"text","text":"event-{i:05}"}}]}}}}"#
+            ).unwrap();
+        }
+        // Add a final distinctive event so we can assert it's in the tail.
+        body.push_str(
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"LAST"}]}}"#,
+        );
+        std::fs::write(&path, &body).unwrap();
+
+        let out = tail_log(&path, 40);
+        assert_eq!(
+            out.len(),
+            40,
+            "expected exactly TAIL_LINES=40, got {}",
+            out.len()
+        );
+        // The tail must include the final LAST event.
+        assert!(
+            out.last().unwrap().contains("LAST"),
+            "last rendered event: {:?}",
+            out.last()
+        );
+        // The first rendered event must NOT be from the very start of the file
+        // — we seeked past it. event-00000 is at byte 0, and 256 KiB of events
+        // later we'll be well into the middle.
+        assert!(
+            !out.iter().any(|s| s.contains("event-00000")),
+            "tail unexpectedly included the file head: {:?}",
+            out.first()
+        );
+    }
+
+    #[test]
+    fn tail_log_missing_file_returns_empty() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let out = tail_log(&dir.path().join("does-not-exist.log"), 40);
+        assert!(out.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
Two fixes that kill the felt latency when switching focused tiles in the TUI.

- **Fix A — interruptible poll.** `thread::sleep(POLL_INTERVAL_MS)` → `focus_rx.recv_timeout(POLL_INTERVAL_MS)`. Worker-switch latency drops from up-to-500ms + rebuild → rebuild only.
- **Fix B — real tail.** `tail_log` seeks to `file_size - 256 KiB` instead of reading the whole file and parsing every stream-json line. O(file_size) → O(constant). First line after a mid-file seek is dropped as likely partial.

## Test plan
- [ ] CI green
- [ ] Three new `tail_log` tests pass (small file, >256 KiB file with partial-first-line drop, missing file)
- [ ] Manual: open pitboss-tui on a run with a large log, press j/k rapidly — should feel instant

## Test counts
- Before: 219
- After: 222 (+3 tail_log tests)

Closes the "switching between workers is sluggish" item from the roadmap refresh.