### PR TITLE
v0.4.0: Live control plane + approval interrupts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,6 +262,25 @@ populated with these. You (the operator) don't list them explicitly.
   heavier workers (Sonnet) under a Haiku lead.
 - `tools` defaults to the lead's tools.
 
+### `mcp__pitboss__pause_worker`
+
+Pause a running worker. Snapshots its `claude_session_id` so
+`continue_worker` can resume. Args: `{task_id: string}`.
+Fails if worker is not in `Running` state with an initialized session.
+
+### `mcp__pitboss__continue_worker`
+
+Continue a previously-paused worker. Spawns `claude --resume <id>`
+under the hood. Args: `{task_id: string, prompt?: string}` (default
+prompt "continue").
+
+### `mcp__pitboss__request_approval`
+
+Block the lead until the operator approves, rejects, or edits.
+Args: `{summary: string, timeout_secs?: number}`. Returns
+`{approved: bool, comment?: string, edited_summary?: string}`.
+Policy-gated: see `approval_policy` below.
+
 ---
 
 ## Error patterns
@@ -298,6 +317,28 @@ You're referring to a worker that was never spawned (or was typo'd).
 
 A worker never started — usually a git worktree prep failure (dirty tree,
 branch conflict, non-git directory). Check the stderr log.
+
+---
+
+## Operator keybindings (pitboss-tui, v0.4.0+)
+
+- `x` — confirm+cancel focused worker
+- `X` — confirm+cancel entire run
+- `p` — pause focused worker (requires initialized session)
+- `c` — continue paused worker
+- `r` — open reprompt textarea (Ctrl+Enter to submit, Esc to cancel)
+- During approval modal: `y` approve, `n` reject (with comment), `e`
+  edit (Ctrl+Enter to submit, Esc to cancel)
+
+## `[run].approval_policy`
+
+Controls handling of `request_approval` calls when no TUI is attached.
+
+- `block` (default) — queue until a TUI connects, or fail after
+  `lead_timeout_secs`.
+- `auto_approve` — immediate `{approved: true}`.
+- `auto_reject` — immediate `{approved: false, comment: "no operator
+  available"}`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ This project uses [Semantic Versioning](https://semver.org/).
   `approvals_requested`, `approvals_approved`, `approvals_rejected`.
   Backfilled on disk via `#[serde(default)]` and in SQLite via the
   idempotent `migrate_v04_event_counters` migration.
+- **`examples/v0.4-approval-demo.toml`** — minimal hierarchical
+  manifest that exercises `approval_policy = "block"` + a
+  `request_approval` interrupt + three tiny workers, for manual
+  smoke-testing of the new keybindings.
 
 ### Changed
 - `WorkerState::Running` now carries an `Option<String> session_id`;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-04-17
+
+### Added
+- **Live control plane.** Per-run `control.sock` unix socket carrying
+  line-JSON operations from `pitboss-tui` to the dispatcher and push
+  events back. New TUI keybindings: `x` cancel focused worker (with
+  confirm modal), `X` cancel entire run, `p` pause, `c` continue, `r`
+  reprompt (textarea-driven).
+- **Three new MCP tools.** `mcp__pitboss__pause_worker`,
+  `mcp__pitboss__continue_worker`, `mcp__pitboss__request_approval` —
+  the last blocks the lead until the operator approves, rejects, or
+  edits, LangGraph-`interrupt()`-style.
+- **`approval_policy` manifest field** under `[run]`. Values: `block`
+  (default), `auto_approve`, `auto_reject`.
+- **Pause = cancel-with-resume.** Pause terminates the worker
+  subprocess but preserves `claude_session_id`; `continue_worker`
+  spawns `claude --resume <id>`.
+- **Per-task `events.jsonl`** audit file: pause, continue, reprompt,
+  approval_request, approval_response events.
+- **5 new `TaskRecord` counters.** `pause_count`, `reprompt_count`,
+  `approvals_requested`, `approvals_approved`, `approvals_rejected`.
+  Backfilled on disk via `#[serde(default)]` and in SQLite via the
+  idempotent `migrate_v04_event_counters` migration.
+
+### Changed
+- `WorkerState::Running` now carries an `Option<String> session_id`;
+  `WorkerState::Paused` is a new variant.
+- `DispatchState::new` gained an `ApprovalPolicy` parameter.
+- The lead's allowed MCP tool list now includes the three new tools.
+
+### Backward compatibility
+- v0.3.x manifests run unchanged; `approval_policy` defaults to
+  `block`.
+- v0.3.x runs on disk deserialize with counter fields defaulting to 0.
+- SQLite DBs auto-migrate on next open.
+- TUI pointed at a v0.3.x completed run enters observe-only mode when
+  `control.sock` is absent.
+
+## [0.3.4] — 2026-04-17
+
 ### Added
 - **`AGENTS.md`** — agent-facing entry point with decision tree, full
   manifest schema reference, invocation patterns, run-directory
@@ -211,7 +251,9 @@ This project uses [Semantic Versioning](https://semver.org/).
   SIGINT terminates.
 - Part 1 offline smoke test harness (`scripts/smoke-part1.sh`, 10 tests).
 
-[Unreleased]: https://github.com/SDS-Mode/pitboss/compare/v0.3.3...HEAD
+[Unreleased]: https://github.com/SDS-Mode/pitboss/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/SDS-Mode/pitboss/compare/v0.3.4...v0.4.0
+[0.3.4]: https://github.com/SDS-Mode/pitboss/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/SDS-Mode/pitboss/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/SDS-Mode/pitboss/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/SDS-Mode/pitboss/compare/v0.3.0...v0.3.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,6 +1161,7 @@ dependencies = [
  "serde_json",
  "shellexpand",
  "tempfile",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-util",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fake-control-client"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "pitboss-cli",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "fake-mcp-client"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,6 +1151,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "fake-control-client",
  "fake-mcp-client",
  "git2",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,12 +1197,15 @@ dependencies = [
  "clap",
  "clap_complete",
  "crossterm",
+ "pitboss-cli",
  "pitboss-core",
  "ratatui",
  "serde",
  "serde_json",
  "tempfile",
+ "tokio",
  "tracing",
+ "tui-textarea",
  "uuid",
 ]
 
@@ -1890,6 +1893,17 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tui-textarea"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5318dd619ed73c52a9417ad19046724effc1287fb75cdcc4eca1d6ac1acbae"
+dependencies = [
+ "crossterm",
+ "ratatui",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,4 @@ crossterm          = "0.28"
 rusqlite           = { version = "0.32", features = ["bundled"] }
 rmcp               = { version = "0.8", features = ["server", "client", "transport-io", "macros"] }
 tokio-util         = { version = "0.7", features = ["rt"] }
+tui-textarea       = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/pitboss-tui",
     "tests-support/fake-claude",
     "tests-support/fake-mcp-client",
+    "tests-support/fake-control-client",
 ]
 
 [workspace.package]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 > schema reference, decision tree, canonical examples, and the rules for
 > translating natural-language requests into valid manifests.
 
+**v0.4.0** ships a live control plane: cancel/pause/continue/reprompt
+and operator-approval interrupts. See CHANGELOG + AGENTS.md for
+keybindings and the three new MCP tools.
+
 Rust toolkit for running and observing parallel Claude Code sessions. A
 dispatcher (`pitboss`) fans out `claude` subprocesses under a concurrency
 cap, captures structured artifacts per run, and — in hierarchical mode —

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,83 +3,18 @@
 Capture of deferred work. Items here are scoped but unscheduled — grab
 one when you're ready, or file issues to formalize priority.
 
-## In progress
+## v0.4.1 — Attach (escape hatch)
 
-### v0.4.0 — Live control plane
-
-**Status:** design spec written, plan pending, build pending.
-
-Expanded from the original "TUI kill" roadmap item into a broader L4
-(human-in-the-loop) surface covering kill, pause, continue, reprompt,
-and approve/edit. Mechanism is a per-run unix control socket. See
-`docs/superpowers/specs/2026-04-17-pitboss-v0.4-live-control-design.md`
-for the full spec.
-
----
-
-## Deferred out of v0.4.0 (promoted from near-term to explicit deferrals)
-
-### `pitboss attach <run-id> <task-id>` — live TTY relay escape hatch
-
-**Status:** designed out of v0.4.0 core; layered on top as v0.4.1.
-
-Uses `portable-pty` crate to allocate a PTY for the worker subprocess;
-`pitboss attach` connects the operator's terminal stdio to that PTY for
-real-time keystroke passthrough. The only L3 feature that requires more
-than the `-p` + `--resume` model can give. Target: v0.4.1 once v0.4.0
-is stable and operator feedback indicates concrete need.
-
-### "Freeze" pause — true SIGSTOP/SIGCONT process freeze
-
-**Status:** future. Concept captured 2026-04-17 during v0.4.0 brainstorm.
-
-v0.4.0 ships pause via cancel-with-resume semantics: subprocess ends,
-session id preserved, continue spawns `claude --resume <id>`. The
-alternative "freeze" semantic — `SIGSTOP` the running process, keep
-it memory-resident, `SIGCONT` to thaw — is precise and fast (no
-subprocess re-spawn cost) but adds failure modes around:
-
-- Anthropic's HTTP stream timing out during the freeze.
-- Orphan stopped processes if pitboss itself dies while a worker is
-  frozen.
-- The question of whether `lead_timeout_secs` should also pause (it
-  currently doesn't, per the v0.4 design decision).
-
-Revisit when a concrete use case surfaces (probably: "pause for hours"
-or "pause for operator meeting" kind of scenarios).
-
-### Out-of-TUI notifications
-
-**Status:** future. Pitboss shouldn't require a TUI to be attached for
-operator awareness. Approval requests, run completion, budget-exceeded
-events, worker failures — all candidates for outbound channels:
-
-- **Webhooks** (HTTP POST to a configurable URL)
-- **Slack / Discord** integration
-- **Email** (SMTP / SES)
-- **Desktop notifications** (notify-send / osascript)
-
-Natural pairing with the `approval_policy` manifest field: a `notify`
-policy that pushes the request to a notification channel and waits
-for an asynchronous response. Requires designing a response mechanism
-(reply link? CLI tool that posts back?).
-
-### Structured plan editing for approval
-
-**Status:** YAGNI unless free-form editing proves insufficient.
-
-v0.4.0's `request_approval` takes a free-form string summary;
-operator `e`-edits it back as a string. If the lead wants structured
-plans (typed fields: workers_to_spawn, budget, rationale) with
-typed in-TUI editing, that's a bigger design: schema, typed UI,
-validation. Add if concrete pain shows up.
-
-### Reprompt via MCP tool
-
-**Status:** operator-only in v0.4.0. Lead can achieve similar via
-`cancel_worker` + `spawn_worker` with `--resume`. Promote to a
-first-class lead-facing `mcp__pitboss__reprompt_worker(task_id,
-prompt)` if friction emerges.
+- `pitboss attach <run-id> <task-id>` — live TTY relay using
+  `portable-pty`. Narrow-scope: no persistent sessions, no tmux
+  dependency. Sits on top of v0.4.0 control-socket primitives.
+- True SIGSTOP freeze-pause (alternative / addition to
+  cancel-with-resume).
+- Out-of-TUI notifications: webhooks / Slack / email for approval
+  requests and run completion.
+- Structured approval schema (JSON-in-TUI plan editing).
+- `mcp__pitboss__reprompt_worker` for lead-driven mid-flight
+  redirection.
 
 ---
 

--- a/crates/pitboss-cli/Cargo.toml
+++ b/crates/pitboss-cli/Cargo.toml
@@ -53,3 +53,4 @@ serde_json      = { workspace = true }
 libc            = { workspace = true }
 pitboss-core    = { path = "../pitboss-core", features = ["test-support"] }
 fake-mcp-client = { path = "../../tests-support/fake-mcp-client" }
+fake-control-client = { path = "../../tests-support/fake-control-client" }

--- a/crates/pitboss-cli/Cargo.toml
+++ b/crates/pitboss-cli/Cargo.toml
@@ -41,6 +41,7 @@ chrono             = { workspace = true }
 async-trait        = { workspace = true }
 rmcp               = { workspace = true }
 tokio-util         = { workspace = true }
+thiserror          = { workspace = true }
 schemars           = "1"
 
 [dev-dependencies]

--- a/crates/pitboss-cli/src/control/mod.rs
+++ b/crates/pitboss-cli/src/control/mod.rs
@@ -9,3 +9,54 @@
 
 pub mod protocol;
 pub mod server;
+
+use std::path::{Path, PathBuf};
+use uuid::Uuid;
+
+/// Compute the control socket path for `run_id`. Mirrors the MCP
+/// `socket_path_for_run` convention: prefers `$XDG_RUNTIME_DIR/pitboss/` if it
+/// exists and is writable, otherwise falls back to `<run_dir>/<run_id>/control.sock`.
+pub fn control_socket_path(run_id: Uuid, run_dir: &Path) -> PathBuf {
+    if let Some(xdg) = std::env::var_os("XDG_RUNTIME_DIR") {
+        let p = PathBuf::from(xdg).join("pitboss");
+        if std::fs::create_dir_all(&p).is_ok() {
+            return p.join(format!("{}.control.sock", run_id));
+        }
+    }
+    let p = run_dir.join(run_id.to_string());
+    let _ = std::fs::create_dir_all(&p);
+    p.join("control.sock")
+}
+
+#[cfg(test)]
+mod path_tests {
+    use super::*;
+    use std::sync::Mutex;
+    use tempfile::TempDir;
+
+    // Serializes tests that mutate XDG_RUNTIME_DIR (env vars are process-global).
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn uses_xdg_runtime_dir_when_set() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = TempDir::new().unwrap();
+        std::env::set_var("XDG_RUNTIME_DIR", dir.path());
+        let run_id = Uuid::now_v7();
+        let p = control_socket_path(run_id, Path::new("/tmp"));
+        assert!(p.starts_with(dir.path()));
+        assert!(p.to_string_lossy().ends_with(".control.sock"));
+        std::env::remove_var("XDG_RUNTIME_DIR");
+    }
+
+    #[test]
+    fn falls_back_to_run_dir_when_xdg_unset() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("XDG_RUNTIME_DIR");
+        let dir = TempDir::new().unwrap();
+        let run_id = Uuid::now_v7();
+        let p = control_socket_path(run_id, dir.path());
+        assert!(p.starts_with(dir.path()));
+        assert_eq!(p.file_name().unwrap(), "control.sock");
+    }
+}

--- a/crates/pitboss-cli/src/control/mod.rs
+++ b/crates/pitboss-cli/src/control/mod.rs
@@ -1,0 +1,11 @@
+//! Per-run control socket: TUI ↔ dispatcher operator control plane.
+//!
+//! Split by file:
+//! - `protocol` — serde types for line-based JSON messages.
+//! - `server`   — unix-socket accept loop + per-connection op dispatch.
+//!
+//! See `docs/superpowers/specs/2026-04-17-pitboss-v0.4-live-control-design.md`
+//! §4–§6 for the design.
+
+pub mod protocol;
+pub mod server;

--- a/crates/pitboss-cli/src/control/protocol.rs
+++ b/crates/pitboss-cli/src/control/protocol.rs
@@ -1,0 +1,278 @@
+//! Wire protocol for the per-run control socket.
+//!
+//! Messages are **one JSON object per line** (UTF-8, LF-terminated).
+//! Client → server messages are `ControlOp`; server → client are `ControlEvent`.
+//! Serialization uses `#[serde(tag = "op")]` / `#[serde(tag = "event")]` so the
+//! discriminator lives in the same object as the payload fields.
+
+#![allow(dead_code)] // Wired up by control::server in Task 4+.
+
+use serde::{Deserialize, Serialize};
+
+/// An operation sent from the TUI (client) to the dispatcher (server).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum ControlOp {
+    Hello {
+        client_version: String,
+    },
+    CancelWorker {
+        task_id: String,
+    },
+    CancelRun,
+    PauseWorker {
+        task_id: String,
+    },
+    ContinueWorker {
+        task_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        prompt: Option<String>,
+    },
+    RepromptWorker {
+        task_id: String,
+        prompt: String,
+    },
+    Approve {
+        request_id: String,
+        approved: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        comment: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        edited_summary: Option<String>,
+    },
+    ListWorkers,
+}
+
+/// An event pushed from the dispatcher (server) to the TUI (client).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum ControlEvent {
+    Hello {
+        server_version: String,
+        run_id: String,
+        run_kind: String,
+        workers: Vec<String>,
+    },
+    OpAcked {
+        op: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        task_id: Option<String>,
+    },
+    OpFailed {
+        op: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        task_id: Option<String>,
+        error: String,
+    },
+    OpUnknown {
+        op: String,
+    },
+    OpUnknownState {
+        op: String,
+        task_id: String,
+        current_state: String,
+    },
+    ApprovalRequest {
+        request_id: String,
+        task_id: String,
+        summary: String,
+    },
+    WorkersSnapshot {
+        workers: Vec<WorkerSnapshotEntry>,
+    },
+    Superseded,
+    RunFinished {
+        summary: RunFinishedSummary,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkerSnapshotEntry {
+    pub task_id: String,
+    pub state: String,
+    pub prompt_preview: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_task_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunFinishedSummary {
+    pub tasks_total: usize,
+    pub tasks_failed: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roundtrip_op(op: &ControlOp) -> ControlOp {
+        let s = serde_json::to_string(op).unwrap();
+        serde_json::from_str(&s).unwrap()
+    }
+
+    fn roundtrip_event(ev: &ControlEvent) -> ControlEvent {
+        let s = serde_json::to_string(ev).unwrap();
+        serde_json::from_str(&s).unwrap()
+    }
+
+    #[test]
+    fn hello_op_parses() {
+        let raw = r#"{"op":"hello","client_version":"0.4.0"}"#;
+        let op: ControlOp = serde_json::from_str(raw).unwrap();
+        assert_eq!(
+            op,
+            ControlOp::Hello {
+                client_version: "0.4.0".into()
+            }
+        );
+    }
+
+    #[test]
+    fn cancel_worker_roundtrips() {
+        let op = ControlOp::CancelWorker {
+            task_id: "w-1".into(),
+        };
+        assert_eq!(roundtrip_op(&op), op);
+    }
+
+    #[test]
+    fn cancel_run_roundtrips() {
+        let op = ControlOp::CancelRun;
+        let s = serde_json::to_string(&op).unwrap();
+        assert_eq!(s, r#"{"op":"cancel_run"}"#);
+        assert_eq!(roundtrip_op(&op), op);
+    }
+
+    #[test]
+    fn pause_continue_reprompt_roundtrip() {
+        for op in [
+            ControlOp::PauseWorker {
+                task_id: "w".into(),
+            },
+            ControlOp::ContinueWorker {
+                task_id: "w".into(),
+                prompt: None,
+            },
+            ControlOp::ContinueWorker {
+                task_id: "w".into(),
+                prompt: Some("go".into()),
+            },
+            ControlOp::RepromptWorker {
+                task_id: "w".into(),
+                prompt: "new plan".into(),
+            },
+        ] {
+            assert_eq!(roundtrip_op(&op), op);
+        }
+    }
+
+    #[test]
+    fn approve_roundtrips_with_all_fields() {
+        let op = ControlOp::Approve {
+            request_id: "req-1".into(),
+            approved: true,
+            comment: Some("LGTM".into()),
+            edited_summary: Some("spawn 2 workers".into()),
+        };
+        assert_eq!(roundtrip_op(&op), op);
+    }
+
+    #[test]
+    fn list_workers_has_no_payload() {
+        let op = ControlOp::ListWorkers;
+        assert_eq!(
+            serde_json::to_string(&op).unwrap(),
+            r#"{"op":"list_workers"}"#
+        );
+        assert_eq!(roundtrip_op(&op), op);
+    }
+
+    #[test]
+    fn hello_event_roundtrips() {
+        let ev = ControlEvent::Hello {
+            server_version: "0.4.0".into(),
+            run_id: "019d...".into(),
+            run_kind: "hierarchical".into(),
+            workers: vec!["triage".into(), "w-1".into()],
+        };
+        assert_eq!(roundtrip_event(&ev), ev);
+    }
+
+    #[test]
+    fn op_acked_and_failed_roundtrip() {
+        let acked = ControlEvent::OpAcked {
+            op: "pause_worker".into(),
+            task_id: Some("w".into()),
+        };
+        assert_eq!(roundtrip_event(&acked), acked);
+
+        let failed = ControlEvent::OpFailed {
+            op: "pause_worker".into(),
+            task_id: Some("w".into()),
+            error: "unknown task_id".into(),
+        };
+        assert_eq!(roundtrip_event(&failed), failed);
+    }
+
+    #[test]
+    fn op_unknown_and_unknown_state_roundtrip() {
+        let unk = ControlEvent::OpUnknown {
+            op: "wibble".into(),
+        };
+        assert_eq!(roundtrip_event(&unk), unk);
+
+        let bad_state = ControlEvent::OpUnknownState {
+            op: "pause_worker".into(),
+            task_id: "w".into(),
+            current_state: "paused".into(),
+        };
+        assert_eq!(roundtrip_event(&bad_state), bad_state);
+    }
+
+    #[test]
+    fn approval_request_roundtrips() {
+        let ev = ControlEvent::ApprovalRequest {
+            request_id: "req-1".into(),
+            task_id: "lead".into(),
+            summary: "spawn 3 workers".into(),
+        };
+        assert_eq!(roundtrip_event(&ev), ev);
+    }
+
+    #[test]
+    fn workers_snapshot_roundtrips() {
+        let ev = ControlEvent::WorkersSnapshot {
+            workers: vec![WorkerSnapshotEntry {
+                task_id: "w-1".into(),
+                state: "running".into(),
+                prompt_preview: "investigate bug".into(),
+                started_at: Some("2026-04-17T00:00:00Z".into()),
+                parent_task_id: Some("lead".into()),
+                session_id: Some("sess-abc".into()),
+            }],
+        };
+        assert_eq!(roundtrip_event(&ev), ev);
+    }
+
+    #[test]
+    fn superseded_and_run_finished_roundtrip() {
+        let sup = ControlEvent::Superseded;
+        assert_eq!(
+            serde_json::to_string(&sup).unwrap(),
+            r#"{"event":"superseded"}"#
+        );
+        assert_eq!(roundtrip_event(&sup), sup);
+
+        let rf = ControlEvent::RunFinished {
+            summary: RunFinishedSummary {
+                tasks_total: 5,
+                tasks_failed: 1,
+            },
+        };
+        assert_eq!(roundtrip_event(&rf), rf);
+    }
+}

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -351,6 +351,51 @@ async fn dispatch_op(
                 },
             }
         }
+        ControlOp::RepromptWorker { task_id, prompt } => {
+            let current = state.workers.read().await.get(&task_id).cloned();
+            let session_id = match current {
+                Some(crate::dispatch::state::WorkerState::Running {
+                    session_id: Some(sid),
+                    ..
+                }) => {
+                    let cancels = state.worker_cancels.read().await;
+                    if let Some(tok) = cancels.get(&task_id) {
+                        tok.terminate();
+                    }
+                    // Brief grace so the prior subprocess exits.
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    sid
+                }
+                Some(crate::dispatch::state::WorkerState::Paused { session_id, .. }) => session_id,
+                Some(_) => {
+                    return ControlEvent::OpUnknownState {
+                        op: "reprompt_worker".into(),
+                        task_id,
+                        current_state: "invalid".into(),
+                    }
+                }
+                None => {
+                    return ControlEvent::OpFailed {
+                        op: "reprompt_worker".into(),
+                        task_id: Some(task_id),
+                        error: "unknown task_id".into(),
+                    }
+                }
+            };
+            match crate::mcp::tools::spawn_resume_worker(state, task_id.clone(), prompt, session_id)
+                .await
+            {
+                Ok(()) => ControlEvent::OpAcked {
+                    op: "reprompt_worker".into(),
+                    task_id: Some(task_id),
+                },
+                Err(e) => ControlEvent::OpFailed {
+                    op: "reprompt_worker".into(),
+                    task_id: Some(task_id),
+                    error: e.to_string(),
+                },
+            }
+        }
         other => ControlEvent::OpUnknown {
             op: op_tag(&other).into(),
         },
@@ -697,6 +742,71 @@ mod tests {
             workers.get("w-1").unwrap(),
             crate::dispatch::state::WorkerState::Running { .. }
         ));
+        drop(handle);
+    }
+
+    #[tokio::test]
+    async fn reprompt_worker_from_running_terminates_and_respawns() {
+        let dir = TempDir::new().unwrap();
+        let run_id = Uuid::now_v7();
+        let state = mk_state(dir.path(), run_id);
+        let worker_token = CancelToken::new();
+        state
+            .worker_cancels
+            .write()
+            .await
+            .insert("w-1".into(), worker_token.clone());
+        state.workers.write().await.insert(
+            "w-1".into(),
+            crate::dispatch::state::WorkerState::Running {
+                started_at: chrono::Utc::now(),
+                session_id: Some("sess-xyz".into()),
+            },
+        );
+        state
+            .worker_prompts
+            .write()
+            .await
+            .insert("w-1".into(), "hi".into());
+        state
+            .worker_models
+            .write()
+            .await
+            .insert("w-1".into(), "claude-haiku-4-5".into());
+
+        let sock = dir.path().join("reprompt.sock");
+        let handle = start_control_server(
+            sock.clone(),
+            "0.4.0".into(),
+            run_id.to_string(),
+            "hierarchical".into(),
+            state.clone(),
+        )
+        .await
+        .unwrap();
+
+        let mut stream = tokio::net::UnixStream::connect(&sock).await.unwrap();
+        stream
+            .write_all(b"{\"op\":\"hello\",\"client_version\":\"0.4.0\"}\n")
+            .await
+            .unwrap();
+        stream
+            .write_all(
+                b"{\"op\":\"reprompt_worker\",\"task_id\":\"w-1\",\"prompt\":\"new plan\"}\n",
+            )
+            .await
+            .unwrap();
+
+        let (r, _w) = stream.split();
+        let mut lines = BufReader::new(r).lines();
+        let _hello = lines.next_line().await.unwrap();
+        let reply_line = lines.next_line().await.unwrap().unwrap();
+        let reply: ControlEvent = serde_json::from_str(&reply_line).unwrap();
+        assert!(matches!(
+            reply,
+            ControlEvent::OpAcked { ref op, .. } if op == "reprompt_worker"
+        ));
+        assert!(worker_token.is_terminated());
         drop(handle);
     }
 }

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -481,6 +481,7 @@ mod tests {
             max_workers: Some(4),
             budget_usd: Some(1.0),
             lead_timeout_secs: None,
+            approval_policy: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -396,6 +396,58 @@ async fn dispatch_op(
                 },
             }
         }
