### PR TITLE
v0.4.1 Stage 0.2: mcp__pitboss__reprompt_worker tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ This project uses [Semantic Versioning](https://semver.org/).
   exercising the MCP→bridge→control→control→bridge→MCP loop with
   `fake-control-client`. Unlocks v0.4.1 feature development without
   Anthropic API calls.
+- **`mcp__pitboss__reprompt_worker` MCP tool.** Lead-facing counterpart
+  to the v0.4.0 operator-only `RepromptWorker` control-socket op. Lets
+  a lead correct a wandering worker mid-flight with a new prompt while
+  preserving the worker's claude session via `--resume`. Matches the
+  control-socket op's state machine, event writes, and counter semantics
+  exactly; prompt is required (not optional like `ContinueWorkerArgs`).
 
 ### Fixed
 - Control-socket `approve` op now writes the `approval_response` event

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -374,6 +374,7 @@ pub const PITBOSS_MCP_TOOLS: &[&str] = &[
     "mcp__pitboss__pause_worker",
     "mcp__pitboss__continue_worker",
     "mcp__pitboss__request_approval",
+    "mcp__pitboss__reprompt_worker",
 ];
 
 /// Builds the argv for spawning the lead subprocess, including the

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -18,9 +18,9 @@ use rmcp::{tool, tool_handler, tool_router, ErrorData, ServerHandler};
 use crate::dispatch::state::DispatchState;
 use crate::mcp::tools::{
     handle_cancel_worker, handle_continue_worker, handle_list_workers, handle_pause_worker,
-    handle_request_approval, handle_spawn_worker, handle_wait_for_any, handle_wait_for_worker,
-    handle_worker_status, ContinueWorkerArgs, RequestApprovalArgs, SpawnWorkerArgs, TaskIdArgs,
-    WaitForAnyArgs, WaitForWorkerArgs,
+    handle_reprompt_worker, handle_request_approval, handle_spawn_worker, handle_wait_for_any,
+    handle_wait_for_worker, handle_worker_status, ContinueWorkerArgs, RepromptWorkerArgs,
+    RequestApprovalArgs, SpawnWorkerArgs, TaskIdArgs, WaitForAnyArgs, WaitForWorkerArgs,
 };
 
 /// Compute the socket path for a given run. Falls back to the run_dir if
@@ -153,6 +153,19 @@ impl PitbossHandler {
         Parameters(args): Parameters<ContinueWorkerArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         match handle_continue_worker(&self.state, args).await {
+            Ok(res) => to_structured_result(&res),
+            Err(e) => Err(ErrorData::invalid_request(e.to_string(), None)),
+        }
+    }
+
+    #[tool(
+        description = "Reprompt a running or paused worker with a new prompt via claude --resume. Preserves the worker's claude session for context continuity."
+    )]
+    async fn reprompt_worker(
+        &self,
+        Parameters(args): Parameters<RepromptWorkerArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        match handle_reprompt_worker(&self.state, args).await {
             Ok(res) => to_structured_result(&res),
             Err(e) => Err(ErrorData::invalid_request(e.to_string(), None)),
         }

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -99,6 +99,15 @@ pub struct ContinueWorkerArgs {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct RepromptWorkerArgs {
+    pub task_id: String,
+    /// New prompt to send via `claude --resume`. Required — unlike
+    /// `ContinueWorkerArgs::prompt`, reprompt semantically *is* a new
+    /// prompt; defaulting to "continue" would conflate the operations.
+    pub prompt: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct RequestApprovalArgs {
     pub summary: String,
     /// Optional per-request timeout override. Falls back to lead_timeout_secs.
@@ -1586,6 +1595,18 @@ mod tests {
         let back: ContinueWorkerArgs = serde_json::from_str(&s).unwrap();
         assert_eq!(back.task_id, "w");
         assert_eq!(back.prompt.as_deref(), Some("next step"));
+    }
+
+    #[test]
+    fn reprompt_worker_args_roundtrip() {
+        let a = RepromptWorkerArgs {
+            task_id: "w-1".into(),
+            prompt: "new plan".into(),
+        };
+        let s = serde_json::to_string(&a).unwrap();
+        let back: RepromptWorkerArgs = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.task_id, "w-1");
+        assert_eq!(back.prompt, "new plan");
     }
 
     #[test]

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -822,6 +822,62 @@ pub async fn handle_continue_worker(
     }
 }
 
+pub async fn handle_reprompt_worker(
+    state: &Arc<DispatchState>,
+    args: RepromptWorkerArgs,
+) -> Result<CancelResult> {
+    let current = state.workers.read().await.get(&args.task_id).cloned();
+    let session_id = match current {
+        Some(WorkerState::Running {
+            session_id: Some(sid),
+            ..
+        }) => {
+            let cancels = state.worker_cancels.read().await;
+            if let Some(tok) = cancels.get(&args.task_id) {
+                tok.terminate();
+            }
+            // Brief grace so the prior subprocess exits before spawn_resume
+            // starts the new one. Matches the control-socket op.
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            sid
+        }
+        Some(WorkerState::Paused { session_id, .. }) => session_id,
+        Some(WorkerState::Running {
+            session_id: None, ..
+        }) => anyhow::bail!("worker not yet initialized (no session_id)"),
+        Some(WorkerState::Pending) => anyhow::bail!("worker is still pending"),
+        Some(WorkerState::Done(_)) => anyhow::bail!("worker already completed"),
+        None => anyhow::bail!("unknown task_id: {}", args.task_id),
+    };
+
+    // Unconditionally record the reprompt attempt — audit trail even if
+    // the subsequent spawn fails.
+    let _ = crate::dispatch::events::append_event(
+        &state.run_subdir,
+        &args.task_id,
+        &crate::dispatch::events::TaskEvent::Reprompt {
+            at: chrono::Utc::now(),
+            prompt_preview: args.prompt.chars().take(80).collect(),
+            prior_session_id: session_id.clone(),
+        },
+    )
+    .await;
+
+    spawn_resume_worker(state, args.task_id.clone(), args.prompt, session_id).await?;
+
+    // Counter bump is conditional on spawn success so a failed spawn
+    // doesn't falsely inflate the reprompt count.
+    state
+        .worker_counters
+        .write()
+        .await
+        .entry(args.task_id)
+        .or_default()
+        .reprompt_count += 1;
+
+    Ok(CancelResult { ok: true })
+}
+
 pub async fn handle_request_approval(
     state: &Arc<DispatchState>,
     args: RequestApprovalArgs,
@@ -1678,6 +1734,72 @@ mod tests {
         .await
         .unwrap();
         assert!(res.ok);
+        let workers = state.workers.read().await;
+        assert!(matches!(
+            workers.get("w-1").unwrap(),
+            WorkerState::Running { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn handle_reprompt_worker_from_running() {
+        let state = test_state().await;
+        let worker_token = pitboss_core::session::CancelToken::new();
+        state
+            .worker_cancels
+            .write()
+            .await
+            .insert("w-1".into(), worker_token.clone());
+        state.workers.write().await.insert(
+            "w-1".into(),
+            WorkerState::Running {
+                started_at: chrono::Utc::now(),
+                session_id: Some("sess-abc".into()),
+            },
+        );
+        state
+            .worker_prompts
+            .write()
+            .await
+            .insert("w-1".into(), "original".into());
+        state
+            .worker_models
+            .write()
+            .await
+            .insert("w-1".into(), "claude-haiku-4-5".into());
+
+        let res = handle_reprompt_worker(
+            &state,
+            RepromptWorkerArgs {
+                task_id: "w-1".into(),
+                prompt: "new plan".into(),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(res.ok);
+        // Counter bumps on success.
+        let counters = state
+            .worker_counters
+            .read()
+            .await
+            .get("w-1")
+            .cloned()
+            .unwrap_or_default();
+        assert_eq!(counters.reprompt_count, 1);
+        // events.jsonl records the reprompt.
+        let events_path = state
+            .run_subdir
+            .join("tasks")
+            .join("w-1")
+            .join("events.jsonl");
+        let events = tokio::fs::read_to_string(&events_path).await.unwrap();
+        assert!(
+            events.contains("\"kind\":\"reprompt\""),
+            "events.jsonl missing reprompt: {events}"
+        );
+        // Worker transitioned back to Running via spawn_resume_worker.
         let workers = state.workers.read().await;
         assert!(matches!(
             workers.get("w-1").unwrap(),

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -1808,6 +1808,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn handle_reprompt_worker_from_done_errors() {
+        let state = test_state().await;
+        // Insert a Done worker — terminal state, no reprompt allowed.
+        let rec = pitboss_core::store::TaskRecord {
+            task_id: "w-done".into(),
+            status: pitboss_core::store::TaskStatus::Success,
+            exit_code: Some(0),
+            started_at: chrono::Utc::now(),
+            ended_at: chrono::Utc::now(),
+            duration_ms: 0,
+            worktree_path: None,
+            log_path: std::path::PathBuf::from("/tmp/x"),
+            token_usage: Default::default(),
+            claude_session_id: Some("sess-done".into()),
+            final_message_preview: None,
+            parent_task_id: Some("lead".into()),
+            pause_count: 0,
+            reprompt_count: 0,
+            approvals_requested: 0,
+            approvals_approved: 0,
+            approvals_rejected: 0,
+        };
+        state
+            .workers
+            .write()
+            .await
+            .insert("w-done".into(), WorkerState::Done(rec));
+
+        let err = handle_reprompt_worker(
+            &state,
+            RepromptWorkerArgs {
+                task_id: "w-done".into(),
+                prompt: "retry".into(),
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("already completed"),
+            "expected 'already completed' in error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
     async fn handle_request_approval_auto_approves() {
         use crate::dispatch::state::ApprovalPolicy;
         // Rebuild a state with AutoApprove.

--- a/crates/pitboss-cli/tests/e2e_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_flows.rs
@@ -503,3 +503,118 @@ async fn e2e_lead_request_approval_round_trip() {
 
     state.cancel.terminate();
 }
+
+#[tokio::test]
+async fn e2e_lead_reprompts_running_worker() {
+    support::ensure_built();
+
+    let dir = TempDir::new().unwrap();
+    let run_id = Uuid::now_v7();
+
+    // Custom state: worker script holds until signal so the reprompt has
+    // something mid-flight to redirect.
+    let lead = ResolvedLead {
+        id: "lead".into(),
+        directory: PathBuf::from("/tmp"),
+        prompt: "lead prompt".into(),
+        branch: None,
+        model: "claude-haiku-4-5".into(),
+        effort: Effort::High,
+        tools: vec![],
+        timeout_secs: 3600,
+        use_worktree: false,
+        env: Default::default(),
+        resume_session_id: None,
+    };
+    let manifest = ResolvedManifest {
+        max_parallel: 4,
+        halt_on_failure: false,
+        run_dir: dir.path().to_path_buf(),
+        worktree_cleanup: WorktreeCleanup::OnSuccess,
+        emit_event_stream: false,
+        tasks: vec![],
+        lead: Some(lead),
+        max_workers: Some(4),
+        budget_usd: Some(5.0),
+        lead_timeout_secs: None,
+        approval_policy: Some(ApprovalPolicy::Block),
+    };
+    let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
+    // Worker script emits init+result so session_id gets captured via the
+    // promote_task mpsc channel, THEN holds so the worker stays Running
+    // when reprompt_worker runs (reprompt requires session_id).
+    let hold_script = FakeScript::new()
+        .stdout_line(r#"{"type":"system","subtype":"init","session_id":"worker-sess"}"#)
+        .stdout_line(
+            r#"{"type":"result","session_id":"worker-sess","usage":{"input_tokens":1,"output_tokens":1}}"#,
+        )
+        .hold_until_signal();
+    let spawner: Arc<dyn ProcessSpawner> = Arc::new(FakeSpawner::new(hold_script));
+    let wt_mgr = Arc::new(WorktreeManager::new());
+    let run_subdir = dir.path().join(run_id.to_string());
+    let state = Arc::new(DispatchState::new(
+        run_id,
+        manifest,
+        store,
+        CancelToken::new(),
+        "lead".into(),
+        spawner,
+        PathBuf::from("claude"),
+        wt_mgr,
+        CleanupPolicy::Never,
+        run_subdir.clone(),
+        ApprovalPolicy::Block,
+    ));
+
+    let sock = socket_path_for_run(run_id, &state.manifest.run_dir);
+    let _server = McpServer::start(sock.clone(), state.clone()).await.unwrap();
+
+    // Spawn a worker, sleep for init+result to land (session_id captured),
+    // reprompt it.
+    let script = dir.path().join("script.jsonl");
+    let script_body = r#"{"stdout":"{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"lead-sess\"}"}
+{"mcp_call":{"name":"spawn_worker","args":{"prompt":"original"},"bind":"w1"}}
+{"sleep_ms":200}
+{"mcp_call":{"name":"reprompt_worker","args":{"task_id":"$w1.task_id","prompt":"reconsider"},"bind":"rep"}}
+{"sleep_ms":100}
+{"stdout":"{\"type\":\"result\",\"subtype\":\"success\",\"session_id\":\"lead-sess\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}"}
+"#;
+    tokio::fs::write(&script, script_body).await.unwrap();
+
+    let outcome = run_fake_claude_lead(
+        dir.path(),
+        &script,
+        &sock,
+        CancelToken::new(),
+        Duration::from_secs(30),
+    )
+    .await;
+
+    assert_eq!(outcome.exit_code, Some(0), "exit non-zero: {outcome:?}");
+
+    // Extract the worker's task_id for subsequent assertions.
+    let task_id = {
+        let workers = state.workers.read().await;
+        workers.keys().next().cloned().expect("at least one worker")
+    };
+
+    // events.jsonl should contain a reprompt entry.
+    let events_path = run_subdir.join("tasks").join(&task_id).join("events.jsonl");
+    let events = tokio::fs::read_to_string(&events_path).await.unwrap();
+    assert!(
+        events.contains("\"kind\":\"reprompt\""),
+        "events.jsonl missing reprompt: {events}"
+    );
+
+    // Counter bumped.
+    let counters = state
+        .worker_counters
+        .read()
+        .await
+        .get(&task_id)
+        .cloned()
+        .unwrap_or_default();
+    assert_eq!(counters.reprompt_count, 1);
+
+    state.cancel.terminate();
+}


### PR DESCRIPTION
## Summary

Second prerequisite for the v0.4.1 dogfood pipeline: leads can now correct a wandering worker mid-flight via MCP without cancel+respawn.

- **New `mcp__pitboss__reprompt_worker` MCP tool** mirroring the v0.4.0 operator-only `RepromptWorker` control-socket op. Same state machine, same event + counter semantics — just a different entry point (lead-facing instead of TUI-facing).
- **`RepromptWorkerArgs { task_id, prompt }`** — `prompt` is required (not `Option<String>` like `ContinueWorkerArgs`): reprompt *is* a new prompt, defaulting to `"continue"` would conflate the two operations.
- **Added to `PITBOSS_MCP_TOOLS`** so the lead's allowed-tools list auto-includes the new tool.
- **Four new tests:** serde roundtrip, happy-path unit test (Running worker → spawn_resume + counter bump + event), invalid-state unit test (Done worker errors clearly), e2e test (fake-claude subprocess calls `reprompt_worker` via `mcp_call`, verifies `events.jsonl` + counters).

## Scope & approach

6 commits following `docs/superpowers/plans/2026-04-17-pitboss-v041-reprompt-worker.md`. Every step TDD'd. Tests jumped from 294 → 298 (+4). `[Unreleased]` CHANGELOG entry; no version tag yet — next tag `v0.4.1` lands after Stage 0.3 + feature stages.

Purely additive. No changes to `spawn_resume_worker`, `TaskEvent::Reprompt`, control-socket protocol, or the TUI.

## Test plan

- [ ] CI: fmt, clippy, `cargo test --workspace`, smoke-part1.sh all green
- [ ] Spot-check: `cargo test -p pitboss-cli mcp::tools::tests::handle_reprompt_worker_from_running` — passes
- [ ] Spot-check: `cargo test -p pitboss-cli --test e2e_flows e2e_lead_reprompts_running_worker` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)