### PR TITLE
v0.4.1 Stage 0.1: fake-claude MCP e2e tests + approval fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **`fake-claude` MCP-client mode.** When `PITBOSS_FAKE_MCP_SOCKET` is
+  set, the test-support `fake-claude` binary connects to a pitboss MCP
+  socket and can issue real tool calls from a new `mcp_call` script
+  action. Supports named bindings + whole-string template substitution
+  (`"$w1.task_id"`) for chaining tool calls — covers realistic lead
+  patterns in integration tests.
+- **`crates/pitboss-cli/tests/e2e_flows.rs`** — four new end-to-end
+  tests driving a real `fake-claude` subprocess through `SessionHandle`
+  + `TokioSpawner`: spawn+wait happy path, 3-worker fan-out with
+  wait_for_any, mid-flight cancel, and a full approval round-trip
+  exercising the MCP→bridge→control→control→bridge→MCP loop with
+  `fake-control-client`. Unlocks v0.4.1 feature development without
+  Anthropic API calls.
+
+### Fixed
+- Control-socket `approve` op now writes the `approval_response` event
+  to `events.jsonl` and increments `worker_counters.approvals_{approved,
+  rejected}` — matching `ApprovalBridge::respond`'s audit trail. The
+  v0.4.0 queue-drain path bypassed `respond`, so approvals drained on
+  TUI connect produced no response event and didn't bump counters.
+  Surfaced by the new e2e approval round-trip test.
+
 ## [0.4.0] — 2026-04-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,7 +426,10 @@ dependencies = [
 name = "fake-claude"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