+        ControlOp::ListWorkers => {
+            let workers = state.workers.read().await;
+            let prompts = state.worker_prompts.read().await;
+            let entries = workers
+                .iter()
+                .map(|(id, w)| {
+                    let (state_str, started_at, session_id) = match w {
+                        crate::dispatch::state::WorkerState::Pending => {
+                            ("pending".to_string(), None, None)
+                        }
+                        crate::dispatch::state::WorkerState::Running {
+                            started_at,
+                            session_id,
+                        } => (
+                            "running".to_string(),
+                            Some(started_at.to_rfc3339()),
+                            session_id.clone(),
+                        ),
+                        crate::dispatch::state::WorkerState::Paused {
+                            paused_at,
+                            session_id,
+                            ..
+                        } => (
+                            "paused".to_string(),
+                            Some(paused_at.to_rfc3339()),
+                            Some(session_id.clone()),
+                        ),
+                        crate::dispatch::state::WorkerState::Done(rec) => (
+                            match rec.status {
+                                pitboss_core::store::TaskStatus::Success => "done_success",
+                                pitboss_core::store::TaskStatus::Failed => "done_failed",
+                                pitboss_core::store::TaskStatus::TimedOut => "done_timed_out",
+                                pitboss_core::store::TaskStatus::Cancelled => "done_cancelled",
+                                pitboss_core::store::TaskStatus::SpawnFailed => "done_spawn_failed",
+                            }
+                            .to_string(),
+                            Some(rec.started_at.to_rfc3339()),
+                            rec.claude_session_id.clone(),
+                        ),
+                    };
+                    crate::control::protocol::WorkerSnapshotEntry {
+                        task_id: id.clone(),
+                        state: state_str,
+                        prompt_preview: prompts.get(id).cloned().unwrap_or_default(),
+                        started_at,
+                        parent_task_id: None,
+                        session_id,
+                    }
+                })
+                .collect();
+            ControlEvent::WorkersSnapshot { workers: entries }
+        }
         other => ControlEvent::OpUnknown {
             op: op_tag(&other).into(),
         },
@@ -513,7 +565,7 @@ mod tests {
             .await
             .unwrap();
         stream
-            .write_all(b"{\"op\":\"list_workers\"}\n")
+            .write_all(b"{\"op\":\"approve\",\"request_id\":\"r\",\"approved\":true}\n")
             .await
             .unwrap();
 
@@ -524,7 +576,7 @@ mod tests {
         let reply: ControlEvent = serde_json::from_str(&reply_line).unwrap();
         assert!(matches!(
             reply,
-            ControlEvent::OpUnknown { op } if op == "list_workers"
+            ControlEvent::OpUnknown { op } if op == "approve"
         ));
         drop(handle);
     }
@@ -807,6 +859,62 @@ mod tests {
             ControlEvent::OpAcked { ref op, .. } if op == "reprompt_worker"
         ));
         assert!(worker_token.is_terminated());
+        drop(handle);
+    }
+
+    #[tokio::test]
+    async fn list_workers_op_returns_workers_snapshot() {
+        let dir = TempDir::new().unwrap();
+        let run_id = Uuid::now_v7();
+        let state = mk_state(dir.path(), run_id);
+        state.workers.write().await.insert(
+            "w-1".into(),
+            crate::dispatch::state::WorkerState::Running {
+                started_at: chrono::Utc::now(),
+                session_id: Some("sess".into()),
+            },
+        );
+        state
+            .worker_prompts
+            .write()
+            .await
+            .insert("w-1".into(), "investigate bug".into());
+
+        let sock = dir.path().join("list.sock");
+        let handle = start_control_server(
+            sock.clone(),
+            "0.4.0".into(),
+            run_id.to_string(),
+            "flat".into(),
+            state,
+        )
+        .await
+        .unwrap();
+
+        let mut stream = tokio::net::UnixStream::connect(&sock).await.unwrap();
+        stream
+            .write_all(b"{\"op\":\"hello\",\"client_version\":\"0.4.0\"}\n")
+            .await
+            .unwrap();
+        stream
+            .write_all(b"{\"op\":\"list_workers\"}\n")
+            .await
+            .unwrap();
+
+        let (r, _w) = stream.split();
+        let mut lines = BufReader::new(r).lines();
+        let _hello = lines.next_line().await.unwrap();
+        let reply_line = lines.next_line().await.unwrap().unwrap();
+        let reply: ControlEvent = serde_json::from_str(&reply_line).unwrap();
+        match reply {
+            ControlEvent::WorkersSnapshot { workers } => {
+                assert_eq!(workers.len(), 1);
+                assert_eq!(workers[0].task_id, "w-1");
+                assert_eq!(workers[0].state, "running");
+                assert_eq!(workers[0].session_id.as_deref(), Some("sess"));
+            }
+            other => panic!("expected WorkersSnapshot, got {other:?}"),
+        }
         drop(handle);
     }
 }

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -126,8 +126,10 @@ pub async fn start_control_server(
     })
 }
 
-/// Serve one client: complete hello handshake, then loop reading ops and
-/// replying. Phase 1 implementation: every non-hello op yields `op_unknown`.
+/// Serve one client: complete hello handshake, install the control_writer,
+/// drain any queued approvals, then concurrently pump outbound events and read
+/// ops from the client. On disconnect clear the control_writer and abort the
+/// pump task.
 async fn serve_connection(
     stream: UnixStream,
     server_version: String,
@@ -140,7 +142,7 @@ async fn serve_connection(
     let writer = Arc::new(Mutex::new(write_half));
     let mut reader = BufReader::new(read_half).lines();
 
-    // Read the client hello.
+    // Hello handshake.
     let first = match reader.next_line().await {
         Ok(Some(line)) => line,
         _ => return,
@@ -185,12 +187,51 @@ async fn serve_connection(
     )
     .await;
 
-    // Read subsequent ops; every one returns OpUnknown until Phase 2.
+    // Install this connection as the control_writer (displace any prior).
+    let (ev_tx, mut ev_rx) = tokio::sync::mpsc::unbounded_channel::<ControlEvent>();
+    {
+        let mut cw = state.control_writer.lock().await;
+        if let Some(old) = cw.take() {
+            let _ = old.send(ControlEvent::Superseded);
+        }
+        *cw = Some(ev_tx.clone());
+    }
+
+    // Drain any queued approvals now that a TUI is connected.
+    {
+        let mut queue = state.approval_queue.lock().await;
+        while let Some(q) = queue.pop_front() {
+            // Transfer responder into the bridge map.
+            state
+                .approval_bridge
+                .lock()
+                .await
+                .insert(q.request_id.clone(), q.responder);
+            // And push the event.
+            let _ = ev_tx.send(ControlEvent::ApprovalRequest {
+                request_id: q.request_id,
+                task_id: q.task_id,
+                summary: q.summary,
+            });
+        }
+    }
+
+    // Concurrent outbound pump: forward events from the mpsc to the socket.
+    let writer_for_pump = writer.clone();
+    let pump = tokio::spawn(async move {
+        while let Some(ev) = ev_rx.recv().await {
+            if send_event(&writer_for_pump, &ev).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    // Read loop.
     while let Ok(Some(line)) = reader.next_line().await {
         let reply = match serde_json::from_str::<ControlOp>(&line) {
             Ok(op) => dispatch_op(&state, op).await,
             Err(e) => ControlEvent::OpFailed {
-                op: "".into(),
+                op: String::new(),
                 task_id: None,
                 error: format!("parse error: {e}"),
             },
@@ -199,6 +240,13 @@ async fn serve_connection(
             break;
         }
     }
+
+    // Clear control_writer on disconnect.
+    {
+        let mut cw = state.control_writer.lock().await;
+        *cw = None;
+    }
+    pump.abort();
 }
 
 async fn send_event(

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -89,6 +89,7 @@ pub async fn start_control_server(
                             let server_version = server_version.clone();
                             let run_id = run_id.clone();
                             let run_kind = run_kind.clone();
+                            let state_inner = state_outer.clone();
                             let workers_names: Vec<String> = {
                                 let guard = state_outer.workers.read().await;
                                 guard.keys().cloned().collect()
@@ -102,6 +103,7 @@ pub async fn start_control_server(
                                         run_id,
                                         run_kind,
                                         workers_names,
+                                        state_inner,
                                     ) => {},
                                 }
                             });
@@ -132,6 +134,7 @@ async fn serve_connection(
     run_id: String,
     run_kind: String,
     workers_names: Vec<String>,
+    state: Arc<crate::dispatch::state::DispatchState>,
 ) {
     let (read_half, write_half) = stream.into_split();
     let writer = Arc::new(Mutex::new(write_half));
@@ -185,9 +188,7 @@ async fn serve_connection(
     // Read subsequent ops; every one returns OpUnknown until Phase 2.
     while let Ok(Some(line)) = reader.next_line().await {
         let reply = match serde_json::from_str::<ControlOp>(&line) {
-            Ok(op) => ControlEvent::OpUnknown {
-                op: op_tag(&op).into(),
-            },
+            Ok(op) => dispatch_op(&state, op).await,
             Err(e) => ControlEvent::OpFailed {
                 op: "".into(),
                 task_id: None,
@@ -222,6 +223,37 @@ fn op_tag(op: &ControlOp) -> &'static str {
         ControlOp::RepromptWorker { .. } => "reprompt_worker",
         ControlOp::Approve { .. } => "approve",
         ControlOp::ListWorkers => "list_workers",
+    }
+}
+
+async fn dispatch_op(
+    state: &Arc<crate::dispatch::state::DispatchState>,
+    op: ControlOp,
+) -> ControlEvent {
+    match op {
+        ControlOp::Hello { .. } => ControlEvent::OpAcked {
+            op: "hello".into(),
+            task_id: None,
+        },
+        ControlOp::CancelWorker { task_id } => {
+            let cancels = state.worker_cancels.read().await;
+            if let Some(tok) = cancels.get(&task_id) {
+                tok.terminate();
+                ControlEvent::OpAcked {
+                    op: "cancel_worker".into(),
+                    task_id: Some(task_id),
+                }
+            } else {
+                ControlEvent::OpFailed {
+                    op: "cancel_worker".into(),
+                    task_id: Some(task_id.clone()),
+                    error: format!("unknown task_id: {task_id}"),
+                }
+            }
+        }
+        other => ControlEvent::OpUnknown {
+            op: op_tag(&other).into(),
+        },
     }
 }
 
@@ -336,7 +368,7 @@ mod tests {
             .await
             .unwrap();
         stream
-            .write_all(b"{\"op\":\"cancel_worker\",\"task_id\":\"w\"}\n")
+            .write_all(b"{\"op\":\"list_workers\"}\n")
             .await
             .unwrap();
 
@@ -347,8 +379,60 @@ mod tests {
         let reply: ControlEvent = serde_json::from_str(&reply_line).unwrap();
         assert!(matches!(
             reply,
-            ControlEvent::OpUnknown { op } if op == "cancel_worker"
+            ControlEvent::OpUnknown { op } if op == "list_workers"
         ));
+        drop(handle);
+    }
+
+    #[tokio::test]
+    async fn cancel_worker_op_terminates_worker_token() {
+        let dir = TempDir::new().unwrap();
+        let run_id = Uuid::now_v7();
+        let state = mk_state(dir.path(), run_id);
+        let worker_token = CancelToken::new();
+        state
+            .worker_cancels
+            .write()
+            .await
+            .insert("w-1".into(), worker_token.clone());
+        state
+            .workers
+            .write()
+            .await
+            .insert("w-1".into(), crate::dispatch::state::WorkerState::Pending);
+
+        let sock = dir.path().join("cancel.sock");
+        let handle = start_control_server(
+            sock.clone(),
+            "0.4.0".into(),
+            run_id.to_string(),
+            "flat".into(),
+            state,
+        )
+        .await
+        .unwrap();
+
+        let mut stream = tokio::net::UnixStream::connect(&sock).await.unwrap();
+        stream
+            .write_all(b"{\"op\":\"hello\",\"client_version\":\"0.4.0\"}\n")
+            .await
+            .unwrap();
+        stream
+            .write_all(b"{\"op\":\"cancel_worker\",\"task_id\":\"w-1\"}\n")
+            .await
+            .unwrap();
+
+        let (r, _w) = stream.split();
+        let mut lines = BufReader::new(r).lines();
+        let _hello = lines.next_line().await.unwrap();
+        let reply_line = lines.next_line().await.unwrap().unwrap();
+        let reply: ControlEvent = serde_json::from_str(&reply_line).unwrap();
+        assert!(matches!(
+            reply,
+            ControlEvent::OpAcked { ref op, task_id: Some(ref tid) }
+                if op == "cancel_worker" && tid == "w-1"
+        ));
+        assert!(worker_token.is_terminated());
         drop(handle);
     }
 }

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -1,0 +1,3 @@
+//! Control-socket server. Filled in by Task 4.
+
+#![allow(dead_code)] // Covered in Task 4.

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -294,6 +294,13 @@ async fn dispatch_op(
                         },
                     )
                     .await;
+                    state
+                        .worker_counters
+                        .write()
+                        .await
+                        .entry(task_id.clone())
+                        .or_default()
+                        .pause_count += 1;
                     ControlEvent::OpAcked {
                         op: "pause_worker".into(),
                         task_id: Some(task_id),
@@ -419,10 +426,19 @@ async fn dispatch_op(
             match crate::mcp::tools::spawn_resume_worker(state, task_id.clone(), prompt, session_id)
                 .await
             {
-                Ok(()) => ControlEvent::OpAcked {
-                    op: "reprompt_worker".into(),
-                    task_id: Some(task_id),
-                },
+                Ok(()) => {
+                    state
+                        .worker_counters
+                        .write()
+                        .await
+                        .entry(task_id.clone())
+                        .or_default()
+                        .reprompt_count += 1;
+                    ControlEvent::OpAcked {
+                        op: "reprompt_worker".into(),
+                        task_id: Some(task_id),
+                    }
+                }
                 Err(e) => ControlEvent::OpFailed {
                     op: "reprompt_worker".into(),
                     task_id: Some(task_id),

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -230,6 +230,7 @@ async fn dispatch_op(
     state: &Arc<crate::dispatch::state::DispatchState>,
     op: ControlOp,
 ) -> ControlEvent {
+    #[allow(unreachable_patterns)]
     match op {
         ControlOp::Hello { .. } => ControlEvent::OpAcked {
             op: "hello".into(),
@@ -448,6 +449,31 @@ async fn dispatch_op(
                 .collect();
             ControlEvent::WorkersSnapshot { workers: entries }
         }
+        ControlOp::Approve {
+            request_id,
+            approved,
+            comment,
+            edited_summary,
+        } => {
+            let tx = state.approval_bridge.lock().await.remove(&request_id);
+            if let Some(tx) = tx {
+                let _ = tx.send(crate::dispatch::state::ApprovalResponse {
+                    approved,
+                    comment,
+                    edited_summary,
+                });
+                ControlEvent::OpAcked {
+                    op: "approve".into(),
+                    task_id: None,
+                }
+            } else {
+                ControlEvent::OpFailed {
+                    op: "approve".into(),
+                    task_id: None,
+                    error: format!("unknown request_id: {request_id}"),
+                }
+            }
+        }
         other => ControlEvent::OpUnknown {
             op: op_tag(&other).into(),
         },
@@ -545,17 +571,62 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unknown_op_returns_op_unknown() {
+    async fn unknown_op_returns_parse_error() {
         let dir = TempDir::new().unwrap();
         let run_id = Uuid::now_v7();
         let state = mk_state(dir.path(), run_id);
-        let sock = dir.path().join("control.sock");
+        let sock = dir.path().join("unknown.sock");
         let handle = start_control_server(
             sock.clone(),
             "0.4.0".into(),
             run_id.to_string(),
             "flat".into(),
             state,
+        )
+        .await
+        .unwrap();
+        let mut stream = tokio::net::UnixStream::connect(&sock).await.unwrap();
+        stream
+            .write_all(b"{\"op\":\"hello\",\"client_version\":\"0.4.0\"}\n")
+            .await
+            .unwrap();
+        stream.write_all(b"{\"op\":\"wibble\"}\n").await.unwrap();
+        let (r, _w) = stream.split();
+        let mut lines = BufReader::new(r).lines();
+        let _hello = lines.next_line().await.unwrap();
+        let reply_line = lines.next_line().await.unwrap().unwrap();
+        let reply: ControlEvent = serde_json::from_str(&reply_line).unwrap();
+        assert!(matches!(
+            reply,
+            ControlEvent::OpFailed { op, .. } if op.is_empty()
+        ));
+        drop(handle);
+    }
+
+    #[tokio::test]
+    async fn approve_op_completes_pending_request() {
+        use crate::mcp::approval::ApprovalBridge;
+        use std::time::Duration;
+
+        let dir = TempDir::new().unwrap();
+        let run_id = Uuid::now_v7();
+        let state = mk_state(dir.path(), run_id);
+
+        // Pre-seed the bridge map with a request_id + oneshot sender.
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        state
+            .approval_bridge
+            .lock()
+            .await
+            .insert("req-1".into(), tx);
+
+        let sock = dir.path().join("approve.sock");
+        let handle = start_control_server(
+            sock.clone(),
+            "0.4.0".into(),
+            run_id.to_string(),
+            "hierarchical".into(),
+            state.clone(),
         )
         .await
         .unwrap();
@@ -566,7 +637,9 @@ mod tests {
             .await
             .unwrap();
         stream
-            .write_all(b"{\"op\":\"approve\",\"request_id\":\"r\",\"approved\":true}\n")
+            .write_all(
+                b"{\"op\":\"approve\",\"request_id\":\"req-1\",\"approved\":true,\"edited_summary\":\"go\"}\n",
+            )
             .await
             .unwrap();
 
@@ -577,8 +650,18 @@ mod tests {
         let reply: ControlEvent = serde_json::from_str(&reply_line).unwrap();
         assert!(matches!(
             reply,
-            ControlEvent::OpUnknown { op } if op == "approve"
+            ControlEvent::OpAcked { ref op, .. } if op == "approve"
         ));
+
+        let resp = tokio::time::timeout(Duration::from_millis(500), rx)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(resp.approved);
+        assert_eq!(resp.edited_summary.as_deref(), Some("go"));
+
+        // Silence unused warnings on ApprovalBridge import.
+        let _ = ApprovalBridge::new(state);
         drop(handle);
     }
 

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -285,6 +285,15 @@ async fn dispatch_op(
                             prior_token_usage: Default::default(),
                         },
                     );
+                    let _ = crate::dispatch::events::append_event(
+                        &state.run_subdir,
+                        &task_id,
+                        &crate::dispatch::events::TaskEvent::Pause {
+                            at: chrono::Utc::now(),
+                            reason: None,
+                        },
+                    )
+                    .await;
                     ControlEvent::OpAcked {
                         op: "pause_worker".into(),
                         task_id: Some(task_id),
@@ -321,6 +330,8 @@ async fn dispatch_op(
             match current {
                 Some(crate::dispatch::state::WorkerState::Paused { session_id, .. }) => {
                     let prompt_text = prompt.unwrap_or_else(|| "continue".into());
+                    let session_id_for_event = session_id.clone();
+                    let prompt_for_event = prompt_text.clone();
                     match crate::mcp::tools::spawn_resume_worker(
                         state,
                         task_id.clone(),
@@ -329,10 +340,22 @@ async fn dispatch_op(
                     )
                     .await
                     {
-                        Ok(()) => ControlEvent::OpAcked {
-                            op: "continue_worker".into(),
-                            task_id: Some(task_id),
-                        },
+                        Ok(()) => {
+                            let _ = crate::dispatch::events::append_event(
+                                &state.run_subdir,
+                                &task_id,
+                                &crate::dispatch::events::TaskEvent::Continue {
+                                    at: chrono::Utc::now(),
+                                    new_session_id: session_id_for_event,
+                                    prompt_preview: prompt_for_event.chars().take(80).collect(),
+                                },
+                            )
+                            .await;
+                            ControlEvent::OpAcked {
+                                op: "continue_worker".into(),
+                                task_id: Some(task_id),
+                            }
+                        }
                         Err(e) => ControlEvent::OpFailed {
                             op: "continue_worker".into(),
                             task_id: Some(task_id),
@@ -383,6 +406,16 @@ async fn dispatch_op(
                     }
                 }
             };
+            let _ = crate::dispatch::events::append_event(
+                &state.run_subdir,
+                &task_id,
+                &crate::dispatch::events::TaskEvent::Reprompt {
+                    at: chrono::Utc::now(),
+                    prompt_preview: prompt.chars().take(80).collect(),
+                    prior_session_id: session_id.clone(),
+                },
+            )
+            .await;
             match crate::mcp::tools::spawn_resume_worker(state, task_id.clone(), prompt, session_id)
                 .await
             {

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -251,6 +251,13 @@ async fn dispatch_op(
                 }
             }
         }
+        ControlOp::CancelRun => {
+            state.cancel.terminate();
+            ControlEvent::OpAcked {
+                op: "cancel_run".into(),
+                task_id: None,
+            }
+        }
         other => ControlEvent::OpUnknown {
             op: op_tag(&other).into(),
         },
@@ -433,6 +440,47 @@ mod tests {
                 if op == "cancel_worker" && tid == "w-1"
         ));
         assert!(worker_token.is_terminated());
+        drop(handle);
+    }
+
+    #[tokio::test]
+    async fn cancel_run_op_terminates_run_cancel_token() {
+        let dir = TempDir::new().unwrap();
+        let run_id = Uuid::now_v7();
+        let state = mk_state(dir.path(), run_id);
+        let run_cancel = state.cancel.clone();
+
+        let sock = dir.path().join("cancel-run.sock");
+        let handle = start_control_server(
+            sock.clone(),
+            "0.4.0".into(),
+            run_id.to_string(),
+            "flat".into(),
+            state,
+        )
+        .await
+        .unwrap();
+
+        let mut stream = tokio::net::UnixStream::connect(&sock).await.unwrap();
+        stream
+            .write_all(b"{\"op\":\"hello\",\"client_version\":\"0.4.0\"}\n")
+            .await
+            .unwrap();
+        stream
+            .write_all(b"{\"op\":\"cancel_run\"}\n")
+            .await
+            .unwrap();
+
+        let (r, _w) = stream.split();
+        let mut lines = BufReader::new(r).lines();
+        let _hello = lines.next_line().await.unwrap();
+        let reply_line = lines.next_line().await.unwrap().unwrap();
+        let reply: ControlEvent = serde_json::from_str(&reply_line).unwrap();
+        assert!(matches!(
+            reply,
+            ControlEvent::OpAcked { ref op, .. } if op == "cancel_run"
+        ));
+        assert!(run_cancel.is_terminated());
         drop(handle);
     }
 }

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -315,6 +315,42 @@ async fn dispatch_op(
                 },
             }
         }
+        ControlOp::ContinueWorker { task_id, prompt } => {
+            let current = state.workers.read().await.get(&task_id).cloned();
+            match current {
+                Some(crate::dispatch::state::WorkerState::Paused { session_id, .. }) => {
+                    let prompt_text = prompt.unwrap_or_else(|| "continue".into());
+                    match crate::mcp::tools::spawn_resume_worker(
+                        state,
+                        task_id.clone(),
+                        prompt_text,
+                        session_id,
+                    )
+                    .await
+                    {
+                        Ok(()) => ControlEvent::OpAcked {
+                            op: "continue_worker".into(),
+                            task_id: Some(task_id),
+                        },
+                        Err(e) => ControlEvent::OpFailed {
+                            op: "continue_worker".into(),
+                            task_id: Some(task_id),
+                            error: e.to_string(),
+                        },
+                    }
+                }
+                Some(_) => ControlEvent::OpUnknownState {
+                    op: "continue_worker".into(),
+                    task_id,
+                    current_state: "not_paused".into(),
+                },
+                None => ControlEvent::OpFailed {
+                    op: "continue_worker".into(),
+                    task_id: Some(task_id),
+                    error: "unknown task_id".into(),
+                },
+            }
+        }
         other => ControlEvent::OpUnknown {
             op: op_tag(&other).into(),
         },
@@ -599,6 +635,68 @@ mod tests {
             }
             other => panic!("expected Paused, got {other:?}"),
         }
+        drop(handle);
+    }
+
+    #[tokio::test]
+    async fn continue_worker_from_paused_transitions_running() {
+        let dir = TempDir::new().unwrap();
+        let run_id = Uuid::now_v7();
+        let state = mk_state(dir.path(), run_id);
+        state.workers.write().await.insert(
+            "w-1".into(),
+            crate::dispatch::state::WorkerState::Paused {
+                session_id: "sess-xyz".into(),
+                paused_at: chrono::Utc::now(),
+                prior_token_usage: Default::default(),
+            },
+        );
+        state
+            .worker_prompts
+            .write()
+            .await
+            .insert("w-1".into(), "hi".into());
+        state
+            .worker_models
+            .write()
+            .await
+            .insert("w-1".into(), "claude-haiku-4-5".into());
+
+        let sock = dir.path().join("continue.sock");
+        let handle = start_control_server(
+            sock.clone(),
+            "0.4.0".into(),
+            run_id.to_string(),
+            "hierarchical".into(),
+            state.clone(),
+        )
+        .await
+        .unwrap();
+
+        let mut stream = tokio::net::UnixStream::connect(&sock).await.unwrap();
+        stream
+            .write_all(b"{\"op\":\"hello\",\"client_version\":\"0.4.0\"}\n")
+            .await
+            .unwrap();
+        stream
+            .write_all(b"{\"op\":\"continue_worker\",\"task_id\":\"w-1\"}\n")
+            .await
+            .unwrap();
+
+        let (r, _w) = stream.split();
+        let mut lines = BufReader::new(r).lines();
+        let _hello = lines.next_line().await.unwrap();
+        let reply_line = lines.next_line().await.unwrap().unwrap();
+        let reply: ControlEvent = serde_json::from_str(&reply_line).unwrap();
+        assert!(matches!(
+            reply,
+            ControlEvent::OpAcked { ref op, .. } if op == "continue_worker"
+        ));
+        let workers = state.workers.read().await;
+        assert!(matches!(
+            workers.get("w-1").unwrap(),
+            crate::dispatch::state::WorkerState::Running { .. }
+        ));
         drop(handle);
     }
 }

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -258,6 +258,63 @@ async fn dispatch_op(
                 task_id: None,
             }
         }
+        ControlOp::PauseWorker { task_id } => {
+            let mut workers = state.workers.write().await;
+            let Some(entry) = workers.get(&task_id).cloned() else {
+                return ControlEvent::OpFailed {
+                    op: "pause_worker".into(),
+                    task_id: Some(task_id),
+                    error: "unknown task_id".into(),
+                };
+            };
+            match entry {
+                crate::dispatch::state::WorkerState::Running {
+                    session_id: Some(sid),
+                    ..
+                } => {
+                    let cancels = state.worker_cancels.read().await;
+                    if let Some(tok) = cancels.get(&task_id) {
+                        tok.terminate();
+                    }
+                    workers.insert(
+                        task_id.clone(),
+                        crate::dispatch::state::WorkerState::Paused {
+                            session_id: sid,
+                            paused_at: chrono::Utc::now(),
+                            prior_token_usage: Default::default(),
+                        },
+                    );
+                    ControlEvent::OpAcked {
+                        op: "pause_worker".into(),
+                        task_id: Some(task_id),
+                    }
+                }
+                crate::dispatch::state::WorkerState::Running {
+                    session_id: None, ..
+                } => ControlEvent::OpUnknownState {
+                    op: "pause_worker".into(),
+                    task_id,
+                    current_state: "spawning".into(),
+                },
+                crate::dispatch::state::WorkerState::Paused { .. } => {
+                    ControlEvent::OpUnknownState {
+                        op: "pause_worker".into(),
+                        task_id,
+                        current_state: "paused".into(),
+                    }
+                }
+                crate::dispatch::state::WorkerState::Pending => ControlEvent::OpUnknownState {
+                    op: "pause_worker".into(),
+                    task_id,
+                    current_state: "pending".into(),
+                },
+                crate::dispatch::state::WorkerState::Done(_) => ControlEvent::OpUnknownState {
+                    op: "pause_worker".into(),
+                    task_id,
+                    current_state: "done".into(),
+                },
+            }
+        }
         other => ControlEvent::OpUnknown {
             op: op_tag(&other).into(),
         },
@@ -481,6 +538,67 @@ mod tests {
             ControlEvent::OpAcked { ref op, .. } if op == "cancel_run"
         ));
         assert!(run_cancel.is_terminated());
+        drop(handle);
+    }
+
+    #[tokio::test]
+    async fn pause_worker_transitions_running_to_paused() {
+        let dir = TempDir::new().unwrap();
+        let run_id = Uuid::now_v7();
+        let state = mk_state(dir.path(), run_id);
+
+        let worker_token = CancelToken::new();
+        state
+            .worker_cancels
+            .write()
+            .await
+            .insert("w-1".into(), worker_token.clone());
+        state.workers.write().await.insert(
+            "w-1".into(),
+            crate::dispatch::state::WorkerState::Running {
+                started_at: chrono::Utc::now(),
+                session_id: Some("sess-xyz".into()),
+            },
+        );
+
+        let sock = dir.path().join("pause.sock");
+        let handle = start_control_server(
+            sock.clone(),
+            "0.4.0".into(),
+            run_id.to_string(),
+            "hierarchical".into(),
+            state.clone(),
+        )
+        .await
+        .unwrap();
+
+        let mut stream = tokio::net::UnixStream::connect(&sock).await.unwrap();
+        stream
+            .write_all(b"{\"op\":\"hello\",\"client_version\":\"0.4.0\"}\n")
+            .await
+            .unwrap();
+        stream
+            .write_all(b"{\"op\":\"pause_worker\",\"task_id\":\"w-1\"}\n")
+            .await
+            .unwrap();
+
+        let (r, _w) = stream.split();
+        let mut lines = BufReader::new(r).lines();
+        let _hello = lines.next_line().await.unwrap();
+        let reply_line = lines.next_line().await.unwrap().unwrap();
+        let reply: ControlEvent = serde_json::from_str(&reply_line).unwrap();
+        assert!(matches!(
+            reply,
+            ControlEvent::OpAcked { ref op, .. } if op == "pause_worker"
+        ));
+        assert!(worker_token.is_terminated());
+        let workers = state.workers.read().await;
+        match workers.get("w-1").unwrap() {
+            crate::dispatch::state::WorkerState::Paused { session_id, .. } => {
+                assert_eq!(session_id, "sess-xyz");
+            }
+            other => panic!("expected Paused, got {other:?}"),
+        }
         drop(handle);
     }
 }

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -1,3 +1,353 @@
-//! Control-socket server. Filled in by Task 4.
+//! Control-socket server. Binds a unix socket, accepts at-most-one active TUI
+//! connection, speaks the `ControlOp` / `ControlEvent` protocol one line of
+//! JSON per message.
+//!
+//! Op handlers land across Phase 2 (Tasks 12–17). For Phase 1 the server only
+//! accepts a connection, completes the hello handshake, and returns
+//! `{event:"op_unknown"}` for every other op — enough to integration-test the
+//! framing.
 
-#![allow(dead_code)] // Covered in Task 4.
+#![allow(dead_code)] // Some fields are set by Phase 2 tasks.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::Result;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{UnixListener, UnixStream};
+use tokio::sync::{oneshot, Mutex};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
+
+use crate::control::protocol::{ControlEvent, ControlOp};
+
+/// Handle returned from `start_control_server`. Drop terminates the accept loop
+/// and removes the socket file.
+pub struct ControlServerHandle {
+    socket_path: PathBuf,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    join_handle: Option<JoinHandle<()>>,
+    tracker: TaskTracker,
+    cancel: CancellationToken,
+}
+
+impl ControlServerHandle {
+    pub fn socket_path(&self) -> &Path {
+        &self.socket_path
+    }
+}
+
+impl Drop for ControlServerHandle {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        self.cancel.cancel();
+        self.tracker.close();
+        if let Some(h) = self.join_handle.take() {
+            h.abort();
+        }
+        let _ = std::fs::remove_file(&self.socket_path);
+    }
+}
+
+/// Start the control server. The returned handle owns the listener's lifetime.
+///
+/// `server_version`, `run_id`, `run_kind` are embedded in the hello response.
+/// `state` is currently unused in Phase 1 — it threads the `DispatchState`
+/// reference forward so Phase 2 op handlers can operate on it.
+pub async fn start_control_server(
+    socket_path: PathBuf,
+    server_version: String,
+    run_id: String,
+    run_kind: String,
+    state: Arc<crate::dispatch::state::DispatchState>,
+) -> Result<ControlServerHandle> {
+    if socket_path.exists() {
+        let _ = std::fs::remove_file(&socket_path);
+    }
+    let listener = UnixListener::bind(&socket_path)?;
+    let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();
+
+    let tracker = TaskTracker::new();
+    let cancel = CancellationToken::new();
+    let tracker_outer = tracker.clone();
+    let cancel_outer = cancel.clone();
+    let state_outer = state;
+
+    let join_handle = tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                biased;
+                _ = &mut shutdown_rx => break,
+                _ = cancel_outer.cancelled() => break,
+                accept = listener.accept() => {
+                    match accept {
+                        Ok((stream, _addr)) => {
+                            let cancel_inner = cancel_outer.clone();
+                            let server_version = server_version.clone();
+                            let run_id = run_id.clone();
+                            let run_kind = run_kind.clone();
+                            let workers_names: Vec<String> = {
+                                let guard = state_outer.workers.read().await;
+                                guard.keys().cloned().collect()
+                            };
+                            tracker_outer.spawn(async move {
+                                tokio::select! {
+                                    _ = cancel_inner.cancelled() => {},
+                                    _ = serve_connection(
+                                        stream,
+                                        server_version,
+                                        run_id,
+                                        run_kind,
+                                        workers_names,
+                                    ) => {},
+                                }
+                            });
+                        }
+                        Err(e) => {
+                            tracing::debug!("control accept error: {e}");
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    Ok(ControlServerHandle {
+        socket_path,
+        shutdown_tx: Some(shutdown_tx),
+        join_handle: Some(join_handle),
+        tracker,
+        cancel,
+    })
+}
+
+/// Serve one client: complete hello handshake, then loop reading ops and
+/// replying. Phase 1 implementation: every non-hello op yields `op_unknown`.
+async fn serve_connection(
+    stream: UnixStream,
+    server_version: String,
+    run_id: String,
+    run_kind: String,
+    workers_names: Vec<String>,
+) {
+    let (read_half, write_half) = stream.into_split();
+    let writer = Arc::new(Mutex::new(write_half));
+    let mut reader = BufReader::new(read_half).lines();
+
+    // Read the client hello.
+    let first = match reader.next_line().await {
+        Ok(Some(line)) => line,
+        _ => return,
+    };
+    match serde_json::from_str::<ControlOp>(&first) {
+        Ok(ControlOp::Hello { .. }) => {}
+        Ok(other) => {
+            let _ = send_event(
+                &writer,
+                &ControlEvent::OpFailed {
+                    op: format!("{other:?}"),
+                    task_id: None,
+                    error: "expected hello as first message".into(),
+                },
+            )
+            .await;
+            return;
+        }
+        Err(e) => {
+            let _ = send_event(
+                &writer,
+                &ControlEvent::OpFailed {
+                    op: "hello".into(),
+                    task_id: None,
+                    error: format!("parse error: {e}"),
+                },
+            )
+            .await;
+            return;
+        }
+    }
+
+    // Send server hello.
+    let _ = send_event(
+        &writer,
+        &ControlEvent::Hello {
+            server_version,
+            run_id,
+            run_kind,
+            workers: workers_names,
+        },
+    )
+    .await;
+
+    // Read subsequent ops; every one returns OpUnknown until Phase 2.
+    while let Ok(Some(line)) = reader.next_line().await {
+        let reply = match serde_json::from_str::<ControlOp>(&line) {
+            Ok(op) => ControlEvent::OpUnknown {
+                op: op_tag(&op).into(),
+            },
+            Err(e) => ControlEvent::OpFailed {
+                op: "".into(),
+                task_id: None,
+                error: format!("parse error: {e}"),
+            },
+        };
+        if send_event(&writer, &reply).await.is_err() {
+            break;
+        }
+    }
+}
+
+async fn send_event(
+    writer: &Arc<Mutex<tokio::net::unix::OwnedWriteHalf>>,
+    ev: &ControlEvent,
+) -> Result<()> {
+    let mut line = serde_json::to_string(ev)?;
+    line.push('\n');
+    let mut guard = writer.lock().await;
+    guard.write_all(line.as_bytes()).await?;
+    guard.flush().await?;
+    Ok(())
+}
+
+fn op_tag(op: &ControlOp) -> &'static str {
+    match op {
+        ControlOp::Hello { .. } => "hello",
+        ControlOp::CancelWorker { .. } => "cancel_worker",
+        ControlOp::CancelRun => "cancel_run",
+        ControlOp::PauseWorker { .. } => "pause_worker",
+        ControlOp::ContinueWorker { .. } => "continue_worker",
+        ControlOp::RepromptWorker { .. } => "reprompt_worker",
+        ControlOp::Approve { .. } => "approve",
+        ControlOp::ListWorkers => "list_workers",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dispatch::state::DispatchState;
+    use crate::manifest::resolve::ResolvedManifest;
+    use crate::manifest::schema::WorktreeCleanup;
+    use pitboss_core::process::{ProcessSpawner, TokioSpawner};
+    use pitboss_core::session::CancelToken;
+    use pitboss_core::store::{JsonFileStore, SessionStore};
+    use pitboss_core::worktree::{CleanupPolicy, WorktreeManager};
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use uuid::Uuid;
+
+    fn mk_state(dir: &Path, run_id: Uuid) -> Arc<DispatchState> {
+        let manifest = ResolvedManifest {
+            max_parallel: 4,
+            halt_on_failure: false,
+            run_dir: dir.to_path_buf(),
+            worktree_cleanup: WorktreeCleanup::OnSuccess,
+            emit_event_stream: false,
+            tasks: vec![],
+            lead: None,
+            max_workers: Some(4),
+            budget_usd: Some(1.0),
+            lead_timeout_secs: None,
+        };
+        let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.to_path_buf()));
+        let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
+        let wt_mgr = Arc::new(WorktreeManager::new());
+        Arc::new(DispatchState::new(
+            run_id,
+            manifest,
+            store,
+            CancelToken::new(),
+            "lead".into(),
+            spawner,
+            PathBuf::from("/bin/true"),
+            wt_mgr,
+            CleanupPolicy::Never,
+            dir.join(run_id.to_string()),
+        ))
+    }
+
+    #[tokio::test]
+    async fn hello_handshake_roundtrips() {
+        let dir = TempDir::new().unwrap();
+        let run_id = Uuid::now_v7();
+        let state = mk_state(dir.path(), run_id);
+        let sock = dir.path().join("control.sock");
+        let handle = start_control_server(
+            sock.clone(),
+            "0.4.0".into(),
+            run_id.to_string(),
+            "flat".into(),
+            state,
+        )
+        .await
+        .unwrap();
+        assert!(sock.exists());
+
+        let mut stream = tokio::net::UnixStream::connect(&sock).await.unwrap();
+        stream
+            .write_all(b"{\"op\":\"hello\",\"client_version\":\"0.4.0\"}\n")
+            .await
+            .unwrap();
+
+        let (r, _w) = stream.split();
+        let mut lines = BufReader::new(r).lines();
+        let hello_line = lines.next_line().await.unwrap().expect("hello line");
+        let ev: ControlEvent = serde_json::from_str(&hello_line).unwrap();
+        match ev {
+            ControlEvent::Hello {
+                server_version,
+                run_id: rid,
+                run_kind,
+                ..
+            } => {
+                assert_eq!(server_version, "0.4.0");
+                assert_eq!(rid, run_id.to_string());
+                assert_eq!(run_kind, "flat");
+            }
+            other => panic!("expected Hello, got {other:?}"),
+        }
+        drop(handle);
+    }
+
+    #[tokio::test]
+    async fn unknown_op_returns_op_unknown() {
+        let dir = TempDir::new().unwrap();
+        let run_id = Uuid::now_v7();
+        let state = mk_state(dir.path(), run_id);
+        let sock = dir.path().join("control.sock");
+        let handle = start_control_server(
+            sock.clone(),
+            "0.4.0".into(),
+            run_id.to_string(),
+            "flat".into(),
+            state,
+        )
+        .await
+        .unwrap();
+
+        let mut stream = tokio::net::UnixStream::connect(&sock).await.unwrap();
+        stream
+            .write_all(b"{\"op\":\"hello\",\"client_version\":\"0.4.0\"}\n")
+            .await
+            .unwrap();
+        stream
+            .write_all(b"{\"op\":\"cancel_worker\",\"task_id\":\"w\"}\n")
+            .await
+            .unwrap();
+
+        let (r, _w) = stream.split();
+        let mut lines = BufReader::new(r).lines();
+        let _hello = lines.next_line().await.unwrap();
+        let reply_line = lines.next_line().await.unwrap().unwrap();
+        let reply: ControlEvent = serde_json::from_str(&reply_line).unwrap();
+        assert!(matches!(
+            reply,
+            ControlEvent::OpUnknown { op } if op == "cancel_worker"
+        ));
+        drop(handle);
+    }
+}

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -228,7 +228,7 @@ fn op_tag(op: &ControlOp) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::dispatch::state::DispatchState;
+    use crate::dispatch::state::{ApprovalPolicy, DispatchState};
     use crate::manifest::resolve::ResolvedManifest;
     use crate::manifest::schema::WorktreeCleanup;
     use pitboss_core::process::{ProcessSpawner, TokioSpawner};
@@ -267,6 +267,7 @@ mod tests {
             wt_mgr,
             CleanupPolicy::Never,
             dir.join(run_id.to_string()),
+            ApprovalPolicy::Block,
         ))
     }
 

--- a/crates/pitboss-cli/src/diff.rs
+++ b/crates/pitboss-cli/src/diff.rs
@@ -530,6 +530,11 @@ mod tests {
             claude_session_id: None,
             final_message_preview: None,
             parent_task_id: None,
+            pause_count: 0,
+            reprompt_count: 0,
+            approvals_requested: 0,
+            approvals_approved: 0,
+            approvals_rejected: 0,
         }
     }
 

--- a/crates/pitboss-cli/src/dispatch/events.rs
+++ b/crates/pitboss-cli/src/dispatch/events.rs
@@ -1,0 +1,111 @@
+//! Per-worker events.jsonl writer. Captures pause/continue/reprompt/approval
+//! events as an append-only JSONL stream. Not loaded by the dispatcher; a
+//! post-hoc audit trail only.
+
+#![allow(dead_code)]
+
+use std::path::Path;
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use tokio::fs::OpenOptions;
+use tokio::io::AsyncWriteExt;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TaskEvent {
+    Pause {
+        at: DateTime<Utc>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+    },
+    Continue {
+        at: DateTime<Utc>,
+        new_session_id: String,
+        prompt_preview: String,
+    },
+    Reprompt {
+        at: DateTime<Utc>,
+        prompt_preview: String,
+        prior_session_id: String,
+    },
+    ApprovalRequest {
+        at: DateTime<Utc>,
+        request_id: String,
+        summary_preview: String,
+    },
+    ApprovalResponse {
+        at: DateTime<Utc>,
+        request_id: String,
+        approved: bool,
+        edited: bool,
+    },
+}
+
+/// Append one event to `<run_subdir>/tasks/<task_id>/events.jsonl`.
+/// Creates the directory if absent.
+pub async fn append_event(run_subdir: &Path, task_id: &str, event: &TaskEvent) -> Result<()> {
+    let dir = run_subdir.join("tasks").join(task_id);
+    tokio::fs::create_dir_all(&dir).await?;
+    let path = dir.join("events.jsonl");
+    let mut f = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .await?;
+    let mut line = serde_json::to_string(event)?;
+    line.push('\n');
+    f.write_all(line.as_bytes()).await?;
+    f.flush().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn append_creates_file_and_writes_event() {
+        let dir = TempDir::new().unwrap();
+        let ev = TaskEvent::Pause {
+            at: Utc::now(),
+            reason: Some("op requested".into()),
+        };
+        append_event(dir.path(), "w-1", &ev).await.unwrap();
+        let path = dir.path().join("tasks").join("w-1").join("events.jsonl");
+        let content = tokio::fs::read_to_string(path).await.unwrap();
+        assert!(content.contains("\"kind\":\"pause\""));
+        assert!(content.contains("\"reason\":\"op requested\""));
+    }
+
+    #[tokio::test]
+    async fn multiple_appends_are_jsonl() {
+        let dir = TempDir::new().unwrap();
+        append_event(
+            dir.path(),
+            "w-2",
+            &TaskEvent::Pause {
+                at: Utc::now(),
+                reason: None,
+            },
+        )
+        .await
+        .unwrap();
+        append_event(
+            dir.path(),
+            "w-2",
+            &TaskEvent::Continue {
+                at: Utc::now(),
+                new_session_id: "sess".into(),
+                prompt_preview: "next".into(),
+            },
+        )
+        .await
+        .unwrap();
+        let path = dir.path().join("tasks").join("w-2").join("events.jsonl");
+        let content = tokio::fs::read_to_string(path).await.unwrap();
+        assert_eq!(content.lines().count(), 2);
+    }
+}

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -198,6 +198,11 @@ pub async fn run_hierarchical(
         claude_session_id: outcome.claude_session_id,
         final_message_preview: outcome.final_message_preview,
         parent_task_id: None, // lead has no parent
+        pause_count: 0,
+        reprompt_count: 0,
+        approvals_requested: 0,
+        approvals_approved: 0,
+        approvals_rejected: 0,
     };
 
     // Cleanup worktree per policy
@@ -250,6 +255,11 @@ pub async fn run_hierarchical(
                         claude_session_id: None,
                         final_message_preview: Some("cancelled when lead exited".into()),
                         parent_task_id: Some(lead.id.clone()),
+                        pause_count: 0,
+                        reprompt_count: 0,
+                        approvals_requested: 0,
+                        approvals_approved: 0,
+                        approvals_rejected: 0,
                     }
                 }
             })

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -12,6 +12,7 @@ use pitboss_core::session::CancelToken;
 use pitboss_core::store::{JsonFileStore, RunMeta, RunSummary, SessionStore};
 use uuid::Uuid;
 
+use crate::control::{control_socket_path, server::start_control_server};
 use crate::dispatch::state::{ApprovalPolicy, DispatchState};
 use crate::manifest::resolve::ResolvedManifest;
 use crate::mcp::{socket_path_for_run, McpServer};
@@ -98,6 +99,18 @@ pub async fn run_hierarchical(
         ApprovalPolicy::Block,
     ));
     let _mcp = McpServer::start(socket.clone(), state.clone()).await?;
+
+    // Bind the control socket for TUI ↔ dispatcher ops.
+    let control_sock = control_socket_path(run_id, &run_dir);
+    let _control = start_control_server(
+        control_sock,
+        env!("CARGO_PKG_VERSION").to_string(),
+        run_id.to_string(),
+        "hierarchical".into(),
+        state.clone(),
+    )
+    .await
+    .context("start control server")?;
 
     // 2. Build the --mcp-config file for the lead.
     let mcp_config_path = run_subdir.join("lead-mcp-config.json");

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -12,7 +12,7 @@ use pitboss_core::session::CancelToken;
 use pitboss_core::store::{JsonFileStore, RunMeta, RunSummary, SessionStore};
 use uuid::Uuid;
 
-use crate::dispatch::state::DispatchState;
+use crate::dispatch::state::{ApprovalPolicy, DispatchState};
 use crate::manifest::resolve::ResolvedManifest;
 use crate::mcp::{socket_path_for_run, McpServer};
 
@@ -95,6 +95,7 @@ pub async fn run_hierarchical(
         wt_mgr.clone(),
         cleanup_policy,
         run_subdir.clone(),
+        ApprovalPolicy::Block,
     ));
     let _mcp = McpServer::start(socket.clone(), state.clone()).await?;
 

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -13,7 +13,7 @@ use pitboss_core::store::{JsonFileStore, RunMeta, RunSummary, SessionStore};
 use uuid::Uuid;
 
 use crate::control::{control_socket_path, server::start_control_server};
-use crate::dispatch::state::{ApprovalPolicy, DispatchState};
+use crate::dispatch::state::DispatchState;
 use crate::manifest::resolve::ResolvedManifest;
 use crate::mcp::{socket_path_for_run, McpServer};
 
@@ -96,7 +96,7 @@ pub async fn run_hierarchical(
         wt_mgr.clone(),
         cleanup_policy,
         run_subdir.clone(),
-        ApprovalPolicy::Block,
+        resolved.approval_policy.unwrap_or_default(),
     ));
     let _mcp = McpServer::start(socket.clone(), state.clone()).await?;
 

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -136,6 +136,7 @@ pub async fn run_hierarchical(
         lead.id.clone(),
         crate::dispatch::state::WorkerState::Running {
             started_at: Utc::now(),
+            session_id: None,
         },
     );
 
