### PR TITLE
v0.3.4: AGENTS.md + canonical ketchup example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,465 @@
+# Pitboss for agents
+
+Instructions for an AI agent (Claude, GPT, whatever) operating `pitboss` on
+behalf of a human. If you're a human: read `README.md`. If you're an agent
+that needs to orchestrate pitboss from natural language, stay here.
+
+---
+
+## Mission
+
+Pitboss is a Rust dispatcher that runs multiple `claude` subprocesses in
+parallel under a concurrency cap and captures structured artifacts per run.
+It has two modes:
+
+- **Flat**: the operator predeclares N tasks; pitboss runs them.
+- **Hierarchical**: the operator declares one **lead**; the lead dynamically
+  spawns **worker** subprocesses via MCP tool calls, under house rules the
+  operator set.
+
+You invoke pitboss from a shell. You do not need to touch rust source to
+use it. You write a TOML manifest, validate it, dispatch it, read the run
+directory.
+
+---
+
+## When to reach for pitboss (decision tree)
+
+Pitboss is the right tool when **all** of the following hold:
+
+1. The task decomposes into **≥ 2 units** that could run in parallel.
+2. Each unit is substantial enough to justify a fresh claude subprocess
+   (order of ≥30 seconds of work), *not* a one-liner the caller could do
+   inline.
+3. You want **isolated git worktrees** per unit (or you've set
+   `use_worktree = false` and accepted the shared-directory tradeoff).
+4. You want **structured artifacts** — per-task logs, token usage, session
+   ids, summary.json — not just "the output scrolled by in a terminal."
+5. The wall-clock win from parallelism beats the setup cost (~1-2 seconds
+   per worker for process spawn + worktree prep).
+
+Anti-patterns — **don't use pitboss** for:
+- Single-shot work. One claude call is simpler than writing a manifest.
+- Tightly coupled work where units must communicate mid-execution. Pitboss
+  workers cannot message each other (by design).
+- Work where the operator needs to inspect intermediate state
+  interactively. Pitboss runs are batch; the TUI is read-only.
+- Deep recursion. Depth is 1 (hub-and-spoke). Workers cannot spawn
+  sub-workers.
+
+---
+
+## Flat vs hierarchical — which one
+
+| | Flat | Hierarchical |
+|---|---|---|
+| **When you know the decomposition up front** | ✓ | |
+| **When the decomposition depends on the input** | | ✓ |
+| **Manifest declares every task statically** | ✓ | |
+| **Lead observes + reacts to intermediate results** | | ✓ |
+| **Number of workers** | fixed | dynamic, bounded by `max_workers` |
+| **Budget enforcement** | no | yes, `budget_usd` |
+| **MCP server runs** | no | yes, on a unix socket |
+
+Rule of thumb: **if the operator can write out every `[[task]]` before
+running, use flat. If the operator is describing a *policy* (e.g., "one
+worker per file in this directory", "one worker per unique author"), use
+hierarchical.**
+
+---
+
+## Vocabulary
+
+| Term | Meaning |
+|---|---|
+| **Pitboss** | The `pitboss` binary you invoke. |
+| **Run** | One `pitboss dispatch` invocation. Produces `~/.local/share/pitboss/runs/<run-id>/`. |
+| **Lead** | In hierarchical mode, the first claude subprocess. Receives the operator's prompt + six MCP tools. Decides how many workers to spawn. |
+| **Worker** | A claude subprocess executing a single task, either declared in `[[task]]` (flat) or dynamically spawned by the lead (hierarchical). |
+| **House rules** | Hierarchical guardrails: `max_workers` (≤16), `budget_usd`, `lead_timeout_secs`. |
+| **Worktree** | A per-task git worktree under a fresh branch, isolating concurrent work. `use_worktree = true` by default. |
+
+---
+
+## Manifest schema
+
+TOML, typically named `pitboss.toml`. Every field annotated below.
+
+### Top-level `[run]`
+
+| Key | Type | Required? | Default | Notes |
+|---|---|---|---|---|
+| `max_parallel` | int | no | 4 | Concurrency cap for flat-mode tasks. Overridden by `ANTHROPIC_MAX_CONCURRENT` env. |
+| `halt_on_failure` | bool | no | false | Flat mode. If a task fails, skip remaining tasks. |
+| `run_dir` | string path | no | `~/.local/share/pitboss/runs` | Where per-run artifacts land. |
+| `worktree_cleanup` | `"always"` \| `"on_success"` \| `"never"` | no | `"on_success"` | What to do with each worker's worktree after completion. `"never"` for inspection-heavy runs. |
+| `emit_event_stream` | bool | no | false | Emit a JSONL event stream alongside summary.jsonl. |
+| `max_workers` | int | only if `[[lead]]` present | unset | Hierarchical: hard cap on concurrent + queued workers (1–16). |
+| `budget_usd` | float | only if `[[lead]]` present | unset | Hierarchical: soft cap with reservation accounting. Worker spawns fail with `budget exceeded` once `spent + reserved + next_estimate > budget`. |
+| `lead_timeout_secs` | int | only if `[[lead]]` present | unset | Hierarchical: wall-clock cap on the lead. |
+
+### `[defaults]`
+
+Inherited by every `[[task]]` and `[[lead]]` unless overridden.
+
+| Key | Type | Notes |
+|---|---|---|
+| `model` | string | e.g. `claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-opus-4-7`. Dated suffixes allowed. |
+| `effort` | `"low"` \| `"medium"` \| `"high"` | Maps to claude's `--effort` flag. |
+| `tools` | array of string | `--allowedTools` value. Defaults to `["Read", "Write", "Edit", "Bash", "Glob", "Grep"]` if unset. |
+| `timeout_secs` | int | Per-task wall-clock cap. |
+| `use_worktree` | bool | Default `true`. Set `false` for read-only analysis runs. |
+| `env` | table (string → string) | Env vars passed to the claude subprocess. |
+
+### `[[task]]` (flat mode, repeat)
+
+| Key | Required? | Notes |
+|---|---|---|
+| `id` | yes | Short slug used in logs, worktree names. Alphanumeric + `_` + `-`. Unique within manifest. |
+| `directory` | yes | Must be inside a git repo if `use_worktree = true`. |
+| `prompt` | yes | What the claude subprocess receives via `-p`. |
+| `branch` | no | Branch name for the worktree. Defaults to a generated name. |
+| `model`, `effort`, `tools`, `timeout_secs`, `use_worktree`, `env` | no | Per-task overrides of `[defaults]`. |
+
+### `[[lead]]` (hierarchical mode, exactly one, mutually exclusive with `[[task]]`)
+
+Same fields as `[[task]]`. `id` is used as the tile label in the TUI.
+Mutually exclusive with `[[task]]` — a manifest is either flat or
+hierarchical.
+
+---
+
+## Invocation patterns
+
+### Validate before dispatch
+
+```bash
+pitboss validate pitboss.toml
+```
+
+Exit 0 = valid. Non-zero = parse error or semantic error. **Always validate
+first.** This catches all the class-of-error issues (mixed `[[task]]` + `[[lead]]`,
+`max_workers = 17`, `budget_usd = 0`, missing `id`, directory doesn't exist)
+before any claude subprocess is spawned.
+
+### Dispatch
+
+```bash
+pitboss dispatch pitboss.toml
+```
+
+Blocks until all tasks finish. Exit codes:
+- `0` — all tasks succeeded
+- `1` — one or more tasks failed (but pitboss itself ran cleanly)
+- `2` — manifest error, claude binary missing, etc.
+- `130` — interrupted (Ctrl-C drained gracefully)
+
+### Resume
+
+```bash
+pitboss resume <run-id>
+```
+
+Re-runs a prior dispatch. For flat-mode runs, each task respawns with its
+original `claude_session_id`. For hierarchical runs, only the lead resumes
+(`--resume <session-id>`); the lead decides whether to spawn fresh workers.
+
+**Gotcha:** if the original run used `worktree_cleanup = "on_success"` (the
+default), the worktrees are gone — claude can't find its sessions by cwd.
+Use `worktree_cleanup = "never"` on runs you know you want to resume.
+
+### Diff
+
+```bash
+pitboss diff <run-a> <run-b>
+```
+
+Compares two runs side-by-side. Useful for A/B testing prompts or models.
+
+---
+
+## Interpreting a run directory
+
+After `pitboss dispatch` finishes, find the run via:
+
+```bash
+RUN_DIR=$(ls -td ~/.local/share/pitboss/runs/*/ | head -1)
+```
+
+Files in the run dir:
+
+| File | Purpose |
+|---|---|
+| `manifest.snapshot.toml` | Exact manifest bytes used for this run. |
+| `resolved.json` | Fully resolved manifest (defaults applied). |
+| `meta.json` | `run_id`, `started_at`, `claude_version`, `pitboss_version`. |
+| `summary.json` | Written on clean finalize. Full structured summary of the run. |
+| `summary.jsonl` | Appended incrementally as tasks finish. Useful for live observation. |
+| `tasks/<id>/stdout.log` | Raw stream-json from the task's claude subprocess. |
+| `tasks/<id>/stderr.log` | Stderr. |
+| `lead-mcp-config.json` | Hierarchical only. The `--mcp-config` file pointed at `pitboss mcp-bridge <socket>`. |
+
+### `summary.json` structure
+
+```json
+{
+  "run_id": "019d9b...",
+  "started_at": "2026-04-17T12:14:22Z",
+  "ended_at":   "2026-04-17T12:14:55Z",
+  "total_duration_ms": 32654,
+  "tasks_total": 4,
+  "tasks_failed": 0,
+  "was_interrupted": false,
+  "pitboss_version": "0.3.3",
+  "claude_version":  "2.1.112 (Claude Code)",
+  "tasks": [
+    {
+      "task_id": "triage",
+      "status": "Success" | "Failed" | "TimedOut" | "Cancelled" | "SpawnFailed",
+      "exit_code": 0,
+      "started_at": "...",
+      "ended_at":   "...",
+      "duration_ms": 22649,
+      "worktree_path": "/path/to/worktree-or-null",
+      "log_path":      "/path/to/tasks/triage/stdout.log",
+      "token_usage": {
+        "input": 26,
+        "output": 1373,
+        "cache_read":     72647,
+        "cache_creation": 37413
+      },
+      "claude_session_id": "...",
+      "final_message_preview": "Done. Composed summary...",
+      "parent_task_id": null | "lead-id"
+    }
+  ]
+}
+```
+
+Lead records have `parent_task_id: null`. Worker records have
+`parent_task_id: "<lead-id>"`. Query with `jq`.
+
+---
+
+## The 6 MCP tools the lead has
+
+When running hierarchical, the lead's `--allowedTools` is automatically
+populated with these. You (the operator) don't list them explicitly.
+
+| Tool | Args | Returns |
+|---|---|---|
+| `mcp__pitboss__spawn_worker` | `{prompt, directory?, branch?, tools?, timeout_secs?, model?}` | `{task_id, worktree_path}` |
+| `mcp__pitboss__worker_status` | `{task_id}` | `{state, started_at, partial_usage, last_text_preview, prompt_preview}` |
+| `mcp__pitboss__wait_for_worker` | `{task_id, timeout_secs?}` | full `TaskRecord` when worker settles |
+| `mcp__pitboss__wait_for_any` | `{task_ids: [...], timeout_secs?}` | `(winner_id, TaskRecord)` on first settle |
+| `mcp__pitboss__list_workers` | `{}` | `[{task_id, state, prompt_preview, started_at}, ...]` |
+| `mcp__pitboss__cancel_worker` | `{task_id}` | `{ok: bool}` |
+
+**Worker spawn arg rules:**
+- `prompt` is the new worker's system prompt / `-p` payload. Required.
+- `directory` defaults to the lead's `directory`.
+- `model` defaults to the lead's model. Override per-worker when you want
+  heavier workers (Sonnet) under a Haiku lead.
+- `tools` defaults to the lead's tools.
+
+---
+
+## Error patterns
+
+### `budget exceeded: $<spent> spent + $<reserved> reserved + $<estimated> estimated > $<budget> budget`
+
+The lead tried `spawn_worker` with insufficient budget headroom. Two
+reactions:
+1. **Fall back gracefully.** Finish the work the lead already has, compose
+   a partial report, note the budget hit in the final output.
+2. **Request a larger budget from the operator.** If you're orchestrating
+   pitboss from natural language, surface this error back to the human and
+   ask whether to re-run with a higher cap.
+
+Don't loop calling `spawn_worker` after budget exhaustion — each call costs
+nothing structurally but adds noise to the logs.
+
+### `worker cap reached: N active (max M)`
+
+More than `max_workers` workers are Pending/Running. Wait for one to finish
+(via `wait_for_worker` or `wait_for_any`), then retry the spawn.
+
+### `run is draining: no new workers accepted`
+
+The operator Ctrl-C'd or the lead's `cancel` was tripped. Finish gracefully;
+don't spawn new work.
+
+### `unknown task_id`
+
+You're referring to a worker that was never spawned (or was typo'd).
+`mcp__pitboss__list_workers` shows what's actually registered.
+
+### `SpawnFailed`
+
+A worker never started — usually a git worktree prep failure (dirty tree,
+branch conflict, non-git directory). Check the stderr log.
+
+---
+
+## Canonical examples
+
+### 1. Fan out a summarization across N files
+
+Flat mode, predeclared tasks.
+
+```toml
+[run]
+max_parallel = 3
+
+[defaults]
+model = "claude-haiku-4-5"
+use_worktree = false
+
+[[task]]
+id = "summarize-a"
+directory = "/path/to/repo"
+prompt = "Read file-a.txt and summarize in one sentence to /tmp/summaries/a.md"
+
+[[task]]
+id = "summarize-b"
+directory = "/path/to/repo"
+prompt = "Read file-b.txt and summarize in one sentence to /tmp/summaries/b.md"
+
+# ... etc
+```
+
+### 2. Lead decides fanout based on the input
+
+Hierarchical mode, dynamic decomposition.
+
+```toml
+[run]
+max_workers = 6
+budget_usd = 1.50
+lead_timeout_secs = 1200
+
+[defaults]
+model = "claude-haiku-4-5"
+use_worktree = false
+
+[[lead]]
+id = "author-digest"
+directory = "/path/to/repo"
+prompt = """
+List the last 20 commits with `git log --format='%H %an %s' -20`. Group
+them by author. Spawn one worker per unique author via
+mcp__pitboss__spawn_worker to summarize that author's work in
+/tmp/digest/<author-slug>.md. Wait for all via mcp__pitboss__wait_for_worker.
+Compose a combined /tmp/digest/SUMMARY.md. Then exit.
+"""
+```
+
+### 3. Refactor analysis of a neighboring repo
+
+This pattern was exercised end-to-end against the
+[Ketchup](https://github.com/SDS-Mode/ketchup) plugin on
+2026-04-17 (branch
+[`feature/pitboss-refactor-analysis`](https://github.com/SDS-Mode/ketchup/tree/feature/pitboss-refactor-analysis)).
+4 Haiku workers ran in parallel auditing one angle each — SKILL.md
+structure, 16 CLI parsing rules, cross-file overlap, README-vs-SKILL.md
+separation — and a Haiku lead synthesized into a single `REFACTOR-PLAN.md`
+with 11 prioritized changes (5 P0, 4 P1, 2 P2) and a ~12% token-footprint
+reduction estimate. **Total: 5 tasks, 0 failed, 201 s wall-clock, under
+$0.40 on Haiku.**
+
+Sketch of the manifest:
+
+```toml
+[run]
+max_workers = 4
+budget_usd = 1.50
+lead_timeout_secs = 1500
+worktree_cleanup = "never"
+
+[defaults]
+model = "claude-haiku-4-5"
+use_worktree = false        # read-only audit — no worktree isolation needed
+
+[[lead]]
+id = "refactor-analyst"
+directory = "/path/to/target-repo"
+prompt = """
+[...concrete directions for spawning 4 workers, one per audit angle,
+each writing to /tmp/refactor/<angle>.md; then reading them back and
+synthesizing into /tmp/refactor/REFACTOR-PLAN.md...]
+"""
+```
+
+The lead spawned workers in an explicit loop, used
+`mcp__pitboss__wait_for_worker` on each before reading their outputs,
+then composed the synthesis. Key patterns the lead applied:
+
+- Each worker received a **specific file path** to write to, so the lead
+  could read the results back deterministically.
+- Workers received **per-angle instructions**, not the whole repo — keeps
+  their context tight and their output focused.
+- The lead's synthesis prompt explicitly asked for *executive summary,
+  before/after file structure, prioritized list, risk section* — giving
+  the output a predictable shape.
+
+Run this pattern against any repo of similar shape by:
+1. Listing the 3–5 files that matter most.
+2. Choosing 4 audit angles (structural / rules / overlap / user-vs-internal
+   / test-coverage / dependencies — pick what applies).
+3. Writing worker prompts that each produce one focused analysis file.
+4. Writing a lead-synthesis prompt that reads those files back and
+   composes an actionable plan.
+
+### 4. Tight-budget stress / graceful degradation
+
+```toml
+[run]
+max_workers = 8
+budget_usd = 0.20
+lead_timeout_secs = 900
+
+[defaults]
+model = "claude-haiku-4-5"
+use_worktree = false
+
+[[lead]]
+id = "partial"
+directory = "/path/to/repo"
+prompt = """
+Attempt to spawn 6 workers with mcp__pitboss__spawn_worker, one per file in
+src/. When a spawn fails with 'budget exceeded', DO NOT retry — record the
+file and move on. Wait for successfully-spawned workers, then compose a
+partial summary noting which files were skipped and why.
+"""
+```
+
+Use this pattern when you want to explore *what you can get* within a fixed
+spend envelope.
+
+---
+
+## Writing manifests from natural-language requests
+
+When a human asks you (the agent) to "run claude on each X in Y and
+combine the results", the canonical translation is:
+
+1. Can I enumerate the Xs up front? → flat mode, one `[[task]]` per X.
+2. Do I need to compute the list of Xs first? → hierarchical mode, lead
+   does the enumeration then spawns workers.
+3. Is the user ok with a worst-case budget? → put it in `budget_usd`.
+4. Does the work need git worktree isolation, or is it read-only? → set
+   `use_worktree` accordingly.
+5. What model? Default to Haiku unless the work is substantial (deep code
+   analysis, multi-file refactor proposals) — then Sonnet.
+
+Write the manifest, run `pitboss validate`, show the human the manifest
+and the validation result, ask for confirmation, then dispatch. If you
+dispatch first and have to ask follow-ups, you've probably wasted budget.
+
+---
+
+## Version
+
+Written for pitboss `v0.3.3`. Schema may evolve; `pitboss validate` is the
+source of truth. This document should stay self-contained — if something
+here conflicts with the actual binary, the binary wins. File a PR.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 > You deal the cards; the pit watches the chips.
 
+> **Operating pitboss from an AI agent?** See [`AGENTS.md`](AGENTS.md) —
+> schema reference, decision tree, canonical examples, and the rules for
+> translating natural-language requests into valid manifests.
+
 Rust toolkit for running and observing parallel Claude Code sessions. A
 dispatcher (`pitboss`) fans out `claude` subprocesses under a concurrency
 cap, captures structured artifacts per run, and — in hierarchical mode —

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,140 @@
+# Pitboss Roadmap
+
+Capture of deferred work. Items here are scoped but unscheduled — grab
+one when you're ready, or file issues to formalize priority.
+
+## Near-term (focused, shippable in ≤1 day)
+
+### TUI kill: cancel a worker or a whole run from `pitboss-tui`
+
+**Status:** designed, not built. Deferred out of v0.3.4.
+
+The TUI is read-only today. Add two keybindings:
+- `x` on a focused tile → cancel that worker (hierarchical mode only).
+- `X` (or `Ctrl-K`) → cancel the whole run (equivalent to Ctrl-C in the
+  dispatch terminal).
+
+Both gated behind a confirmation modal.
+
+**Mechanism — per-run control socket.** The dispatcher binds a second unix
+socket at `$XDG_RUNTIME_DIR/pitboss/<run-id>.control.sock` (alongside the
+existing MCP socket for hierarchical runs). TUI connects and sends a
+line-based protocol:
+
+```
+cancel-run
+cancel-worker <task_id>
+```
+
+Dispatcher receives → looks up the appropriate `CancelToken` → terminates.
+Reuses the same `CancelToken` plumbing we already have for Ctrl-C,
+lead-exit cleanup, and `mcp__pitboss__cancel_worker`.
+
+**Scope estimate:** ~380 lines across the dispatcher control server, TUI
+client, keybindings + modal, a `fake-control-client` test-support crate,
+and one integration test. Half a day.
+
+**Gotchas:**
+- Socket lifecycle tied to run lifecycle — if the TUI opens a completed
+  run, `x`/`X` should show "run finished, nothing to cancel" rather
+  than error.
+- `x` on the lead tile in hierarchical mode is semantically equivalent
+  to `X` — probably forbid `x` on the lead and require `X` for that
+  action.
+- `⊘ Cancelling...` intermediate state in the TUI while the worker
+  drains (up to `TERMINATE_GRACE` = 10 s).
+
+---
+
+## Medium-term — deferred from earlier versions
+
+### Broadcast mode (`pitboss b "<prompt>"`)
+
+Send the same prompt to every running tile. From the v0.2.1 roadmap.
+Depends on interactive snap-in (deferred indefinitely — see below).
+**Status:** parked. No design doc.
+
+### Depth > 1 hierarchies
+
+A worker can itself be a lead. Needs recursion guardrails, a nested
+socket addressing scheme, and a product decision: *should this exist at
+all, or is "I want a deeper tree" a code smell for a flatter
+decomposition?* **Status:** parked pending need.
+
+### Peer messaging
+
+Workers pass results to siblings without the lead in the middle. Would
+need a new MCP surface or a shared blackboard. Risk: contention /
+ordering complexity for marginal benefit. **Status:** parked.
+
+### Plan approval flow
+
+Lead proposes a plan, human operator approves in the TUI (or via
+`pitboss plan`) before workers actually dispatch. UX question:
+modal-in-TUI vs. separate subcommand. **Status:** parked.
+
+### Full end-to-end `fake-claude` integration test
+
+Task 26 of the v0.3 plan left a placeholder. Requires `fake-claude` to
+speak real MCP. Medium lift; pays off once more hierarchical features
+land. **Status:** would take 1–2 days.
+
+---
+
+## Long-term / explicitly retired
+
+### Interactive snap-in (keystroke passthrough)
+
+Forwarding keystrokes from a focused TUI tile into a running claude
+subprocess. Analyzed in v0.3.4 as part of "AGENTS.md week" and
+**retired** — hierarchical mode is the correct abstraction for the
+"operator can't watch 16 workers" problem. Keeping view-only snap-in;
+not building interactive.
+
+---
+
+## Code-quality follow-ups (Tier 3/4 from earlier reviews)
+
+- `TokenUsageSchema` compile-time sync check with `TokenUsage`
+  (e.g., `static_assertions::assert_fields!`). Currently two structs
+  can diverge silently.
+- Resume + worktree cleanup interaction — `pitboss resume` loses the
+  claude session if the original worktree was cleaned. Either default
+  hierarchical to `worktree_cleanup = "never"` or reuse the original
+  worktree path on resume.
+- More Claude models in `prices.rs` as they ship.
+- `cargo-dist` migration — current release workflow is manual cross-
+  compile. `cargo-dist` adds installers (`curl|sh`), updater binaries,
+  Homebrew formula publishing. Worth it once we add more targets.
+- Dockerfile / container image.
+- MCP protocol extensions (we only implement tools; resources + prompts
+  would be cheap adds).
+- Opt-in telemetry (aggregate run counts, token totals).
+- systemd unit for running as a long-lived dispatcher.
+- `cargo publish` once we want crates.io distribution.
+
+---
+
+## Non-goals (don't build these)
+
+### Worker → worker MCP channel
+
+Specifically: don't let workers spawn sub-workers or send tool calls
+laterally. Depth = 1 is a design invariant, not an accidental limit.
+Breaking it re-introduces contention + ordering complexity that
+pitboss was built to avoid.
+
+### Windows-native builds
+
+Pitboss relies on unix sockets + SIGTERM for cancellation. Porting to
+Windows would mean a named-pipe abstraction + different process
+signaling. The current target audience runs on Linux + macOS; supporting
+Windows would materially expand the surface area for zero incremental
+use cases we know about. Happy to revisit if a concrete need emerges.
+
+### Heavy dependency-manager features
+
+Pitboss is a dispatcher, not a workflow engine. Don't add DAG
+dependencies between tasks, conditional branches, retry policies, etc.
+If you want those, you want a proper workflow system (Airflow,
+Prefect). Pitboss's value is that it stays simple.

--- a/examples/ketchup-refactor.toml
+++ b/examples/ketchup-refactor.toml
@@ -1,0 +1,49 @@
+[run]
+max_workers = 4
+budget_usd = 1.50
+lead_timeout_secs = 1500
+worktree_cleanup = "never"
+
+[defaults]
+model = "claude-haiku-4-5"
+use_worktree = false
+
+[[lead]]
+id = "refactor-analyst"
+directory = "/run/media/system/Dos/Projects/ketchup"
+prompt = """You are the lead refactor analyst for the Ketchup project — a Claude Code plugin that generates perspective-shaped technical research reports. The repo is currently on branch `feature/pitboss-refactor-analysis`.
+
+Key files to understand:
+- skills/ketchup/SKILL.md (~31 KB, ~496 lines — the monolithic core skill)
+- skills/ketchup/notebook-format.md (~12 KB, 256 lines — supplementary format doc)
+- skills/ketchup/cite-and-tag.md (~2 KB, 48 lines — citation rules)
+- skills/ketchup/plugin-registry.yaml (20 lines)
+- README.md (321 lines, user-facing)
+- CHANGELOG.md
+
+Your job: produce a refactor plan that makes the Ketchup skill more efficient. Efficiency here means some mix of: smaller total token footprint when Claude loads the skill; fewer duplicated rules across files; tighter decomposition (split the 31 KB SKILL.md into focused sub-skills if justified); cleaner CLI-parsing rules; fewer cross-reference footguns.
+
+Spawn 4 workers in parallel, each analyzing one angle:
+
+Worker A — SKILL.md structural audit:
+  prompt: "Read /run/media/system/Dos/Projects/ketchup/skills/ketchup/SKILL.md in full. Identify the top-level sections. Count lines/estimated-tokens per section. Flag: sections that could be split into a sub-skill, sections with internal duplication, sections that are over-specified (checklists/rules that the model would follow regardless). Write a 400-600 word audit to /tmp/ketchup-refactor/01-skill-audit.md with section-by-section recommendations."
+
+Worker B — CLI parsing rules audit:
+  prompt: "Read /run/media/system/Dos/Projects/ketchup/skills/ketchup/SKILL.md, focus on the 'Arguments' table and the 16 numbered 'Parsing Rules' underneath. Identify: rules that duplicate each other in different words, rules that can be collapsed into a single schema, rules that describe behavior the model handles by default, and rules that are essential. Propose a tighter 5-8 rule replacement preserving correctness. Write to /tmp/ketchup-refactor/02-cli-audit.md (~400 words)."
+
+Worker C — Cross-file overlap audit:
+  prompt: "Read /run/media/system/Dos/Projects/ketchup/skills/ketchup/SKILL.md, notebook-format.md, and cite-and-tag.md. Identify content that appears in multiple files (formatting rules, citation conventions, output templates). Propose which file should own each piece and what should be deleted/consolidated. Write to /tmp/ketchup-refactor/03-overlap-audit.md (~400 words) with a 'canonical location' table at the end."
+
+Worker D — README vs SKILL.md audit:
+  prompt: "Compare /run/media/system/Dos/Projects/ketchup/README.md against /run/media/system/Dos/Projects/ketchup/skills/ketchup/SKILL.md. The README is user-facing; SKILL.md is Claude-facing. Flag: content that belongs only in README (install, examples, quickstart), content that belongs only in SKILL.md (internal rules, decomposition recipes), and content duplicated across both. Recommend specific excisions from each file. Write to /tmp/ketchup-refactor/04-readme-vs-skill.md (~400 words)."
+
+Pass directory=/run/media/system/Dos/Projects/ketchup and model=claude-haiku-4-5 to each worker.
+
+Spawn all 4 workers in parallel via mcp__pitboss__spawn_worker. Call mcp__pitboss__wait_for_worker on each to wait for completion. Once all finish, read /tmp/ketchup-refactor/*.md and compose a combined REFACTOR-PLAN.md at /tmp/ketchup-refactor/REFACTOR-PLAN.md (~800 words) with:
+  1. Executive summary (3-4 sentences on the overall direction)
+  2. Concrete proposed file structure (before / after)
+  3. Prioritized list of changes (P0 must-do, P1 should-do, P2 nice-to-have)
+  4. Estimated token-footprint reduction
+  5. Risks / what NOT to touch
+
+Then exit."""


### PR DESCRIPTION
## Summary

AGENTS.md as a companion to README.md — the agent-facing entry point for operating pitboss from natural language. Plus a canonical example manifest derived from a real working run against the Ketchup plugin.

### AGENTS.md contents
- Mission + decision tree (when to reach for pitboss, flat vs hierarchical)
- Vocabulary + full manifest schema (every field annotated)
- Invocation patterns (validate/dispatch/resume/diff)
- Run-directory layout + summary.json structure
- The 6 MCP tools the lead sees
- Error patterns (budget exceeded, worker cap, draining, etc.)
- 4 canonical examples including the ketchup refactor case study

### examples/ketchup-refactor.toml
The literal manifest used to produce the case study. 4 Haiku workers in parallel audit a target plugin from 4 angles; Haiku lead synthesizes into REFACTOR-PLAN.md. Runs in ~3 min on ~\$0.30 of Haiku. Output for the actual Ketchup run lives at https://github.com/SDS-Mode/ketchup/tree/feature/pitboss-refactor-analysis/refactor-analysis

### README.md
One-line pointer to AGENTS.md at the top.

## Test plan
- [ ] CI green (docs-only paths-ignore should skip CI entirely; if CI runs, it passes)
- [ ] AGENTS.md renders on GitHub
- [ ] examples/ketchup-refactor.toml validates: \`pitboss validate examples/ketchup-refactor.toml\`