+ "rmcp",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -554,11 +554,36 @@ async fn dispatch_op(
         } => {
             let tx = state.approval_bridge.lock().await.remove(&request_id);
             if let Some(tx) = tx {
+                let edited = edited_summary.is_some();
                 let _ = tx.send(crate::dispatch::state::ApprovalResponse {
                     approved,
                     comment,
                     edited_summary,
                 });
+                // Write an approval_response event + bump counters so the
+                // control-socket path produces the same audit trail as
+                // ApprovalBridge::respond would. Matters when the approval
+                // was drained from the queue (no TUI at request time).
+                let _ = crate::dispatch::events::append_event(
+                    &state.run_subdir,
+                    &state.lead_id,
+                    &crate::dispatch::events::TaskEvent::ApprovalResponse {
+                        at: chrono::Utc::now(),
+                        request_id: request_id.clone(),
+                        approved,
+                        edited,
+                    },
+                )
+                .await;
+                {
+                    let mut guard = state.worker_counters.write().await;
+                    let entry = guard.entry(state.lead_id.clone()).or_default();
+                    if approved {
+                        entry.approvals_approved += 1;
+                    } else {
+                        entry.approvals_rejected += 1;
+                    }
+                }
                 ControlEvent::OpAcked {
                     op: "approve".into(),
                     task_id: None,

--- a/crates/pitboss-cli/tests/e2e_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_flows.rs
@@ -210,3 +210,62 @@ async fn e2e_lead_spawns_worker_via_real_subprocess() {
     // Explicit cleanup: cancel the run token so any stray tasks exit.
     state.cancel.terminate();
 }
+
+#[tokio::test]
+async fn e2e_lead_spawns_three_workers_and_waits_for_any() {
+    support::ensure_built();
+
+    let dir = TempDir::new().unwrap();
+    let (run_id, state) = mk_state(dir.path(), ApprovalPolicy::Block);
+
+    let sock = socket_path_for_run(run_id, &state.manifest.run_dir);
+    let _server = McpServer::start(sock.clone(), state.clone()).await.unwrap();
+
+    // Three spawn_workers then one wait_for_any. Workers complete quickly
+    // under the FakeSpawner so wait_for_any resolves once the first exits.
+    let script = dir.path().join("script.jsonl");
+    let script_body = r#"{"stdout":"{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"lead-sess\"}"}
+{"mcp_call":{"name":"spawn_worker","args":{"prompt":"a"},"bind":"w1"}}
+{"mcp_call":{"name":"spawn_worker","args":{"prompt":"b"},"bind":"w2"}}
+{"mcp_call":{"name":"spawn_worker","args":{"prompt":"c"},"bind":"w3"}}
+{"mcp_call":{"name":"wait_for_any","args":{"task_ids":["$w1.task_id","$w2.task_id","$w3.task_id"]},"bind":"first"}}
+{"stdout":"{\"type\":\"result\",\"subtype\":\"success\",\"session_id\":\"lead-sess\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}"}
+"#;
+    tokio::fs::write(&script, script_body).await.unwrap();
+
+    let outcome = run_fake_claude_lead(
+        dir.path(),
+        &script,
+        &sock,
+        CancelToken::new(),
+        Duration::from_secs(30),
+    )
+    .await;
+
+    assert_eq!(outcome.exit_code, Some(0), "exit non-zero: {outcome:?}");
+    assert!(matches!(
+        outcome.final_state,
+        pitboss_core::session::SessionState::Completed
+    ));
+
+    // All 3 workers should be registered (at least 1 Done; the rest can be
+    // Done or Running depending on timing).
+    let workers = state.workers.read().await;
+    assert_eq!(
+        workers.len(),
+        3,
+        "expected 3 workers, got {}",
+        workers.len()
+    );
+
+    let done_count = workers
+        .values()
+        .filter(|w| matches!(w, pitboss_cli::dispatch::state::WorkerState::Done(_)))
+        .count();
+    assert!(
+        done_count >= 1,
+        "expected at least one Done worker after wait_for_any, got {done_count}"
+    );
+
+    state.cancel.terminate();
+}

--- a/crates/pitboss-cli/tests/e2e_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_flows.rs
@@ -1,0 +1,145 @@
+//! End-to-end hierarchical integration tests. Unlike `hierarchical_flows.rs`
+//! which drives the MCP server directly as a client (via FakeMcpClient),
+//! these tests spawn fake-claude as a real subprocess via SessionHandle +
+//! TokioSpawner. The subprocess connects to the MCP socket directly and
+//! issues real tool calls via its mcp_call script action.
+//!
+//! Decisions locked in
+//! docs/superpowers/specs/2026-04-17-pitboss-v041-fake-claude-mcp-e2e-design.md.
+
+#![allow(dead_code)]
+#![allow(unused_imports)] // Helpers + types re-used by Tasks 7-10.
+
+mod support;
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tempfile::TempDir;
+
+use pitboss_cli::dispatch::state::{ApprovalPolicy, DispatchState};
+use pitboss_cli::manifest::resolve::{ResolvedLead, ResolvedManifest};
+use pitboss_cli::manifest::schema::{Effort, WorktreeCleanup};
+use pitboss_cli::mcp::{socket_path_for_run, McpServer};
+use pitboss_core::process::fake::{FakeScript, FakeSpawner};
+use pitboss_core::process::{ProcessSpawner, SpawnCmd, TokioSpawner};
+use pitboss_core::session::{CancelToken, SessionHandle, SessionOutcome};
+use pitboss_core::store::{JsonFileStore, SessionStore};
+use pitboss_core::worktree::{CleanupPolicy, WorktreeManager};
+use uuid::Uuid;
+
+use support::fake_claude_path;
+
+/// Build a DispatchState configured with a FakeSpawner producing short,
+/// successful worker runs. Lead is NOT run here — callers spawn fake-claude
+/// themselves via a separate TokioSpawner.
+fn mk_state(
+    run_dir: &std::path::Path,
+    approval_policy: ApprovalPolicy,
+) -> (Uuid, Arc<DispatchState>) {
+    let run_id = Uuid::now_v7();
+    let lead = ResolvedLead {
+        id: "lead".into(),
+        directory: PathBuf::from("/tmp"),
+        prompt: "lead prompt".into(),
+        branch: None,
+        model: "claude-haiku-4-5".into(),
+        effort: Effort::High,
+        tools: vec![],
+        timeout_secs: 3600,
+        use_worktree: false,
+        env: Default::default(),
+        resume_session_id: None,
+    };
+    let manifest = ResolvedManifest {
+        max_parallel: 4,
+        halt_on_failure: false,
+        run_dir: run_dir.to_path_buf(),
+        worktree_cleanup: WorktreeCleanup::OnSuccess,
+        emit_event_stream: false,
+        tasks: vec![],
+        lead: Some(lead),
+        max_workers: Some(4),
+        budget_usd: Some(5.0),
+        lead_timeout_secs: None,
+        approval_policy: Some(approval_policy),
+    };
+    let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(run_dir.to_path_buf()));
+    // Worker-side spawner: emits a complete stream-json run then exits 0.
+    let worker_script = FakeScript::new()
+        .stdout_line(r#"{"type":"system","subtype":"init","session_id":"worker-sess"}"#)
+        .stdout_line(
+            r#"{"type":"result","session_id":"worker-sess","usage":{"input_tokens":10,"output_tokens":20}}"#,
+        )
+        .exit_code(0);
+    let spawner: Arc<dyn ProcessSpawner> = Arc::new(FakeSpawner::new(worker_script));
+    let wt_mgr = Arc::new(WorktreeManager::new());
+    let run_subdir = run_dir.join(run_id.to_string());
+    let state = Arc::new(DispatchState::new(
+        run_id,
+        manifest,
+        store,
+        CancelToken::new(),
+        "lead".into(),
+        spawner,
+        PathBuf::from("claude"),
+        wt_mgr,
+        CleanupPolicy::Never,
+        run_subdir,
+        approval_policy,
+    ));
+    (run_id, state)
+}
+
+/// Build + spawn fake-claude as the lead subprocess, connecting to `mcp_sock`.
+/// Returns the SessionOutcome.
+async fn run_fake_claude_lead(
+    cwd: &std::path::Path,
+    script_path: &std::path::Path,
+    mcp_sock: &std::path::Path,
+    cancel: CancelToken,
+    timeout: Duration,
+) -> SessionOutcome {
+    let mut env = HashMap::new();
+    env.insert(
+        "MOSAIC_FAKE_SCRIPT".to_string(),
+        script_path.to_string_lossy().to_string(),
+    );
+    env.insert(
+        "PITBOSS_FAKE_MCP_SOCKET".to_string(),
+        mcp_sock.to_string_lossy().to_string(),
+    );
+    let cmd = SpawnCmd {
+        program: fake_claude_path(),
+        args: vec![],
+        cwd: cwd.to_path_buf(),
+        env,
+    };
+    let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
+    SessionHandle::new("lead", spawner, cmd)
+        .run_to_completion(cancel, timeout)
+        .await
+}
+
+#[tokio::test]
+async fn fake_claude_smoke_prints_version_stderr() {
+    // Sanity-check that the fake-claude binary was built and can run without
+    // the MCP env vars set. Uses --version fast-path which prints to stdout
+    // and exits 0, doesn't touch any script.
+    support::ensure_built();
+    let output = std::process::Command::new(fake_claude_path())
+        .arg("--version")
+        .output()
+        .expect("exec fake-claude --version");
+    assert!(
+        output.status.success(),
+        "fake-claude --version failed: {output:?}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("fake-claude"),
+        "expected --version output to mention fake-claude, got: {stdout:?}"
+    );
+}

--- a/crates/pitboss-cli/tests/e2e_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_flows.rs
@@ -269,3 +269,104 @@ async fn e2e_lead_spawns_three_workers_and_waits_for_any() {
 
     state.cancel.terminate();
 }
+
+#[tokio::test]
+async fn e2e_lead_cancels_worker_mid_flight() {
+    support::ensure_built();
+
+    let dir = TempDir::new().unwrap();
+    let run_id = Uuid::now_v7();
+
+    // Custom state: worker script holds until signal so cancel has
+    // something to actually cancel.
+    let lead = ResolvedLead {
+        id: "lead".into(),
+        directory: PathBuf::from("/tmp"),
+        prompt: "lead prompt".into(),
+        branch: None,
+        model: "claude-haiku-4-5".into(),
+        effort: Effort::High,
+        tools: vec![],
+        timeout_secs: 3600,
+        use_worktree: false,
+        env: Default::default(),
+        resume_session_id: None,
+    };
+    let manifest = ResolvedManifest {
+        max_parallel: 4,
+        halt_on_failure: false,
+        run_dir: dir.path().to_path_buf(),
+        worktree_cleanup: WorktreeCleanup::OnSuccess,
+        emit_event_stream: false,
+        tasks: vec![],
+        lead: Some(lead),
+        max_workers: Some(4),
+        budget_usd: Some(5.0),
+        lead_timeout_secs: None,
+        approval_policy: Some(ApprovalPolicy::Block),
+    };
+    let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
+    let hold_script = FakeScript::new().hold_until_signal();
+    let spawner: Arc<dyn ProcessSpawner> = Arc::new(FakeSpawner::new(hold_script));
+    let wt_mgr = Arc::new(WorktreeManager::new());
+    let run_subdir = dir.path().join(run_id.to_string());
+    let state = Arc::new(DispatchState::new(
+        run_id,
+        manifest,
+        store,
+        CancelToken::new(),
+        "lead".into(),
+        spawner,
+        PathBuf::from("claude"),
+        wt_mgr,
+        CleanupPolicy::Never,
+        run_subdir,
+        ApprovalPolicy::Block,
+    ));
+
+    let sock = socket_path_for_run(run_id, &state.manifest.run_dir);
+    let _server = McpServer::start(sock.clone(), state.clone()).await.unwrap();
+
+    // spawn_worker (worker hangs), sleep for slot fill, cancel_worker, list.
+    let script = dir.path().join("script.jsonl");
+    let script_body = r#"{"stdout":"{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"lead-sess\"}"}
+{"mcp_call":{"name":"spawn_worker","args":{"prompt":"hi"},"bind":"w1"}}
+{"sleep_ms":200}
+{"mcp_call":{"name":"cancel_worker","args":{"task_id":"$w1.task_id"},"bind":"cancel_res"}}
+{"mcp_call":{"name":"list_workers","args":{},"bind":"snapshot"}}
+{"stdout":"{\"type\":\"result\",\"subtype\":\"success\",\"session_id\":\"lead-sess\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}"}
+"#;
+    tokio::fs::write(&script, script_body).await.unwrap();
+
+    let outcome = run_fake_claude_lead(
+        dir.path(),
+        &script,
+        &sock,
+        CancelToken::new(),
+        Duration::from_secs(30),
+    )
+    .await;
+
+    assert_eq!(outcome.exit_code, Some(0), "exit non-zero: {outcome:?}");
+
+    // Give the backgrounded worker a moment to finalize as Cancelled after
+    // receiving the terminate signal from cancel_worker.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Worker should now be Cancelled.
+    let workers = state.workers.read().await;
+    let (_, w) = workers.iter().next().expect("at least one worker");
+    match w {
+        pitboss_cli::dispatch::state::WorkerState::Done(rec) => {
+            assert_eq!(
+                rec.status,
+                pitboss_core::store::TaskStatus::Cancelled,
+                "expected Cancelled status, got {:?}",
+                rec.status
+            );
+        }
+        other => panic!("expected Done(Cancelled), got {other:?}"),
+    }
+
+    state.cancel.terminate();
+}

--- a/crates/pitboss-cli/tests/e2e_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_flows.rs
@@ -143,3 +143,70 @@ async fn fake_claude_smoke_prints_version_stderr() {
         "expected --version output to mention fake-claude, got: {stdout:?}"
     );
 }
+
+#[tokio::test]
+async fn e2e_lead_spawns_worker_via_real_subprocess() {
+    support::ensure_built();
+
+    let dir = TempDir::new().unwrap();
+    let (run_id, state) = mk_state(dir.path(), ApprovalPolicy::Block);
+
+    // Start the MCP server so fake-claude's mcp_call can land somewhere.
+    let sock = socket_path_for_run(run_id, &state.manifest.run_dir);
+    let _server = McpServer::start(sock.clone(), state.clone()).await.unwrap();
+
+    // Write the script. spawn_worker returns {task_id: "worker-..."},
+    // stored under "w1"; wait_for_worker then consumes $w1.task_id.
+    let script = dir.path().join("script.jsonl");
+    // Lead emits init + result stream-json so SessionHandle sees a clean
+    // Completed outcome (saw_result=true). The mcp_call actions between
+    // them exercise the actual MCP flow.
+    let script_body = r#"{"stdout":"{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"lead-sess\"}"}
+{"mcp_call":{"name":"spawn_worker","args":{"prompt":"hi"},"bind":"w1"}}
+{"mcp_call":{"name":"wait_for_worker","args":{"task_id":"$w1.task_id"},"bind":"rec"}}
+{"stdout":"{\"type\":\"result\",\"subtype\":\"success\",\"session_id\":\"lead-sess\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}"}
+"#;
+    tokio::fs::write(&script, script_body).await.unwrap();
+
+    // Run fake-claude as the lead. A real TokioSpawner subprocess, not the
+    // FakeSpawner in state.spawner (which backs the workers it spawns).
+    let outcome = run_fake_claude_lead(
+        dir.path(),
+        &script,
+        &sock,
+        CancelToken::new(),
+        Duration::from_secs(30),
+    )
+    .await;
+
+    // Subprocess must have exited cleanly.
+    assert_eq!(
+        outcome.exit_code,
+        Some(0),
+        "fake-claude exited non-zero: outcome={outcome:?}"
+    );
+    assert!(matches!(
+        outcome.final_state,
+        pitboss_core::session::SessionState::Completed
+    ));
+
+    // Worker state should be Done with a captured session_id.
+    let workers = state.workers.read().await;
+    assert_eq!(
+        workers.len(),
+        1,
+        "expected exactly one worker, got {}",
+        workers.len()
+    );
+    let (task_id, w) = workers.iter().next().unwrap();
+    match w {
+        pitboss_cli::dispatch::state::WorkerState::Done(rec) => {
+            assert_eq!(&rec.task_id, task_id);
+            assert!(rec.claude_session_id.is_some(), "session_id not captured");
+        }
+        other => panic!("expected Done, got {other:?}"),
+    }
+
+    // Explicit cleanup: cancel the run token so any stray tasks exit.
+    state.cancel.terminate();
+}

--- a/crates/pitboss-cli/tests/e2e_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_flows.rs
@@ -370,3 +370,136 @@ async fn e2e_lead_cancels_worker_mid_flight() {
 
     state.cancel.terminate();
 }
+
+#[tokio::test]
+async fn e2e_lead_request_approval_round_trip() {
+    support::ensure_built();
+
+    let dir = TempDir::new().unwrap();
+    let (run_id, state) = mk_state(dir.path(), ApprovalPolicy::Block);
+
+    // Ensure the run subdir exists so events.jsonl writes don't fail.
+    tokio::fs::create_dir_all(&state.run_subdir).await.unwrap();
+
+    // Start BOTH the MCP server (for the lead) and the Control server
+    // (for FakeControlClient).
+    let mcp_sock = socket_path_for_run(run_id, &state.manifest.run_dir);
+    let _mcp_server = McpServer::start(mcp_sock.clone(), state.clone())
+        .await
+        .unwrap();
+
+    let ctrl_sock = pitboss_cli::control::control_socket_path(run_id, &state.manifest.run_dir);
+    let _ctrl_server = pitboss_cli::control::server::start_control_server(
+        ctrl_sock.clone(),
+        "0.4.1".into(),
+        run_id.to_string(),
+        "hierarchical".into(),
+        state.clone(),
+    )
+    .await
+    .unwrap();
+
+    // Background task: poll until there's a queued approval so we don't race
+    // the lead. When queue non-empty, connect the FakeControlClient (which
+    // triggers the server-side drain + ApprovalRequest push). FCC responds
+    // with Approve{approved:true}.
+    let ctrl_sock_bg = ctrl_sock.clone();
+    let state_for_fcc = state.clone();
+    let fcc_task = tokio::spawn(async move {
+        // Poll up to 2s for the approval_queue to fill.
+        let poll_deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            if !state_for_fcc.approval_queue.lock().await.is_empty() {
+                break;
+            }
+            if tokio::time::Instant::now() >= poll_deadline {
+                panic!("FCC timed out waiting for queued approval");
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        let mut client =
+            fake_control_client::FakeControlClient::connect(&ctrl_sock_bg, "0.4.1-fcc")
+                .await
+                .unwrap();
+        // First event should be the drained ApprovalRequest.
+        match client.recv_timeout(Duration::from_secs(5)).await.unwrap() {
+            Some(pitboss_cli::control::protocol::ControlEvent::ApprovalRequest {
+                request_id,
+                ..
+            }) => {
+                client
+                    .send(&pitboss_cli::control::protocol::ControlOp::Approve {
+                        request_id,
+                        approved: true,
+                        comment: None,
+                        edited_summary: None,
+                    })
+                    .await
+                    .unwrap();
+            }
+            Some(other) => panic!("expected ApprovalRequest first, got {other:?}"),
+            None => panic!("FakeControlClient timed out waiting for event"),
+        }
+    });
+
+    // Script: one request_approval call.
+    let script = dir.path().join("script.jsonl");
+    let script_body = r#"{"stdout":"{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"lead-sess\"}"}
+{"mcp_call":{"name":"request_approval","args":{"summary":"spawn 3 workers","timeout_secs":10},"bind":"approval"}}
+{"stdout":"{\"type\":\"result\",\"subtype\":\"success\",\"session_id\":\"lead-sess\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}"}
+"#;
+    tokio::fs::write(&script, script_body).await.unwrap();
+
+    let outcome = run_fake_claude_lead(
+        dir.path(),
+        &script,
+        &mcp_sock,
+        CancelToken::new(),
+        Duration::from_secs(30),
+    )
+    .await;
+
+    // Clean up the background FCC task (should have finished by now).
+    fcc_task.await.expect("FCC task panicked");
+
+    assert_eq!(
+        outcome.exit_code,
+        Some(0),
+        "fake-claude exit non-zero: {outcome:?}"
+    );
+
+    // Check events.jsonl for both approval_request and approval_response.
+    let events_path = state
+        .run_subdir
+        .join("tasks")
+        .join("lead")
+        .join("events.jsonl");
+    let events = tokio::fs::read_to_string(&events_path)
+        .await
+        .unwrap_or_else(|e| {
+            panic!("read {}: {e}", events_path.display());
+        });
+    assert!(
+        events.contains("\"kind\":\"approval_request\""),
+        "events.jsonl missing approval_request: {events}"
+    );
+    assert!(
+        events.contains("\"kind\":\"approval_response\""),
+        "events.jsonl missing approval_response: {events}"
+    );
+
+    // Counters should record one request + one approval.
+    let counters = state
+        .worker_counters
+        .read()
+        .await
+        .get("lead")
+        .cloned()
+        .unwrap_or_default();
+    assert_eq!(counters.approvals_requested, 1);
+    assert_eq!(counters.approvals_approved, 1);
+    assert_eq!(counters.approvals_rejected, 0);
+
+    state.cancel.terminate();
+}

--- a/crates/pitboss-cli/tests/support/mod.rs
+++ b/crates/pitboss-cli/tests/support/mod.rs
@@ -46,6 +46,17 @@ pub fn fake_claude_path() -> PathBuf {
     workspace_root().join("target/debug/fake-claude")
 }
 
+/// Build the pitboss-cli + fake-claude binaries so tests that spawn
+/// them as real subprocesses can find them at `target/debug/...`.
+#[allow(dead_code)]
+pub fn ensure_built() {
+    let status = Command::new(env!("CARGO"))
+        .args(["build", "-p", "pitboss-cli", "-p", "fake-claude"])
+        .status()
+        .unwrap();
+    assert!(status.success(), "build failed");
+}
+
 #[allow(dead_code)]
 pub fn pitboss_binary() -> PathBuf {
     workspace_root().join("target/debug/pitboss")

--- a/tests-support/fake-claude/Cargo.toml
+++ b/tests-support/fake-claude/Cargo.toml
@@ -11,3 +11,6 @@ path = "src/main.rs"
 
 [dependencies]
 serde_json = { workspace = true }
+rmcp       = { workspace = true, features = ["client", "transport-io"] }
+tokio      = { workspace = true, features = ["macros", "rt-multi-thread", "net", "io-util", "sync", "process", "fs", "time"] }
+anyhow     = { workspace = true }

--- a/tests-support/fake-claude/src/bindings.rs
+++ b/tests-support/fake-claude/src/bindings.rs
@@ -1,0 +1,142 @@
+//! Script-local variable bindings and template substitution.
+//!
+//! Scripts in MCP-client mode can bind MCP tool results under a name
+//! (`bind: "w1"`) and reference them in later action args via whole-string
+//! templates like `"$w1.task_id"`. This module provides the map and the
+//! substitution walker.
+
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+
+pub type Bindings = HashMap<String, Value>;
+
+/// Recursively walk `value` in place. Any JSON string whose full content
+/// matches `^\$<name>(\.<field>)*$` is replaced with the bound value at
+/// that path. Returns Err if a reference names an unknown binding or the
+/// path can't be walked.
+pub fn substitute(value: &mut Value, bindings: &Bindings) -> Result<()> {
+    match value {
+        Value::String(s) => {
+            if let Some(replacement) = resolve(s, bindings)? {
+                *value = replacement;
+            }
+        }
+        Value::Array(items) => {
+            for v in items {
+                substitute(v, bindings)?;
+            }
+        }
+        Value::Object(map) => {
+            for v in map.values_mut() {
+                substitute(v, bindings)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// If `s` is a whole-string template reference (starts with `$` and
+/// contains only name + optional `.field` segments), return the resolved
+/// value. Ok(None) if `s` isn't a template. Err if resolution fails.
+fn resolve(s: &str, bindings: &Bindings) -> Result<Option<Value>> {
+    if !s.starts_with('$') {
+        return Ok(None);
+    }
+    // Reject partial-string templates like "prefix $w1 suffix". We only
+    // support whole-string references — tests that need interpolation
+    // can build the string in Rust.
+    if s.contains(' ') {
+        return Ok(None);
+    }
+    let rest = &s[1..];
+    if rest.is_empty() {
+        return Err(anyhow!("empty binding reference: {s:?}"));
+    }
+    let mut parts = rest.split('.');
+    let name = parts.next().unwrap(); // split always yields at least one element
+    if name.is_empty() {
+        return Err(anyhow!("empty binding name in {s:?}"));
+    }
+    let root = bindings
+        .get(name)
+        .ok_or_else(|| anyhow!("unknown binding {name:?} referenced in {s:?}"))?;
+    let mut current = root;
+    for field in parts {
+        current = current.get(field).ok_or_else(|| {
+            anyhow!("binding {name:?} has no path .{field} (referenced in {s:?})")
+        })?;
+    }
+    Ok(Some(current.clone()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn substitute_noop_on_plain_string() {
+        let mut v = json!("hello");
+        let b = Bindings::new();
+        substitute(&mut v, &b).unwrap();
+        assert_eq!(v, json!("hello"));
+    }
+
+    #[test]
+    fn substitute_whole_string_reference() {
+        let mut v = json!("$w1");
+        let mut b = Bindings::new();
+        b.insert("w1".into(), json!({"task_id": "worker-abc"}));
+        substitute(&mut v, &b).unwrap();
+        assert_eq!(v, json!({"task_id": "worker-abc"}));
+    }
+
+    #[test]
+    fn substitute_path_walk() {
+        let mut v = json!({"task_id": "$w1.task_id"});
+        let mut b = Bindings::new();
+        b.insert("w1".into(), json!({"task_id": "worker-abc"}));
+        substitute(&mut v, &b).unwrap();
+        assert_eq!(v, json!({"task_id": "worker-abc"}));
+    }
+
+    #[test]
+    fn substitute_nested_array() {
+        let mut v = json!({"task_ids": ["$w1.task_id", "$w2.task_id"]});
+        let mut b = Bindings::new();
+        b.insert("w1".into(), json!({"task_id": "a"}));
+        b.insert("w2".into(), json!({"task_id": "b"}));
+        substitute(&mut v, &b).unwrap();
+        assert_eq!(v, json!({"task_ids": ["a", "b"]}));
+    }
+
+    #[test]
+    fn substitute_missing_binding_errors() {
+        let mut v = json!("$w9.task_id");
+        let b = Bindings::new();
+        let err = substitute(&mut v, &b).unwrap_err();
+        assert!(err.to_string().contains("unknown binding"), "got: {err}");
+    }
+
+    #[test]
+    fn substitute_missing_path_errors() {
+        let mut v = json!("$w1.nonexistent");
+        let mut b = Bindings::new();
+        b.insert("w1".into(), json!({"task_id": "a"}));
+        let err = substitute(&mut v, &b).unwrap_err();
+        assert!(err.to_string().contains("no path"), "got: {err}");
+    }
+
+    #[test]
+    fn substitute_ignores_dollar_within_text() {
+        let mut v = json!("some $text here");
+        let b = Bindings::new();
+        substitute(&mut v, &b).unwrap();
+        assert_eq!(v, json!("some $text here"));
+    }
+}

--- a/tests-support/fake-claude/src/main.rs
+++ b/tests-support/fake-claude/src/main.rs
@@ -50,9 +50,36 @@ fn main() {
             .build()
             .expect("build tokio runtime");
 
-        if let Err(e) = rt.block_on(script::execute_script(reader)) {
-            eprintln!("fake-claude: script error: {e:#}");
-            std::process::exit(5);
+        // Open an MCP client if the socket env var is set. Unset => None.
+        let client = match std::env::var("PITBOSS_FAKE_MCP_SOCKET") {
+            Ok(sock) => {
+                let path = std::path::PathBuf::from(sock);
+                match rt.block_on(mcp_client::McpClient::connect(&path)) {
+                    Ok(c) => Some(c),
+                    Err(e) => {
+                        eprintln!("fake-claude: mcp connect {}: {e:#}", path.display());
+                        std::process::exit(2);
+                    }
+                }
+            }
+            Err(_) => None,
+        };
+
+        if let Err(e) = rt.block_on(script::execute_script(reader, client)) {
+            let msg = format!("{e:#}");
+            eprintln!("fake-claude: script error: {msg}");
+            // Distinguish exit codes by error type (see spec §Error handling).
+            let code = if msg.contains("unknown binding")
+                || msg.contains("no path")
+                || msg.contains("substitute")
+            {
+                4
+            } else if msg.contains("requires PITBOSS_FAKE_MCP_SOCKET") {
+                3
+            } else {
+                5
+            };
+            std::process::exit(code);
         }
     }
 

--- a/tests-support/fake-claude/src/main.rs
+++ b/tests-support/fake-claude/src/main.rs
@@ -11,6 +11,8 @@
 //! If MOSAIC_FAKE_HOLD=1, blocks indefinitely after the script (for Ctrl-C tests).
 //! Special-cases --version to print "fake-claude 0.0.0".
 
+mod bindings;
+
 use std::io::{self, BufRead, Write};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread;

--- a/tests-support/fake-claude/src/main.rs
+++ b/tests-support/fake-claude/src/main.rs
@@ -6,6 +6,8 @@
 //!   {"sleep_ms": N}   — sleeps for N milliseconds
 //!   {"tool_use": {"name": "...", "input": {...}}}
 //!       — emits a stream-json assistant tool_use event on stdout
+//!   {"mcp_call": {"name": "...", "args": {...}, "bind": "...", "allow_err": bool}}
+//!       — issues an MCP tool call (requires PITBOSS_FAKE_MCP_SOCKET).
 //!
 //! After the script, exits with MOSAIC_FAKE_EXIT_CODE (default 0).
 //! If MOSAIC_FAKE_HOLD=1, blocks indefinitely after the script (for Ctrl-C tests).
@@ -13,23 +15,16 @@
 
 mod bindings;
 mod mcp_client;
+mod script;
 
-use std::io::{self, BufRead, Write};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::io::BufReader;
 use std::thread;
 use std::time::Duration;
-
-/// Monotonic counter used to generate unique tool_use ids within a process.
-static NEXT_ID: AtomicU64 = AtomicU64::new(1);
-
-fn random_id() -> u64 {
-    NEXT_ID.fetch_add(1, Ordering::Relaxed)
-}
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
 
-    // Handle --version flag
+    // Handle --version flag.
     if args.iter().any(|a| a == "--version") {
         println!("fake-claude 0.0.0");
         return;
@@ -44,62 +39,25 @@ fn main() {
         .map(|v| v.trim() == "1")
         .unwrap_or(false);
 
-    // Execute the script if provided
+    // Execute the script if provided.
     if let Ok(script_path) = std::env::var("MOSAIC_FAKE_SCRIPT") {
         let file = std::fs::File::open(&script_path)
             .unwrap_or_else(|e| panic!("fake-claude: cannot open script {script_path:?}: {e}"));
-        let reader = io::BufReader::new(file);
+        let reader = BufReader::new(file);
 
-        let stdout = io::stdout();
-        let stderr = io::stderr();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build tokio runtime");
 
-        for (line_no, line) in reader.lines().enumerate() {
-            let line =
-                line.unwrap_or_else(|e| panic!("fake-claude: read error at line {line_no}: {e}"));
-            let line = line.trim();
-            if line.is_empty() {
-                continue;
-            }
-
-            let action: serde_json::Value = serde_json::from_str(line).unwrap_or_else(|e| {
-                panic!("fake-claude: invalid JSON at line {line_no}: {e}\n  line: {line}")
-            });
-
-            if let Some(text) = action.get("stdout").and_then(|v| v.as_str()) {
-                let mut out = stdout.lock();
-                writeln!(out, "{text}").unwrap();
-                out.flush().unwrap();
-            } else if let Some(text) = action.get("stderr").and_then(|v| v.as_str()) {
-                let mut err = stderr.lock();
-                writeln!(err, "{text}").unwrap();
-                err.flush().unwrap();
-            } else if let Some(ms) = action.get("sleep_ms").and_then(|v| v.as_u64()) {
-                thread::sleep(Duration::from_millis(ms));
-            } else if let Some(tu) = action.get("tool_use") {
-                // Emit a stream-json tool_use event wrapper, mirroring how real
-                // claude emits `{"type":"assistant","message":{"content":[...]}}`.
-                let wrapper = serde_json::json!({
-                    "type": "assistant",
-                    "message": {
-                        "content": [{
-                            "type": "tool_use",
-                            "id": format!("call-{}", random_id()),
-                            "name": tu.get("name").and_then(|n| n.as_str()).unwrap_or(""),
-                            "input": tu.get("input").cloned().unwrap_or(serde_json::Value::Null),
-                        }]
-                    }
-                });
-                let mut out = stdout.lock();
-                writeln!(out, "{}", serde_json::to_string(&wrapper).unwrap()).unwrap();
-                out.flush().unwrap();
-            } else {
-                eprintln!("fake-claude: unknown action at line {line_no}: {line}");
-            }
+        if let Err(e) = rt.block_on(script::execute_script(reader)) {
+            eprintln!("fake-claude: script error: {e:#}");
+            std::process::exit(5);
         }
     }
 
     if hold {
-        // Block indefinitely — wait for SIGINT/SIGTERM from the test harness
+        // Block indefinitely — wait for SIGINT/SIGTERM from the test harness.
         loop {
             thread::sleep(Duration::from_secs(3600));
         }

--- a/tests-support/fake-claude/src/main.rs
+++ b/tests-support/fake-claude/src/main.rs
@@ -12,6 +12,7 @@
 //! Special-cases --version to print "fake-claude 0.0.0".
 
 mod bindings;
+mod mcp_client;
 
 use std::io::{self, BufRead, Write};
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/tests-support/fake-claude/src/mcp_client.rs
+++ b/tests-support/fake-claude/src/mcp_client.rs
@@ -1,0 +1,64 @@
+//! Minimal MCP client for fake-claude's MCP-client mode.
+//!
+//! Connects to a pitboss MCP server over a unix socket, performs the
+//! init handshake, and exposes `call_tool`. Intentionally near-duplicate
+//! of `fake-mcp-client/src/lib.rs` — the two crates have different roles
+//! (one drives the server as a test peer; the other emulates a lead
+//! subprocess), and inlining avoids a test-support dependency cycle.
+
+#![allow(dead_code)]
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use rmcp::model::{CallToolRequestParam, CallToolResult};
+use rmcp::service::{RoleClient, RunningService};
+use rmcp::ServiceExt;
+use serde_json::Value;
+
+pub struct McpClient {
+    inner: RunningService<RoleClient, ()>,
+}
+
+impl McpClient {
+    /// Connect to a pitboss MCP server on `socket` and complete the MCP
+    /// initialization handshake.
+    pub async fn connect(socket: &Path) -> Result<Self> {
+        let stream = tokio::net::UnixStream::connect(socket)
+            .await
+            .with_context(|| format!("connect to {}", socket.display()))?;
+        let inner = ()
+            .serve(stream)
+            .await
+            .with_context(|| format!("mcp init handshake on {}", socket.display()))?;
+        Ok(Self { inner })
+    }
+
+    /// Call a tool and return its structured content as JSON. Pitboss
+    /// tools always populate `CallToolResult::structured_content` via the
+    /// `to_structured_result` helper server-side, so we prefer that.
+    /// Falls back to serializing the whole `CallToolResult`.
+    pub async fn call_tool(&mut self, name: &str, args: Value) -> Result<Value> {
+        let arguments = match args {
+            Value::Null => None,
+            Value::Object(map) => Some(map),
+            other => {
+                anyhow::bail!("call_tool args must be a JSON object or null, got {other}");
+            }
+        };
+        let param = CallToolRequestParam {
+            name: name.to_owned().into(),
+            arguments,
+        };
+        let result: CallToolResult = self
+            .inner
+            .call_tool(param)
+            .await
+            .with_context(|| format!("call_tool {name}"))?;
+        if let Some(structured) = result.structured_content {
+            Ok(structured)
+        } else {
+            serde_json::to_value(&result).context("serialize CallToolResult")
+        }
+    }
+}

--- a/tests-support/fake-claude/src/script.rs
+++ b/tests-support/fake-claude/src/script.rs
@@ -1,0 +1,76 @@
+//! Script action loop for fake-claude.
+//!
+//! Reads a JSONL script line-by-line from a `BufRead`, executing each
+//! action in order. Existing action types (stdout/stderr/sleep_ms/
+//! tool_use) preserve their pre-v0.4.1 behavior exactly. The new
+//! `mcp_call` action lands in Task 5.
+
+#![allow(dead_code)]
+
+use std::io::{self, BufRead, Write};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+/// Monotonic counter used to generate unique tool_use ids within a process.
+static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+
+fn random_id() -> u64 {
+    NEXT_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+/// Execute the script file, dispatching each action in order. Returns
+/// Ok(()) when the script completes without error.
+///
+/// For v0.4.1: the only action that needs async is `mcp_call` (Task 5).
+/// Existing actions are sync; we call them directly from this async fn.
+pub async fn execute_script<R: BufRead>(reader: R) -> Result<()> {
+    let stdout = io::stdout();
+    let stderr = io::stderr();
+
+    for (line_no, line) in reader.lines().enumerate() {
+        let line = line.with_context(|| format!("read error at line {line_no}"))?;
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let action: Value = serde_json::from_str(line)
+            .with_context(|| format!("invalid JSON at line {line_no}: {line}"))?;
+
+        if let Some(text) = action.get("stdout").and_then(|v| v.as_str()) {
+            let mut out = stdout.lock();
+            writeln!(out, "{text}")?;
+            out.flush()?;
+        } else if let Some(text) = action.get("stderr").and_then(|v| v.as_str()) {
+            let mut err = stderr.lock();
+            writeln!(err, "{text}")?;
+            err.flush()?;
+        } else if let Some(ms) = action.get("sleep_ms").and_then(|v| v.as_u64()) {
+            tokio::time::sleep(Duration::from_millis(ms)).await;
+        } else if let Some(tu) = action.get("tool_use") {
+            // Emit a stream-json tool_use event wrapper, mirroring how real
+            // claude emits `{"type":"assistant","message":{"content":[...]}}`.
+            let wrapper = serde_json::json!({
+                "type": "assistant",
+                "message": {
+                    "content": [{
+                        "type": "tool_use",
+                        "id": format!("call-{}", random_id()),
+                        "name": tu.get("name").and_then(|n| n.as_str()).unwrap_or(""),
+                        "input": tu.get("input").cloned().unwrap_or(Value::Null),
+                    }]
+                }
+            });
+            let mut out = stdout.lock();
+            writeln!(out, "{}", serde_json::to_string(&wrapper)?)?;
+            out.flush()?;
+        } else {
+            eprintln!("fake-claude: unknown action at line {line_no}: {line}");
+        }
+    }
+
+    Ok(())
+}

--- a/tests-support/fake-claude/src/script.rs
+++ b/tests-support/fake-claude/src/script.rs
@@ -3,7 +3,8 @@
 //! Reads a JSONL script line-by-line from a `BufRead`, executing each
 //! action in order. Existing action types (stdout/stderr/sleep_ms/
 //! tool_use) preserve their pre-v0.4.1 behavior exactly. The new
-//! `mcp_call` action lands in Task 5.
+//! `mcp_call` action issues a real MCP tool call through an optionally-
+//! provided client.
 
 #![allow(dead_code)]
 
@@ -13,6 +14,9 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use serde_json::Value;
+
+use crate::bindings::{substitute, Bindings};
+use crate::mcp_client::McpClient;
 
 /// Monotonic counter used to generate unique tool_use ids within a process.
 static NEXT_ID: AtomicU64 = AtomicU64::new(1);
@@ -24,9 +28,10 @@ fn random_id() -> u64 {
 /// Execute the script file, dispatching each action in order. Returns
 /// Ok(()) when the script completes without error.
 ///
-/// For v0.4.1: the only action that needs async is `mcp_call` (Task 5).
-/// Existing actions are sync; we call them directly from this async fn.
-pub async fn execute_script<R: BufRead>(reader: R) -> Result<()> {
+/// `client` is only required when the script contains `mcp_call`
+/// actions; if None, those actions return an error.
+pub async fn execute_script<R: BufRead>(reader: R, mut client: Option<McpClient>) -> Result<()> {
+    let mut bindings = Bindings::new();
     let stdout = io::stdout();
     let stderr = io::stderr();
 
@@ -67,6 +72,43 @@ pub async fn execute_script<R: BufRead>(reader: R) -> Result<()> {
             let mut out = stdout.lock();
             writeln!(out, "{}", serde_json::to_string(&wrapper)?)?;
             out.flush()?;
+        } else if let Some(call) = action.get("mcp_call") {
+            let name = call
+                .get("name")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow::anyhow!("mcp_call at line {line_no} missing 'name' string"))?
+                .to_string();
+            let mut args = call.get("args").cloned().unwrap_or(Value::Null);
+            let bind = call
+                .get("bind")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            let allow_err = call
+                .get("allow_err")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+
+            substitute(&mut args, &bindings)
+                .with_context(|| format!("substitute at line {line_no}"))?;
+
+            let Some(c) = client.as_mut() else {
+                anyhow::bail!("mcp_call at line {line_no} requires PITBOSS_FAKE_MCP_SOCKET");
+            };
+
+            match c.call_tool(&name, args).await {
+                Ok(result) => {
+                    if let Some(name) = bind {
+                        bindings.insert(name, result);
+                    }
+                }
+                Err(e) => {
+                    if allow_err {
+                        eprintln!("fake-claude: mcp_call {name} (line {line_no}): {e:#}");
+                    } else {
+                        return Err(e.context(format!("mcp_call {name} at line {line_no}")));
+                    }
+                }
+            }
         } else {
             eprintln!("fake-claude: unknown action at line {line_no}: {line}");
         }


### PR DESCRIPTION
## Summary

First prerequisite for the v0.4.1 dogfood pipeline: fake-claude now
speaks MCP so hierarchical flows can be tested end-to-end without
Anthropic calls.

- **fake-claude MCP-client mode** (opt-in via `PITBOSS_FAKE_MCP_SOCKET`). New `mcp_call` script action issues real tool invocations over the socket and binds results under names for template substitution in later actions (`"$w1.task_id"` → the real task_id returned by spawn_worker).
- **Four new e2e integration tests** in `crates/pitboss-cli/tests/e2e_flows.rs` driving a real fake-claude subprocess through `SessionHandle + TokioSpawner`: happy-path spawn+wait, 3-worker fan-out with wait_for_any, mid-flight cancel, and a full approval round-trip via FakeControlClient. Direct-to-socket path (skips `pitboss mcp-bridge` — the bridge has its own unit tests).
- **Drive-by v0.4.0 fix:** the approval round-trip test surfaced a gap where control-socket `approve` ops short-circuited `ApprovalBridge::respond`, so queue-drained approvals produced no `approval_response` event and never bumped `worker_counters.approvals_{approved,rejected}`. Fixed by appending the missing event + counter writes directly in the op handler.

## Scope & approach

12 commits following `docs/superpowers/plans/2026-04-17-pitboss-v041-fake-claude-e2e.md`. Every step TDD'd. Tests jumped from 282 → 294 (+7 unit tests for bindings, +1 smoke test, +4 e2e). CHANGELOG under `[Unreleased]`; no version tag — next tag lands after more of the v0.4.1 series completes.

Zero production code changes beyond the approval fix. fake-claude's existing MOSAIC_FAKE_SCRIPT path stays behavior-identical; the new MCP mode is opt-in.

## Test plan

- [ ] CI: fmt, clippy, `cargo test --workspace`, smoke-part1.sh all green
- [ ] Spot-check: `cargo test -p pitboss-cli --test e2e_flows -- --nocapture` — all 5 e2e tests pass (smoke + 4 real)
- [ ] Manual: existing `cargo test -p pitboss-cli --test dispatch_flows` still passes (fake-claude backwards-compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)