@@ -219,7 +220,8 @@ pub async fn run_hierarchical(
             .map(|(id, w)| match w {
                 crate::dispatch::state::WorkerState::Done(rec) => rec.clone(),
                 crate::dispatch::state::WorkerState::Pending
-                | crate::dispatch::state::WorkerState::Running { .. } => {
+                | crate::dispatch::state::WorkerState::Running { .. }
+                | crate::dispatch::state::WorkerState::Paused { .. } => {
                     let now = Utc::now();
                     pitboss_core::store::TaskRecord {
                         task_id: id.clone(),

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -164,6 +164,13 @@ pub async fn run_hierarchical(
         .await;
 
     // Build lead TaskRecord
+    let lead_counters = state
+        .worker_counters
+        .read()
+        .await
+        .get(&state.lead_id)
+        .cloned()
+        .unwrap_or_default();
     let lead_record = pitboss_core::store::TaskRecord {
         task_id: lead.id.clone(),
         status: match outcome.final_state {
@@ -198,11 +205,11 @@ pub async fn run_hierarchical(
         claude_session_id: outcome.claude_session_id,
         final_message_preview: outcome.final_message_preview,
         parent_task_id: None, // lead has no parent
-        pause_count: 0,
-        reprompt_count: 0,
-        approvals_requested: 0,
-        approvals_approved: 0,
-        approvals_rejected: 0,
+        pause_count: lead_counters.pause_count,
+        reprompt_count: lead_counters.reprompt_count,
+        approvals_requested: lead_counters.approvals_requested,
+        approvals_approved: lead_counters.approvals_approved,
+        approvals_rejected: lead_counters.approvals_rejected,
     };
 
     // Cleanup worktree per policy

--- a/crates/pitboss-cli/src/dispatch/mod.rs
+++ b/crates/pitboss-cli/src/dispatch/mod.rs
@@ -1,3 +1,4 @@
+pub mod events;
 pub mod hierarchical;
 pub mod probe;
 pub mod resume;

--- a/crates/pitboss-cli/src/dispatch/resume.rs
+++ b/crates/pitboss-cli/src/dispatch/resume.rs
@@ -394,6 +394,7 @@ mod tests {
             max_workers: Some(4),
             budget_usd: Some(5.0),
             lead_timeout_secs: None,
+            approval_policy: None,
         };
         std::fs::write(
             run_dir.join("resolved.json"),

--- a/crates/pitboss-cli/src/dispatch/resume.rs
+++ b/crates/pitboss-cli/src/dispatch/resume.rs
@@ -215,6 +215,11 @@ mod tests {
                 claude_session_id: session_id.map(str::to_string),
                 final_message_preview: None,
                 parent_task_id: None,
+                pause_count: 0,
+                reprompt_count: 0,
+                approvals_requested: 0,
+                approvals_approved: 0,
+                approvals_rejected: 0,
             })
             .collect();
 
@@ -416,6 +421,11 @@ mod tests {
             claude_session_id: Some("session-abc-123".into()),
             final_message_preview: None,
             parent_task_id: None,
+            pause_count: 0,
+            reprompt_count: 0,
+            approvals_requested: 0,
+            approvals_approved: 0,
+            approvals_rejected: 0,
         };
         let summary = RunSummary {
             run_id: Uuid::now_v7(),

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -17,6 +17,14 @@ use uuid::Uuid;
 
 use crate::manifest::resolve::{ResolvedManifest, ResolvedTask};
 
+fn cleanup_policy_from(w: crate::manifest::schema::WorktreeCleanup) -> CleanupPolicy {
+    match w {
+        crate::manifest::schema::WorktreeCleanup::Always => CleanupPolicy::Always,
+        crate::manifest::schema::WorktreeCleanup::OnSuccess => CleanupPolicy::OnSuccess,
+        crate::manifest::schema::WorktreeCleanup::Never => CleanupPolicy::Never,
+    }
+}
+
 /// Public entry — main.rs calls this. Constructs production spawner + store.
 pub async fn run_dispatch_inner(
     resolved: ResolvedManifest,
@@ -100,6 +108,33 @@ pub async fn execute(
     crate::dispatch::signals::install_ctrl_c_watcher(cancel.clone());
     let wt_mgr = Arc::new(WorktreeManager::new());
     let records: Arc<Mutex<Vec<TaskRecord>>> = Arc::new(Mutex::new(Vec::new()));
+
+    // Build a minimal DispatchState so the control server has something to bind
+    // against. Flat mode has no lead and no spawn_worker path, but cancel and
+    // list_workers still apply.
+    let flat_state = Arc::new(crate::dispatch::state::DispatchState::new(
+        run_id,
+        resolved.clone(),
+        store.clone(),
+        cancel.clone(),
+        "".into(),
+        spawner.clone(),
+        claude_binary.clone(),
+        wt_mgr.clone(),
+        cleanup_policy_from(resolved.worktree_cleanup),
+        run_subdir.clone(),
+        crate::dispatch::state::ApprovalPolicy::Block,
+    ));
+    let control_sock = crate::control::control_socket_path(run_id, &run_dir);
+    let _control = crate::control::server::start_control_server(
+        control_sock,
+        env!("CARGO_PKG_VERSION").to_string(),
+        run_id.to_string(),
+        "flat".into(),
+        flat_state,
+    )
+    .await
+    .context("start control server")?;
 
     let mut handles = Vec::new();
 

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -487,6 +487,7 @@ mod tests {
             max_workers: None,
             budget_usd: None,
             lead_timeout_secs: None,
+            approval_policy: None,
         };
 
         // Script: first call succeeds, second call fails. FakeSpawner is single-shot,
@@ -570,6 +571,7 @@ mod tests {
             max_workers: None,
             budget_usd: None,
             lead_timeout_secs: None,
+            approval_policy: None,
         };
 
         let spawner = Arc::new(CyclingFake(
@@ -666,6 +668,7 @@ mod tests {
             max_workers: None,
             budget_usd: None,
             lead_timeout_secs: None,
+            approval_policy: None,
         };
 
         let spawner = Arc::new(CyclingFake(

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -273,6 +273,11 @@ async fn execute_task(
                     claude_session_id: None,
                     final_message_preview: Some(format!("worktree error: {e}")),
                     parent_task_id: None,
+                    pause_count: 0,
+                    reprompt_count: 0,
+                    approvals_requested: 0,
+                    approvals_approved: 0,
+                    approvals_rejected: 0,
                 };
             }
         }
@@ -324,6 +329,11 @@ async fn execute_task(
         claude_session_id: outcome.claude_session_id,
         final_message_preview: outcome.final_message_preview,
         parent_task_id: None,
+        pause_count: 0,
+        reprompt_count: 0,
+        approvals_requested: 0,
+        approvals_approved: 0,
+        approvals_rejected: 0,
     }
 }
 

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -361,6 +361,9 @@ pub const PITBOSS_MCP_TOOLS: &[&str] = &[
     "mcp__pitboss__wait_for_any",
     "mcp__pitboss__list_workers",
     "mcp__pitboss__cancel_worker",
+    "mcp__pitboss__pause_worker",
+    "mcp__pitboss__continue_worker",
+    "mcp__pitboss__request_approval",
 ];
 
 /// Builds the argv for spawning the lead subprocess, including the

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -123,7 +123,7 @@ pub async fn execute(
         wt_mgr.clone(),
         cleanup_policy_from(resolved.worktree_cleanup),
         run_subdir.clone(),
-        crate::dispatch::state::ApprovalPolicy::Block,
+        resolved.approval_policy.unwrap_or_default(),
     ));
     let control_sock = crate::control::control_socket_path(run_id, &run_dir);
     let _control = crate::control::server::start_control_server(

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -207,6 +207,7 @@ mod tests {
             max_workers,
             budget_usd: budget,
             lead_timeout_secs: None,
+            approval_policy: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -21,6 +21,20 @@ pub enum WorkerState {
     Pending,
     Running {
         started_at: chrono::DateTime<chrono::Utc>,
+        /// Populated once the worker's claude subprocess emits its
+        /// `{"type":"system","subtype":"init"}` event. `None` during the brief
+        /// window between spawn and first init event (≤ ~1s in practice);
+        /// pause/reprompt fail with `op_unknown_state{current_state:"spawning"}`
+        /// when None.
+        session_id: Option<String>,
+    },
+    Paused {
+        /// Captured from the Running variant at pause time.
+        session_id: String,
+        paused_at: chrono::DateTime<chrono::Utc>,
+        /// Snapshot of token usage at pause time, so continue's final
+        /// TaskRecord knows what the prior subprocess cost.
+        prior_token_usage: pitboss_core::parser::TokenUsage,
     },
     Done(TaskRecord),
 }
@@ -111,7 +125,12 @@ impl DispatchState {
             .read()
             .await
             .values()
-            .filter(|w| matches!(w, WorkerState::Pending | WorkerState::Running { .. }))
+            .filter(|w| {
+                matches!(
+                    w,
+                    WorkerState::Pending | WorkerState::Running { .. } | WorkerState::Paused { .. }
+                )
+            })
             .count()
     }
 
@@ -188,5 +207,24 @@ mod tests {
     async fn budget_remaining_is_none_when_uncapped() {
         let st = mk_state(None, None);
         assert_eq!(st.budget_remaining().await, None);
+    }
+
+    #[test]
+    fn running_worker_state_captures_session_id() {
+        let started_at = chrono::Utc::now();
+        let sid: Option<String> = Some("sess-abc".into());
+        let w = WorkerState::Running {
+            started_at,
+            session_id: sid.clone(),
+        };
+        match w {
+            WorkerState::Running {
+                session_id,
+                started_at: _,
+            } => {
+                assert_eq!(session_id, Some("sess-abc".to_string()));
+            }
+            other => panic!("expected Running, got {other:?}"),
+        }
     }
 }

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -47,6 +47,15 @@ pub struct ApprovalResponse {
     pub edited_summary: Option<String>,
 }
 
+#[derive(Default, Clone, Debug)]
+pub struct WorkerCounters {
+    pub pause_count: u32,
+    pub reprompt_count: u32,
+    pub approvals_requested: u32,
+    pub approvals_approved: u32,
+    pub approvals_rejected: u32,
+}
+
 /// Policy for approval requests when no TUI is attached.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -120,6 +129,9 @@ pub struct DispatchState {
     /// control server clears it on disconnect.
     pub control_writer:
         Mutex<Option<mpsc::UnboundedSender<crate::control::protocol::ControlEvent>>>,
+    /// Per-task event counters. Mutated by pause/continue/reprompt/approval
+    /// paths; read when building the final `TaskRecord`.
+    pub worker_counters: RwLock<HashMap<String, WorkerCounters>>,
 }
 
 impl DispatchState {
@@ -161,6 +173,7 @@ impl DispatchState {
             approval_queue: Mutex::new(VecDeque::new()),
             approval_policy,
             control_writer: Mutex::new(None),
+            worker_counters: RwLock::new(HashMap::new()),
         }
     }
 
@@ -284,5 +297,18 @@ mod tests {
             crate::dispatch::state::ApprovalPolicy::Block
         ));
         assert!(st.control_writer.lock().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn worker_counters_default_zero() {
+        let st = mk_state(None, None);
+        let c = st
+            .worker_counters
+            .read()
+            .await
+            .get("absent")
+            .cloned()
+            .unwrap_or_default();
+        assert_eq!(c.pause_count, 0);
     }
 }

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -2,7 +2,7 @@
 //! between the dispatch runner (which writes TaskRecords) and the MCP server
 //! (which reads worker status, enforces caps, enqueues spawns).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -10,7 +10,7 @@ use pitboss_core::process::ProcessSpawner;
 use pitboss_core::session::CancelToken;
 use pitboss_core::store::{SessionStore, TaskRecord};
 use pitboss_core::worktree::{CleanupPolicy, WorktreeManager};
-use tokio::sync::{broadcast, Mutex, RwLock};
+use tokio::sync::{broadcast, mpsc, oneshot, Mutex, RwLock};
 use uuid::Uuid;
 
 use crate::manifest::resolve::ResolvedManifest;
@@ -37,6 +37,33 @@ pub enum WorkerState {
         prior_token_usage: pitboss_core::parser::TokenUsage,
     },
     Done(TaskRecord),
+}
+
+/// Response returned to a lead that called `request_approval`.
+#[derive(Debug, Clone)]
+pub struct ApprovalResponse {
+    pub approved: bool,
+    pub comment: Option<String>,
+    pub edited_summary: Option<String>,
+}
+
+/// Policy for approval requests when no TUI is attached.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalPolicy {
+    #[default]
+    Block,
+    AutoApprove,
+    AutoReject,
+}
+
+/// An approval request that arrived before a TUI attached. Block-mode runs
+/// queue these; they drain when the next TUI connects.
+pub struct QueuedApproval {
+    pub request_id: String,
+    pub task_id: String,
+    pub summary: String,
+    pub responder: oneshot::Sender<ApprovalResponse>,
 }
 
 pub struct DispatchState {
@@ -81,6 +108,18 @@ pub struct DispatchState {
     pub cleanup_policy: CleanupPolicy,
     /// The per-run subdirectory where worker logs/artifacts land (`run_dir/<run_id>/`).
     pub run_subdir: PathBuf,
+    /// Approval bridge: maps request_id → sender that completes when the
+    /// TUI responds to an approval request. Seeded by `ApprovalBridge::request`,
+    /// drained by the `approve` control op.
+    pub approval_bridge: Mutex<HashMap<String, oneshot::Sender<ApprovalResponse>>>,
+    /// Queued approval requests waiting for a TUI to attach.
+    pub approval_queue: Mutex<VecDeque<QueuedApproval>>,
+    /// Approval policy from the manifest.
+    pub approval_policy: ApprovalPolicy,
+    /// Outbound control-socket event channel. Set when a TUI is connected; the
+    /// control server clears it on disconnect.
+    pub control_writer:
+        Mutex<Option<mpsc::UnboundedSender<crate::control::protocol::ControlEvent>>>,
 }
 
 impl DispatchState {
@@ -96,6 +135,7 @@ impl DispatchState {
         wt_mgr: Arc<WorktreeManager>,
         cleanup_policy: CleanupPolicy,
         run_subdir: PathBuf,
+        approval_policy: ApprovalPolicy,
     ) -> Self {
         let (done_tx, _) = broadcast::channel(64);
         Self {
@@ -117,6 +157,10 @@ impl DispatchState {
             wt_mgr,
             cleanup_policy,
             run_subdir,
+            approval_bridge: Mutex::new(HashMap::new()),
+            approval_queue: Mutex::new(VecDeque::new()),
+            approval_policy,
+            control_writer: Mutex::new(None),
         }
     }
 
@@ -181,6 +225,7 @@ mod tests {
             wt_mgr,
             CleanupPolicy::Never,
             run_subdir,
+            ApprovalPolicy::Block,
         ));
         // Keep the TempDir alive for the test by leaking it — the state holds
         // PathBufs into it, and dropping `dir` at end of scope would invalidate
@@ -226,5 +271,17 @@ mod tests {
             }
             other => panic!("expected Running, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn state_initializes_new_v04_fields() {
+        let st = mk_state(None, None);
+        assert!(st.approval_bridge.lock().await.is_empty());
+        assert!(st.approval_queue.lock().await.is_empty());
+        assert!(matches!(
+            st.approval_policy,
+            crate::dispatch::state::ApprovalPolicy::Block
+        ));
+        assert!(st.control_writer.lock().await.is_none());
     }
 }

--- a/crates/pitboss-cli/src/lib.rs
+++ b/crates/pitboss-cli/src/lib.rs
@@ -5,6 +5,7 @@
 //! from this lib crate rather than re-declaring them.
 
 pub mod cli;
+pub mod control;
 pub mod diff;
 pub mod dispatch;
 pub mod manifest;

--- a/crates/pitboss-cli/src/manifest/resolve.rs
+++ b/crates/pitboss-cli/src/manifest/resolve.rs
@@ -58,6 +58,8 @@ pub struct ResolvedManifest {
     pub max_workers: Option<u32>,
     pub budget_usd: Option<f64>,
     pub lead_timeout_secs: Option<u64>,
+    // NEW in v0.4:
+    pub approval_policy: Option<crate::dispatch::state::ApprovalPolicy>,
 }
 
 const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
@@ -108,6 +110,7 @@ pub fn resolve(manifest: Manifest, env_max_parallel: Option<u32>) -> Result<Reso
         max_workers: manifest.run.max_workers,
         budget_usd: manifest.run.budget_usd,
         lead_timeout_secs: manifest.run.lead_timeout_secs,
+        approval_policy: manifest.run.approval_policy,
     })
 }
 
@@ -411,5 +414,35 @@ mod tests {
         "#);
         let r = resolve(m, None).unwrap();
         assert_eq!(r.lead.unwrap().timeout_secs, 7200);
+    }
+
+    #[test]
+    fn resolves_approval_policy_from_run() {
+        let m = man(r#"
+            [run]
+            approval_policy = "auto_reject"
+
+            [[lead]]
+            id = "triage"
+            directory = "/tmp"
+            prompt = "p"
+        "#);
+        let r = resolve(m, None).unwrap();
+        assert_eq!(
+            r.approval_policy,
+            Some(crate::dispatch::state::ApprovalPolicy::AutoReject)
+        );
+    }
+
+    #[test]
+    fn resolves_missing_approval_policy_as_none() {
+        let m = man(r#"
+            [[task]]
+            id = "a"
+            directory = "/tmp"
+            prompt = "p"
+        "#);
+        let r = resolve(m, None).unwrap();
+        assert!(r.approval_policy.is_none());
     }
 }

--- a/crates/pitboss-cli/src/manifest/schema.rs
+++ b/crates/pitboss-cli/src/manifest/schema.rs
@@ -39,6 +39,10 @@ pub struct RunConfig {
     pub budget_usd: Option<f64>,
     #[serde(default)]
     pub lead_timeout_secs: Option<u64>,
+
+    // NEW in v0.4 — approval policy for when no TUI is attached.
+    #[serde(default)]
+    pub approval_policy: Option<crate::dispatch::state::ApprovalPolicy>,
 }
 
 impl Default for RunConfig {
@@ -52,6 +56,7 @@ impl Default for RunConfig {
             max_workers: None,
             budget_usd: None,
             lead_timeout_secs: None,
+            approval_policy: None,
         }
     }
 }
@@ -251,5 +256,38 @@ mod tests {
         "#;
         let m: Manifest = toml::from_str(toml_src).unwrap();
         assert_eq!(m.run.max_workers, Some(2));
+    }
+
+    #[test]
+    fn parses_approval_policy() {
+        let toml_src = r#"
+            [run]
+            approval_policy = "auto_approve"
+
+            [[lead]]
+            id = "triage"
+            directory = "/tmp"
+            prompt = "p"
+        "#;
+        let m: Manifest = toml::from_str(toml_src).unwrap();
+        assert_eq!(
+            m.run.approval_policy,
+            Some(crate::dispatch::state::ApprovalPolicy::AutoApprove)
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_approval_policy() {
+        let toml_src = r#"
+            [run]
+            approval_policy = "wibble"
+
+            [[lead]]
+            id = "triage"
+            directory = "/tmp"
+            prompt = "p"
+        "#;
+        let err: Result<Manifest, _> = toml::from_str(toml_src);
+        assert!(err.is_err());
     }
 }

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -241,6 +241,7 @@ mod tests {
             max_workers: None,
             budget_usd: None,
             lead_timeout_secs: None,
+            approval_policy: None,
         }
     }
 
@@ -314,6 +315,7 @@ mod tests {
             max_workers: Some(4),
             budget_usd: Some(5.0),
             lead_timeout_secs: Some(600),
+            approval_policy: None,
         };
         let err = validate(&r).unwrap_err().to_string();
         assert!(
@@ -336,6 +338,7 @@ mod tests {
             max_workers: Some(4), // set without a lead → error
             budget_usd: None,
             lead_timeout_secs: None,
+            approval_policy: None,
         };
         let err = validate(&r).unwrap_err().to_string();
         assert!(err.contains("max_workers"), "got: {err}");
@@ -355,6 +358,7 @@ mod tests {
             max_workers: Some(17),
             budget_usd: Some(1.0),
             lead_timeout_secs: Some(600),
+            approval_policy: None,
         };
         assert!(validate(&r).is_err());
     }
@@ -373,6 +377,7 @@ mod tests {
             max_workers: Some(4),
             budget_usd: Some(0.0),
             lead_timeout_secs: Some(600),
+            approval_policy: None,
         };
         assert!(validate(&r).is_err());
     }
@@ -390,6 +395,7 @@ mod tests {
             max_workers: None,
             budget_usd: None,
             lead_timeout_secs: None,
+            approval_policy: None,
         };
         let err = validate(&r).unwrap_err().to_string();
         assert!(err.contains("empty manifest"), "got: {err}");

--- a/crates/pitboss-cli/src/mcp/approval.rs
+++ b/crates/pitboss-cli/src/mcp/approval.rs
@@ -1,0 +1,209 @@
+//! Approval bridge: wires an in-dispatcher MCP `request_approval` call to
+//! either (a) a connected TUI via the control socket, or (b) an auto-resolve
+//! per `ApprovalPolicy` when no TUI is attached.
+
+#![allow(dead_code)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use thiserror::Error;
+use tokio::sync::oneshot;
+use uuid::Uuid;
+
+use crate::dispatch::state::{ApprovalPolicy, ApprovalResponse, DispatchState, QueuedApproval};
+
+#[derive(Debug, Error)]
+pub enum ApprovalError {
+    #[error("approval request timed out")]
+    Timeout,
+    #[error("approval request cancelled")]
+    Cancelled,
+    #[error("control socket disconnected mid-request")]
+    ControlDisconnected,
+}
+
+pub struct ApprovalBridge {
+    state: Arc<DispatchState>,
+}
+
+impl ApprovalBridge {
+    pub fn new(state: Arc<DispatchState>) -> Self {
+        Self { state }
+    }
+
+    /// Request operator approval. Blocks until either (a) the operator
+    /// responds, (b) the policy auto-resolves, or (c) `timeout` elapses.
+    pub async fn request(
+        &self,
+        task_id: String,
+        summary: String,
+        timeout: Duration,
+    ) -> Result<ApprovalResponse, ApprovalError> {
+        let request_id = format!("req-{}", Uuid::now_v7());
+        let (tx, rx) = oneshot::channel::<ApprovalResponse>();
+
+        // Does a TUI have the control writer?
+        let writer_present = self.state.control_writer.lock().await.is_some();
+
+        if writer_present {
+            self.state
+                .approval_bridge
+                .lock()
+                .await
+                .insert(request_id.clone(), tx);
+            // Push the event to the TUI.
+            if let Some(w) = self.state.control_writer.lock().await.as_ref() {
+                let ev = crate::control::protocol::ControlEvent::ApprovalRequest {
+                    request_id: request_id.clone(),
+                    task_id,
+                    summary,
+                };
+                // Best-effort send.
+                let _ = w.send(ev);
+            }
+        } else {
+            // No TUI attached: policy decides.
+            match self.state.approval_policy {
+                ApprovalPolicy::AutoApprove => {
+                    let _ = tx.send(ApprovalResponse {
+                        approved: true,
+                        comment: None,
+                        edited_summary: None,
+                    });
+                }
+                ApprovalPolicy::AutoReject => {
+                    let _ = tx.send(ApprovalResponse {
+                        approved: false,
+                        comment: Some("no operator available".into()),
+                        edited_summary: None,
+                    });
+                }
+                ApprovalPolicy::Block => {
+                    // Queue; drain when a TUI connects (see control/server.rs).
+                    self.state
+                        .approval_queue
+                        .lock()
+                        .await
+                        .push_back(QueuedApproval {
+                            request_id: request_id.clone(),
+                            task_id,
+                            summary,
+                            responder: tx,
+                        });
+                }
+            }
+        }
+
+        match tokio::time::timeout(timeout, rx).await {
+            Ok(Ok(resp)) => Ok(resp),
+            Ok(Err(_)) => Err(ApprovalError::Cancelled),
+            Err(_) => {
+                // Timeout: remove the pending entry so a late respond doesn't panic.
+                self.state.approval_bridge.lock().await.remove(&request_id);
+                Err(ApprovalError::Timeout)
+            }
+        }
+    }
+
+    /// Respond to a pending request from the control side.
+    pub async fn respond(
+        &self,
+        request_id: &str,
+        resp: ApprovalResponse,
+    ) -> Result<(), ApprovalError> {
+        let tx = self
+            .state
+            .approval_bridge
+            .lock()
+            .await
+            .remove(request_id)
+            .ok_or(ApprovalError::ControlDisconnected)?;
+        tx.send(resp).map_err(|_| ApprovalError::Cancelled)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dispatch::state::DispatchState;
+    use crate::manifest::resolve::ResolvedManifest;
+    use crate::manifest::schema::WorktreeCleanup;
+    use pitboss_core::process::{ProcessSpawner, TokioSpawner};
+    use pitboss_core::session::CancelToken;
+    use pitboss_core::store::{JsonFileStore, SessionStore};
+    use pitboss_core::worktree::{CleanupPolicy, WorktreeManager};
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+    use uuid::Uuid;
+
+    async fn mk_state(policy: ApprovalPolicy) -> Arc<DispatchState> {
+        let dir = TempDir::new().unwrap();
+        let manifest = ResolvedManifest {
+            max_parallel: 4,
+            halt_on_failure: false,
+            run_dir: dir.path().to_path_buf(),
+            worktree_cleanup: WorktreeCleanup::OnSuccess,
+            emit_event_stream: false,
+            tasks: vec![],
+            lead: None,
+            max_workers: Some(4),
+            budget_usd: Some(1.0),
+            lead_timeout_secs: None,
+            approval_policy: Some(policy),
+        };
+        let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
+        let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
+        let wt_mgr = Arc::new(WorktreeManager::new());
+        let run_id = Uuid::now_v7();
+        std::mem::forget(dir);
+        Arc::new(DispatchState::new(
+            run_id,
+            manifest,
+            store,
+            CancelToken::new(),
+            "lead".into(),
+            spawner,
+            PathBuf::from("/bin/true"),
+            wt_mgr,
+            CleanupPolicy::Never,
+            PathBuf::from("/tmp"),
+            policy,
+        ))
+    }
+
+    #[tokio::test]
+    async fn auto_approve_returns_immediately() {
+        let state = mk_state(ApprovalPolicy::AutoApprove).await;
+        let bridge = ApprovalBridge::new(state);
+        let resp = bridge
+            .request("lead".into(), "spawn 2".into(), Duration::from_secs(1))
+            .await
+            .unwrap();
+        assert!(resp.approved);
+    }
+
+    #[tokio::test]
+    async fn auto_reject_returns_immediately() {
+        let state = mk_state(ApprovalPolicy::AutoReject).await;
+        let bridge = ApprovalBridge::new(state);
+        let resp = bridge
+            .request("lead".into(), "spawn 2".into(), Duration::from_secs(1))
+            .await
+            .unwrap();
+        assert!(!resp.approved);
+        assert_eq!(resp.comment.as_deref(), Some("no operator available"));
+    }
+
+    #[tokio::test]
+    async fn block_policy_times_out_with_no_tui() {
+        let state = mk_state(ApprovalPolicy::Block).await;
+        let bridge = ApprovalBridge::new(state);
+        let err = bridge
+            .request("lead".into(), "spawn 2".into(), Duration::from_millis(50))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ApprovalError::Timeout));
+    }
+}

--- a/crates/pitboss-cli/src/mcp/approval.rs
+++ b/crates/pitboss-cli/src/mcp/approval.rs
@@ -41,6 +41,16 @@ impl ApprovalBridge {
         timeout: Duration,
     ) -> Result<ApprovalResponse, ApprovalError> {
         let request_id = format!("req-{}", Uuid::now_v7());
+        let _ = crate::dispatch::events::append_event(
+            &self.state.run_subdir,
+            &self.state.lead_id,
+            &crate::dispatch::events::TaskEvent::ApprovalRequest {
+                at: chrono::Utc::now(),
+                request_id: request_id.clone(),
+                summary_preview: summary.chars().take(80).collect(),
+            },
+        )
+        .await;
         let (tx, rx) = oneshot::channel::<ApprovalResponse>();
 
         // Does a TUI have the control writer?
@@ -119,6 +129,17 @@ impl ApprovalBridge {
             .await
             .remove(request_id)
             .ok_or(ApprovalError::ControlDisconnected)?;
+        let _ = crate::dispatch::events::append_event(
+            &self.state.run_subdir,
+            &self.state.lead_id,
+            &crate::dispatch::events::TaskEvent::ApprovalResponse {
+                at: chrono::Utc::now(),
+                request_id: request_id.to_string(),
+                approved: resp.approved,
+                edited: resp.edited_summary.is_some(),
+            },
+        )
+        .await;
         tx.send(resp).map_err(|_| ApprovalError::Cancelled)?;
         Ok(())
     }

--- a/crates/pitboss-cli/src/mcp/approval.rs
+++ b/crates/pitboss-cli/src/mcp/approval.rs
@@ -105,6 +105,14 @@ impl ApprovalBridge {
             }
         }
 
+        self.state
+            .worker_counters
+            .write()
+            .await
+            .entry(self.state.lead_id.clone())
+            .or_default()
+            .approvals_requested += 1;
+
         match tokio::time::timeout(timeout, rx).await {
             Ok(Ok(resp)) => Ok(resp),
             Ok(Err(_)) => Err(ApprovalError::Cancelled),
@@ -140,7 +148,17 @@ impl ApprovalBridge {
             },
         )
         .await;
+        let approved = resp.approved;
         tx.send(resp).map_err(|_| ApprovalError::Cancelled)?;
+        {
+            let mut guard = self.state.worker_counters.write().await;
+            let entry = guard.entry(self.state.lead_id.clone()).or_default();
+            if approved {
+                entry.approvals_approved += 1;
+            } else {
+                entry.approvals_rejected += 1;
+            }
+        }
         Ok(())
     }
 }

--- a/crates/pitboss-cli/src/mcp/mod.rs
+++ b/crates/pitboss-cli/src/mcp/mod.rs
@@ -2,6 +2,7 @@
 //! worker Hobbits via structured tool calls. Bound to a single hierarchical
 //! run; started before the lead, shut down after the lead + workers drain.
 
+pub mod approval;
 pub mod bridge;
 pub mod server;
 pub mod tools;

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -17,9 +17,9 @@ use rmcp::{tool, tool_handler, tool_router, ErrorData, ServerHandler};
 
 use crate::dispatch::state::DispatchState;
 use crate::mcp::tools::{
-    handle_cancel_worker, handle_list_workers, handle_pause_worker, handle_spawn_worker,
-    handle_wait_for_any, handle_wait_for_worker, handle_worker_status, SpawnWorkerArgs, TaskIdArgs,
-    WaitForAnyArgs, WaitForWorkerArgs,
+    handle_cancel_worker, handle_continue_worker, handle_list_workers, handle_pause_worker,
+    handle_spawn_worker, handle_wait_for_any, handle_wait_for_worker, handle_worker_status,
+    ContinueWorkerArgs, SpawnWorkerArgs, TaskIdArgs, WaitForAnyArgs, WaitForWorkerArgs,
 };
 
 /// Compute the socket path for a given run. Falls back to the run_dir if
@@ -139,6 +139,19 @@ impl PitbossHandler {
         Parameters(args): Parameters<TaskIdArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         match handle_pause_worker(&self.state, &args.task_id).await {
+            Ok(res) => to_structured_result(&res),
+            Err(e) => Err(ErrorData::invalid_request(e.to_string(), None)),
+        }
+    }
+
+    #[tool(
+        description = "Continue a previously-paused worker. Spawns claude --resume under the hood."
+    )]
+    async fn continue_worker(
+        &self,
+        Parameters(args): Parameters<ContinueWorkerArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        match handle_continue_worker(&self.state, args).await {
             Ok(res) => to_structured_result(&res),
             Err(e) => Err(ErrorData::invalid_request(e.to_string(), None)),
         }

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -293,7 +293,7 @@ mod tests {
 
     #[tokio::test]
     async fn server_starts_and_accepts_connection() {
-        use crate::dispatch::state::DispatchState;
+        use crate::dispatch::state::{ApprovalPolicy, DispatchState};
         use crate::manifest::resolve::ResolvedManifest;
         use crate::manifest::schema::WorktreeCleanup;
         use pitboss_core::process::{ProcessSpawner, TokioSpawner};
@@ -332,6 +332,7 @@ mod tests {
             wt_mgr,
             CleanupPolicy::Never,
             run_subdir,
+            ApprovalPolicy::Block,
         ));
 
         let sock = dir.path().join("test.sock");
@@ -349,7 +350,7 @@ mod tests {
 
     #[tokio::test]
     async fn server_drops_cleanly_even_with_active_connection() {
-        use crate::dispatch::state::DispatchState;
+        use crate::dispatch::state::{ApprovalPolicy, DispatchState};
         use crate::manifest::resolve::ResolvedManifest;
         use crate::manifest::schema::WorktreeCleanup;
         use pitboss_core::process::{ProcessSpawner, TokioSpawner};
@@ -389,6 +390,7 @@ mod tests {
             wt_mgr,
             CleanupPolicy::Never,
             run_subdir,
+            ApprovalPolicy::Block,
         ));
 
         let sock = dir.path().join("drop-test.sock");

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -17,9 +17,9 @@ use rmcp::{tool, tool_handler, tool_router, ErrorData, ServerHandler};
 
 use crate::dispatch::state::DispatchState;
 use crate::mcp::tools::{
-    handle_cancel_worker, handle_list_workers, handle_spawn_worker, handle_wait_for_any,
-    handle_wait_for_worker, handle_worker_status, SpawnWorkerArgs, TaskIdArgs, WaitForAnyArgs,
-    WaitForWorkerArgs,
+    handle_cancel_worker, handle_list_workers, handle_pause_worker, handle_spawn_worker,
+    handle_wait_for_any, handle_wait_for_worker, handle_worker_status, SpawnWorkerArgs, TaskIdArgs,
+    WaitForAnyArgs, WaitForWorkerArgs,
 };
 
 /// Compute the socket path for a given run. Falls back to the run_dir if
@@ -126,6 +126,19 @@ impl PitbossHandler {
         Parameters(args): Parameters<TaskIdArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         match handle_cancel_worker(&self.state, &args.task_id).await {
+            Ok(res) => to_structured_result(&res),
+            Err(e) => Err(ErrorData::invalid_request(e.to_string(), None)),
+        }
+    }
+
+    #[tool(
+        description = "Pause a running worker. Snapshots its session id so continue_worker can resume."
+    )]
+    async fn pause_worker(
+        &self,
+        Parameters(args): Parameters<TaskIdArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        match handle_pause_worker(&self.state, &args.task_id).await {
             Ok(res) => to_structured_result(&res),
             Err(e) => Err(ErrorData::invalid_request(e.to_string(), None)),
         }

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -341,6 +341,7 @@ mod tests {
             max_workers: Some(4),
             budget_usd: Some(5.0),
             lead_timeout_secs: None,
+            approval_policy: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();
@@ -399,6 +400,7 @@ mod tests {
             max_workers: Some(4),
             budget_usd: Some(5.0),
             lead_timeout_secs: None,
+            approval_policy: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -18,8 +18,9 @@ use rmcp::{tool, tool_handler, tool_router, ErrorData, ServerHandler};
 use crate::dispatch::state::DispatchState;
 use crate::mcp::tools::{
     handle_cancel_worker, handle_continue_worker, handle_list_workers, handle_pause_worker,
-    handle_spawn_worker, handle_wait_for_any, handle_wait_for_worker, handle_worker_status,
-    ContinueWorkerArgs, SpawnWorkerArgs, TaskIdArgs, WaitForAnyArgs, WaitForWorkerArgs,
+    handle_request_approval, handle_spawn_worker, handle_wait_for_any, handle_wait_for_worker,
+    handle_worker_status, ContinueWorkerArgs, RequestApprovalArgs, SpawnWorkerArgs, TaskIdArgs,
+    WaitForAnyArgs, WaitForWorkerArgs,
 };
 
 /// Compute the socket path for a given run. Falls back to the run_dir if
@@ -152,6 +153,19 @@ impl PitbossHandler {
         Parameters(args): Parameters<ContinueWorkerArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         match handle_continue_worker(&self.state, args).await {
+            Ok(res) => to_structured_result(&res),
+            Err(e) => Err(ErrorData::invalid_request(e.to_string(), None)),
+        }
+    }
+
+    #[tool(
+        description = "Request operator approval before proceeding. Blocks until operator responds or timeout."
+    )]
+    async fn request_approval(
+        &self,
+        Parameters(args): Parameters<RequestApprovalArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        match handle_request_approval(&self.state, args).await {
             Ok(res) => to_structured_result(&res),
             Err(e) => Err(ErrorData::invalid_request(e.to_string(), None)),
         }

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -768,6 +768,22 @@ pub async fn handle_pause_worker(
     }
 }
 
+pub async fn handle_continue_worker(
+    state: &Arc<DispatchState>,
+    args: ContinueWorkerArgs,
+) -> Result<CancelResult> {
+    let current = state.workers.read().await.get(&args.task_id).cloned();
+    match current {
+        Some(WorkerState::Paused { session_id, .. }) => {
+            let prompt = args.prompt.unwrap_or_else(|| "continue".into());
+            spawn_resume_worker(state, args.task_id, prompt, session_id).await?;
+            Ok(CancelResult { ok: true })
+        }
+        Some(_) => anyhow::bail!("worker not paused"),
+        None => anyhow::bail!("unknown task_id: {}", args.task_id),
+    }
+}
+
 pub async fn handle_wait_for_worker(
     state: &Arc<DispatchState>,
     task_id: &str,
@@ -1543,6 +1559,44 @@ mod tests {
         assert!(matches!(
             workers.get("w-1").unwrap(),
             WorkerState::Paused { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn handle_continue_worker_resumes_paused() {
+        let state = test_state().await;
+        state.workers.write().await.insert(
+            "w-1".into(),
+            WorkerState::Paused {
+                session_id: "sess".into(),
+                paused_at: chrono::Utc::now(),
+                prior_token_usage: Default::default(),
+            },
+        );
+        state
+            .worker_prompts
+            .write()
+            .await
+            .insert("w-1".into(), "hi".into());
+        state
+            .worker_models
+            .write()
+            .await
+            .insert("w-1".into(), "claude-haiku-4-5".into());
+        let res = handle_continue_worker(
+            &state,
+            ContinueWorkerArgs {
+                task_id: "w-1".into(),
+                prompt: Some("resume please".into()),
+            },
+        )
+        .await
+        .unwrap();
+        assert!(res.ok);
+        let workers = state.workers.read().await;
+        assert!(matches!(
+            workers.get("w-1").unwrap(),
+            WorkerState::Running { .. }
         ));
     }
 }

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -784,6 +784,29 @@ pub async fn handle_continue_worker(
     }
 }
 
+pub async fn handle_request_approval(
+    state: &Arc<DispatchState>,
+    args: RequestApprovalArgs,
+) -> Result<ApprovalToolResponse> {
+    let timeout = Duration::from_secs(
+        args.timeout_secs
+            .or(state.manifest.lead_timeout_secs)
+            .unwrap_or(3600),
+    );
+    let bridge = crate::mcp::approval::ApprovalBridge::new(Arc::clone(state));
+    match bridge
+        .request(state.lead_id.clone(), args.summary, timeout)
+        .await
+    {
+        Ok(resp) => Ok(ApprovalToolResponse {
+            approved: resp.approved,
+            comment: resp.comment,
+            edited_summary: resp.edited_summary,
+        }),
+        Err(e) => anyhow::bail!("approval failed: {e}"),
+    }
+}
+
 pub async fn handle_wait_for_worker(
     state: &Arc<DispatchState>,
     task_id: &str,
@@ -1600,5 +1623,79 @@ mod tests {
             workers.get("w-1").unwrap(),
             WorkerState::Running { .. }
         ));
+    }
+
+    #[tokio::test]
+    async fn handle_request_approval_auto_approves() {
+        use crate::dispatch::state::ApprovalPolicy;
+        // Rebuild a state with AutoApprove.
+        use crate::manifest::resolve::{ResolvedLead, ResolvedManifest};
+        use crate::manifest::schema::{Effort, WorktreeCleanup};
+        use pitboss_core::process::fake::{FakeScript, FakeSpawner};
+        use pitboss_core::process::ProcessSpawner;
+        use pitboss_core::session::CancelToken;
+        use pitboss_core::store::{JsonFileStore, SessionStore};
+        use pitboss_core::worktree::{CleanupPolicy, WorktreeManager};
+        use std::path::PathBuf;
+        use tempfile::TempDir;
+        use uuid::Uuid;
+
+        let dir = TempDir::new().unwrap();
+        let lead = ResolvedLead {
+            id: "lead".into(),
+            directory: PathBuf::from("/tmp"),
+            prompt: "p".into(),
+            branch: None,
+            model: "claude-haiku-4-5".into(),
+            effort: Effort::High,
+            tools: vec![],
+            timeout_secs: 60,
+            use_worktree: false,
+            env: Default::default(),
+            resume_session_id: None,
+        };
+        let manifest = ResolvedManifest {
+            max_parallel: 4,
+            halt_on_failure: false,
+            run_dir: dir.path().to_path_buf(),
+            worktree_cleanup: WorktreeCleanup::OnSuccess,
+            emit_event_stream: false,
+            tasks: vec![],
+            lead: Some(lead),
+            max_workers: Some(4),
+            budget_usd: Some(1.0),
+            lead_timeout_secs: None,
+            approval_policy: Some(ApprovalPolicy::AutoApprove),
+        };
+        let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
+        let script = FakeScript::new().hold_until_signal();
+        let spawner: Arc<dyn ProcessSpawner> = Arc::new(FakeSpawner::new(script));
+        let wt_mgr = Arc::new(WorktreeManager::new());
+        let run_id = Uuid::now_v7();
+        let run_subdir = dir.path().join(run_id.to_string());
+        std::mem::forget(dir);
+        let state = Arc::new(DispatchState::new(
+            run_id,
+            manifest,
+            store,
+            CancelToken::new(),
+            "lead".into(),
+            spawner,
+            PathBuf::from("claude"),
+            wt_mgr,
+            CleanupPolicy::Never,
+            run_subdir,
+            ApprovalPolicy::AutoApprove,
+        ));
+        let resp = handle_request_approval(
+            &state,
+            RequestApprovalArgs {
+                summary: "spawn 3".into(),
+                timeout_secs: Some(2),
+            },
+        )
+        .await
+        .unwrap();
+        assert!(resp.approved);
     }
 }

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -325,6 +325,11 @@ async fn run_worker(
                     claude_session_id: None,
                     final_message_preview: Some(format!("worktree error: {e}")),
                     parent_task_id: Some(lead_id),
+                    pause_count: 0,
+                    reprompt_count: 0,
+                    approvals_requested: 0,
+                    approvals_approved: 0,
+                    approvals_rejected: 0,
                 };
                 let _ = state.store.append_record(state.run_id, &rec).await;
                 state
@@ -415,6 +420,11 @@ async fn run_worker(
         claude_session_id: outcome.claude_session_id,
         final_message_preview: outcome.final_message_preview,
         parent_task_id: Some(lead_id),
+        pause_count: 0,
+        reprompt_count: 0,
+        approvals_requested: 0,
+        approvals_approved: 0,
+        approvals_rejected: 0,
     };
 
     // Persist record.
@@ -571,6 +581,11 @@ pub async fn spawn_resume_worker(
             claude_session_id: outcome.claude_session_id,
             final_message_preview: outcome.final_message_preview,
             parent_task_id: Some(lead_id_bg),
+            pause_count: 0,
+            reprompt_count: 0,
+            approvals_requested: 0,
+            approvals_approved: 0,
+            approvals_rejected: 0,
         };
         let _ = state_bg.store.append_record(state_bg.run_id, &rec).await;
         state_bg
@@ -1188,6 +1203,11 @@ mod tests {
                 claude_session_id: None,
                 final_message_preview: Some("ok".into()),
                 parent_task_id: Some("lead".into()),
+                pause_count: 0,
+                reprompt_count: 0,
+                approvals_requested: 0,
+                approvals_approved: 0,
+                approvals_rejected: 0,
             };
             let mut w = state_clone.workers.write().await;
             w.insert(task_id_clone.clone(), WorkerState::Done(rec));
@@ -1254,6 +1274,11 @@ mod tests {
                 claude_session_id: None,
                 final_message_preview: None,
                 parent_task_id: Some("lead".into()),
+                pause_count: 0,
+                reprompt_count: 0,
+                approvals_requested: 0,
+                approvals_approved: 0,
+                approvals_rejected: 0,
             };
             let mut w = state_clone.workers.write().await;
             w.insert("w-b".into(), WorkerState::Done(rec));

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -926,6 +926,7 @@ mod tests {
             max_workers: Some(4),
             budget_usd: Some(budget),
             lead_timeout_secs: None,
+            approval_policy: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();
@@ -1284,6 +1285,7 @@ mod tests {
             max_workers: Some(4),
             budget_usd: budget,
             lead_timeout_secs: None,
+            approval_policy: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -331,11 +331,35 @@ async fn run_worker(
         env: Default::default(),
     };
 
-    let outcome = SessionHandle::new(task_id.clone(), Arc::clone(&state.spawner), cmd)
-        .with_log_path(log_path.clone())
-        .with_stderr_log_path(stderr_path)
-        .run_to_completion(cancel, Duration::from_secs(timeout_secs))
-        .await;
+    let outcome = {
+        let (session_id_tx, mut session_id_rx) = tokio::sync::mpsc::channel::<String>(1);
+        let session_state = Arc::clone(&state);
+        let task_id_for_rx = task_id.clone();
+        let promote_task = tokio::spawn(async move {
+            if let Some(sid) = session_id_rx.recv().await {
+                let mut workers = session_state.workers.write().await;
+                if let Some(WorkerState::Running { started_at, .. }) =
+                    workers.get(&task_id_for_rx).cloned()
+                {
+                    workers.insert(
+                        task_id_for_rx,
+                        WorkerState::Running {
+                            started_at,
+                            session_id: Some(sid),
+                        },
+                    );
+                }
+            }
+        });
+        let outcome = SessionHandle::new(task_id.clone(), Arc::clone(&state.spawner), cmd)
+            .with_log_path(log_path.clone())
+            .with_stderr_log_path(stderr_path)
+            .with_session_id_tx(session_id_tx)
+            .run_to_completion(cancel, Duration::from_secs(timeout_secs))
+            .await;
+        promote_task.abort();
+        outcome
+    };
 
     let status = match outcome.final_state {
         pitboss_core::session::SessionState::Completed => TaskStatus::Success,
@@ -1263,5 +1287,36 @@ mod tests {
         assert!((initial_estimate_for("claude-haiku-4-5-20251001") - 0.10).abs() < 1e-9);
         assert!((initial_estimate_for("claude-sonnet-4-6-20251001") - 0.50).abs() < 1e-9);
         assert!((initial_estimate_for("claude-opus-4-7-20251001") - 2.00).abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn running_worker_state_gets_session_id_after_init() {
+        use std::time::Duration;
+
+        let state = completing_test_state().await;
+        let mut rx = state.done_tx.subscribe();
+        let args = SpawnWorkerArgs {
+            prompt: "analyze".into(),
+            directory: None,
+            branch: None,
+            tools: None,
+            timeout_secs: None,
+            model: None,
+        };
+        let spawn = handle_spawn_worker(&state, args).await.unwrap();
+        let _ = tokio::time::timeout(Duration::from_secs(10), rx.recv())
+            .await
+            .expect("broadcast arrives")
+            .expect("broadcast open");
+
+        // Post-completion, the worker is in Done state. The session_id is
+        // preserved on TaskRecord via SessionOutcome. Assert it.
+        let workers = state.workers.read().await;
+        match workers.get(&spawn.task_id).unwrap() {
+            WorkerState::Done(rec) => {
+                assert_eq!(rec.claude_session_id.as_deref(), Some("sess_ok"));
+            }
+            other => panic!("expected Done, got {other:?}"),
+        }
     }
 }

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -690,7 +690,7 @@ pub async fn handle_wait_for_any(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::dispatch::state::{DispatchState, WorkerState};
+    use crate::dispatch::state::{ApprovalPolicy, DispatchState, WorkerState};
     use std::sync::Arc;
 
     async fn test_state() -> Arc<DispatchState> {
@@ -763,6 +763,7 @@ mod tests {
             wt_mgr,
             CleanupPolicy::Never,
             run_subdir,
+            ApprovalPolicy::Block,
         ))
     }
 
@@ -1118,6 +1119,7 @@ mod tests {
             wt_mgr,
             CleanupPolicy::Never,
             run_subdir,
+            ApprovalPolicy::Block,
         ))
     }
 

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -407,6 +407,13 @@ async fn run_worker(
     }
 
     let worktree_path = if use_worktree { Some(cwd) } else { None };
+    let counters = state
+        .worker_counters
+        .read()
+        .await
+        .get(&task_id)
+        .cloned()
+        .unwrap_or_default();
     let rec = TaskRecord {
         task_id: task_id.clone(),
         status,
@@ -420,11 +427,11 @@ async fn run_worker(
         claude_session_id: outcome.claude_session_id,
         final_message_preview: outcome.final_message_preview,
         parent_task_id: Some(lead_id),
-        pause_count: 0,
-        reprompt_count: 0,
-        approvals_requested: 0,
-        approvals_approved: 0,
-        approvals_rejected: 0,
+        pause_count: counters.pause_count,
+        reprompt_count: counters.reprompt_count,
+        approvals_requested: counters.approvals_requested,
+        approvals_approved: counters.approvals_approved,
+        approvals_rejected: counters.approvals_rejected,
     };
 
     // Persist record.
@@ -568,6 +575,13 @@ pub async fn spawn_resume_worker(
             pitboss_core::session::SessionState::SpawnFailed { .. } => TaskStatus::SpawnFailed,
             _ => TaskStatus::Failed,
         };
+        let counters = state_bg
+            .worker_counters
+            .read()
+            .await
+            .get(&task_id_bg)
+            .cloned()
+            .unwrap_or_default();
         let rec = TaskRecord {
             task_id: task_id_bg.clone(),
             status,
@@ -581,11 +595,11 @@ pub async fn spawn_resume_worker(
             claude_session_id: outcome.claude_session_id,
             final_message_preview: outcome.final_message_preview,
             parent_task_id: Some(lead_id_bg),
-            pause_count: 0,
-            reprompt_count: 0,
-            approvals_requested: 0,
-            approvals_approved: 0,
-            approvals_rejected: 0,
+            pause_count: counters.pause_count,
+            reprompt_count: counters.reprompt_count,
+            approvals_requested: counters.approvals_requested,
+            approvals_approved: counters.approvals_approved,
+            approvals_rejected: counters.approvals_rejected,
         };
         let _ = state_bg.store.append_record(state_bg.run_id, &rec).await;
         state_bg

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -445,6 +445,120 @@ fn worker_spawn_args(prompt: &str, model: &str, tools: &[String]) -> Vec<String>
     args
 }
 
+/// Spawn a resume-subprocess for `task_id`, replacing the worker's current
+/// SessionHandle. Used by `pause_worker` → `continue_worker` and by
+/// `reprompt_worker`. Returns immediately after setting state to Running; the
+/// background task drives `run_to_completion` and the terminal TaskRecord.
+pub async fn spawn_resume_worker(
+    state: &Arc<DispatchState>,
+    task_id: String,
+    prompt: String,
+    session_id: String,
+) -> anyhow::Result<()> {
+    use chrono::Utc;
+    let model = state
+        .worker_models
+        .read()
+        .await
+        .get(&task_id)
+        .cloned()
+        .unwrap_or_else(|| "claude-haiku-4-5".to_string());
+    let tools: Vec<String> = state
+        .manifest
+        .lead
+        .as_ref()
+        .map(|l| l.tools.clone())
+        .unwrap_or_default();
+    let timeout_secs = state
+        .manifest
+        .lead
+        .as_ref()
+        .map(|l| l.timeout_secs)
+        .unwrap_or(3600);
+    let cwd = state
+        .manifest
+        .lead
+        .as_ref()
+        .map(|l| l.directory.clone())
+        .unwrap_or_else(|| std::path::PathBuf::from("/tmp"));
+    let worker_cancel = pitboss_core::session::CancelToken::new();
+    state
+        .worker_cancels
+        .write()
+        .await
+        .insert(task_id.clone(), worker_cancel.clone());
+    state.workers.write().await.insert(
+        task_id.clone(),
+        WorkerState::Running {
+            started_at: Utc::now(),
+            session_id: Some(session_id.clone()),
+        },
+    );
+    let state_bg = Arc::clone(state);
+    let task_id_bg = task_id.clone();
+    let lead_id_bg = state.lead_id.clone();
+
+    // Build spawn args with --resume.
+    let mut spawn_args_v = worker_spawn_args(&prompt, &model, &tools);
+    spawn_args_v.insert(0, "--resume".into());
+    spawn_args_v.insert(1, session_id);
+
+    let cmd = pitboss_core::process::SpawnCmd {
+        program: state.claude_binary.clone(),
+        args: spawn_args_v,
+        cwd,
+        env: Default::default(),
+    };
+    let task_dir = state.run_subdir.join("tasks").join(&task_id);
+    let _ = tokio::fs::create_dir_all(&task_dir).await;
+    let log_path = task_dir.join("stdout.log");
+    let stderr_path = task_dir.join("stderr.log");
+
+    tokio::spawn(async move {
+        use pitboss_core::store::{TaskRecord, TaskStatus};
+        let outcome = pitboss_core::session::SessionHandle::new(
+            task_id_bg.clone(),
+            Arc::clone(&state_bg.spawner),
+            cmd,
+        )
+        .with_log_path(log_path.clone())
+        .with_stderr_log_path(stderr_path)
+        .run_to_completion(worker_cancel, std::time::Duration::from_secs(timeout_secs))
+        .await;
+        let status = match outcome.final_state {
+            pitboss_core::session::SessionState::Completed => TaskStatus::Success,
+            pitboss_core::session::SessionState::Failed { .. } => TaskStatus::Failed,
+            pitboss_core::session::SessionState::TimedOut => TaskStatus::TimedOut,
+            pitboss_core::session::SessionState::Cancelled => TaskStatus::Cancelled,
+            pitboss_core::session::SessionState::SpawnFailed { .. } => TaskStatus::SpawnFailed,
+            _ => TaskStatus::Failed,
+        };
+        let rec = TaskRecord {
+            task_id: task_id_bg.clone(),
+            status,
+            exit_code: outcome.exit_code,
+            started_at: outcome.started_at,
+            ended_at: outcome.ended_at,
+            duration_ms: outcome.duration_ms(),
+            worktree_path: None,
+            log_path,
+            token_usage: outcome.token_usage,
+            claude_session_id: outcome.claude_session_id,
+            final_message_preview: outcome.final_message_preview,
+            parent_task_id: Some(lead_id_bg),
+        };
+        let _ = state_bg.store.append_record(state_bg.run_id, &rec).await;
+        state_bg
+            .workers
+            .write()
+            .await
+            .insert(task_id_bg.clone(), WorkerState::Done(rec));
+        let _ = state_bg.done_tx.send(task_id_bg);
+    });
+
+    Ok(())
+}
+
 async fn estimate_new_worker_cost(state: &Arc<DispatchState>, intended_model: &str) -> f64 {
     use pitboss_core::prices::cost_usd;
     let workers = state.workers.read().await;

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -733,6 +733,41 @@ pub async fn handle_cancel_worker(
     Ok(CancelResult { ok: true })
 }
 
+pub async fn handle_pause_worker(
+    state: &Arc<DispatchState>,
+    task_id: &str,
+) -> Result<CancelResult> {
+    let mut workers = state.workers.write().await;
+    let Some(entry) = workers.get(task_id).cloned() else {
+        anyhow::bail!("unknown task_id: {task_id}");
+    };
+    match entry {
+        WorkerState::Running {
+            session_id: Some(sid),
+            ..
+        } => {
+            let cancels = state.worker_cancels.read().await;
+            if let Some(tok) = cancels.get(task_id) {
+                tok.terminate();
+            }
+            workers.insert(
+                task_id.to_string(),
+                WorkerState::Paused {
+                    session_id: sid,
+                    paused_at: chrono::Utc::now(),
+                    prior_token_usage: Default::default(),
+                },
+            );
+            Ok(CancelResult { ok: true })
+        }
+        WorkerState::Running {
+            session_id: None, ..
+        } => anyhow::bail!("worker not yet initialized (no session_id)"),
+        WorkerState::Paused { .. } => anyhow::bail!("worker already paused"),
+        _ => anyhow::bail!("worker not in a pausable state"),
+    }
+}
+
 pub async fn handle_wait_for_worker(
     state: &Arc<DispatchState>,
     task_id: &str,
@@ -1483,5 +1518,31 @@ mod tests {
         let back: RequestApprovalArgs = serde_json::from_str(&s).unwrap();
         assert_eq!(back.summary, "spawn 3 workers");
         assert_eq!(back.timeout_secs, Some(60));
+    }
+
+    #[tokio::test]
+    async fn handle_pause_worker_pauses_running_worker() {
+        let state = test_state().await;
+        let worker_token = pitboss_core::session::CancelToken::new();
+        state
+            .worker_cancels
+            .write()
+            .await
+            .insert("w-1".into(), worker_token.clone());
+        state.workers.write().await.insert(
+            "w-1".into(),
+            WorkerState::Running {
+                started_at: chrono::Utc::now(),
+                session_id: Some("sess".into()),
+            },
+        );
+        let res = handle_pause_worker(&state, "w-1").await.unwrap();
+        assert!(res.ok);
+        assert!(worker_token.is_terminated());
+        let workers = state.workers.read().await;
+        assert!(matches!(
+            workers.get("w-1").unwrap(),
+            WorkerState::Paused { .. }
+        ));
     }
 }

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -320,6 +320,7 @@ async fn run_worker(
         task_id.clone(),
         WorkerState::Running {
             started_at: Utc::now(),
+            session_id: None,
         },
     );
 
@@ -467,8 +468,11 @@ pub async fn handle_list_workers(state: &Arc<DispatchState>) -> Vec<WorkerSummar
         .map(|(id, w)| {
             let (state_str, started_at) = match w {
                 WorkerState::Pending => ("Pending".to_string(), None),
-                WorkerState::Running { started_at } => {
+                WorkerState::Running { started_at, .. } => {
                     ("Running".to_string(), Some(started_at.to_rfc3339()))
+                }
+                WorkerState::Paused { paused_at, .. } => {
+                    ("Paused".to_string(), Some(paused_at.to_rfc3339()))
                 }
                 WorkerState::Done(rec) => (
                     match rec.status {
@@ -508,10 +512,20 @@ pub async fn handle_worker_status(
             pitboss_core::parser::TokenUsage::default(),
             None,
         ),
-        WorkerState::Running { started_at } => (
+        WorkerState::Running { started_at, .. } => (
             "Running".to_string(),
             Some(started_at.to_rfc3339()),
             pitboss_core::parser::TokenUsage::default(),
+            None,
+        ),
+        WorkerState::Paused {
+            paused_at,
+            prior_token_usage,
+            ..
+        } => (
+            "Paused".to_string(),
+            Some(paused_at.to_rfc3339()),
+            *prior_token_usage,
             None,
         ),
         WorkerState::Done(rec) => (
@@ -745,6 +759,7 @@ mod tests {
                 "w-2".into(),
                 WorkerState::Running {
                     started_at: chrono::Utc::now(),
+                    session_id: None,
                 },
             );
         }

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -90,6 +90,31 @@ pub struct WaitForAnyArgs {
     pub timeout_secs: Option<u64>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ContinueWorkerArgs {
+    pub task_id: String,
+    /// Optional prompt to send with --resume. Defaults to "continue".
+    #[serde(default)]
+    pub prompt: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct RequestApprovalArgs {
+    pub summary: String,
+    /// Optional per-request timeout override. Falls back to lead_timeout_secs.
+    #[serde(default)]
+    pub timeout_secs: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ApprovalToolResponse {
+    pub approved: bool,
+    #[serde(default)]
+    pub comment: Option<String>,
+    #[serde(default)]
+    pub edited_summary: Option<String>,
+}
+
 use std::sync::Arc;
 
 use anyhow::{bail, Result};
@@ -1434,5 +1459,29 @@ mod tests {
             }
             other => panic!("expected Done, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn continue_worker_args_roundtrip() {
+        let a = ContinueWorkerArgs {
+            task_id: "w".into(),
+            prompt: Some("next step".into()),
+        };
+        let s = serde_json::to_string(&a).unwrap();
+        let back: ContinueWorkerArgs = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.task_id, "w");
+        assert_eq!(back.prompt.as_deref(), Some("next step"));
+    }
+
+    #[test]
+    fn request_approval_args_roundtrip() {
+        let a = RequestApprovalArgs {
+            summary: "spawn 3 workers".into(),
+            timeout_secs: Some(60),
+        };
+        let s = serde_json::to_string(&a).unwrap();
+        let back: RequestApprovalArgs = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.summary, "spawn 3 workers");
+        assert_eq!(back.timeout_secs, Some(60));
     }
 }

--- a/crates/pitboss-cli/src/tui_table.rs
+++ b/crates/pitboss-cli/src/tui_table.rs
@@ -170,6 +170,11 @@ mod tests {
             claude_session_id: None,
             final_message_preview: None,
             parent_task_id: None,
+            pause_count: 0,
+            reprompt_count: 0,
+            approvals_requested: 0,
+            approvals_approved: 0,
+            approvals_rejected: 0,
         }
     }
 

--- a/crates/pitboss-cli/tests/control_flows.rs
+++ b/crates/pitboss-cli/tests/control_flows.rs
@@ -206,3 +206,92 @@ async fn block_policy_queue_drains_on_tui_connect() {
         .unwrap();
     assert!(resp.approved);
 }
+
+#[tokio::test]
+async fn auto_approve_policy_responds_without_tui() {
+    use std::time::Duration;
+    let dir = TempDir::new().unwrap();
+    let run_id = uuid::Uuid::now_v7();
+    let manifest = ResolvedManifest {
+        max_parallel: 4,
+        halt_on_failure: false,
+        run_dir: dir.path().to_path_buf(),
+        worktree_cleanup: WorktreeCleanup::OnSuccess,
+        emit_event_stream: false,
+        tasks: vec![],
+        lead: None,
+        max_workers: Some(4),
+        budget_usd: Some(1.0),
+        lead_timeout_secs: None,
+        approval_policy: Some(ApprovalPolicy::AutoApprove),
+    };
+    let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
+    let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
+    let wt_mgr = Arc::new(WorktreeManager::new());
+    let run_subdir = dir.path().join(run_id.to_string());
+    tokio::fs::create_dir_all(&run_subdir).await.unwrap();
+    let state = Arc::new(DispatchState::new(
+        run_id,
+        manifest,
+        store,
+        CancelToken::new(),
+        "lead".into(),
+        spawner,
+        PathBuf::from("/bin/true"),
+        wt_mgr,
+        CleanupPolicy::Never,
+        run_subdir,
+        ApprovalPolicy::AutoApprove,
+    ));
+    let bridge = ApprovalBridge::new(state);
+    let resp = bridge
+        .request("lead".into(), "spawn".into(), Duration::from_millis(200))
+        .await
+        .unwrap();
+    assert!(resp.approved);
+}
+
+#[tokio::test]
+async fn auto_reject_policy_responds_without_tui() {
+    use std::time::Duration;
+    let dir = TempDir::new().unwrap();
+    let run_id = uuid::Uuid::now_v7();
+    let manifest = ResolvedManifest {
+        max_parallel: 4,
+        halt_on_failure: false,
+        run_dir: dir.path().to_path_buf(),
+        worktree_cleanup: WorktreeCleanup::OnSuccess,
+        emit_event_stream: false,
+        tasks: vec![],
+        lead: None,
+        max_workers: Some(4),
+        budget_usd: Some(1.0),
+        lead_timeout_secs: None,
+        approval_policy: Some(ApprovalPolicy::AutoReject),
+    };
+    let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
+    let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
+    let wt_mgr = Arc::new(WorktreeManager::new());
+    let run_subdir = dir.path().join(run_id.to_string());
+    tokio::fs::create_dir_all(&run_subdir).await.unwrap();
+    let state = Arc::new(DispatchState::new(
+        run_id,
+        manifest,
+        store,
+        CancelToken::new(),
+        "lead".into(),
+        spawner,
+        PathBuf::from("/bin/true"),
+        wt_mgr,
+        CleanupPolicy::Never,
+        run_subdir,
+        ApprovalPolicy::AutoReject,
+    ));
+    let bridge = ApprovalBridge::new(state);
+    let resp = bridge
+        .request("lead".into(), "spawn".into(), Duration::from_millis(200))
+        .await
+        .unwrap();
+    assert!(!resp.approved);
+    assert_eq!(resp.comment.as_deref(), Some("no operator available"));
+}

--- a/crates/pitboss-cli/tests/control_flows.rs
+++ b/crates/pitboss-cli/tests/control_flows.rs
@@ -107,3 +107,102 @@ async fn pause_op_writes_events_jsonl() {
     let contents = tokio::fs::read_to_string(&events_path).await.unwrap();
     assert!(contents.contains("\"kind\":\"pause\""));
 }
+
+use pitboss_cli::mcp::approval::ApprovalBridge;
+
+#[tokio::test]
+async fn block_policy_queue_drains_on_tui_connect() {
+    use std::time::Duration;
+
+    let dir = TempDir::new().unwrap();
+    let run_id = uuid::Uuid::now_v7();
+    let manifest = ResolvedManifest {
+        max_parallel: 4,
+        halt_on_failure: false,
+        run_dir: dir.path().to_path_buf(),
+        worktree_cleanup: WorktreeCleanup::OnSuccess,
+        emit_event_stream: false,
+        tasks: vec![],
+        lead: None,
+        max_workers: Some(4),
+        budget_usd: Some(1.0),
+        lead_timeout_secs: None,
+        approval_policy: Some(ApprovalPolicy::Block),
+    };
+    let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
+    let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
+    let wt_mgr = Arc::new(WorktreeManager::new());
+    let run_subdir = dir.path().join(run_id.to_string());
+    tokio::fs::create_dir_all(&run_subdir).await.unwrap();
+    let state = Arc::new(DispatchState::new(
+        run_id,
+        manifest,
+        store,
+        CancelToken::new(),
+        "lead".into(),
+        spawner,
+        PathBuf::from("/bin/true"),
+        wt_mgr,
+        CleanupPolicy::Never,
+        run_subdir.clone(),
+        ApprovalPolicy::Block,
+    ));
+
+    // Kick off a blocking request on a background task (no TUI attached yet).
+    let bridge = ApprovalBridge::new(state.clone());
+    let req_handle = tokio::spawn(async move {
+        bridge
+            .request("lead".into(), "spawn 3".into(), Duration::from_secs(5))
+            .await
+    });
+
+    // Give the request a moment to queue.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert_eq!(state.approval_queue.lock().await.len(), 1);
+
+    // Connect a TUI. The server drains the queue on connect.
+    let sock = dir.path().join("block-drain.sock");
+    let _h = pitboss_cli::control::server::start_control_server(
+        sock.clone(),
+        "0.4.0".into(),
+        run_id.to_string(),
+        "hierarchical".into(),
+        state.clone(),
+    )
+    .await
+    .unwrap();
+
+    let mut client = fake_control_client::FakeControlClient::connect(&sock, "0.4.0")
+        .await
+        .unwrap();
+
+    // Expect an ApprovalRequest event pushed from the drain.
+    let ev = client
+        .recv_timeout(Duration::from_secs(2))
+        .await
+        .unwrap()
+        .expect("drain pushes approval_request");
+    let request_id = match ev {
+        ControlEvent::ApprovalRequest { request_id, .. } => request_id,
+        other => panic!("expected ApprovalRequest, got {other:?}"),
+    };
+
+    // Respond.
+    client
+        .send(&ControlOp::Approve {
+            request_id,
+            approved: true,
+            comment: None,
+            edited_summary: None,
+        })
+        .await
+        .unwrap();
+
+    // Await the original request's resolution.
+    let resp = tokio::time::timeout(Duration::from_secs(3), req_handle)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert!(resp.approved);
+}

--- a/crates/pitboss-cli/tests/control_flows.rs
+++ b/crates/pitboss-cli/tests/control_flows.rs
@@ -1,0 +1,17 @@
+//! Dispatcher-side control-socket integration tests. Uses
+//! fake-control-client to drive the flow end-to-end.
+
+use pitboss_cli::control::control_socket_path;
+use tempfile::TempDir;
+use uuid::Uuid;
+
+#[test]
+fn control_socket_path_uses_xdg_or_run_dir() {
+    // Ensure the helper at least produces a valid path (regression guard for
+    // Phase 1 wiring).
+    std::env::remove_var("XDG_RUNTIME_DIR");
+    let dir = TempDir::new().unwrap();
+    let p = control_socket_path(Uuid::now_v7(), dir.path());
+    assert!(p.starts_with(dir.path()));
+    assert_eq!(p.file_name().unwrap(), "control.sock");
+}

--- a/crates/pitboss-cli/tests/control_flows.rs
+++ b/crates/pitboss-cli/tests/control_flows.rs
@@ -1,7 +1,19 @@
 //! Dispatcher-side control-socket integration tests. Uses
 //! fake-control-client to drive the flow end-to-end.
 
+use fake_control_client::FakeControlClient;
 use pitboss_cli::control::control_socket_path;
+use pitboss_cli::control::protocol::{ControlEvent, ControlOp};
+use pitboss_cli::control::server::start_control_server;
+use pitboss_cli::dispatch::state::{ApprovalPolicy, DispatchState, WorkerState};
+use pitboss_cli::manifest::resolve::ResolvedManifest;
+use pitboss_cli::manifest::schema::WorktreeCleanup;
+use pitboss_core::process::{ProcessSpawner, TokioSpawner};
+use pitboss_core::session::CancelToken;
+use pitboss_core::store::{JsonFileStore, SessionStore};
+use pitboss_core::worktree::{CleanupPolicy, WorktreeManager};
+use std::path::PathBuf;
+use std::sync::Arc;
 use tempfile::TempDir;
 use uuid::Uuid;
 
@@ -14,4 +26,84 @@ fn control_socket_path_uses_xdg_or_run_dir() {
     let p = control_socket_path(Uuid::now_v7(), dir.path());
     assert!(p.starts_with(dir.path()));
     assert_eq!(p.file_name().unwrap(), "control.sock");
+}
+
+#[tokio::test]
+async fn pause_op_writes_events_jsonl() {
+    let dir = TempDir::new().unwrap();
+    let run_id = uuid::Uuid::now_v7();
+    let run_subdir = dir.path().join(run_id.to_string());
+    tokio::fs::create_dir_all(&run_subdir).await.unwrap();
+    let manifest = ResolvedManifest {
+        max_parallel: 4,
+        halt_on_failure: false,
+        run_dir: dir.path().to_path_buf(),
+        worktree_cleanup: WorktreeCleanup::OnSuccess,
+        emit_event_stream: false,
+        tasks: vec![],
+        lead: None,
+        max_workers: Some(4),
+        budget_usd: Some(1.0),
+        lead_timeout_secs: None,
+        approval_policy: Some(ApprovalPolicy::Block),
+    };
+    let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
+    let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
+    let wt_mgr = Arc::new(WorktreeManager::new());
+    let state = Arc::new(DispatchState::new(
+        run_id,
+        manifest,
+        store,
+        CancelToken::new(),
+        "".into(),
+        spawner,
+        PathBuf::from("/bin/true"),
+        wt_mgr,
+        CleanupPolicy::Never,
+        run_subdir.clone(),
+        ApprovalPolicy::Block,
+    ));
+    let worker_token = CancelToken::new();
+    state
+        .worker_cancels
+        .write()
+        .await
+        .insert("w-1".into(), worker_token);
+    state.workers.write().await.insert(
+        "w-1".into(),
+        WorkerState::Running {
+            started_at: chrono::Utc::now(),
+            session_id: Some("sess".into()),
+        },
+    );
+
+    let sock = dir.path().join("events-pause.sock");
+    let _h = start_control_server(
+        sock.clone(),
+        "0.4.0".into(),
+        run_id.to_string(),
+        "flat".into(),
+        state,
+    )
+    .await
+    .unwrap();
+
+    let mut client = FakeControlClient::connect(&sock, "0.4.0").await.unwrap();
+    client
+        .send(&ControlOp::PauseWorker {
+            task_id: "w-1".into(),
+        })
+        .await
+        .unwrap();
+    let ev = client
+        .recv_timeout(std::time::Duration::from_secs(1))
+        .await
+        .unwrap()
+        .expect("reply");
+    assert!(matches!(ev, ControlEvent::OpAcked { .. }));
+
+    // Assert events.jsonl was written.
+    let events_path = run_subdir.join("tasks").join("w-1").join("events.jsonl");
+    let contents = tokio::fs::read_to_string(&events_path).await.unwrap();
+    assert!(contents.contains("\"kind\":\"pause\""));
 }

--- a/crates/pitboss-cli/tests/hierarchical_flows.rs
+++ b/crates/pitboss-cli/tests/hierarchical_flows.rs
@@ -47,6 +47,7 @@ fn mk_state() -> (TempDir, Arc<DispatchState>) {
         max_workers: Some(4),
         budget_usd: Some(5.0),
         lead_timeout_secs: None,
+        approval_policy: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/tests/hierarchical_flows.rs
+++ b/crates/pitboss-cli/tests/hierarchical_flows.rs
@@ -8,7 +8,7 @@ use serde_json::json;
 use tempfile::TempDir;
 
 use fake_mcp_client::FakeMcpClient;
-use pitboss_cli::dispatch::state::DispatchState;
+use pitboss_cli::dispatch::state::{ApprovalPolicy, DispatchState};
 use pitboss_cli::manifest::resolve::{ResolvedLead, ResolvedManifest};
 use pitboss_cli::manifest::schema::{Effort, WorktreeCleanup};
 use pitboss_cli::mcp::{socket_path_for_run, McpServer};
@@ -67,6 +67,7 @@ fn mk_state() -> (TempDir, Arc<DispatchState>) {
         wt_mgr,
         CleanupPolicy::Never,
         run_subdir,
+        ApprovalPolicy::Block,
     ));
     (dir, state)
 }

--- a/crates/pitboss-core/src/session/handle.rs
+++ b/crates/pitboss-core/src/session/handle.rs
@@ -19,6 +19,7 @@ pub struct SessionHandle {
     cmd: SpawnCmd,
     log_path: Option<PathBuf>,
     stderr_log_path: Option<PathBuf>,
+    session_id_tx: Option<tokio::sync::mpsc::Sender<String>>,
 }
 
 impl SessionHandle {
@@ -33,6 +34,7 @@ impl SessionHandle {
             cmd,
             log_path: None,
             stderr_log_path: None,
+            session_id_tx: None,
         }
     }
 
@@ -45,6 +47,12 @@ impl SessionHandle {
     #[must_use]
     pub fn with_stderr_log_path(mut self, p: PathBuf) -> Self {
         self.stderr_log_path = Some(p);
+        self
+    }
+
+    #[must_use]
+    pub fn with_session_id_tx(mut self, tx: tokio::sync::mpsc::Sender<String>) -> Self {
+        self.session_id_tx = Some(tx);
         self
     }
 
@@ -93,7 +101,12 @@ impl SessionHandle {
         let accum = Arc::new(Mutex::new(StreamAccum::default()));
         let accum_stream = accum.clone();
 
-        let stream_task = tokio::spawn(stream_loop(reader, log_writer, accum_stream));
+        let stream_task = tokio::spawn(stream_loop(
+            reader,
+            log_writer,
+            accum_stream,
+            self.session_id_tx.clone(),
+        ));
 
         // Drain stderr into a separate log file if requested. Many subprocess errors
         // (including claude's "--verbose required" rejection) only surface on stderr.
@@ -209,6 +222,7 @@ async fn stream_loop(
     mut reader: tokio::io::Lines<BufReader<Pin<Box<dyn tokio::io::AsyncRead + Send + Unpin>>>>,
     mut log: Option<tokio::fs::File>,
     accum: Arc<Mutex<StreamAccum>>,
+    session_id_tx: Option<tokio::sync::mpsc::Sender<String>>,
 ) {
     loop {
         match reader.next_line().await {
@@ -239,6 +253,10 @@ async fn stream_loop(
                         ..
                     }) => {
                         let mut a = accum.lock().await;
+                        if let Some(tx) = &session_id_tx {
+                            // Best-effort: if receiver is closed or full, drop the send.
+                            let _ = tx.try_send(sid.clone());
+                        }
                         a.session_id = Some(sid);
                         a.usage.add(&u);
                         a.saw_result = true;
@@ -318,5 +336,40 @@ mod preview_tests {
         let out = truncate_preview(&s);
         assert!(!out.ends_with('…'));
         assert_eq!(out.chars().count(), 200);
+    }
+}
+
+#[cfg(test)]
+mod session_id_tests {
+    use super::*;
+    use crate::process::fake::{FakeScript, FakeSpawner};
+    use crate::process::ProcessSpawner;
+    use crate::session::CancelToken;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn session_id_fires_on_init_event() {
+        let script = FakeScript::new()
+            .stdout_line(r#"{"type":"system","subtype":"init","session_id":"sess-xyz"}"#)
+            .stdout_line(r#"{"type":"result","session_id":"sess-xyz","usage":{"input_tokens":1,"output_tokens":1}}"#)
+            .exit_code(0);
+        let spawner: Arc<dyn ProcessSpawner> = Arc::new(FakeSpawner::new(script));
+        let cmd = crate::process::SpawnCmd {
+            program: std::path::PathBuf::from("fake-claude"),
+            args: vec![],
+            cwd: std::path::PathBuf::from("/tmp"),
+            env: std::collections::HashMap::new(),
+        };
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<String>(1);
+        let handle = SessionHandle::new("t", spawner, cmd).with_session_id_tx(tx);
+        let _outcome = handle
+            .run_to_completion(CancelToken::new(), Duration::from_secs(5))
+            .await;
+        let got = tokio::time::timeout(Duration::from_millis(500), rx.recv())
+            .await
+            .expect("channel fires before deadline")
+            .expect("sender not dropped");
+        assert_eq!(got, "sess-xyz");
     }
 }

--- a/crates/pitboss-core/src/store/mod.rs
+++ b/crates/pitboss-core/src/store/mod.rs
@@ -47,6 +47,11 @@ mod integration_tests {
             claude_session_id: None,
             final_message_preview: None,
             parent_task_id: None,
+            pause_count: 0,
+            reprompt_count: 0,
+            approvals_requested: 0,
+            approvals_approved: 0,
+            approvals_rejected: 0,
         }
     }
 

--- a/crates/pitboss-core/src/store/record.rs
+++ b/crates/pitboss-core/src/store/record.rs
@@ -33,6 +33,16 @@ pub struct TaskRecord {
     /// tasks and the lead itself.
     #[serde(default)]
     pub parent_task_id: Option<String>,
+    #[serde(default)]
+    pub pause_count: u32,
+    #[serde(default)]
+    pub reprompt_count: u32,
+    #[serde(default)]
+    pub approvals_requested: u32,
+    #[serde(default)]
+    pub approvals_approved: u32,
+    #[serde(default)]
+    pub approvals_rejected: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -85,6 +95,11 @@ mod tests {
             claude_session_id: Some("sess".into()),
             final_message_preview: Some("ok".into()),
             parent_task_id: None,
+            pause_count: 0,
+            reprompt_count: 0,
+            approvals_requested: 0,
+            approvals_approved: 0,
+            approvals_rejected: 0,
         };
         let json = serde_json::to_string(&rec).unwrap();
         let back: TaskRecord = serde_json::from_str(&json).unwrap();
@@ -107,6 +122,11 @@ mod tests {
             claude_session_id: None,
             final_message_preview: None,
             parent_task_id: Some("lead-abc".into()),
+            pause_count: 0,
+            reprompt_count: 0,
+            approvals_requested: 0,
+            approvals_approved: 0,
+            approvals_rejected: 0,
         };
         let json = serde_json::to_string(&rec).unwrap();
         assert!(json.contains("parent_task_id"));
@@ -131,5 +151,55 @@ mod tests {
         }"#;
         let rec: TaskRecord = serde_json::from_str(old_json).unwrap();
         assert!(rec.parent_task_id.is_none());
+    }
+
+    #[test]
+    fn task_record_new_counter_fields_default_to_zero() {
+        let old_json = r#"{
+            "task_id": "t1",
+            "status": "Success",
+            "exit_code": 0,
+            "started_at": "2026-04-17T00:00:00Z",
+            "ended_at":   "2026-04-17T00:00:30Z",
+            "duration_ms": 30000,
+            "worktree_path": null,
+            "log_path": "/dev/null",
+            "token_usage": {"input":0,"output":0,"cache_read":0,"cache_creation":0},
+            "claude_session_id": null,
+            "final_message_preview": null
+        }"#;
+        let rec: TaskRecord = serde_json::from_str(old_json).unwrap();
+        assert_eq!(rec.pause_count, 0);
+        assert_eq!(rec.reprompt_count, 0);
+        assert_eq!(rec.approvals_requested, 0);
+        assert_eq!(rec.approvals_approved, 0);
+        assert_eq!(rec.approvals_rejected, 0);
+    }
+
+    #[test]
+    fn task_record_roundtrips_counters() {
+        let rec = TaskRecord {
+            task_id: "w".into(),
+            status: TaskStatus::Success,
+            exit_code: Some(0),
+            started_at: Utc.with_ymd_and_hms(2026, 4, 17, 0, 0, 0).unwrap(),
+            ended_at: Utc.with_ymd_and_hms(2026, 4, 17, 0, 0, 30).unwrap(),
+            duration_ms: 30_000,
+            worktree_path: None,
+            log_path: PathBuf::from("/tmp/log"),
+            token_usage: TokenUsage::default(),
+            claude_session_id: None,
+            final_message_preview: None,
+            parent_task_id: None,
+            pause_count: 2,
+            reprompt_count: 1,
+            approvals_requested: 3,
+            approvals_approved: 2,
+            approvals_rejected: 1,
+        };
+        let s = serde_json::to_string(&rec).unwrap();
+        let back: TaskRecord = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.pause_count, 2);
+        assert_eq!(back.approvals_rejected, 1);
     }
 }

--- a/crates/pitboss-core/src/store/sqlite.rs
+++ b/crates/pitboss-core/src/store/sqlite.rs
@@ -309,6 +309,11 @@ impl TaskRow {
             claude_session_id: self.claude_session_id,
             final_message_preview: self.final_message_preview,
             parent_task_id: self.parent_task_id,
+            pause_count: 0,
+            reprompt_count: 0,
+            approvals_requested: 0,
+            approvals_approved: 0,
+            approvals_rejected: 0,
         })
     }
 }
@@ -583,6 +588,11 @@ mod sqlite_tests {
             claude_session_id: None,
             final_message_preview: None,
             parent_task_id: None,
+            pause_count: 0,
+            reprompt_count: 0,
+            approvals_requested: 0,
+            approvals_approved: 0,
+            approvals_rejected: 0,
         }
     }
 

--- a/crates/pitboss-core/src/store/sqlite.rs
+++ b/crates/pitboss-core/src/store/sqlite.rs
@@ -59,6 +59,7 @@ impl SqliteStore {
         migrate_rename_shire_version_to_pitboss_version(&conn)?;
         init_schema(&conn)?;
         migrate_parent_task_id(&conn)?;
+        migrate_v04_event_counters(&conn)?;
         Ok(Self {
             inner: Arc::new(Mutex::new(conn)),
         })
@@ -88,6 +89,35 @@ fn migrate_parent_task_id(conn: &rusqlite::Connection) -> Result<(), StoreError>
             [],
         )
         .map_err(|e| StoreError::Incomplete(format!("migrate alter: {e}")))?;
+    }
+    Ok(())
+}
+
+/// Idempotent migration: add v0.4 counter columns to `task_records` if missing.
+fn migrate_v04_event_counters(conn: &rusqlite::Connection) -> Result<(), StoreError> {
+    for col in [
+        "pause_count",
+        "reprompt_count",
+        "approvals_requested",
+        "approvals_approved",
+        "approvals_rejected",
+    ] {
+        let has = {
+            let mut stmt = conn
+                .prepare(&format!(
+                    "SELECT 1 FROM pragma_table_info('task_records') WHERE name = '{col}'"
+                ))
+                .map_err(|e| StoreError::Incomplete(format!("migrate v04 prepare: {e}")))?;
+            stmt.exists([])
+                .map_err(|e| StoreError::Incomplete(format!("migrate v04 exists: {e}")))?
+        };
+        if !has {
+            conn.execute(
+                &format!("ALTER TABLE task_records ADD COLUMN {col} INTEGER NOT NULL DEFAULT 0"),
+                [],
+            )
+            .map_err(|e| StoreError::Incomplete(format!("migrate v04 alter {col}: {e}")))?;
+        }
     }
     Ok(())
 }
@@ -170,6 +200,11 @@ fn init_schema(conn: &rusqlite::Connection) -> Result<(), StoreError> {
             claude_session_id     TEXT,
             final_message_preview TEXT,
             parent_task_id        TEXT NULL,
+            pause_count           INTEGER NOT NULL DEFAULT 0,
+            reprompt_count        INTEGER NOT NULL DEFAULT 0,
+            approvals_requested   INTEGER NOT NULL DEFAULT 0,
+            approvals_approved    INTEGER NOT NULL DEFAULT 0,
+            approvals_rejected    INTEGER NOT NULL DEFAULT 0,
             PRIMARY KEY (run_id, task_id)
         );
         ",
@@ -263,6 +298,11 @@ struct TaskRow {
     claude_session_id: Option<String>,
     final_message_preview: Option<String>,
     parent_task_id: Option<String>,
+    pause_count: i64,
+    reprompt_count: i64,
+    approvals_requested: i64,
+    approvals_approved: i64,
+    approvals_rejected: i64,
 }
 
 impl TaskRow {
@@ -283,6 +323,11 @@ impl TaskRow {
             claude_session_id: row.get("claude_session_id")?,
             final_message_preview: row.get("final_message_preview")?,
             parent_task_id: row.get("parent_task_id")?,
+            pause_count: row.get("pause_count").unwrap_or(0),
+            reprompt_count: row.get("reprompt_count").unwrap_or(0),
+            approvals_requested: row.get("approvals_requested").unwrap_or(0),
+            approvals_approved: row.get("approvals_approved").unwrap_or(0),
+            approvals_rejected: row.get("approvals_rejected").unwrap_or(0),
         })
     }
 
@@ -309,11 +354,11 @@ impl TaskRow {
             claude_session_id: self.claude_session_id,
             final_message_preview: self.final_message_preview,
             parent_task_id: self.parent_task_id,
-            pause_count: 0,
-            reprompt_count: 0,
-            approvals_requested: 0,
-            approvals_approved: 0,
-            approvals_rejected: 0,
+            pause_count: self.pause_count.try_into().unwrap_or(0),
+            reprompt_count: self.reprompt_count.try_into().unwrap_or(0),
+            approvals_requested: self.approvals_requested.try_into().unwrap_or(0),
+            approvals_approved: self.approvals_approved.try_into().unwrap_or(0),
+            approvals_rejected: self.approvals_rejected.try_into().unwrap_or(0),
         })
     }
 }
@@ -349,7 +394,9 @@ fn fetch_task_records(
                   started_at, ended_at, duration_ms, \
                   worktree_path, log_path, \
                   token_input, token_output, token_cache_read, token_cache_creation, \
-                  claude_session_id, final_message_preview, parent_task_id \
+                  claude_session_id, final_message_preview, parent_task_id, \
+                  pause_count, reprompt_count, approvals_requested, \
+                  approvals_approved, approvals_rejected \
              FROM task_records WHERE run_id = ?1 ORDER BY rowid",
         )
         .map_err(|e| StoreError::Incomplete(format!("task query prepare: {e}")))?;
@@ -465,8 +512,11 @@ impl SessionStore for SqliteStore {
                       started_at, ended_at, duration_ms, \
                       worktree_path, log_path, \
                       token_input, token_output, token_cache_read, token_cache_creation, \
-                      claude_session_id, final_message_preview, parent_task_id) \
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+                      claude_session_id, final_message_preview, parent_task_id, \
+                      pause_count, reprompt_count, approvals_requested, \
+                      approvals_approved, approvals_rejected) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, \
+                             ?17, ?18, ?19, ?20, ?21)",
                     rusqlite::params![
                         run_id_str,
                         record.task_id,
@@ -487,6 +537,11 @@ impl SessionStore for SqliteStore {
                         record.claude_session_id,
                         record.final_message_preview,
                         record.parent_task_id.as_deref(),
+                        i64::from(record.pause_count),
+                        i64::from(record.reprompt_count),
+                        i64::from(record.approvals_requested),
+                        i64::from(record.approvals_approved),
+                        i64::from(record.approvals_rejected),
                     ],
                 )
                 .map_err(|e| StoreError::Incomplete(format!("append_record insert: {e}")))?;
@@ -842,5 +897,41 @@ mod sqlite_tests {
 
         // Re-opening is idempotent — must not attempt another rename.
         let _store2 = SqliteStore::new(db_path).unwrap();
+    }
+
+    #[tokio::test]
+    async fn sqlite_migrates_old_db_missing_counter_columns() {
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("v03.db");
+        // Create a v0.3.3-shape DB by hand (no counter columns).
+        {
+            let conn = rusqlite::Connection::open(&db_path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE runs (run_id TEXT PRIMARY KEY, manifest_path TEXT NOT NULL, \
+                 pitboss_version TEXT NOT NULL, claude_version TEXT, started_at TEXT NOT NULL, \
+                 ended_at TEXT, tasks_total INTEGER, tasks_failed INTEGER, was_interrupted INTEGER DEFAULT 0); \
+                 CREATE TABLE task_records (run_id TEXT NOT NULL, task_id TEXT NOT NULL, \
+                 status TEXT NOT NULL, exit_code INTEGER, started_at TEXT, ended_at TEXT, \
+                 duration_ms INTEGER, worktree_path TEXT, log_path TEXT, token_input INTEGER, \
+                 token_output INTEGER, token_cache_read INTEGER, token_cache_creation INTEGER, \
+                 claude_session_id TEXT, final_message_preview TEXT, parent_task_id TEXT NULL, \
+                 PRIMARY KEY (run_id, task_id));",
+            )
+            .unwrap();
+        }
+        // Open with the new store → migration should add all 5 counter columns.
+        let store = SqliteStore::new(db_path.clone()).unwrap();
+        let run_id = Uuid::now_v7();
+        store.init_run(&meta(run_id, dir.path())).await.unwrap();
+        let mut rec = rec("t", TaskStatus::Success);
+        rec.pause_count = 2;
+        rec.approvals_approved = 1;
+        store.append_record(run_id, &rec).await.unwrap();
+        let back = store.load_run(run_id).await.unwrap();
+        assert_eq!(back.tasks[0].pause_count, 2);
+        assert_eq!(back.tasks[0].approvals_approved, 1);
+
+        // Re-open: must not ALTER again.
+        let _s2 = SqliteStore::new(db_path).unwrap();
     }
 }

--- a/crates/pitboss-tui/Cargo.toml
+++ b/crates/pitboss-tui/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 pitboss-core = { path = "../pitboss-core" }
+pitboss-cli  = { path = "../pitboss-cli" }
 ratatui      = { workspace = true }
 crossterm    = { workspace = true }
 anyhow       = { workspace = true }
@@ -21,6 +22,8 @@ serde_json   = { workspace = true }
 chrono       = { workspace = true }
 uuid         = { workspace = true }
 tracing      = { workspace = true }
+tui-textarea = { workspace = true }
+tokio        = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/pitboss-tui/Cargo.toml
+++ b/crates/pitboss-tui/Cargo.toml
@@ -5,6 +5,10 @@ edition      = { workspace = true }
 rust-version = { workspace = true }
 license      = { workspace = true }
 
+[lib]
+name = "pitboss_tui"
+path = "src/lib.rs"
+
 [[bin]]
 name = "pitboss-tui"
 path = "src/main.rs"

--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -2,6 +2,7 @@
 
 use std::path::PathBuf;
 use std::sync::mpsc;
+use std::sync::Arc;
 use std::time::Duration;
 
 use crossterm::event::{self, Event, KeyCode, KeyModifiers};
@@ -32,6 +33,50 @@ pub fn run(run_dir: PathBuf, run_id: String) -> anyhow::Result<()> {
     let mut terminal = crate::tui::init()?;
 
     let mut state = AppState::new(run_dir.clone(), run_id);
+
+    // Build a tokio runtime for the ControlClient + its background reader task.
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    let (ctrl_events_tx, ctrl_events_rx) =
+        std::sync::mpsc::channel::<pitboss_cli::control::protocol::ControlEvent>();
+
+    // Resolve the control socket path from the run dir. Best-effort: if the
+    // uuid parse or socket open fails, the TUI continues in observe-only mode.
+    let control_client = match uuid::Uuid::parse_str(&state.run_id) {
+        Ok(uuid) => {
+            let socket_path = pitboss_cli::control::control_socket_path(uuid, &state.run_dir);
+            let (bridge_tx, mut bridge_rx) =
+                tokio::sync::mpsc::channel::<pitboss_cli::control::protocol::ControlEvent>(64);
+            // Forward async → sync so the render loop can pull without tokio.
+            let forward_tx = ctrl_events_tx.clone();
+            runtime.spawn(async move {
+                while let Some(ev) = bridge_rx.recv().await {
+                    if forward_tx.send(ev).is_err() {
+                        break;
+                    }
+                }
+            });
+            let client = runtime
+                .block_on(crate::control::ControlClient::connect(
+                    socket_path,
+                    bridge_tx,
+                ))
+                .ok();
+            client.map(Arc::new)
+        }
+        Err(_) => None,
+    };
+    state.control_connected = control_client.as_ref().is_some_and(|c| c.is_connected());
+    state.control_client = control_client;
+    // `runtime` owns the background reader + forward tasks and must be kept
+    // alive for the full event loop. It falls out of scope at the end of
+    // `run()`; the tasks are dropped cleanly then.
+    let _runtime = runtime;
+    // Our local handle to `ctrl_events_tx` is unused past this point — the
+    // forward task owns the only clone that matters. Dropping makes the
+    // receiver observe a closed channel once the forwarder exits.
+    drop(ctrl_events_tx);
 
     // Mutable channel endpoints so we can swap them when switching runs.
     let (mut snapshot_rx, mut focus_tx) = spawn_watcher(run_dir);
@@ -81,6 +126,11 @@ pub fn run(run_dir: PathBuf, run_id: String) -> anyhow::Result<()> {
             if matches!(state.mode, Mode::SnapIn { .. }) {
                 state.snap_auto_scroll(SNAP_VISIBLE_ROWS);
             }
+        }
+
+        // --- Drain any queued control events (non-blocking). ---
+        while let Ok(ev) = ctrl_events_rx.try_recv() {
+            apply_control_event(&mut state, ev);
         }
     }
 
@@ -243,4 +293,28 @@ fn handle_picking_run(state: &mut AppState, code: KeyCode) -> Action {
         _ => {}
     }
     Action::Continue
+}
+
+/// Apply a single control-socket event to the app state. Called for each event
+/// drained from the async-to-sync bridge channel once per event-loop tick.
+fn apply_control_event(state: &mut AppState, ev: pitboss_cli::control::protocol::ControlEvent) {
+    use pitboss_cli::control::protocol::ControlEvent as E;
+    match ev {
+        E::ApprovalRequest {
+            request_id,
+            task_id,
+            summary,
+        } => {
+            state.mode = Mode::ApprovalModal {
+                request_id,
+                task_id,
+                summary,
+                sub_mode: crate::state::ApprovalSubMode::Overview,
+            };
+        }
+        E::Superseded | E::RunFinished { .. } => {
+            state.control_connected = false;
+        }
+        _ => {}
+    }
 }

--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -120,6 +120,10 @@ fn handle_key(state: &mut AppState, code: KeyCode, modifiers: KeyModifiers) -> A
         Mode::Help => handle_help(state, code),
         Mode::PickingRun { .. } => handle_picking_run(state, code),
         Mode::SnapIn { .. } => handle_snap_in(state, code, modifiers),
+        // v0.4 modal states — keybindings wired in later tasks.
+        Mode::ConfirmKill { .. } | Mode::PromptReprompt { .. } | Mode::ApprovalModal { .. } => {
+            Action::Continue
+        }
     }
 }
 

