### PR TITLE
TUI polish pass v0.4.1.x: grid-clear, poll, word-wrap, theme + log coloring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ This project uses [Semantic Versioning](https://semver.org/).
   900ms), LRU dedup cache (size 64) prevents retry storms. New
   `TaskEvent::NotificationFailed` variant records delivery failures
   in `events.jsonl`.
+- **Semantic log-line coloring.** TUI's focus-log pane and full-screen
+  snap-in view now color each stream-json line by event type: white
+  for assistant text, cyan for tool use, green for tool results, gray
+  for system/unknown, magenta for result events, yellow for rate
+  limits. Driven by the new `pitboss_tui::theme::log_line_style`
+  helper. Unparseable lines fall back to gray.
 
 ### Fixed
 - Control-socket `approve` op now writes the `approval_response` event
@@ -47,6 +53,24 @@ This project uses [Semantic Versioning](https://semver.org/).
   v0.4.0 queue-drain path bypassed `respond`, so approvals drained on
   TUI connect produced no response event and didn't bump counters.
   Surfaced by the new e2e approval round-trip test.
+- **TUI tile grid no longer retains prior-frame content in empty cells.**
+  `render_tile_grid` now calls `frame.render_widget(Clear, area)`
+  before drawing tiles, so partial-final-row dead space stays clean.
+  Observed as character leakage during Stage 1 dogfood run (#129).
+- **TUI summary/count responsiveness improved.** Watcher poll interval
+  lowered from 500ms to 250ms; on-disk `summary.jsonl` writes now
+  surface in the TUI within 250ms instead of up to 500ms (#128).
+- **TUI text word-wraps at window width in log/tile/overlay bodies.**
+  Added `Wrap { trim: false }` to Paragraphs in `render_tile`,
+  `render_focus_log`, `render_snap_in`, `render_run_picker_overlay`,
+  and `render_approval_modal`. Title bar and status bar intentionally
+  stay single-line (truncation is desired there) (#130).
+- **TUI color usage consolidated.** New `pitboss_tui::theme` module
+  holds palette constants + style helpers. Status colors and UI
+  accent colors flow through `theme::*` instead of inline `Color::*`
+  literals scattered across `tui.rs`. No user-visible change in most
+  views; fixes accidental drift where the same semantic state
+  rendered in different colors in different contexts (#131).
 
 ## [0.4.0] — 2026-04-17
 

--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -90,31 +90,47 @@ pub fn run(run_dir: PathBuf, run_id: String) -> anyhow::Result<()> {
 
         // --- Input (50ms poll) ---
         if event::poll(Duration::from_millis(50))? {
-            if let Event::Key(key) = event::read()? {
-                let action = handle_key(&mut state, key.code, key.modifiers);
-                match action {
-                    Action::Quit => break,
-                    Action::SwitchRun { run_dir, run_id } => {
-                        // Restart the watcher on the new run dir.
-                        let (new_rx, new_tx) = spawn_watcher(run_dir.clone());
-                        snapshot_rx = new_rx;
-                        focus_tx = new_tx;
-                        state.run_dir = run_dir;
-                        state.run_id = run_id;
-                        state.tasks = vec![];
-                        state.focus = 0;
-                        state.run_list.clear();
-                        state.mode = Mode::Normal;
-                        let _ = focus_tx.send(String::new());
-                        continue;
+            match event::read()? {
+                Event::Resize(_, _) => {
+                    // Force a visible clear + full redraw on the next frame.
+                    // Ratatui's autoresize shuffles buffer content when the
+                    // width changes (linear array re-indexes), so the diff
+                    // vs prev can leave stale cells physically visible in
+                    // the terminal. terminal.clear() emits `\x1b[2J` and
+                    // resets the back buffer, guaranteeing a clean redraw.
+                    terminal.clear()?;
+                }
+                Event::Key(key) => {
+                    let action = handle_key(&mut state, key.code, key.modifiers);
+                    match action {
+                        Action::Quit => break,
+                        Action::SwitchRun { run_dir, run_id } => {
+                            // Restart the watcher on the new run dir.
+                            let (new_rx, new_tx) = spawn_watcher(run_dir.clone());
+                            snapshot_rx = new_rx;
+                            focus_tx = new_tx;
+                            state.run_dir = run_dir;
+                            state.run_id = run_id;
+                            state.tasks = vec![];
+                            state.focus = 0;
+                            state.run_list.clear();
+                            state.mode = Mode::Normal;
+                            let _ = focus_tx.send(String::new());
+                            // Tile count and layout change; force a clean
+                            // redraw to avoid stale content from the prior
+                            // run's tiles.
+                            terminal.clear()?;
+                            continue;
+                        }
+                        Action::Continue => {}
                     }
-                    Action::Continue => {}
-                }
 
-                // Notify watcher of new focus.
-                if let Some(tile) = state.focused_tile() {
-                    let _ = focus_tx.send(tile.id.clone());
+                    // Notify watcher of new focus.
+                    if let Some(tile) = state.focused_tile() {
+                        let _ = focus_tx.send(tile.id.clone());
+                    }
                 }
+                _ => {}
             }
         }
 

--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -84,23 +84,30 @@ pub fn run(run_dir: PathBuf, run_id: String) -> anyhow::Result<()> {
     // Send the initial focus (empty → watcher will tail first tile).
     let _ = focus_tx.send(String::new());
 
+    // When true, the physical terminal may have stale cells that ratatui's
+    // diff won't repaint (e.g., after a resize, focus change, or mode
+    // transition — some terminal emulators don't reliably apply every cell
+    // update emitted by crossterm). A `terminal.clear()` emits `\x1b[2J`
+    // and resets the back buffer, forcing a clean full redraw.
+    let mut dirty = false;
     loop {
         // --- Render ---
+        if dirty {
+            terminal.clear()?;
+            dirty = false;
+        }
         terminal.draw(|frame| crate::tui::render(frame, &state))?;
 
         // --- Input (50ms poll) ---
         if event::poll(Duration::from_millis(50))? {
             match event::read()? {
                 Event::Resize(_, _) => {
-                    // Force a visible clear + full redraw on the next frame.
-                    // Ratatui's autoresize shuffles buffer content when the
-                    // width changes (linear array re-indexes), so the diff
-                    // vs prev can leave stale cells physically visible in
-                    // the terminal. terminal.clear() emits `\x1b[2J` and
-                    // resets the back buffer, guaranteeing a clean redraw.
-                    terminal.clear()?;
+                    dirty = true;
                 }
                 Event::Key(key) => {
+                    let prev_focus = state.focus;
+                    let prev_mode_disc = std::mem::discriminant(&state.mode);
+
                     let action = handle_key(&mut state, key.code, key.modifiers);
                     match action {
                         Action::Quit => break,
@@ -116,13 +123,18 @@ pub fn run(run_dir: PathBuf, run_id: String) -> anyhow::Result<()> {
                             state.run_list.clear();
                             state.mode = Mode::Normal;
                             let _ = focus_tx.send(String::new());
-                            // Tile count and layout change; force a clean
-                            // redraw to avoid stale content from the prior
-                            // run's tiles.
-                            terminal.clear()?;
+                            dirty = true;
                             continue;
                         }
                         Action::Continue => {}
+                    }
+
+                    // Mark dirty if focus or mode changed — those are the
+                    // transitions where terminal-side cell staleness shows.
+                    if prev_focus != state.focus
+                        || prev_mode_disc != std::mem::discriminant(&state.mode)
+                    {
+                        dirty = true;
                     }
 
                     // Notify watcher of new focus.

--- a/crates/pitboss-tui/src/lib.rs
+++ b/crates/pitboss-tui/src/lib.rs
@@ -13,5 +13,6 @@ pub mod app;
 pub mod control;
 pub mod runs;
 pub mod state;
+pub mod theme;
 pub mod tui;
 pub mod watcher;

--- a/crates/pitboss-tui/src/main.rs
+++ b/crates/pitboss-tui/src/main.rs
@@ -174,14 +174,13 @@ fn cmd_list() -> Result<()> {
 
     for e in &entries {
         let started = runs::format_mtime(e.mtime);
-        let status = if e.is_complete {
-            "complete"
-        } else {
-            "in-progress"
-        };
         println!(
             "{:<38}  {:<22}  {:>6}  {:>6}  {}",
-            e.run_id, started, e.tasks_total, e.tasks_failed, status
+            e.run_id,
+            started,
+            e.tasks_total,
+            e.tasks_failed,
+            e.status.label()
         );
     }
 

--- a/crates/pitboss-tui/src/runs.rs
+++ b/crates/pitboss-tui/src/runs.rs
@@ -4,6 +4,34 @@ use std::io::BufRead;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
+/// Status of a discovered run directory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunStatus {
+    /// `summary.json` exists and parsed — run finalized cleanly.
+    Complete,
+    /// `summary.jsonl` has at least one task record but no final
+    /// `summary.json` yet — dispatcher is (or was) running.
+    Running,
+    /// Neither `summary.json` nor any records in `summary.jsonl` — the
+    /// dispatcher wrote the initial manifest + resolved.json but never
+    /// produced task output (orphaned/aborted invocation).
+    Aborted,
+}
+
+impl RunStatus {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Complete => "complete",
+            Self::Running => "running",
+            Self::Aborted => "aborted",
+        }
+    }
+
+    pub fn is_complete(self) -> bool {
+        matches!(self, Self::Complete)
+    }
+}
+
 /// A summary entry for a single run directory.
 #[derive(Debug)]
 pub struct RunEntry {
@@ -12,7 +40,7 @@ pub struct RunEntry {
     pub mtime: SystemTime,
     pub tasks_total: usize,
     pub tasks_failed: usize,
-    pub is_complete: bool,
+    pub status: RunStatus,
 }
 
 /// Returns the base directory that holds all run sub-directories.
@@ -63,21 +91,28 @@ pub fn collect_run_entry(run_dir: &Path, run_id: String, mtime: SystemTime) -> R
                 mtime,
                 tasks_total: s.tasks_total,
                 tasks_failed: s.tasks_failed,
-                is_complete: true,
+                status: RunStatus::Complete,
             };
         }
     }
 
-    // Fall back: count lines in summary.jsonl.
+    // Fall back: count lines in summary.jsonl. If the file is missing or
+    // empty, treat the run as aborted — the dispatcher wrote the initial
+    // manifest + resolved.json but never produced any task records.
     let jsonl = run_dir.join("summary.jsonl");
     let (total, failed) = count_jsonl_tasks(&jsonl);
+    let status = if total > 0 {
+        RunStatus::Running
+    } else {
+        RunStatus::Aborted
+    };
     RunEntry {
         run_id,
         run_dir: run_dir.to_path_buf(),
         mtime,
         tasks_total: total,
         tasks_failed: failed,
-        is_complete: false,
+        status,
     }
 }
 
@@ -184,7 +219,7 @@ mod tests {
         assert_eq!(entry.run_id, "run-x");
         assert_eq!(entry.tasks_total, 0);
         assert_eq!(entry.tasks_failed, 0);
-        assert!(!entry.is_complete);
+        assert_eq!(entry.status, RunStatus::Aborted);
     }
 
     #[test]

--- a/crates/pitboss-tui/src/state.rs
+++ b/crates/pitboss-tui/src/state.rs
@@ -389,7 +389,7 @@ mod tests {
                 mtime: SystemTime::UNIX_EPOCH,
                 tasks_total: i,
                 tasks_failed: 0,
-                is_complete: false,
+                status: crate::runs::RunStatus::Aborted,
             })
             .collect()
     }

--- a/crates/pitboss-tui/src/theme.rs
+++ b/crates/pitboss-tui/src/theme.rs
@@ -68,10 +68,72 @@ pub fn idle_border() -> Style {
     Style::default().fg(BORDER)
 }
 
+// ---------- Log-line event palette ----------
+pub const LOG_ASSISTANT_TEXT: Color = Color::White; // Primary output
+pub const LOG_TOOL_USE: Color = Color::Cyan; // Model reaching out
+pub const LOG_TOOL_RESULT: Color = Color::Green; // What came back
+pub const LOG_SYSTEM: Color = Color::DarkGray; // Metadata (init etc.)
+pub const LOG_RESULT: Color = Color::Magenta; // Terminal event
+pub const LOG_RATE_LIMIT: Color = Color::Yellow; // Warning
+pub const LOG_UNKNOWN: Color = Color::Gray; // Unknown shape
+pub const LOG_UNPARSEABLE: Color = Color::Gray; // parse_line Err
+
+/// Given a raw stream-json log line, return a `Style` for coloring it
+/// in the log pane. Parses the line and matches on `Event` variant.
+/// On parse failure, returns the `LOG_UNPARSEABLE` fallback.
+pub fn log_line_style(line: &str) -> Style {
+    use pitboss_core::parser::{parse_line, Event};
+    let color = match parse_line(line.as_bytes()) {
+        Ok(Event::AssistantText { .. }) => LOG_ASSISTANT_TEXT,
+        Ok(Event::AssistantToolUse { .. }) => LOG_TOOL_USE,
+        Ok(Event::ToolResult { .. }) => LOG_TOOL_RESULT,
+        Ok(Event::System { .. }) => LOG_SYSTEM,
+        Ok(Event::Result { .. }) => LOG_RESULT,
+        Ok(Event::RateLimit { .. }) => LOG_RATE_LIMIT,
+        Ok(Event::Unknown { .. }) => LOG_UNKNOWN,
+        Err(_) => LOG_UNPARSEABLE,
+    };
+    Style::default().fg(color)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::collections::HashSet;
+
+    #[test]
+    fn log_line_style_maps_event_variants() {
+        let cases = [
+            (
+                r#"{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}"#,
+                LOG_ASSISTANT_TEXT,
+            ),
+            (
+                r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t","name":"Read","input":{}}]}}"#,
+                LOG_TOOL_USE,
+            ),
+            (
+                r#"{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t","content":[{"type":"text","text":"ok"}]}]}}"#,
+                LOG_TOOL_RESULT,
+            ),
+            (r#"{"type":"system","subtype":"init"}"#, LOG_SYSTEM),
+            (
+                r#"{"type":"result","session_id":"s","usage":{"input_tokens":1,"output_tokens":1}}"#,
+                LOG_RESULT,
+            ),
+            (r#"{"type":"unknown","whatever":true}"#, LOG_UNKNOWN),
+            ("{not valid json", LOG_UNPARSEABLE),
+        ];
+        for (line, expected) in cases {
+            let style = log_line_style(line);
+            assert_eq!(
+                style.fg,
+                Some(expected),
+                "line {line:?} expected color {expected:?}, got {:?}",
+                style.fg
+            );
+        }
+    }
 
     #[test]
     fn status_colors_are_unique() {

--- a/crates/pitboss-tui/src/theme.rs
+++ b/crates/pitboss-tui/src/theme.rs
@@ -78,20 +78,24 @@ pub const LOG_RATE_LIMIT: Color = Color::Yellow; // Warning
 pub const LOG_UNKNOWN: Color = Color::Gray; // Unknown shape
 pub const LOG_UNPARSEABLE: Color = Color::Gray; // parse_line Err
 
-/// Given a raw stream-json log line, return a `Style` for coloring it
-/// in the log pane. Parses the line and matches on `Event` variant.
-/// On parse failure, returns the `LOG_UNPARSEABLE` fallback.
+/// Given a pre-rendered focus-log line, return a `Style` for coloring
+/// it in the log pane. Matches on the display prefix written by
+/// `watcher::format_event`: `"> "` assistant text, `"* "` tool use,
+/// `"< "` tool result, `"v "` result, `"! "` rate limit. Anything else
+/// falls back to `LOG_UNPARSEABLE` gray.
 pub fn log_line_style(line: &str) -> Style {
-    use pitboss_core::parser::{parse_line, Event};
-    let color = match parse_line(line.as_bytes()) {
-        Ok(Event::AssistantText { .. }) => LOG_ASSISTANT_TEXT,
-        Ok(Event::AssistantToolUse { .. }) => LOG_TOOL_USE,
-        Ok(Event::ToolResult { .. }) => LOG_TOOL_RESULT,
-        Ok(Event::System { .. }) => LOG_SYSTEM,
-        Ok(Event::Result { .. }) => LOG_RESULT,
-        Ok(Event::RateLimit { .. }) => LOG_RATE_LIMIT,
-        Ok(Event::Unknown { .. }) => LOG_UNKNOWN,
-        Err(_) => LOG_UNPARSEABLE,
+    let color = if line.starts_with("> ") {
+        LOG_ASSISTANT_TEXT
+    } else if line.starts_with("* ") {
+        LOG_TOOL_USE
+    } else if line.starts_with("< ") {
+        LOG_TOOL_RESULT
+    } else if line.starts_with("v ") {
+        LOG_RESULT
+    } else if line.starts_with("! ") {
+        LOG_RATE_LIMIT
+    } else {
+        LOG_UNPARSEABLE
     };
     Style::default().fg(color)
 }
@@ -103,26 +107,16 @@ mod tests {
 
     #[test]
     fn log_line_style_maps_event_variants() {
+        // Inputs are the display strings produced by
+        // `watcher::format_event` (prefix char + content), not raw JSON.
         let cases = [
-            (
-                r#"{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}"#,
-                LOG_ASSISTANT_TEXT,
-            ),
-            (
-                r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t","name":"Read","input":{}}]}}"#,
-                LOG_TOOL_USE,
-            ),
-            (
-                r#"{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t","content":[{"type":"text","text":"ok"}]}]}}"#,
-                LOG_TOOL_RESULT,
-            ),
-            (r#"{"type":"system","subtype":"init"}"#, LOG_SYSTEM),
-            (
-                r#"{"type":"result","session_id":"s","usage":{"input_tokens":1,"output_tokens":1}}"#,
-                LOG_RESULT,
-            ),
-            (r#"{"type":"unknown","whatever":true}"#, LOG_UNKNOWN),
-            ("{not valid json", LOG_UNPARSEABLE),
+            ("> hi there", LOG_ASSISTANT_TEXT),
+            ("* Read {\"file_path\":\"/tmp/x\"}", LOG_TOOL_USE),
+            ("< ok", LOG_TOOL_RESULT),
+            ("v result (session=abcd1234... | in=1 out=1)", LOG_RESULT),
+            ("! rate-limit 429 (input) resets=?", LOG_RATE_LIMIT),
+            ("something unprefixed", LOG_UNPARSEABLE),
+            ("", LOG_UNPARSEABLE),
         ];
         for (line, expected) in cases {
             let style = log_line_style(line);

--- a/crates/pitboss-tui/src/theme.rs
+++ b/crates/pitboss-tui/src/theme.rs
@@ -1,0 +1,96 @@
+//! Central palette + style helpers for pitboss-tui. Single source of
+//! truth for colors — no `Color::*` literals should appear elsewhere
+//! in this crate (enforced by review).
+
+use pitboss_core::store::TaskStatus;
+use ratatui::style::{Color, Modifier, Style};
+
+use crate::state::TileStatus;
+
+// ---------- Status palette ----------
+pub const STATUS_PENDING: Color = Color::Gray;
+pub const STATUS_RUNNING: Color = Color::Cyan;
+pub const STATUS_SUCCESS: Color = Color::Green;
+pub const STATUS_FAILED: Color = Color::Red;
+pub const STATUS_TIMED_OUT: Color = Color::Yellow;
+pub const STATUS_CANCELLED: Color = Color::Magenta;
+pub const STATUS_SPAWN_FAILED: Color = Color::Red;
+pub const STATUS_PAUSED: Color = Color::Blue;
+
+// ---------- UI palette ----------
+pub const TEXT_PRIMARY: Color = Color::White;
+pub const TEXT_SECONDARY: Color = Color::Gray;
+pub const TEXT_MUTED: Color = Color::DarkGray;
+pub const BORDER: Color = Color::DarkGray;
+pub const BORDER_FOCUSED: Color = Color::Cyan;
+pub const OVERLAY_ACCENT_WARNING: Color = Color::Yellow;
+pub const OVERLAY_ACCENT_INFO: Color = Color::Green;
+pub const OVERLAY_ACCENT_PICKER: Color = Color::Cyan;
+
+/// Color for a tile based on its `TileStatus` variant (matches the
+/// existing `status_icon` mappings at `tui.rs:746` verbatim; the
+/// spawn-failed icon shares Red with Failed by design).
+pub fn tile_status_color(status: &TileStatus) -> Color {
+    match status {
+        TileStatus::Pending => STATUS_PENDING,
+        TileStatus::Running => STATUS_RUNNING,
+        TileStatus::Done(TaskStatus::Success) => STATUS_SUCCESS,
+        TileStatus::Done(TaskStatus::Failed) => STATUS_FAILED,
+        TileStatus::Done(TaskStatus::TimedOut) => STATUS_TIMED_OUT,
+        TileStatus::Done(TaskStatus::Cancelled) => STATUS_CANCELLED,
+        TileStatus::Done(TaskStatus::SpawnFailed) => STATUS_SPAWN_FAILED,
+    }
+}
+
+pub fn tile_status_style(status: &TileStatus) -> Style {
+    Style::default().fg(tile_status_color(status))
+}
+
+pub fn muted_style() -> Style {
+    Style::default().fg(TEXT_MUTED)
+}
+
+pub fn secondary_style() -> Style {
+    Style::default().fg(TEXT_SECONDARY)
+}
+
+pub fn primary_style() -> Style {
+    Style::default().fg(TEXT_PRIMARY)
+}
+
+pub fn focused_border() -> Style {
+    Style::default()
+        .fg(BORDER_FOCUSED)
+        .add_modifier(Modifier::BOLD)
+}
+
+pub fn idle_border() -> Style {
+    Style::default().fg(BORDER)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn status_colors_are_unique() {
+        // SpawnFailed and Failed both map to Red by design (they're
+        // semantically "the worker died"). Excluded from uniqueness
+        // check to keep the intentional alias.
+        let colors = [
+            STATUS_PENDING,
+            STATUS_RUNNING,
+            STATUS_SUCCESS,
+            STATUS_FAILED,
+            STATUS_TIMED_OUT,
+            STATUS_CANCELLED,
+        ];
+        let set: HashSet<_> = colors.iter().collect();
+        assert_eq!(
+            set.len(),
+            colors.len(),
+            "status palette has accidental color collision: {colors:?}"
+        );
+    }
+}

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -427,7 +427,7 @@ fn render_tile(frame: &mut Frame, area: Rect, state: &AppState, tile_idx: usize,
         Line::from(Span::styled(cost_str, Style::default().fg(Color::DarkGray))),
     ];
 
-    let para = Paragraph::new(lines);
+    let para = Paragraph::new(lines).wrap(Wrap { trim: false });
     frame.render_widget(para, inner);
 }
 
@@ -461,10 +461,10 @@ fn render_focus_log(frame: &mut Frame, area: Rect, state: &AppState) {
 
     let lines: Vec<Line> = log_slice
         .iter()
-        .map(|l| Line::from(Span::styled(l.as_str(), Style::default().fg(Color::Gray))))
+        .map(|l| Line::from(Span::styled(l.as_str(), crate::theme::log_line_style(l))))
         .collect();
 
-    let para = Paragraph::new(lines);
+    let para = Paragraph::new(lines).wrap(Wrap { trim: false });
     frame.render_widget(para, inner);
 }
 
@@ -535,10 +535,10 @@ fn render_snap_in(frame: &mut Frame, area: Rect, state: &AppState, task_id: &str
 
     let lines: Vec<Line> = log_slice
         .iter()
-        .map(|l| Line::from(Span::styled(l.as_str(), Style::default().fg(Color::White))))
+        .map(|l| Line::from(Span::styled(l.as_str(), crate::theme::log_line_style(l))))
         .collect();
 
-    let log_para = Paragraph::new(lines);
+    let log_para = Paragraph::new(lines).wrap(Wrap { trim: false });
     frame.render_widget(log_para, chunks[1]);
 
     // --- Status bar ---

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -163,6 +163,13 @@ pub fn teardown(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> anyhow::Re
 pub fn render(frame: &mut Frame, state: &AppState) {
     let area = frame.area();
 
+    // Wipe the full frame before any widget draws. Ratatui's Block/Paragraph
+    // only set STYLE for cells they "cover" — they don't clear character
+    // content for cells that no text lands in. On terminal resize or when
+    // a tile's inner content is shorter than the inner height, stale chars
+    // from the prior frame persist (visible leakage — fix for #129).
+    frame.render_widget(Clear, area);
+
     // SnapIn is a full-screen replacement — skip the normal grid entirely.
     if let Mode::SnapIn {
         ref task_id,

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -647,7 +647,7 @@ fn render_run_picker_overlay(frame: &mut Frame, area: Rect, state: &AppState, se
         .iter()
         .map(|e| {
             let started = crate::runs::format_mtime(e.mtime);
-            let status = if e.is_complete { "complete" } else { "running" };
+            let status = e.status.label();
             // Format: "run-id  started  N tasks  N failed  status"
             let short_id = if e.run_id.len() > 38 {
                 &e.run_id[..38]

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -16,6 +16,7 @@ use ratatui::{
 };
 
 use crate::state::{AppState, Mode, TileStatus};
+use crate::theme;
 use pitboss_core::store::TaskStatus;
 
 // ---------------------------------------------------------------------------
@@ -275,11 +276,7 @@ fn render_title(frame: &mut Frame, area: Rect, state: &AppState) {
     );
 
     let para = Paragraph::new(title_text)
-        .style(
-            Style::default()
-                .fg(Color::White)
-                .add_modifier(Modifier::BOLD),
-        )
+        .style(theme::primary_style().add_modifier(Modifier::BOLD))
         .alignment(Alignment::Left);
     frame.render_widget(para, area);
 }
@@ -291,7 +288,7 @@ fn render_title(frame: &mut Frame, area: Rect, state: &AppState) {
 fn render_body(frame: &mut Frame, area: Rect, state: &AppState) {
     if state.tasks.is_empty() {
         let msg =
-            Paragraph::new(" No tasks found in this run.").style(Style::default().fg(Color::Gray));
+            Paragraph::new(" No tasks found in this run.").style(theme::secondary_style());
         frame.render_widget(msg, area);
         return;
     }
@@ -365,11 +362,9 @@ fn render_tile(frame: &mut Frame, area: Rect, state: &AppState, tile_idx: usize,
     // border. The focused branch stays first for semantic clarity even though
     // it produces an identical style to the unfocused-lead branch today.
     let border_style = if focused || is_lead {
-        Style::default()
-            .fg(Color::Cyan)
-            .add_modifier(Modifier::BOLD)
+        theme::focused_border()
     } else {
-        Style::default().fg(Color::DarkGray)
+        theme::idle_border()
     };
 
     let mut block = Block::default()
@@ -383,7 +378,7 @@ fn render_tile(frame: &mut Frame, area: Rect, state: &AppState, tile_idx: usize,
     if !subtitle.is_empty() {
         block = block.title_bottom(Span::styled(
             format!(" {subtitle} "),
-            Style::default().fg(Color::DarkGray),
+            theme::muted_style(),
         ));
     }
 
@@ -416,15 +411,15 @@ fn render_tile(frame: &mut Frame, area: Rect, state: &AppState, tile_idx: usize,
             Span::raw(" "),
             Span::styled(status_label, Style::default().fg(icon_color)),
         ]),
-        Line::from(Span::styled(duration_str, Style::default().fg(Color::Gray))),
+        Line::from(Span::styled(duration_str, theme::secondary_style())),
         Line::from(Span::styled(
             format!(
                 "in:{} out:{}",
                 tile.token_usage_input, tile.token_usage_output
             ),
-            Style::default().fg(Color::DarkGray),
+            theme::muted_style(),
         )),
-        Line::from(Span::styled(cost_str, Style::default().fg(Color::DarkGray))),
+        Line::from(Span::styled(cost_str, theme::muted_style())),
     ];
 
     let para = Paragraph::new(lines).wrap(Wrap { trim: false });
@@ -446,7 +441,7 @@ fn render_focus_log(frame: &mut Frame, area: Rect, state: &AppState) {
     let block = Block::default()
         .borders(Borders::TOP)
         .title(format!(" Focus: {focused_id} ({status_str}) "))
-        .border_style(Style::default().fg(Color::DarkGray));
+        .border_style(theme::idle_border());
 
     let inner = block.inner(area);
     frame.render_widget(block, area);
@@ -478,7 +473,7 @@ fn render_statusbar(frame: &mut Frame, area: Rect, state: &AppState) {
     } else {
         " [h/j/k/l] nav  [L] log  [o] open run  [?] help  [q] quit"
     };
-    let para = Paragraph::new(keys).style(Style::default().fg(Color::DarkGray));
+    let para = Paragraph::new(keys).style(theme::muted_style());
     frame.render_widget(para, area);
 }
 
@@ -516,6 +511,8 @@ fn render_snap_in(frame: &mut Frame, area: Rect, state: &AppState, task_id: &str
 
     // --- Title bar ---
     let title_text = format!(" Snap-in: {task_id} ({status_str}) — line {n}/{total_lines} ");
+    // Intentional: inverted text on highlight bar — selection highlight pairing,
+    // not a palette color. Keep inline.
     let title_para = Paragraph::new(title_text).style(
         Style::default()
             .fg(Color::Black)
@@ -543,7 +540,7 @@ fn render_snap_in(frame: &mut Frame, area: Rect, state: &AppState, task_id: &str
 
     // --- Status bar ---
     let hint = " [Esc] back  [j/k] scroll  [Ctrl-D/U] page  [G] bottom  [g] top  [q] quit";
-    let status_para = Paragraph::new(hint).style(Style::default().fg(Color::DarkGray));
+    let status_para = Paragraph::new(hint).style(theme::muted_style());
     frame.render_widget(status_para, chunks[2]);
 }
 
@@ -558,7 +555,7 @@ fn render_log_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
     let block = Block::default()
         .borders(Borders::ALL)
         .title(format!(" Log: {focused_id}  [L/Esc] close "))
-        .border_style(Style::default().fg(Color::Yellow));
+        .border_style(Style::default().fg(theme::OVERLAY_ACCENT_WARNING));
 
     let inner = block.inner(overlay_area);
     frame.render_widget(block, overlay_area);
@@ -580,7 +577,7 @@ fn render_help_overlay(frame: &mut Frame, area: Rect) {
     let block = Block::default()
         .borders(Borders::ALL)
         .title(" Help — Pitboss TUI ")
-        .border_style(Style::default().fg(Color::Green));
+        .border_style(Style::default().fg(theme::OVERLAY_ACCENT_INFO));
 
     let inner = block.inner(overlay_area);
     frame.render_widget(block, overlay_area);
@@ -603,7 +600,7 @@ fn render_help_overlay(frame: &mut Frame, area: Rect) {
         Line::from(""),
         Line::from(Span::styled(
             "  Press Esc or ? to close",
-            Style::default().fg(Color::DarkGray),
+            theme::muted_style(),
         )),
     ];
 
@@ -619,13 +616,13 @@ fn render_run_picker_overlay(frame: &mut Frame, area: Rect, state: &AppState, se
     let block = Block::default()
         .borders(Borders::ALL)
         .title(" Open Run  [j/k] navigate  [Enter] open  [Esc] cancel ")
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(theme::OVERLAY_ACCENT_PICKER));
 
     let inner = block.inner(overlay_area);
     frame.render_widget(block, overlay_area);
 
     if state.run_list.is_empty() {
-        let msg = Paragraph::new(" No runs found.").style(Style::default().fg(Color::DarkGray));
+        let msg = Paragraph::new(" No runs found.").style(theme::muted_style());
         frame.render_widget(msg, inner);
         return;
     }
@@ -651,6 +648,7 @@ fn render_run_picker_overlay(frame: &mut Frame, area: Rect, state: &AppState, se
         })
         .collect();
 
+    // Intentional: inverted selection highlight pairing, not a palette color.
     let list = List::new(items)
         .highlight_style(
             Style::default()
@@ -684,7 +682,7 @@ fn render_confirm_kill(frame: &mut Frame, area: Rect, target: &crate::state::Kil
     let para = Paragraph::new(msg)
         .block(block)
         .alignment(Alignment::Center)
-        .style(Style::default().fg(Color::Yellow));
+        .style(Style::default().fg(theme::OVERLAY_ACCENT_WARNING));
     frame.render_widget(para, modal);
 }
 
@@ -702,7 +700,7 @@ fn render_prompt_reprompt(frame: &mut Frame, area: Rect, task_id: &str, draft: &
     let para = Paragraph::new(draft)
         .block(block)
         .wrap(Wrap { trim: false })
-        .style(Style::default().fg(Color::White));
+        .style(theme::primary_style());
     frame.render_widget(para, modal);
 }
 
@@ -739,7 +737,7 @@ fn render_approval_modal(
     let para = Paragraph::new(body)
         .block(block)
         .wrap(Wrap { trim: false })
-        .style(Style::default().fg(Color::White));
+        .style(theme::primary_style());
     frame.render_widget(para, modal);
 }
 
@@ -748,15 +746,16 @@ fn render_approval_modal(
 // ---------------------------------------------------------------------------
 
 fn status_icon(status: &TileStatus) -> (&'static str, Color) {
-    match status {
-        TileStatus::Pending => ("…", Color::Gray),
-        TileStatus::Running => ("●", Color::Cyan),
-        TileStatus::Done(TaskStatus::Success) => ("✓", Color::Green),
-        TileStatus::Done(TaskStatus::Failed) => ("✗", Color::Red),
-        TileStatus::Done(TaskStatus::TimedOut) => ("⏱", Color::Yellow),
-        TileStatus::Done(TaskStatus::Cancelled) => ("⊘", Color::Magenta),
-        TileStatus::Done(TaskStatus::SpawnFailed) => ("!", Color::Red),
-    }
+    let icon = match status {
+        TileStatus::Pending => "…",
+        TileStatus::Running => "●",
+        TileStatus::Done(TaskStatus::Success) => "✓",
+        TileStatus::Done(TaskStatus::Failed) => "✗",
+        TileStatus::Done(TaskStatus::TimedOut) => "⏱",
+        TileStatus::Done(TaskStatus::Cancelled) => "⊘",
+        TileStatus::Done(TaskStatus::SpawnFailed) => "!",
+    };
+    (icon, theme::tile_status_color(status))
 }
 
 fn status_label(status: &TileStatus) -> &'static str {

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -314,6 +314,10 @@ fn render_body(frame: &mut Frame, area: Rect, state: &AppState) {
 // ---------------------------------------------------------------------------
 
 fn render_tile_grid(frame: &mut Frame, area: Rect, state: &AppState) {
+    // Wipe any prior-frame content in the grid area before drawing tiles.
+    // Partial final rows would otherwise retain text from an earlier
+    // render, causing visible character leakage (fix for #129).
+    frame.render_widget(Clear, area);
     let n = state.tasks.len();
     let cols = TILE_COLS.min(n);
     let rows = n.div_ceil(cols);

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -474,7 +474,7 @@ fn render_statusbar(frame: &mut Frame, area: Rect, state: &AppState) {
     let keys = if matches!(state.mode, Mode::PickingRun { .. }) {
         " [j/k] navigate  [Enter] open  [Esc] cancel"
     } else {
-        " [h/j/k/l] nav  [L] log  [o] open run  [?] help  [q] quit"
+        " [hjkl] nav  [Enter] snap  [L] log  [x/X] kill wrk/run  [p/c] pause/cont  [r] reprompt  [o] open  [?] help  [q] quit"
     };
     let para = Paragraph::new(keys).style(theme::muted_style());
     frame.render_widget(para, area);
@@ -574,7 +574,7 @@ fn render_log_overlay(frame: &mut Frame, area: Rect, state: &AppState) {
 }
 
 fn render_help_overlay(frame: &mut Frame, area: Rect) {
-    let overlay_area = centered_rect(60, 60, area);
+    let overlay_area = centered_rect(70, 80, area);
     frame.render_widget(Clear, overlay_area);
 
     let block = Block::default()
@@ -589,17 +589,28 @@ fn render_help_overlay(frame: &mut Frame, area: Rect) {
         Line::from(""),
         Line::from("  Keybindings"),
         Line::from("  ──────────────────────────────"),
-        Line::from("  h / ← : focus left"),
-        Line::from("  l / → : focus right"),
-        Line::from("  k / ↑ : focus up (4 cols)"),
-        Line::from("  j / ↓ : focus down (4 cols)"),
-        Line::from("  L     : view full log overlay"),
-        Line::from("  r     : force refresh"),
-        Line::from("  ?     : toggle this help"),
-        Line::from("  q     : quit"),
-        Line::from("  Esc   : close overlay"),
+        Line::from("  Navigation"),
+        Line::from("    h / ←  : focus left"),
+        Line::from("    l / →  : focus right"),
+        Line::from("    k / ↑  : focus up (4 cols)"),
+        Line::from("    j / ↓  : focus down (4 cols)"),
         Line::from(""),
-        Line::from("  OBSERVE mode — no task spawning in v0.2-alpha."),
+        Line::from("  Views"),
+        Line::from("    Enter  : snap-in to focused tile (full-screen log)"),
+        Line::from("    L      : view full log overlay"),
+        Line::from("    o      : open run picker"),
+        Line::from(""),
+        Line::from("  Control (v0.4)"),
+        Line::from("    x      : cancel focused worker (confirm)"),
+        Line::from("    X      : cancel entire run (confirm)"),
+        Line::from("    p      : pause focused worker"),
+        Line::from("    c      : continue focused worker"),
+        Line::from("    r      : reprompt focused worker"),
+        Line::from(""),
+        Line::from("  System"),
+        Line::from("    ?      : toggle this help"),
+        Line::from("    q      : quit"),
+        Line::from("    Esc    : close overlay / modal"),
         Line::from(""),
         Line::from(Span::styled(
             "  Press Esc or ? to close",

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -287,8 +287,7 @@ fn render_title(frame: &mut Frame, area: Rect, state: &AppState) {
 
 fn render_body(frame: &mut Frame, area: Rect, state: &AppState) {
     if state.tasks.is_empty() {
-        let msg =
-            Paragraph::new(" No tasks found in this run.").style(theme::secondary_style());
+        let msg = Paragraph::new(" No tasks found in this run.").style(theme::secondary_style());
         frame.render_widget(msg, area);
         return;
     }
@@ -376,10 +375,7 @@ fn render_tile(frame: &mut Frame, area: Rect, state: &AppState, tile_idx: usize,
     // so the hierarchy is visible without consuming content rows.
     let subtitle = format_tile_subtitle(state, tile_idx);
     if !subtitle.is_empty() {
-        block = block.title_bottom(Span::styled(
-            format!(" {subtitle} "),
-            theme::muted_style(),
-        ));
+        block = block.title_bottom(Span::styled(format!(" {subtitle} "), theme::muted_style()));
     }
 
     let inner = block.inner(area);

--- a/crates/pitboss-tui/src/watcher.rs
+++ b/crates/pitboss-tui/src/watcher.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 
 use crate::state::{AppSnapshot, TileState, TileStatus};
 
-const POLL_INTERVAL_MS: u64 = 500;
+const POLL_INTERVAL_MS: u64 = 250;
 /// Number of parsed focus-pane lines to keep.
 const TAIL_LINES: usize = 40;
 /// Maximum bytes to read off the end of a log file when tailing. Chosen so

--- a/crates/pitboss-tui/tests/tui_control.rs
+++ b/crates/pitboss-tui/tests/tui_control.rs
@@ -87,3 +87,67 @@ fn approval_modal_overview_renders_summary() {
         "modal should include the summary, got:\n{text}"
     );
 }
+
+#[test]
+fn empty_grid_cells_are_cleared() {
+    // Render a state with many tasks, then render a state with fewer
+    // tasks. Assert leftover content from the first render is not
+    // visible in cells now occupied by dead space.
+    use pitboss_tui::state::{AppState, TileState, TileStatus};
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    use std::path::PathBuf;
+
+    fn mk_tile(id: &str) -> TileState {
+        TileState {
+            id: id.into(),
+            status: TileStatus::Running,
+            duration_ms: None,
+            token_usage_input: 0,
+            token_usage_output: 0,
+            cache_read: 0,
+            cache_creation: 0,
+            exit_code: None,
+            log_path: PathBuf::from("/tmp/nope"),
+            model: None,
+            parent_task_id: None,
+        }
+    }
+
+    let backend = TestBackend::new(120, 40);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    // First render: 8 tiles whose IDs contain a distinctive marker.
+    let mut state = AppState::new(PathBuf::from("/tmp"), "run-1".into());
+    state.tasks = (0..8)
+        .map(|i| mk_tile(&format!("DEADBEEF-LEFTOVER-{i}")))
+        .collect();
+    terminal
+        .draw(|frame| pitboss_tui::tui::render(frame, &state))
+        .unwrap();
+
+    // Second render: 2 tiles — leaves 6 grid cells previously filled
+    // with DEADBEEF content empty.
+    state.tasks = (0..2).map(|i| mk_tile(&format!("active-{i}"))).collect();
+    terminal
+        .draw(|frame| pitboss_tui::tui::render(frame, &state))
+        .unwrap();
+
+    // Scrape the buffer. "DEADBEEF" should not appear anywhere anymore.
+    let buf = terminal.backend().buffer();
+    let mut text = String::new();
+    for y in 0..40 {
+        for x in 0..120 {
+            text.push_str(buf.cell((x, y)).unwrap().symbol());
+        }
+        text.push('\n');
+    }
+    assert!(
+        !text.contains("DEADBEEF"),
+        "grid retained leftover content from prior render:\n{text}"
+    );
+    assert!(
+        !text.contains("LEFTOVER"),
+        "grid retained leftover content from prior render:\n{text}"
+    );
+}

--- a/crates/pitboss-tui/tests/tui_control.rs
+++ b/crates/pitboss-tui/tests/tui_control.rs
@@ -151,3 +151,70 @@ fn empty_grid_cells_are_cleared() {
         "grid retained leftover content from prior render:\n{text}"
     );
 }
+
+#[test]
+fn focus_log_content_does_not_bleed_into_tile_grid() {
+    // Simulates user's reported scenario: render a frame with focus_log
+    // containing long lines (which wrap), then re-render with *different*
+    // focus_log content. Assert no fragment from the first log's text
+    // appears in the upper (tile grid) region of the buffer.
+    use pitboss_tui::state::{AppState, TileState, TileStatus};
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    use std::path::PathBuf;
+
+    fn mk_tile(id: &str) -> TileState {
+        TileState {
+            id: id.into(),
+            status: TileStatus::Running,
+            duration_ms: None,
+            token_usage_input: 0,
+            token_usage_output: 0,
+            cache_read: 0,
+            cache_creation: 0,
+            exit_code: None,
+            log_path: PathBuf::from("/tmp/nope"),
+            model: None,
+            parent_task_id: None,
+        }
+    }
+
+    let backend = TestBackend::new(120, 40);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    let mut state = AppState::new(PathBuf::from("/tmp"), "run-1".into());
+    state.tasks = (0..16).map(|i| mk_tile(&format!("worker-{i}"))).collect();
+    state.focus = 0;
+    state.focus_log = vec![
+        "* Bash MAGICTOKENONE very long command with lots of content that WORDWRAPS".into(),
+        "< tool_result MAGICTOKENONE response data here with additional details".into(),
+        "> assistant text MAGICTOKENONE some explanation about what to do next".into(),
+    ];
+    terminal
+        .draw(|frame| pitboss_tui::tui::render(frame, &state))
+        .unwrap();
+
+    // Now simulate tile-focus change: different focus + different log content.
+    state.focus = 1;
+    state.focus_log = vec!["* Bash short cmd".into(), "< ok".into()];
+    terminal
+        .draw(|frame| pitboss_tui::tui::render(frame, &state))
+        .unwrap();
+
+    // Scrape ONLY the upper region (tile grid area, roughly rows 1..24 out
+    // of 40-row buffer — 60% body minus 1 title row). The string
+    // MAGICTOKENONE is unique to the first log; it must not appear anywhere
+    // in the tile grid.
+    let buf = terminal.backend().buffer();
+    let mut upper_region = String::new();
+    for y in 0..24 {
+        for x in 0..120 {
+            upper_region.push_str(buf.cell((x, y)).unwrap().symbol());
+        }
+        upper_region.push('\n');
+    }
+    assert!(
+        !upper_region.contains("MAGICTOKENONE"),
+        "tile grid retained focus-log content from prior render:\n{upper_region}"
+    );
+}


### PR DESCRIPTION
## Summary

Four TUI fixes surfaced during the Stage 1 dogfood run, plus a new semantic log-line coloring feature. All changes are scoped to `crates/pitboss-tui/`.

- **#128 — responsiveness:** watcher poll interval 500ms → 250ms so `summary.jsonl` writes surface promptly.
- **#129 — char leakage (partial):** `render_tile_grid` calls `Clear` before tiles, full-frame `Clear` at top of `render()`, and a `dirty` flag forces `terminal.clear()` on focus/mode/resize/SwitchRun transitions. A repro test (`focus_log_content_does_not_bleed_into_tile_grid`) confirms ratatui's diff is clean at the buffer level; residual occasional leaks observed during manual testing appear to be terminal-emulator-side and are left for follow-up — #129 stays open.
- **#130 — word-wrap:** added `.wrap(Wrap { trim: false })` to five Paragraphs (tile body, focus-log, snap-in, run-picker, approval-modal). Title/status bars intentionally stay single-line.
- **#131 — color consolidation:** new `pitboss_tui::theme` module holds palette constants + style helpers (`tile_status_style`, `focused_border`, `muted_style`, `log_line_style`, …). All but two inverted selection-highlight pairings have been pulled through the theme.
- **New:** semantic coloring of stream-json log lines — matches on `watcher::format_event`'s display prefix chars (`> ` assistant text, `* ` tool use, `< ` tool result, `v ` result, `! ` rate limit). Unparseable lines fall back to gray.

## Test Plan

- [x] Workspace tests pass (331 → 335: `+status_colors_are_unique`, `+log_line_style_maps_event_variants`, `+empty_grid_cells_are_cleared`, `+focus_log_content_does_not_bleed_into_tile_grid`)
- [x] `cargo lint` clean
- [x] `cargo build --release -p pitboss-cli` clean
- [x] `scripts/smoke-part1.sh` — 10/10 passed
- [x] Manual: TUI verified against live dogfood run; log coloring visible, tile grid no longer bleeds focus-log content on focus change (residual emulator-specific cells noted under #129).

Closes #128, #130, #131. Partial progress on #129 (see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)