### PR TITLE
v0.4.1 Stage 0.3: lead_timeout_secs decision (docs only)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ TOML, typically named `pitboss.toml`. Every field annotated below.
 | `emit_event_stream` | bool | no | false | Emit a JSONL event stream alongside summary.jsonl. |
 | `max_workers` | int | only if `[[lead]]` present | unset | Hierarchical: hard cap on concurrent + queued workers (1–16). |
 | `budget_usd` | float | only if `[[lead]]` present | unset | Hierarchical: soft cap with reservation accounting. Worker spawns fail with `budget exceeded` once `spent + reserved + next_estimate > budget`. |
-| `lead_timeout_secs` | int | only if `[[lead]]` present | unset | Hierarchical: wall-clock cap on the lead. |
+| `lead_timeout_secs` | int | only if `[[lead]]` present | 3600 (fallback) | Hierarchical: wall-clock cap on the lead. No upper bound — set generously for multi-hour orchestration plans (e.g. `21600` for a 6-hour plan executor). The 3600s fallback is tuned for single-task leads, not plan drivers. |
 
 ### `[defaults]`
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,6 +5,12 @@ one when you're ready, or file issues to formalize priority.
 
 ## v0.4.1 — Attach (escape hatch)
 
+Remaining feature stages. Prerequisites (Stage 0.1 fake-claude MCP
+e2e, Stage 0.2 `mcp__pitboss__reprompt_worker`, Stage 0.3
+`lead_timeout_secs` decision) are all resolved — see
+`docs/superpowers/plans/2026-04-17-pitboss-v0.4.1-series.md` and
+the per-stage specs under `docs/superpowers/specs/`.
+
 - `pitboss attach <run-id> <task-id>` — live TTY relay using
   `portable-pty`. Narrow-scope: no persistent sessions, no tmux
   dependency. Sits on top of v0.4.0 control-socket primitives.
@@ -13,8 +19,6 @@ one when you're ready, or file issues to formalize priority.
 - Out-of-TUI notifications: webhooks / Slack / email for approval
   requests and run completion.
 - Structured approval schema (JSON-in-TUI plan editing).
-- `mcp__pitboss__reprompt_worker` for lead-driven mid-flight
-  redirection.
 
 ---
 


### PR DESCRIPTION
## Summary

Third and final prerequisite for the v0.4.1 dogfood pipeline. **Docs only — no code.**

The v0.4.1 staging doc flagged a concern that `lead_timeout_secs` had a 1-hour cap that would kill multi-hour dogfood plans. On closer inspection, 3600s is the *fallback default*, not a cap — `lead_timeout_secs: Option<u64>` accepts any positive value, validation only rejects `0`. So: no code change needed. Dogfood manifests set the timeout they need.

- **AGENTS.md**: clarify `lead_timeout_secs` has no upper bound; recommend generous values for orchestration-style plans (e.g. `21600` for 6hr).
- **ROADMAP.md**: remove `mcp__pitboss__reprompt_worker` bullet (delivered in Stage 0.2); note Stage 0 prereqs are resolved so v0.4.1's in-flight work starts at the feature stages.

Full decision record (with rejected options B/C/D and "what would flip this" criteria) is captured in a local-only spec at `docs/superpowers/specs/2026-04-17-pitboss-v041-lead-timeout-decision.md`.

## Stage 0 complete

This closes v0.4.1 prerequisites:
- ✅ 0.1 fake-claude MCP e2e (PR #7)
- ✅ 0.2 reprompt_worker MCP tool (PR #8)
- ✅ 0.3 lead_timeout_secs decision (this PR)

Next up: Stage 1 — notifications plugin system (first dogfood target).

## Test plan

- [ ] CI passes (AGENTS.md and ROADMAP.md aren't in `paths-ignore`, so fmt/clippy/test still run; should all be green since no code changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)