--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -172,8 +172,7 @@ fn handle_key(state: &mut AppState, code: KeyCode, modifiers: KeyModifiers) -> A
         Mode::SnapIn { .. } => handle_snap_in(state, code, modifiers),
         Mode::ConfirmKill { .. } => handle_confirm_kill(state, code),
         Mode::PromptReprompt { .. } => handle_prompt_reprompt(state, code, modifiers),
-        // v0.4 modal states — keybindings wired in later tasks.
-        Mode::ApprovalModal { .. } => Action::Continue,
+        Mode::ApprovalModal { .. } => handle_approval_modal(state, code, modifiers),
     }
 }
 
@@ -425,6 +424,139 @@ fn handle_prompt_reprompt(state: &mut AppState, code: KeyCode, modifiers: KeyMod
     }
     state.mode = Mode::PromptReprompt { task_id, draft };
     Action::Continue
+}
+
+/// Non-draft fields of `Mode::ApprovalModal`, shared across sub-mode handlers.
+struct ApprovalCtx {
+    request_id: String,
+    task_id: String,
+    summary: String,
+}
+
+fn handle_approval_modal(state: &mut AppState, code: KeyCode, modifiers: KeyModifiers) -> Action {
+    use crate::state::ApprovalSubMode;
+    let Mode::ApprovalModal {
+        request_id,
+        task_id,
+        summary,
+        sub_mode,
+    } = state.mode.clone()
+    else {
+        return Action::Continue;
+    };
+    let ctx = ApprovalCtx {
+        request_id,
+        task_id,
+        summary,
+    };
+
+    match sub_mode {
+        ApprovalSubMode::Overview => handle_approval_overview(state, code, ctx),
+        ApprovalSubMode::Editing { draft } => {
+            handle_approval_draft(state, code, modifiers, ctx, draft, true);
+        }
+        ApprovalSubMode::Rejecting { draft } => {
+            handle_approval_draft(state, code, modifiers, ctx, draft, false);
+        }
+    }
+    Action::Continue
+}
+
+fn handle_approval_overview(state: &mut AppState, code: KeyCode, ctx: ApprovalCtx) {
+    use crate::state::ApprovalSubMode;
+    match code {
+        KeyCode::Char('y') => {
+            send_approve(state, &ctx.request_id, true, None, None);
+            state.mode = Mode::Normal;
+        }
+        KeyCode::Char('n') => {
+            state.mode = Mode::ApprovalModal {
+                request_id: ctx.request_id,
+                task_id: ctx.task_id,
+                summary: ctx.summary,
+                sub_mode: ApprovalSubMode::Rejecting {
+                    draft: String::new(),
+                },
+            };
+        }
+        KeyCode::Char('e') => {
+            let draft = ctx.summary.clone();
+            state.mode = Mode::ApprovalModal {
+                request_id: ctx.request_id,
+                task_id: ctx.task_id,
+                summary: ctx.summary,
+                sub_mode: ApprovalSubMode::Editing { draft },
+            };
+        }
+        KeyCode::Esc => state.mode = Mode::Normal,
+        _ => {}
+    }
+}
+
+/// Shared draft-editing handler for both the `Editing` and `Rejecting`
+/// sub-modes. `editing` distinguishes which branch we're in: `true` means
+/// an edit-summary draft (Ctrl+Enter sends approve with `edited_summary`);
+/// `false` means a rejection-comment draft (Ctrl+Enter sends reject with
+/// `comment`).
+fn handle_approval_draft(
+    state: &mut AppState,
+    code: KeyCode,
+    modifiers: KeyModifiers,
+    ctx: ApprovalCtx,
+    mut draft: String,
+    editing: bool,
+) {
+    use crate::state::ApprovalSubMode;
+    match code {
+        KeyCode::Enter if modifiers.contains(KeyModifiers::CONTROL) => {
+            if editing {
+                send_approve(state, &ctx.request_id, true, None, Some(draft));
+            } else {
+                send_approve(state, &ctx.request_id, false, Some(draft), None);
+            }
+            state.mode = Mode::Normal;
+            return;
+        }
+        KeyCode::Esc => {
+            state.mode = Mode::Normal;
+            return;
+        }
+        KeyCode::Char(c) => draft.push(c),
+        KeyCode::Backspace => {
+            draft.pop();
+        }
+        KeyCode::Enter => draft.push('\n'),
+        _ => return,
+    }
+    let sub_mode = if editing {
+        ApprovalSubMode::Editing { draft }
+    } else {
+        ApprovalSubMode::Rejecting { draft }
+    };
+    state.mode = Mode::ApprovalModal {
+        request_id: ctx.request_id,
+        task_id: ctx.task_id,
+        summary: ctx.summary,
+        sub_mode,
+    };
+}
+
+fn send_approve(
+    state: &mut AppState,
+    request_id: &str,
+    approved: bool,
+    comment: Option<String>,
+    edited_summary: Option<String>,
+) {
+    if let Some(client) = state.control_client.clone() {
+        let op = pitboss_cli::control::protocol::ControlOp::Approve {
+            request_id: request_id.to_string(),
+            approved,
+            comment,
+            edited_summary,
+        };
+        let _ = futures_block_on(async move { client.send_op(op).await });
+    }
 }
 
 // The TUI event loop runs outside any tokio runtime context (crossterm polls

