### PR TITLE
scripts: smoke-part1 uses --run-dir so test runs self-clean

### DIFF
--- a/scripts/smoke-part1.sh
+++ b/scripts/smoke-part1.sh
@@ -141,7 +141,7 @@ id = "x"
 directory = "$REPO"
 prompt = "p"
 EOF
-"$PITBOSS" dispatch "$SCRATCH/bad-key.toml" >/dev/null 2>&1; CODE=$?
+"$PITBOSS" dispatch --run-dir "$SCRATCH/runs" "$SCRATCH/bad-key.toml" >/dev/null 2>&1; CODE=$?
 expect_exit 2 "$CODE" "1.4 validate unknown field" "must reject at parse"
 
 # --------------------------------------------------------------------
@@ -152,7 +152,7 @@ id = "x"
 directory = "/absolutely/does/not/exist"
 prompt = "p"
 EOF
-"$PITBOSS" dispatch "$SCRATCH/bad-dir.toml" >/dev/null 2>&1; CODE=$?
+"$PITBOSS" dispatch --run-dir "$SCRATCH/runs" "$SCRATCH/bad-dir.toml" >/dev/null 2>&1; CODE=$?
 expect_exit 2 "$CODE" "1.5 missing directory"
 
 # --------------------------------------------------------------------
@@ -163,7 +163,7 @@ id = "x"
 directory = "$NOT_GIT"
 prompt = "p"
 EOF
-"$PITBOSS" dispatch "$SCRATCH/bad-nongit.toml" >/dev/null 2>&1; CODE=$?
+"$PITBOSS" dispatch --run-dir "$SCRATCH/runs" "$SCRATCH/bad-nongit.toml" >/dev/null 2>&1; CODE=$?
 expect_exit 2 "$CODE" "1.6 non-git dir"
 
 # --------------------------------------------------------------------
@@ -179,12 +179,12 @@ id = "same"
 directory = "$REPO"
 prompt = "b"
 EOF
-"$PITBOSS" dispatch "$SCRATCH/bad-dups.toml" >/dev/null 2>&1; CODE=$?
+"$PITBOSS" dispatch --run-dir "$SCRATCH/runs" "$SCRATCH/bad-dups.toml" >/dev/null 2>&1; CODE=$?
 expect_exit 2 "$CODE" "1.7 duplicate task ids"
 
 # --------------------------------------------------------------------
 # 1.8 Dry-run
-OUT=$("$PITBOSS" dispatch --dry-run "$SCRATCH/happy.toml" 2>&1); CODE=$?
+OUT=$("$PITBOSS" dispatch --run-dir "$SCRATCH/runs" --dry-run "$SCRATCH/happy.toml" 2>&1); CODE=$?
 if [ "$CODE" = "0" ] && echo "$OUT" | grep -q "DRY-RUN"; then
     say PASS "1.8 dry-run"
     record "1.8 dry-run" PASS ""
@@ -195,7 +195,7 @@ fi
 
 # --------------------------------------------------------------------
 # 1.9 Missing claude binary — probe should fail with exit 2
-PITBOSS_CLAUDE_BINARY=/nope/claude "$PITBOSS" dispatch "$SCRATCH/happy.toml" >/dev/null 2>&1; CODE=$?
+PITBOSS_CLAUDE_BINARY=/nope/claude "$PITBOSS" dispatch --run-dir "$SCRATCH/runs" "$SCRATCH/happy.toml" >/dev/null 2>&1; CODE=$?
 expect_exit 2 "$CODE" "1.9 missing claude binary"
 
 # --------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The \`--run-dir\` flag already exists on \`pitboss dispatch\`. This PR wires it into \`scripts/smoke-part1.sh\` so the smoke test's trap cleanup sweeps run artifacts alongside everything else in \$SCRATCH.

## Why

Previously, test case 1.9 (\"missing claude binary\") and a few others created run dirs under \`~/.local/share/pitboss/runs/\` that were never cleaned up, leaving small orphan run dirs on every CI and local invocation of the script. Over time these accumulate. One such orphan was found during a routine check today: \`019d9bdd-049d-7970-924c-deda6835f0fc\`.

## Test plan
- [ ] CI green
- [ ] \`scripts/smoke-part1.sh\` still reports 10/10 pass
- [ ] No new dirs created under \`~/.local/share/pitboss/runs/\` when the script runs