--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -170,10 +170,9 @@ fn handle_key(state: &mut AppState, code: KeyCode, modifiers: KeyModifiers) -> A
         Mode::Help => handle_help(state, code),
         Mode::PickingRun { .. } => handle_picking_run(state, code),
         Mode::SnapIn { .. } => handle_snap_in(state, code, modifiers),
+        Mode::ConfirmKill { .. } => handle_confirm_kill(state, code),
         // v0.4 modal states — keybindings wired in later tasks.
-        Mode::ConfirmKill { .. } | Mode::PromptReprompt { .. } | Mode::ApprovalModal { .. } => {
-            Action::Continue
-        }
+        Mode::PromptReprompt { .. } | Mode::ApprovalModal { .. } => Action::Continue,
     }
 }
 
@@ -199,6 +198,21 @@ fn handle_normal(state: &mut AppState, code: KeyCode) -> Action {
 
         // Snap-in: enter full-screen view for the focused tile.
         KeyCode::Enter => state.enter_snap_in(),
+
+        // v0.4 — cancel focused worker.
+        KeyCode::Char('x') => {
+            if let Some(tile) = state.focused_tile() {
+                state.mode = Mode::ConfirmKill {
+                    target: crate::state::KillTarget::Worker(tile.id.clone()),
+                };
+            }
+        }
+        // v0.4 — cancel entire run.
+        KeyCode::Char('X') => {
+            state.mode = Mode::ConfirmKill {
+                target: crate::state::KillTarget::Run,
+            };
+        }
 
         // Refresh — watcher already polls every 500ms; render at loop top
         // covers forced redraw. All other keys are intentionally ignored.
@@ -317,4 +331,45 @@ fn apply_control_event(state: &mut AppState, ev: pitboss_cli::control::protocol:
         }
         _ => {}
     }
+}
+
+fn handle_confirm_kill(state: &mut AppState, code: KeyCode) -> Action {
+    let Mode::ConfirmKill { target } = state.mode.clone() else {
+        return Action::Continue;
+    };
+    match code {
+        KeyCode::Char('y' | 'Y') => {
+            if let Some(client) = state.control_client.clone() {
+                let op = match target {
+                    crate::state::KillTarget::Worker(id) => {
+                        pitboss_cli::control::protocol::ControlOp::CancelWorker { task_id: id }
+                    }
+                    crate::state::KillTarget::Run => {
+                        pitboss_cli::control::protocol::ControlOp::CancelRun
+                    }
+                };
+                // Best-effort async send. Detach via fire-and-forget.
+                let _ = futures_block_on(async move { client.send_op(op).await });
+            }
+            state.mode = Mode::Normal;
+        }
+        _ => state.mode = Mode::Normal,
+    }
+    Action::Continue
+}
+
+// The TUI event loop runs outside any tokio runtime context (crossterm polls
+// synchronously). For fire-and-forget control-socket sends we use a tiny
+// single-threaded runtime per call. The operation is short — one writeln —
+// so the overhead is acceptable. If it ever becomes hot, migrate to a
+// persistent runtime handle threaded through AppState.
+fn futures_block_on<F>(fut: F) -> F::Output
+where
+    F: std::future::Future,
+{
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio rt")
+        .block_on(fut)
 }

--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -171,8 +171,9 @@ fn handle_key(state: &mut AppState, code: KeyCode, modifiers: KeyModifiers) -> A
         Mode::PickingRun { .. } => handle_picking_run(state, code),
         Mode::SnapIn { .. } => handle_snap_in(state, code, modifiers),
         Mode::ConfirmKill { .. } => handle_confirm_kill(state, code),
+        Mode::PromptReprompt { .. } => handle_prompt_reprompt(state, code, modifiers),
         // v0.4 modal states — keybindings wired in later tasks.
-        Mode::PromptReprompt { .. } | Mode::ApprovalModal { .. } => Action::Continue,
+        Mode::ApprovalModal { .. } => Action::Continue,
     }
 }
 
@@ -234,6 +235,16 @@ fn handle_normal(state: &mut AppState, code: KeyCode) -> Action {
                     prompt: None,
                 };
                 let _ = futures_block_on(async move { client.send_op(op).await });
+            }
+        }
+
+        // v0.4 — reprompt focused worker.
+        KeyCode::Char('r') => {
+            if let Some(tile) = state.focused_tile().cloned() {
+                state.mode = Mode::PromptReprompt {
+                    task_id: tile.id,
+                    draft: String::new(),
+                };
             }
         }
 
@@ -378,6 +389,41 @@ fn handle_confirm_kill(state: &mut AppState, code: KeyCode) -> Action {
         }
         _ => state.mode = Mode::Normal,
     }
+    Action::Continue
+}
+
+fn handle_prompt_reprompt(state: &mut AppState, code: KeyCode, modifiers: KeyModifiers) -> Action {
+    let Mode::PromptReprompt { task_id, draft } = state.mode.clone() else {
+        return Action::Continue;
+    };
+    let mut draft = draft;
+    match code {
+        KeyCode::Esc => {
+            state.mode = Mode::Normal;
+            return Action::Continue;
+        }
+        KeyCode::Enter if modifiers.contains(KeyModifiers::CONTROL) => {
+            // Ctrl+Enter: submit.
+            if !draft.is_empty() {
+                if let Some(client) = state.control_client.clone() {
+                    let op = pitboss_cli::control::protocol::ControlOp::RepromptWorker {
+                        task_id: task_id.clone(),
+                        prompt: draft.clone(),
+                    };
+                    let _ = futures_block_on(async move { client.send_op(op).await });
+                }
+            }
+            state.mode = Mode::Normal;
+            return Action::Continue;
+        }
+        KeyCode::Char(c) => draft.push(c),
+        KeyCode::Backspace => {
+            draft.pop();
+        }
+        KeyCode::Enter => draft.push('\n'),
+        _ => {}
+    }
+    state.mode = Mode::PromptReprompt { task_id, draft };
     Action::Continue
 }
 

--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -214,6 +214,29 @@ fn handle_normal(state: &mut AppState, code: KeyCode) -> Action {
             };
         }
 
+        // v0.4 — pause focused worker.
+        KeyCode::Char('p') => {
+            if let (Some(client), Some(tile)) =
+                (state.control_client.clone(), state.focused_tile().cloned())
+            {
+                let op =
+                    pitboss_cli::control::protocol::ControlOp::PauseWorker { task_id: tile.id };
+                let _ = futures_block_on(async move { client.send_op(op).await });
+            }
+        }
+        // v0.4 — continue focused worker (if paused).
+        KeyCode::Char('c') => {
+            if let (Some(client), Some(tile)) =
+                (state.control_client.clone(), state.focused_tile().cloned())
+            {
+                let op = pitboss_cli::control::protocol::ControlOp::ContinueWorker {
+                    task_id: tile.id,
+                    prompt: None,
+                };
+                let _ = futures_block_on(async move { client.send_op(op).await });
+            }
+        }
+
         // Refresh — watcher already polls every 500ms; render at loop top
         // covers forced redraw. All other keys are intentionally ignored.
         _ => {}

--- a/crates/pitboss-tui/src/control.rs
+++ b/crates/pitboss-tui/src/control.rs
@@ -1,0 +1,103 @@
+//! TUI-side client for the per-run control socket. Handles connect,
+//! handshake, reader task that forwards events via `mpsc::Sender`, and a
+//! `send_op` entry point for keypress handlers.
+
+#![allow(dead_code)]
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use pitboss_cli::control::protocol::{ControlEvent, ControlOp};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
+use tokio::net::UnixStream;
+use tokio::sync::{mpsc, Mutex};
+
+pub struct ControlClient {
+    writer: Arc<Mutex<Option<OwnedWriteHalf>>>,
+    connected: Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl ControlClient {
+    /// Connect to `socket`, send hello, spawn a reader task that forwards
+    /// events onto `events_tx`. Returns immediately even on connection failure
+    /// — the client enters disconnected state and `send_op` no-ops with Err.
+    pub async fn connect(socket: PathBuf, events_tx: mpsc::Sender<ControlEvent>) -> Result<Self> {
+        let connected = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let writer_holder: Arc<Mutex<Option<OwnedWriteHalf>>> = Arc::new(Mutex::new(None));
+
+        if let Ok(stream) = UnixStream::connect(&socket).await {
+            let (r, mut w) = stream.into_split();
+            let hello = ControlOp::Hello {
+                client_version: env!("CARGO_PKG_VERSION").to_string(),
+            };
+            let mut line = serde_json::to_string(&hello)?;
+            line.push('\n');
+            w.write_all(line.as_bytes()).await.context("send hello")?;
+            w.flush().await?;
+
+            *writer_holder.lock().await = Some(w);
+            connected.store(true, std::sync::atomic::Ordering::Relaxed);
+
+            let events_tx_bg = events_tx.clone();
+            let connected_bg = connected.clone();
+            tokio::spawn(read_loop(r, events_tx_bg, connected_bg));
+        }
+        // Socket doesn't exist (run already finished) or dispatcher not ready.
+        // Remain disconnected; the TUI stays observe-only.
+
+        Ok(Self {
+            writer: writer_holder,
+            connected,
+        })
+    }
+
+    pub fn is_connected(&self) -> bool {
+        self.connected.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Send a single control op. Returns Err if disconnected or write fails.
+    pub async fn send_op(&self, op: ControlOp) -> Result<()> {
+        let mut guard = self.writer.lock().await;
+        let Some(w) = guard.as_mut() else {
+            anyhow::bail!("control client is disconnected");
+        };
+        let mut line = serde_json::to_string(&op)?;
+        line.push('\n');
+        w.write_all(line.as_bytes()).await?;
+        w.flush().await?;
+        Ok(())
+    }
+}
+
+async fn read_loop(
+    r: OwnedReadHalf,
+    events_tx: mpsc::Sender<ControlEvent>,
+    connected: Arc<std::sync::atomic::AtomicBool>,
+) {
+    let mut lines = BufReader::new(r).lines();
+    while let Ok(Some(line)) = lines.next_line().await {
+        if let Ok(ev) = serde_json::from_str::<ControlEvent>(&line) {
+            if events_tx.send(ev).await.is_err() {
+                break;
+            }
+        }
+    }
+    connected.store(false, std::sync::atomic::Ordering::Relaxed);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn connect_to_nonexistent_socket_returns_disconnected_client() {
+        let dir = TempDir::new().unwrap();
+        let sock = dir.path().join("missing.sock");
+        let (tx, _rx) = mpsc::channel(16);
+        let client = ControlClient::connect(sock, tx).await.unwrap();
+        assert!(!client.is_connected());
+    }
+}

--- a/crates/pitboss-tui/src/control.rs
+++ b/crates/pitboss-tui/src/control.rs
@@ -14,6 +14,7 @@ use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::net::UnixStream;
 use tokio::sync::{mpsc, Mutex};
 
+#[derive(Debug)]
 pub struct ControlClient {
     writer: Arc<Mutex<Option<OwnedWriteHalf>>>,
     connected: Arc<std::sync::atomic::AtomicBool>,

--- a/crates/pitboss-tui/src/lib.rs
+++ b/crates/pitboss-tui/src/lib.rs
@@ -1,0 +1,17 @@
+//! Library surface for pitboss-tui, so integration tests in `tests/` can
+//! pull state types and render functions without shelling out to the bin.
+
+#![deny(unsafe_code)]
+#![warn(clippy::all, clippy::pedantic)]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::missing_errors_doc,
+    clippy::must_use_candidate
+)]
+
+pub mod app;
+pub mod control;
+pub mod runs;
+pub mod state;
+pub mod tui;
+pub mod watcher;

--- a/crates/pitboss-tui/src/main.rs
+++ b/crates/pitboss-tui/src/main.rs
@@ -11,12 +11,7 @@
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(clippy::module_name_repetitions, clippy::missing_errors_doc)]
 
-mod app;
-mod control;
-mod runs;
-mod state;
-mod tui;
-mod watcher;
+use pitboss_tui::{app, runs, state, tui};
 
 use std::path::PathBuf;
 
@@ -207,14 +202,14 @@ fn cmd_screenshot(run: Option<&str>, cols: u16, rows: u16) -> Result<()> {
     };
 
     // Build a one-shot AppState from the run dir (no background thread).
-    let mut state = crate::state::AppState::new(run_dir.clone(), run_id);
+    let mut state = state::AppState::new(run_dir.clone(), run_id);
     let snapshot = build_one_shot_snapshot(&run_dir);
     state.apply_snapshot(snapshot);
 
     // Render into a ratatui TestBackend.
     let backend = TestBackend::new(cols, rows);
     let mut terminal = Terminal::new(backend)?;
-    terminal.draw(|frame| crate::tui::render(frame, &state))?;
+    terminal.draw(|frame| tui::render(frame, &state))?;
 
     // Dump buffer as plain text, one line per row.
     let buf = terminal.backend().buffer();
@@ -230,9 +225,9 @@ fn cmd_screenshot(run: Option<&str>, cols: u16, rows: u16) -> Result<()> {
 }
 
 /// Same shape as `watcher::build_snapshot` but synchronous and self-contained.
-fn build_one_shot_snapshot(run_dir: &std::path::Path) -> crate::state::AppSnapshot {
-    use crate::state::{AppSnapshot, TileState, TileStatus};
+fn build_one_shot_snapshot(run_dir: &std::path::Path) -> state::AppSnapshot {
     use pitboss_core::store::{TaskRecord, TaskStatus};
+    use pitboss_tui::state::{AppSnapshot, TileState, TileStatus};
     use serde::Deserialize;
     use std::io::BufRead;
 

--- a/crates/pitboss-tui/src/main.rs
+++ b/crates/pitboss-tui/src/main.rs
@@ -12,6 +12,7 @@
 #![allow(clippy::module_name_repetitions, clippy::missing_errors_doc)]
 
 mod app;
+mod control;
 mod runs;
 mod state;
 mod tui;

--- a/crates/pitboss-tui/src/state.rs
+++ b/crates/pitboss-tui/src/state.rs
@@ -31,7 +31,6 @@ pub enum Mode {
         target: KillTarget,
     },
     /// v0.4: textarea-driven reprompt modal.
-    #[allow(dead_code)]
     PromptReprompt {
         task_id: String,
         draft: String,

--- a/crates/pitboss-tui/src/state.rs
+++ b/crates/pitboss-tui/src/state.rs
@@ -112,6 +112,12 @@ pub struct AppState {
     pub run_list: Vec<crate::runs::RunEntry>,
     /// Earliest wall-clock start time across all completed tiles in the current run.
     pub run_started_at: Option<DateTime<Utc>>,
+    /// v0.4 control-socket client. None when the TUI was launched against a
+    /// completed run or the control socket couldn't be opened.
+    pub control_client: Option<std::sync::Arc<crate::control::ControlClient>>,
+    /// Whether the control socket is currently connected. Mirrored from the
+    /// client; used for the status-bar indicator.
+    pub control_connected: bool,
 }
 
 impl AppState {
@@ -126,6 +132,8 @@ impl AppState {
             failed_count: 0,
             run_list: Vec::new(),
             run_started_at: None,
+            control_client: None,
+            control_connected: false,
         }
     }
 

--- a/crates/pitboss-tui/src/state.rs
+++ b/crates/pitboss-tui/src/state.rs
@@ -27,7 +27,6 @@ pub enum Mode {
         at_bottom: bool,
     },
     /// v0.4: confirm modal before sending a destructive control op.
-    #[allow(dead_code)]
     ConfirmKill {
         target: KillTarget,
     },
@@ -49,7 +48,6 @@ pub enum Mode {
 
 /// What `ConfirmKill` targets.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub enum KillTarget {
     Worker(String),
     Run,
@@ -868,5 +866,21 @@ mod tests {
             sub_mode: ApprovalSubMode::Overview,
         };
         assert!(matches!(m, Mode::ApprovalModal { .. }));
+    }
+
+    #[test]
+    fn confirm_kill_mode_stores_worker_target_from_focus() {
+        let mut state = make_state_with_tile("task-001");
+        state.mode = Mode::ConfirmKill {
+            target: KillTarget::Worker("task-001".into()),
+        };
+        if let Mode::ConfirmKill {
+            target: KillTarget::Worker(id),
+        } = &state.mode
+        {
+            assert_eq!(id, "task-001");
+        } else {
+            panic!("not ConfirmKill::Worker");
+        }
     }
 }

--- a/crates/pitboss-tui/src/state.rs
+++ b/crates/pitboss-tui/src/state.rs
@@ -6,7 +6,7 @@ use chrono::{DateTime, Utc};
 use pitboss_core::store::TaskStatus;
 
 /// Overall display mode of the TUI.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub enum Mode {
     Normal,
     ViewingLog,
@@ -26,6 +26,45 @@ pub enum Mode {
         scroll: usize,
         at_bottom: bool,
     },
+    /// v0.4: confirm modal before sending a destructive control op.
+    #[allow(dead_code)]
+    ConfirmKill {
+        target: KillTarget,
+    },
+    /// v0.4: textarea-driven reprompt modal.
+    #[allow(dead_code)]
+    PromptReprompt {
+        task_id: String,
+        draft: String,
+    },
+    /// v0.4: approval modal. Driven by an `approval_request` event.
+    #[allow(dead_code)]
+    ApprovalModal {
+        request_id: String,
+        task_id: String,
+        summary: String,
+        sub_mode: ApprovalSubMode,
+    },
+}
+
+/// What `ConfirmKill` targets.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum KillTarget {
+    Worker(String),
+    Run,
+}
+
+/// Sub-state of the `ApprovalModal`.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum ApprovalSubMode {
+    /// Just showing the summary; awaiting y/n/e.
+    Overview,
+    /// User pressed `e`: editing the summary in a textarea.
+    Editing { draft: String },
+    /// User pressed `n`: writing a rejection comment.
+    Rejecting { draft: String },
 }
 
 /// Status of a single tile.
@@ -391,7 +430,7 @@ mod tests {
 
         state.cancel_picker();
 
-        assert_eq!(state.mode, Mode::Normal);
+        assert!(matches!(state.mode, Mode::Normal));
         assert!(state.run_list.is_empty());
         assert_eq!(state.focus, 1, "cancel_picker must not touch focus");
     }
@@ -456,7 +495,7 @@ mod tests {
         state.picker_down();
 
         // Mode unchanged.
-        assert_eq!(state.mode, Mode::Normal);
+        assert!(matches!(state.mode, Mode::Normal));
     }
 
     #[test]
@@ -521,7 +560,10 @@ mod tests {
 
         state.enter_snap_in();
 
-        assert_eq!(state.mode, Mode::Normal, "should stay Normal with no tiles");
+        assert!(
+            matches!(state.mode, Mode::Normal),
+            "should stay Normal with no tiles"
+        );
     }
 
     #[test]
@@ -550,7 +592,7 @@ mod tests {
 
         state.exit_snap_in();
 
-        assert_eq!(state.mode, Mode::Normal);
+        assert!(matches!(state.mode, Mode::Normal));
     }
 
     #[test]
@@ -781,5 +823,42 @@ mod tests {
             Some(t_earlier),
             "should keep the earlier start time"
         );
+    }
+
+    #[test]
+    fn confirm_kill_variant_round_trip() {
+        let m = Mode::ConfirmKill {
+            target: KillTarget::Worker("w-1".into()),
+        };
+        assert!(matches!(m, Mode::ConfirmKill { .. }));
+        let m2 = Mode::ConfirmKill {
+            target: KillTarget::Run,
+        };
+        assert!(matches!(
+            m2,
+            Mode::ConfirmKill {
+                target: KillTarget::Run
+            }
+        ));
+    }
+
+    #[test]
+    fn prompt_reprompt_variant_constructs() {
+        let m = Mode::PromptReprompt {
+            task_id: "w-1".into(),
+            draft: String::new(),
+        };
+        assert!(matches!(m, Mode::PromptReprompt { .. }));
+    }
+
+    #[test]
+    fn approval_modal_variant_constructs() {
+        let m = Mode::ApprovalModal {
+            request_id: "req-1".into(),
+            task_id: "lead".into(),
+            summary: "spawn 3".into(),
+            sub_mode: ApprovalSubMode::Overview,
+        };
+        assert!(matches!(m, Mode::ApprovalModal { .. }));
     }
 }

--- a/crates/pitboss-tui/src/state.rs
+++ b/crates/pitboss-tui/src/state.rs
@@ -36,7 +36,6 @@ pub enum Mode {
         draft: String,
     },
     /// v0.4: approval modal. Driven by an `approval_request` event.
-    #[allow(dead_code)]
     ApprovalModal {
         request_id: String,
         task_id: String,
@@ -54,7 +53,6 @@ pub enum KillTarget {
 
 /// Sub-state of the `ApprovalModal`.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub enum ApprovalSubMode {
     /// Just showing the summary; awaiting y/n/e.
     Overview,
@@ -881,5 +879,21 @@ mod tests {
         } else {
             panic!("not ConfirmKill::Worker");
         }
+    }
+
+    #[test]
+    fn approval_modal_overview_y_sets_mode_normal() {
+        // Simulate the state transition that `handle_approval_modal` performs.
+        let mut state = make_state();
+        state.mode = Mode::ApprovalModal {
+            request_id: "req-1".into(),
+            task_id: "lead".into(),
+            summary: "spawn 3".into(),
+            sub_mode: ApprovalSubMode::Overview,
+        };
+        // Direct transition — we don't call into app::handle_* here to avoid
+        // tokio-runtime coupling; this test exercises only the state model.
+        state.mode = Mode::Normal;
+        assert!(matches!(state.mode, Mode::Normal));
     }
 }

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -188,11 +188,17 @@ pub fn render(frame: &mut Frame, state: &AppState) {
     render_statusbar(frame, chunks[2], state);
 
     // Overlays (drawn last so they appear on top).
+    // v0.4 modal overlays (ConfirmKill / PromptReprompt / ApprovalModal) are
+    // no-ops here; rendering is wired in later tasks.
     match state.mode {
         Mode::ViewingLog => render_log_overlay(frame, area, state),
         Mode::Help => render_help_overlay(frame, area),
         Mode::PickingRun { selected } => render_run_picker_overlay(frame, area, state, selected),
-        Mode::Normal | Mode::SnapIn { .. } => {}
+        Mode::Normal
+        | Mode::SnapIn { .. }
+        | Mode::ConfirmKill { .. }
+        | Mode::PromptReprompt { .. }
+        | Mode::ApprovalModal { .. } => {}
     }
 }
 

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -703,14 +703,40 @@ fn render_prompt_reprompt(frame: &mut Frame, area: Rect, task_id: &str, draft: &
 }
 
 fn render_approval_modal(
-    _frame: &mut Frame,
-    _area: Rect,
+    frame: &mut Frame,
+    area: Rect,
     _request_id: &str,
-    _task_id: &str,
-    _summary: &str,
-    _sub_mode: &crate::state::ApprovalSubMode,
+    task_id: &str,
+    summary: &str,
+    sub_mode: &crate::state::ApprovalSubMode,
 ) {
-    // Covered in Task 32.
+    use crate::state::ApprovalSubMode;
+    let modal_w = (area.width * 3 / 4).min(90);
+    let modal_h = (area.height * 2 / 3).clamp(10, 24);
+    let x = area.x + area.width.saturating_sub(modal_w) / 2;
+    let y = area.y + area.height.saturating_sub(modal_h) / 2;
+    let modal = Rect::new(x, y, modal_w, modal_h);
+    frame.render_widget(Clear, modal);
+    let (title, body) = match sub_mode {
+        ApprovalSubMode::Overview => (
+            format!(" Approval from `{task_id}` — y=approve  n=reject  e=edit  Esc=cancel "),
+            summary.to_string(),
+        ),
+        ApprovalSubMode::Editing { draft } => (
+            " Edit summary — Ctrl+Enter to submit  Esc cancel ".to_string(),
+            draft.clone(),
+        ),
+        ApprovalSubMode::Rejecting { draft } => (
+            " Rejection comment — Ctrl+Enter to send  Esc cancel ".to_string(),
+            draft.clone(),
+        ),
+    };
+    let block = Block::default().borders(Borders::ALL).title(title);
+    let para = Paragraph::new(body)
+        .block(block)
+        .wrap(Wrap { trim: false })
+        .style(Style::default().fg(Color::White));
+    frame.render_widget(para, modal);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -685,8 +685,21 @@ fn render_confirm_kill(frame: &mut Frame, area: Rect, target: &crate::state::Kil
 }
 
 // Forward decls filled in by Task 26 / Task 32.
-fn render_prompt_reprompt(_frame: &mut Frame, _area: Rect, _task_id: &str, _draft: &str) {
-    // Covered in Task 26.
+fn render_prompt_reprompt(frame: &mut Frame, area: Rect, task_id: &str, draft: &str) {
+    let modal_w = (area.width * 3 / 4).min(80);
+    let modal_h = (area.height / 2).clamp(8, 20);
+    let x = area.x + area.width.saturating_sub(modal_w) / 2;
+    let y = area.y + area.height.saturating_sub(modal_h) / 2;
+    let modal = Rect::new(x, y, modal_w, modal_h);
+    frame.render_widget(Clear, modal);
+    let block = Block::default().borders(Borders::ALL).title(format!(
+        " Reprompt `{task_id}` — Ctrl+Enter to send, Esc cancel "
+    ));
+    let para = Paragraph::new(draft)
+        .block(block)
+        .wrap(Wrap { trim: false })
+        .style(Style::default().fg(Color::White));
+    frame.render_widget(para, modal);
 }
 
 fn render_approval_modal(

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -188,17 +188,21 @@ pub fn render(frame: &mut Frame, state: &AppState) {
     render_statusbar(frame, chunks[2], state);
 
     // Overlays (drawn last so they appear on top).
-    // v0.4 modal overlays (ConfirmKill / PromptReprompt / ApprovalModal) are
-    // no-ops here; rendering is wired in later tasks.
-    match state.mode {
+    match &state.mode {
         Mode::ViewingLog => render_log_overlay(frame, area, state),
         Mode::Help => render_help_overlay(frame, area),
-        Mode::PickingRun { selected } => render_run_picker_overlay(frame, area, state, selected),
-        Mode::Normal
-        | Mode::SnapIn { .. }
-        | Mode::ConfirmKill { .. }
-        | Mode::PromptReprompt { .. }
-        | Mode::ApprovalModal { .. } => {}
+        Mode::PickingRun { selected } => render_run_picker_overlay(frame, area, state, *selected),
+        Mode::ConfirmKill { target } => render_confirm_kill(frame, area, target),
+        Mode::PromptReprompt { task_id, draft } => {
+            render_prompt_reprompt(frame, area, task_id, draft);
+        }
+        Mode::ApprovalModal {
+            request_id,
+            task_id,
+            summary,
+            sub_mode,
+        } => render_approval_modal(frame, area, request_id, task_id, summary, sub_mode),
+        Mode::Normal | Mode::SnapIn { .. } => {}
     }
 }
 
@@ -656,6 +660,44 @@ fn render_run_picker_overlay(frame: &mut Frame, area: Rect, state: &AppState, se
     list_state.select(Some(selected));
 
     frame.render_stateful_widget(list, inner, &mut list_state);
+}
+
+fn render_confirm_kill(frame: &mut Frame, area: Rect, target: &crate::state::KillTarget) {
+    let msg = match target {
+        crate::state::KillTarget::Worker(id) => format!(" Cancel worker `{id}`? [y/N] "),
+        crate::state::KillTarget::Run => {
+            " Cancel the ENTIRE RUN? All workers terminate. [y/N] ".into()
+        }
+    };
+    let msg_w = u16::try_from(msg.len()).unwrap_or(u16::MAX);
+    let modal_w = msg_w.saturating_add(4).min(area.width);
+    let modal_h = 3u16;
+    let x = area.x + area.width.saturating_sub(modal_w) / 2;
+    let y = area.y + area.height.saturating_sub(modal_h) / 2;
+    let modal = Rect::new(x, y, modal_w, modal_h);
+    frame.render_widget(Clear, modal);
+    let block = Block::default().borders(Borders::ALL).title(" Confirm ");
+    let para = Paragraph::new(msg)
+        .block(block)
+        .alignment(Alignment::Center)
+        .style(Style::default().fg(Color::Yellow));
+    frame.render_widget(para, modal);
+}
+
+// Forward decls filled in by Task 26 / Task 32.
+fn render_prompt_reprompt(_frame: &mut Frame, _area: Rect, _task_id: &str, _draft: &str) {
+    // Covered in Task 26.
+}
+
+fn render_approval_modal(
+    _frame: &mut Frame,
+    _area: Rect,
+    _request_id: &str,
+    _task_id: &str,
+    _summary: &str,
+    _sub_mode: &crate::state::ApprovalSubMode,
+) {
+    // Covered in Task 32.
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -747,6 +747,8 @@ mod tests {
             failed_count: 0,
             run_list: Vec::new(),
             run_started_at: None,
+            control_client: None,
+            control_connected: false,
         }
     }
 

--- a/crates/pitboss-tui/tests/tui_control.rs
+++ b/crates/pitboss-tui/tests/tui_control.rs
@@ -1,0 +1,89 @@
+//! TUI-side control tests. Uses ratatui's TestBackend to render a frame and
+//! assert on the rendered buffer content. Does not drive a real control
+//! socket — the keybinding → op plumbing is covered by the dispatcher-side
+//! tests in `pitboss-cli/tests/control_flows.rs`.
+
+use pitboss_tui::state::*;
+use ratatui::backend::TestBackend;
+use ratatui::Terminal;
+
+#[test]
+fn confirm_kill_modal_renders_for_worker_target() {
+    let mut state = AppState::new(std::path::PathBuf::from("/tmp"), "run-1".into());
+    state.mode = Mode::ConfirmKill {
+        target: KillTarget::Worker("worker-abc".into()),
+    };
+
+    let backend = TestBackend::new(80, 20);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| pitboss_tui::tui::render(frame, &state))
+        .unwrap();
+    let buf = terminal.backend().buffer();
+    let mut text = String::new();
+    for y in 0..20 {
+        for x in 0..80 {
+            text.push_str(buf.cell((x, y)).unwrap().symbol());
+        }
+        text.push('\n');
+    }
+    assert!(
+        text.contains("worker-abc"),
+        "modal should mention target id, got:\n{text}"
+    );
+}
+
+#[test]
+fn confirm_kill_modal_renders_for_run_target() {
+    let mut state = AppState::new(std::path::PathBuf::from("/tmp"), "run-1".into());
+    state.mode = Mode::ConfirmKill {
+        target: KillTarget::Run,
+    };
+
+    let backend = TestBackend::new(80, 20);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| pitboss_tui::tui::render(frame, &state))
+        .unwrap();
+    let buf = terminal.backend().buffer();
+    let mut text = String::new();
+    for y in 0..20 {
+        for x in 0..80 {
+            text.push_str(buf.cell((x, y)).unwrap().symbol());
+        }
+        text.push('\n');
+    }
+    assert!(
+        text.contains("ENTIRE RUN") || text.contains("entire run"),
+        "modal should mention run-wide cancellation, got:\n{text}"
+    );
+}
+
+#[test]
+fn approval_modal_overview_renders_summary() {
+    let mut state = AppState::new(std::path::PathBuf::from("/tmp"), "run-1".into());
+    state.mode = Mode::ApprovalModal {
+        request_id: "req-1".into(),
+        task_id: "lead".into(),
+        summary: "SPAWN THREE HOBBITS".into(),
+        sub_mode: ApprovalSubMode::Overview,
+    };
+
+    let backend = TestBackend::new(100, 24);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| pitboss_tui::tui::render(frame, &state))
+        .unwrap();
+    let buf = terminal.backend().buffer();
+    let mut text = String::new();
+    for y in 0..24 {
+        for x in 0..100 {
+            text.push_str(buf.cell((x, y)).unwrap().symbol());
+        }
+        text.push('\n');
+    }
+    assert!(
+        text.contains("SPAWN THREE HOBBITS"),
+        "modal should include the summary, got:\n{text}"
+    );
+}

--- a/examples/v0.4-approval-demo.toml
+++ b/examples/v0.4-approval-demo.toml
@@ -1,0 +1,58 @@
+# v0.4 live-control demo: a hierarchical run that exercises every new
+# feature in v0.4.0 — approval_policy=block, request_approval interrupt,
+# and a lead/worker layout the operator can pause/continue/reprompt/cancel
+# from the TUI.
+#
+# Usage:
+#   mkdir -p /tmp/pitboss-v04-demo && cd /tmp/pitboss-v04-demo && git init -q
+#   pitboss dispatch examples/v0.4-approval-demo.toml
+#
+# In another terminal:
+#   pitboss-tui
+#
+# Keybindings to try while the lead is running:
+#   x  — confirm + cancel the focused worker
+#   X  — confirm + cancel the whole run
+#   p  — pause the focused worker (keeps its claude session)
+#   c  — continue a paused worker (spawns claude --resume)
+#   r  — reprompt (Ctrl-Enter to send, Esc to cancel)
+#   y / n / e  — when the approval modal is up: approve, reject, or edit
+
+[run]
+max_workers       = 3
+budget_usd        = 0.50
+lead_timeout_secs = 900
+worktree_cleanup  = "never"
+# v0.4 NEW: what happens when the lead calls request_approval and no TUI
+# is attached. "block" = queue until a TUI connects. Alternatives:
+# "auto_approve" (immediate yes), "auto_reject" (immediate no).
+approval_policy   = "block"
+
+[defaults]
+model        = "claude-haiku-4-5"
+use_worktree = false
+
+[[lead]]
+id        = "orchestrator"
+directory = "/tmp/pitboss-v04-demo"
+prompt    = """You are a small demo lead for pitboss v0.4.
+
+1. Briefly introduce yourself in one sentence.
+2. Before spawning any workers, call mcp__pitboss__request_approval
+   with summary = "About to spawn 3 tiny demo workers (write a haiku each)"
+   and timeout_secs = 120. Wait for the operator response.
+3. If approved: spawn three workers concurrently via mcp__pitboss__spawn_worker.
+   Each worker prompt: "Write a 3-line haiku about <topic>." Topics:
+   worker w-a -> "rust ownership"
+   worker w-b -> "unix sockets"
+   worker w-c -> "unfinished coffee"
+   Pass directory=/tmp/pitboss-v04-demo and model=claude-haiku-4-5 to each.
+4. Use mcp__pitboss__wait_for_any / wait_for_worker to collect the results.
+5. Print the three haikus and a one-sentence conclusion.
+
+If rejected: apologize briefly and exit. If the operator edits your
+summary before approving, use the edited summary as your guidance for
+what to do (may differ from the 3-haiku plan).
+"""
+tools        = ["Read", "Write", "Bash"]
+timeout_secs = 900

--- a/scripts/smoke-part3-tui.sh
+++ b/scripts/smoke-part3-tui.sh
@@ -119,6 +119,48 @@ else
 fi
 
 # -------------------------------------------------------------------
+# v0.4: rendered help overlay includes new keybindings
+LATEST_RUN=$("$PITBOSS_TUI" list 2>&1 | tail -n +3 | head -1 | awk '{print $1}')
+if [ -n "$LATEST_RUN" ]; then
+    echo "-- smoke: v0.4 help mentions new keybindings"
+    HELP_OUT=$("$PITBOSS_TUI" screenshot --run "$LATEST_RUN" --cols 120 --rows 40 2>/dev/null || true)
+    # Best-effort: the help overlay requires interactive entry, so we just check
+    # the run-level render includes the standard title; full help check is in
+    # cargo tests. This case guards that --rows 40 renders without panicking.
+    if test -n "$HELP_OUT"; then
+        record "v0.4 help keybindings" PASS
+    else
+        record "v0.4 help keybindings" FAIL "screenshot produced no output"
+    fi
+else
+    record "v0.4 help keybindings" SKIP "no runs available for screenshot"
+fi
+
+# -------------------------------------------------------------------
+# v0.4: screenshot renders with no control socket attached
+if [ -n "$LATEST_RUN" ]; then
+    echo "-- smoke: v0.4 screenshot on completed run renders normally"
+    OUT=$("$PITBOSS_TUI" screenshot --run "$LATEST_RUN" --cols 120 --rows 30 2>&1); CODE=$?
+    if [ "$CODE" = "0" ]; then
+        record "v0.4 screenshot completed run" PASS
+    else
+        record "v0.4 screenshot completed run" FAIL "exit $CODE"
+    fi
+else
+    record "v0.4 screenshot completed run" SKIP "no runs available"
+fi
+
+# -------------------------------------------------------------------
+# v0.4: paused-worker tile (post-hoc) smoke
+echo "-- smoke: v0.4 pitboss-tui list still works"
+OUT=$("$PITBOSS_TUI" list 2>&1); CODE=$?
+if [ "$CODE" = "0" ] && echo "$OUT" | head -n 5 >/dev/null; then
+    record "v0.4 list command" PASS
+else
+    record "v0.4 list command" FAIL "exit $CODE"
+fi
+
+# -------------------------------------------------------------------
 # Interactive tests (5, 8) — cannot automate
 record "5 open most recent (interactive)" SKIP "run pitboss-tui manually in a real TTY"
 record "8 live updates (interactive)"    SKIP "pair with a running pitboss dispatch"

--- a/tests-support/fake-control-client/Cargo.toml
+++ b/tests-support/fake-control-client/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name         = "fake-control-client"
+version      = "0.0.0"
+edition      = "2021"
+rust-version = "1.82"
+publish      = false
+
+[dependencies]
+tokio      = { workspace = true, features = ["net","io-util","rt-multi-thread","macros","sync","time"] }
+anyhow     = { workspace = true }
+serde      = { workspace = true }
+serde_json = { workspace = true }
+pitboss-cli = { path = "../../crates/pitboss-cli" }

--- a/tests-support/fake-control-client/src/lib.rs
+++ b/tests-support/fake-control-client/src/lib.rs
@@ -1,0 +1,69 @@
+//! Minimal line-JSON client for the pitboss control socket. Mirrors the shape
+//! of `fake-mcp-client`: connect, handshake, send ops, read events. Used by
+//! `crates/pitboss-cli/tests/control_flows.rs`.
+
+#![allow(dead_code)]
+
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
+use tokio::net::UnixStream;
+
+use pitboss_cli::control::protocol::{ControlEvent, ControlOp};
+
+pub struct FakeControlClient {
+    writer: OwnedWriteHalf,
+    reader: BufReader<OwnedReadHalf>,
+}
+
+impl FakeControlClient {
+    /// Connect to `socket`, send `hello`, read the server hello, return a ready
+    /// client.
+    pub async fn connect(socket: &Path, client_version: &str) -> Result<Self> {
+        let stream = UnixStream::connect(socket)
+            .await
+            .with_context(|| format!("connect {}", socket.display()))?;
+        let (r, w) = stream.into_split();
+        let mut c = Self {
+            writer: w,
+            reader: BufReader::new(r),
+        };
+        c.send(&ControlOp::Hello {
+            client_version: client_version.into(),
+        })
+        .await?;
+        // Wait for the server hello so the connection is fully established.
+        let _hello = c.recv().await?;
+        Ok(c)
+    }
+
+    /// Send a single op as one line of JSON.
+    pub async fn send(&mut self, op: &ControlOp) -> Result<()> {
+        let mut line = serde_json::to_string(op)?;
+        line.push('\n');
+        self.writer.write_all(line.as_bytes()).await?;
+        self.writer.flush().await?;
+        Ok(())
+    }
+
+    /// Read one event (blocks indefinitely).
+    pub async fn recv(&mut self) -> Result<ControlEvent> {
+        let mut line = String::new();
+        let n = self.reader.read_line(&mut line).await?;
+        if n == 0 {
+            anyhow::bail!("control socket EOF");
+        }
+        Ok(serde_json::from_str(line.trim_end_matches('\n'))?)
+    }
+
+    /// Read events with a deadline; `None` on timeout.
+    pub async fn recv_timeout(&mut self, d: Duration) -> Result<Option<ControlEvent>> {
+        match tokio::time::timeout(d, self.recv()).await {
+            Ok(ev) => Ok(Some(ev?)),
+            Err(_) => Ok(None),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Per-run `control.sock`** — line-JSON unix socket carrying operator ops (cancel/pause/continue/reprompt/approve) and push events (approval_request, run_finished).
- **Three new MCP tools** — `pause_worker`, `continue_worker`, `request_approval`. Last one blocks the lead until the operator approves/rejects/edits, LangGraph `interrupt()`-style.
- **TUI keybindings** — `x`/`X` cancel (with confirm modal), `p`/`c` pause/continue, `r` reprompt (textarea), `y`/`n`/`e` during approval modal. All round-trip through the control socket to the dispatcher.
- **`approval_policy` manifest field** under `[run]`: `block` (default), `auto_approve`, `auto_reject`.
- **`events.jsonl`** per-task audit trail + **5 new `TaskRecord` counters** (pause_count, reprompt_count, approvals_requested/approved/rejected). Backfilled via `#[serde(default)]` + idempotent SQLite migration (`migrate_v04_event_counters`).

### Scope & approach

46 commits across 8 phases following the plan in `docs/superpowers/plans/2026-04-17-pitboss-v0.4-live-control-v0.4.md`. Every task was TDD'd; tests jumped from 223 → 282 (+59).

Backward compatible: v0.3.x manifests run unchanged, v0.3.x on-disk runs deserialize cleanly, SQLite DBs auto-migrate on first open, TUI pointed at a completed v0.3.x run enters observe-only mode.

## Test plan

- [ ] CI: fmt, clippy, `cargo test --workspace`, smoke-part1.sh all green
- [ ] Manual: `cargo build --release && pitboss dispatch examples/v0.4-approval-demo.toml`, attach `pitboss-tui`, exercise approval modal (y/n/e) and keybindings (x/X/p/c/r)
- [ ] Manual: verify a v0.3.x run dir still opens cleanly in the new TUI (observe-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)