### PR TITLE
fix: v0.4.1 dogfood pass — MCP shape, /peer/self, kill cascade, TUI QoL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,28 @@ This project uses [Semantic Versioning](https://semver.org/).
   per run; optional finalize-time dump to `<run-dir>/shared-store.json`
   via `[run] dump_shared_store = true`. See
   `docs/superpowers/specs/2026-04-18-worker-shared-store-design.md`.
+- **`/peer/self/` path alias for shared-store writes.** Workers don't
+  have a natural way to discover their own actor_id (UUIDs are assigned
+  at spawn for dynamically-spawned workers). Paths starting with
+  `/peer/self/` are auto-resolved against the caller's actor_id, so
+  task prompts can say "write to `/peer/self/findings.md`" without
+  needing to template an id. Applies to `kv_get`/`kv_set`/`kv_cas`/
+  `kv_list`/`kv_wait`.
+
+### Changed
+- **MCP `structuredContent` is now always a record.** The shared-store
+  tools `kv_get`, `kv_list`, and `list_workers` previously returned
+  bare `null` / arrays, which Claude Code's MCP client rejected with
+  `{"code":"invalid_type","message":"expected record, received ..."}`.
+  Return shapes are now `{ entry: ... }`, `{ entries: [...] }`, and
+  `{ workers: [...] }` respectively. Existing callers that expected
+  bare arrays/nulls need to unwrap one level.
+- **Shared-store `Forbidden` errors now include caller's actor_id and
+  a remediation hint.** Previously, "workers may write only their own
+  `/peer/<self>/*`" left workers guessing what `<self>` resolves to.
+  The message now names both the target peer and the caller's actual
+  `actor_id`, and points at `/peer/self/...` as the always-correct
+  path.
 
 ## [0.4.1] — 2026-04-18
 

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -301,6 +301,18 @@ async fn dispatch_op(
             }
         }
         ControlOp::CancelRun => {
+            // Cascade the cancel into every live worker's own token FIRST, then
+            // flip the run-level flag. The run-level `state.cancel` is only
+            // observed by the lead's SessionHandle; workers have independent
+            // per-task tokens and would otherwise keep running after the lead
+            // dies. Without this cascade, users saw "kill run" ack but ps
+            // still showed live claude workers.
+            {
+                let cancels = state.worker_cancels.read().await;
+                for tok in cancels.values() {
+                    tok.terminate();
+                }
+            }
             state.cancel.terminate();
             ControlEvent::OpAcked {
                 op: "cancel_run".into(),
@@ -840,6 +852,70 @@ mod tests {
                 if op == "cancel_worker" && tid == "w-1"
         ));
         assert!(worker_token.is_terminated());
+        drop(handle);
+    }
+
+    #[tokio::test]
+    async fn cancel_run_op_cascades_to_every_worker_token() {
+        // Regression: `CancelRun` used to only fire state.cancel (lead-only
+        // token). Workers have per-task tokens in state.worker_cancels;
+        // without cascading, workers stayed alive after a kill-run and the
+        // TUI showed the run as dead while `ps` showed live claude procs.
+        let dir = TempDir::new().unwrap();
+        let run_id = Uuid::now_v7();
+        let state = mk_state(dir.path(), run_id);
+
+        let w1 = pitboss_core::session::CancelToken::new();
+        let w2 = pitboss_core::session::CancelToken::new();
+        state
+            .worker_cancels
+            .write()
+            .await
+            .insert("w-1".into(), w1.clone());
+        state
+            .worker_cancels
+            .write()
+            .await
+            .insert("w-2".into(), w2.clone());
+
+        let sock = dir.path().join("cancel-run-cascade.sock");
+        let handle = start_control_server(
+            sock.clone(),
+            "0.4.0".into(),
+            run_id.to_string(),
+            "flat".into(),
+            state,
+        )
+        .await
+        .unwrap();
+
+        let mut stream = tokio::net::UnixStream::connect(&sock).await.unwrap();
+        stream
+            .write_all(b"{\"op\":\"hello\",\"client_version\":\"0.4.0\"}\n")
+            .await
+            .unwrap();
+        stream
+            .write_all(b"{\"op\":\"cancel_run\"}\n")
+            .await
+            .unwrap();
+
+        let (r, _w) = stream.split();
+        let mut lines = BufReader::new(r).lines();
+        let _hello = lines.next_line().await.unwrap();
+        let reply_line = lines.next_line().await.unwrap().unwrap();
+        let reply: ControlEvent = serde_json::from_str(&reply_line).unwrap();
+        assert!(matches!(
+            reply,
+            ControlEvent::OpAcked { ref op, .. } if op == "cancel_run"
+        ));
+        assert!(
+            w1.is_terminated(),
+            "worker 1 cancel token must be terminated"
+        );
+        assert!(
+            w2.is_terminated(),
+            "worker 2 cancel token must be terminated"
+        );
         drop(handle);
     }
 

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -255,8 +255,19 @@ pub async fn run_hierarchical(
     // and our internal cleanup termination signal to drain workers.
     let was_interrupted = cancel.is_draining() || cancel.is_terminated();
 
-    // Any in-flight workers get cancelled, their TaskRecord synthesized.
-    // `cancel.terminate()` signals all in-flight SessionHandles.
+    // Any in-flight workers get cancelled. `cancel` is the RUN-level token
+    // (observed only by the lead's SessionHandle), so terminating it alone
+    // leaves workers orphaned — their sessions use per-task tokens in
+    // `state.worker_cancels`. Cascade to every live worker so their
+    // SessionHandles SIGTERM the child claude processes too. Without this
+    // cascade, `ps` showed live claude workers after the run "finished"
+    // and the summary marked them Cancelled with no actual termination.
+    {
+        let cancels = state.worker_cancels.read().await;
+        for tok in cancels.values() {
+            tok.terminate();
+        }
+    }
     cancel.terminate();
     // Give them up to TERMINATE_GRACE to drain.
     tokio::time::sleep(pitboss_core::session::TERMINATE_GRACE).await;

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -188,7 +188,7 @@ impl PitbossHandler {
     }
 
     #[tool(
-        description = "Read a value from the shared store. Returns { entry: null } when the key is missing."
+        description = "Read a value from the shared store. Returns { entry: null } when the key is missing. Paths starting with /peer/self/ are resolved against the caller's actor_id."
     )]
     async fn kv_get(
         &self,
@@ -204,7 +204,7 @@ impl PitbossHandler {
     }
 
     #[tool(
-        description = "Write a value to the shared store. Namespace-authz checked against the caller's actor_role + actor_id."
+        description = "Write a value to the shared store. Namespace-authz checked against the caller's actor_role + actor_id. Workers should write to /peer/self/... (auto-resolves to /peer/<your-actor-id>/...) or /shared/..."
     )]
     async fn kv_set(
         &self,
@@ -217,7 +217,7 @@ impl PitbossHandler {
     }
 
     #[tool(
-        description = "Atomic compare-and-swap. expected_version=0 means the key must not exist."
+        description = "Atomic compare-and-swap. expected_version=0 means the key must not exist. Paths starting with /peer/self/ are resolved against the caller's actor_id."
     )]
     async fn kv_cas(
         &self,
@@ -230,7 +230,7 @@ impl PitbossHandler {
     }
 
     #[tool(
-        description = "List metadata of entries matching a glob pattern. * is single-segment; ** is cross-segment. Caps at 1000 results. Returns { entries: [...] }."
+        description = "List metadata of entries matching a glob pattern. * is single-segment; ** is cross-segment. Caps at 1000 results. Returns { entries: [...] }. Patterns starting with /peer/self/ are resolved against the caller's actor_id (requires _meta)."
     )]
     async fn kv_list(
         &self,
@@ -245,7 +245,7 @@ impl PitbossHandler {
     }
 
     #[tool(
-        description = "Block until a key is written (or exists with version >= min_version). Times out."
+        description = "Block until a key is written (or exists with version >= min_version). Times out. Paths starting with /peer/self/ are resolved against the caller's actor_id."
     )]
     async fn kv_wait(
         &self,

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -118,7 +118,10 @@ impl PitbossHandler {
     #[tool(description = "List all workers in the current run (excludes the lead).")]
     async fn list_workers(&self) -> Result<CallToolResult, ErrorData> {
         let summaries = handle_list_workers(&self.state).await;
-        to_structured_result(&summaries)
+        // MCP spec: structuredContent MUST be a record/object. Bare arrays
+        // (as `Vec<WorkerSummary>` would serialize) are rejected by the
+        // client's schema validator with "expected record, received array".
+        to_structured_result(&serde_json::json!({ "workers": summaries }))
     }
 
     #[tool(description = "Cancel a worker by task_id. Sends SIGTERM, grace, SIGKILL.")]
@@ -184,13 +187,18 @@ impl PitbossHandler {
         }
     }
 
-    #[tool(description = "Read a value from the shared store. Returns null if the key is missing.")]
+    #[tool(
+        description = "Read a value from the shared store. Returns { entry: null } when the key is missing."
+    )]
     async fn kv_get(
         &self,
         Parameters(args): Parameters<crate::shared_store::tools::KvGetArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         match crate::shared_store::tools::handle_kv_get(&self.state.shared_store, args).await {
-            Ok(v) => to_structured_result(&v),
+            // Wrap Option<Entry> in an object so structuredContent is a
+            // record (per MCP spec). A bare null was rejected by the
+            // client's schema validator in early dogfood runs.
+            Ok(v) => to_structured_result(&serde_json::json!({ "entry": v })),
             Err(e) => Err(shared_store_err(&e)),
         }
     }
@@ -222,14 +230,16 @@ impl PitbossHandler {
     }
 
     #[tool(
-        description = "List metadata of entries matching a glob pattern. * is single-segment; ** is cross-segment. Caps at 1000 results."
+        description = "List metadata of entries matching a glob pattern. * is single-segment; ** is cross-segment. Caps at 1000 results. Returns { entries: [...] }."
     )]
     async fn kv_list(
         &self,
         Parameters(args): Parameters<crate::shared_store::tools::KvListArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         match crate::shared_store::tools::handle_kv_list(&self.state.shared_store, args).await {
-            Ok(v) => to_structured_result(&v),
+            // Wrap Vec<ListMetadata> in an object — MCP spec requires
+            // structuredContent to be a record.
+            Ok(v) => to_structured_result(&serde_json::json!({ "entries": v })),
             Err(e) => Err(shared_store_err(&e)),
         }
     }
@@ -591,5 +601,61 @@ mod tests {
             elapsed
         );
         assert!(!sock.exists(), "socket file should be removed on drop");
+    }
+
+    // MCP spec requires CallToolResult.structuredContent to be a record/object.
+    // Claude Code's MCP client validates it and rejects arrays / nulls with
+    // `{"code":"invalid_type","message":"expected record, received array|null"}`.
+    // These tests pin the wrapper shape for tools that return Option<_> / Vec<_>
+    // so the shape can't regress silently.
+    //
+    // Earlier dogfood runs (2026-04-18) showed ~32 tool failures across four
+    // runs, all rooted in this bug. Regression guard.
+
+    #[test]
+    fn kv_get_wraps_missing_entry_as_object_not_null() {
+        let none: Option<crate::shared_store::Entry> = None;
+        let result = to_structured_result(&serde_json::json!({ "entry": none })).unwrap();
+        let v = result
+            .structured_content
+            .expect("structured content present");
+        assert!(
+            v.is_object(),
+            "structuredContent must be a record, got {v:?}"
+        );
+        let obj = v.as_object().unwrap();
+        assert!(obj.contains_key("entry"), "missing `entry` key: {obj:?}");
+        assert!(
+            obj["entry"].is_null(),
+            "missing key should serialize as null INSIDE the record"
+        );
+    }
+
+    #[test]
+    fn kv_list_wraps_empty_result_as_object_not_array() {
+        let empty: Vec<crate::shared_store::ListMetadata> = Vec::new();
+        let result = to_structured_result(&serde_json::json!({ "entries": empty })).unwrap();
+        let v = result
+            .structured_content
+            .expect("structured content present");
+        assert!(
+            v.is_object(),
+            "structuredContent must be a record, got {v:?}"
+        );
+        assert!(v["entries"].is_array(), "entries should be an array");
+    }
+
+    #[test]
+    fn list_workers_wraps_empty_result_as_object_not_array() {
+        let empty: Vec<crate::mcp::tools::WorkerSummary> = Vec::new();
+        let result = to_structured_result(&serde_json::json!({ "workers": empty })).unwrap();
+        let v = result
+            .structured_content
+            .expect("structured content present");
+        assert!(
+            v.is_object(),
+            "structuredContent must be a record, got {v:?}"
+        );
+        assert!(v["workers"].is_array(), "workers should be an array");
     }
 }

--- a/crates/pitboss-cli/src/shared_store/mod.rs
+++ b/crates/pitboss-cli/src/shared_store/mod.rs
@@ -117,18 +117,25 @@ fn authorize_write(
     let namespace = path.split('/').nth(1).unwrap_or("");
     match (namespace, caller.role) {
         ("ref", ActorRole::Lead) => Ok(()),
-        ("ref", ActorRole::Worker) => Err(StoreError::Forbidden("/ref is lead-write-only".into())),
+        ("ref", ActorRole::Worker) => Err(StoreError::Forbidden(format!(
+            "/ref is lead-write-only (your actor_id={}, role=worker); \
+             write to /peer/self/... or /shared/... instead",
+            caller.id
+        ))),
         ("peer", _) => {
             let actor_seg = path.split('/').nth(2).unwrap_or("");
             match (actor_seg == caller.id, caller.role, override_flag) {
                 (true, _, _) => Ok(()),
                 (_, ActorRole::Lead, true) => Ok(()),
-                (_, ActorRole::Lead, false) => Err(StoreError::Forbidden(
-                    "lead may write /peer/<other>/* only with override=true".into(),
-                )),
-                (_, ActorRole::Worker, _) => Err(StoreError::Forbidden(
-                    "workers may write only their own /peer/<self>/*".into(),
-                )),
+                (_, ActorRole::Lead, false) => Err(StoreError::Forbidden(format!(
+                    "lead (actor_id={}) may write /peer/{}/* only with override=true",
+                    caller.id, actor_seg
+                ))),
+                (_, ActorRole::Worker, _) => Err(StoreError::Forbidden(format!(
+                    "worker tried to write /peer/{}/* but your actor_id is {}; \
+                     use /peer/self/... (auto-resolves) or /peer/{}/... explicitly",
+                    actor_seg, caller.id, caller.id
+                ))),
             }
         }
         ("shared", _) => Ok(()),
@@ -136,7 +143,7 @@ fn authorize_write(
             "use lease_acquire, not kv_set on /leases/*".into(),
         )),
         _ => Err(StoreError::Forbidden(format!(
-            "unknown namespace: /{namespace}"
+            "unknown namespace: /{namespace} (valid: /ref, /peer/<id>, /shared, /leases)"
         ))),
     }
 }
@@ -814,7 +821,22 @@ mod tests {
             .authorized_set("/peer/w2/out", b"v".to_vec(), &worker("w1"), false)
             .await
             .unwrap_err();
-        assert!(matches!(err, StoreError::Forbidden(_)));
+        // Message must call out BOTH the target path's actor segment AND
+        // the caller's actual actor_id so workers can self-correct without
+        // a separate round-trip. Earlier message ("workers may write only
+        // their own /peer/<self>/*") left workers guessing what <self>
+        // resolves to — they burned turns experimenting with paths.
+        let StoreError::Forbidden(msg) = err else {
+            panic!("expected Forbidden, got {:?}", err);
+        };
+        assert!(
+            msg.contains("w2") && msg.contains("w1"),
+            "message must include target peer id (w2) and caller actor_id (w1): {msg}"
+        );
+        assert!(
+            msg.contains("/peer/self"),
+            "message should suggest /peer/self/... alias: {msg}"
+        );
     }
 
     #[tokio::test]

--- a/crates/pitboss-cli/src/shared_store/tools.rs
+++ b/crates/pitboss-cli/src/shared_store/tools.rs
@@ -105,13 +105,57 @@ pub struct KvSetResult {
     pub version: u64,
 }
 
+// ---------- Path helpers ----------
+
+/// Rewrite `/peer/self/...` to `/peer/<caller_id>/...` so workers can use
+/// the generic `self` keyword without knowing their own actor_id.
+///
+/// Workers don't have a natural way to discover their actor_id (the
+/// dispatcher assigns UUIDs for dynamically-spawned workers). Before this
+/// helper, a task-prompt instruction like "write your findings to
+/// `/peer/p0-4/findings.md`" would fail authz because the worker's actual
+/// actor_id is a UUID, not `p0-4`. Workers would then narrate about the
+/// mismatch and waste turns experimenting with paths. `self` is an
+/// always-correct alias.
+///
+/// Applies to both `/peer/self/...` (single-segment) and `/peer/self`
+/// (exact). Any other path is returned unchanged.
+fn resolve_peer_self(path: &str, caller_id: &str) -> String {
+    if path == "/peer/self" {
+        return format!("/peer/{caller_id}");
+    }
+    if let Some(rest) = path.strip_prefix("/peer/self/") {
+        return format!("/peer/{caller_id}/{rest}");
+    }
+    path.to_string()
+}
+
+/// Reject `self`-aliased paths when identity is missing. Used by read-only
+/// tools where `meta` is optional — if a caller omits `_meta` AND uses
+/// `/peer/self/...`, we can't resolve and return a clear error instead of
+/// silently reading the literal path `/peer/self/...`.
+fn require_identity_for_self(path: &str, meta: Option<&MetaField>) -> Result<String, StoreError> {
+    if path.starts_with("/peer/self") {
+        let Some(m) = meta else {
+            return Err(StoreError::InvalidArg(
+                "/peer/self/... requires caller identity (missing _meta). \
+                 Prefer /peer/<actor_id>/... when calling without identity."
+                    .into(),
+            ));
+        };
+        return Ok(resolve_peer_self(path, &m.actor_id));
+    }
+    Ok(path.to_string())
+}
+
 // ---------- Handlers ----------
 
 pub async fn handle_kv_get(
     store: &Arc<SharedStore>,
     args: KvGetArgs,
 ) -> Result<Option<Entry>, StoreError> {
-    Ok(store.get(&args.path).await)
+    let path = require_identity_for_self(&args.path, args.meta.as_ref())?;
+    Ok(store.get(&path).await)
 }
 
 pub async fn handle_kv_set(
@@ -119,8 +163,9 @@ pub async fn handle_kv_set(
     args: KvSetArgs,
 ) -> Result<KvSetResult, StoreError> {
     let caller: CallerIdentity = args.meta.into();
+    let path = resolve_peer_self(&args.path, &caller.id);
     let version = store
-        .authorized_set(&args.path, args.value, &caller, args.override_flag)
+        .authorized_set(&path, args.value, &caller, args.override_flag)
         .await?;
     Ok(KvSetResult { version })
 }
@@ -130,9 +175,10 @@ pub async fn handle_kv_cas(
     args: KvCasArgs,
 ) -> Result<super::CasResult, StoreError> {
     let caller: CallerIdentity = args.meta.into();
+    let path = resolve_peer_self(&args.path, &caller.id);
     store
         .authorized_cas(
-            &args.path,
+            &path,
             args.expected_version,
             args.new_value,
             &caller,
@@ -145,16 +191,18 @@ pub async fn handle_kv_list(
     store: &Arc<SharedStore>,
     args: KvListArgs,
 ) -> Result<Vec<ListMetadata>, StoreError> {
-    store.list(&args.glob).await
+    let glob = require_identity_for_self(&args.glob, args.meta.as_ref())?;
+    store.list(&glob).await
 }
 
 pub async fn handle_kv_wait(
     store: &Arc<SharedStore>,
     args: KvWaitArgs,
 ) -> Result<Entry, StoreError> {
+    let path = require_identity_for_self(&args.path, args.meta.as_ref())?;
     store
         .wait(
-            &args.path,
+            &path,
             Duration::from_secs(u64::from(args.timeout_secs)),
             args.min_version,
         )
@@ -182,4 +230,73 @@ pub async fn handle_lease_release(
 ) -> Result<(), StoreError> {
     let caller: CallerIdentity = args.meta.into();
     store.lease_release(&args.lease_id, &caller).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_peer_self_rewrites_exact_match() {
+        assert_eq!(
+            resolve_peer_self("/peer/self", "worker-abc"),
+            "/peer/worker-abc"
+        );
+    }
+
+    #[test]
+    fn resolve_peer_self_rewrites_subpath() {
+        assert_eq!(
+            resolve_peer_self("/peer/self/findings.md", "worker-abc"),
+            "/peer/worker-abc/findings.md"
+        );
+    }
+
+    #[test]
+    fn resolve_peer_self_rewrites_nested_subpath() {
+        assert_eq!(
+            resolve_peer_self("/peer/self/out/a/b.json", "worker-abc"),
+            "/peer/worker-abc/out/a/b.json"
+        );
+    }
+
+    #[test]
+    fn resolve_peer_self_leaves_other_paths_untouched() {
+        assert_eq!(resolve_peer_self("/peer/other/x", "me"), "/peer/other/x");
+        assert_eq!(resolve_peer_self("/shared/foo", "me"), "/shared/foo");
+        assert_eq!(resolve_peer_self("/ref/x", "me"), "/ref/x");
+    }
+
+    #[test]
+    fn resolve_peer_self_does_not_rewrite_peer_selfx() {
+        // Path `/peer/selfish/...` is a different peer id that happens to
+        // start with "self" — must NOT be rewritten.
+        assert_eq!(
+            resolve_peer_self("/peer/selfish/out", "me"),
+            "/peer/selfish/out"
+        );
+    }
+
+    #[test]
+    fn require_identity_rejects_self_without_meta() {
+        let err = require_identity_for_self("/peer/self/x", None).unwrap_err();
+        assert!(matches!(err, StoreError::InvalidArg(_)));
+    }
+
+    #[test]
+    fn require_identity_allows_non_self_without_meta() {
+        // Reads to any other path are fine without meta.
+        let out = require_identity_for_self("/shared/x", None).unwrap();
+        assert_eq!(out, "/shared/x");
+    }
+
+    #[test]
+    fn require_identity_rewrites_self_with_meta() {
+        let meta = MetaField {
+            actor_id: "worker-abc".into(),
+            actor_role: ActorRole::Worker,
+        };
+        let out = require_identity_for_self("/peer/self/x", Some(&meta)).unwrap();
+        assert_eq!(out, "/peer/worker-abc/x");
+    }
 }

--- a/crates/pitboss-cli/tests/hierarchical_flows.rs
+++ b/crates/pitboss-cli/tests/hierarchical_flows.rs
@@ -99,7 +99,9 @@ async fn mcp_spawn_and_list_round_trip() {
     assert!(task_id.starts_with("worker-"));
 
     let list_result = client.call_tool("list_workers", json!({})).await.unwrap();
-    let list = list_result.as_array().unwrap();
+    // list_workers returns `{ workers: [...] }` — MCP spec requires
+    // structuredContent to be a record, not a bare array.
+    let list = list_result["workers"].as_array().unwrap();
     assert_eq!(list.len(), 1);
     assert_eq!(list[0]["task_id"].as_str().unwrap(), task_id);
 

--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -155,11 +155,14 @@ pub fn run(run_dir: PathBuf, run_id: String) -> anyhow::Result<()> {
                     // added later if useful.
                     if matches!(state.mode, Mode::Detail { .. }) {
                         match mouse.kind {
+                            // Wheel scroll: 5 rows/tick — matches `J`/`K`
+                            // shift-scroll cadence and feels natural for
+                            // quick log navigation without overshooting.
                             MouseEventKind::ScrollDown => {
-                                state.detail_scroll_down(3, DETAIL_VISIBLE_ROWS);
+                                state.detail_scroll_down(5, DETAIL_VISIBLE_ROWS);
                             }
                             MouseEventKind::ScrollUp => {
-                                state.detail_scroll_up(3);
+                                state.detail_scroll_up(5);
                             }
                             _ => {}
                         }
@@ -313,6 +316,12 @@ fn handle_detail(state: &mut AppState, code: KeyCode, modifiers: KeyModifiers) -
 
         // Scroll up one line.
         KeyCode::Char('k') | KeyCode::Up => state.detail_scroll_up(1),
+
+        // Medium-speed scroll: 5 lines. Sits between single-line j/k and
+        // half-page Ctrl-D/U. Shift-variants of the vim keys keep muscle
+        // memory intact for users who live on j/k=1.
+        KeyCode::Char('J') => state.detail_scroll_down(5, DETAIL_VISIBLE_ROWS),
+        KeyCode::Char('K') => state.detail_scroll_up(5),
 
         // Page down (Ctrl-D or PageDown).
         KeyCode::Char('d') if modifiers.contains(KeyModifiers::CONTROL) => {

--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -70,6 +70,12 @@ pub fn run(run_dir: PathBuf, run_id: String) -> anyhow::Result<()> {
     };
     state.control_connected = control_client.as_ref().is_some_and(|c| c.is_connected());
     state.control_client = control_client;
+    // Stash a handle to THE runtime the ControlClient was built under.
+    // `send_op` callers must spawn on this handle — spinning up a fresh
+    // runtime per call (as the removed `futures_block_on` helper did)
+    // left the socket writer registered with a dead reactor and every
+    // kill/pause/reprompt op hung without error.
+    state.runtime_handle = Some(runtime.handle().clone());
     // `runtime` owns the background reader + forward tasks and must be kept
     // alive for the full event loop. It falls out of scope at the end of
     // `run()`; the tasks are dropped cleanly then.
@@ -257,24 +263,23 @@ fn handle_normal(state: &mut AppState, code: KeyCode) -> Action {
 
         // v0.4 — pause focused worker.
         KeyCode::Char('p') => {
-            if let (Some(client), Some(tile)) =
-                (state.control_client.clone(), state.focused_tile().cloned())
-            {
-                let op =
-                    pitboss_cli::control::protocol::ControlOp::PauseWorker { task_id: tile.id };
-                let _ = futures_block_on(async move { client.send_op(op).await });
+            if let Some(tile) = state.focused_tile().cloned() {
+                spawn_control_op(
+                    state,
+                    pitboss_cli::control::protocol::ControlOp::PauseWorker { task_id: tile.id },
+                );
             }
         }
         // v0.4 — continue focused worker (if paused).
         KeyCode::Char('c') => {
-            if let (Some(client), Some(tile)) =
-                (state.control_client.clone(), state.focused_tile().cloned())
-            {
-                let op = pitboss_cli::control::protocol::ControlOp::ContinueWorker {
-                    task_id: tile.id,
-                    prompt: None,
-                };
-                let _ = futures_block_on(async move { client.send_op(op).await });
+            if let Some(tile) = state.focused_tile().cloned() {
+                spawn_control_op(
+                    state,
+                    pitboss_cli::control::protocol::ControlOp::ContinueWorker {
+                        task_id: tile.id,
+                        prompt: None,
+                    },
+                );
             }
         }
 
@@ -404,18 +409,15 @@ fn handle_confirm_kill(state: &mut AppState, code: KeyCode) -> Action {
     };
     match code {
         KeyCode::Char('y' | 'Y') => {
-            if let Some(client) = state.control_client.clone() {
-                let op = match target {
-                    crate::state::KillTarget::Worker(id) => {
-                        pitboss_cli::control::protocol::ControlOp::CancelWorker { task_id: id }
-                    }
-                    crate::state::KillTarget::Run => {
-                        pitboss_cli::control::protocol::ControlOp::CancelRun
-                    }
-                };
-                // Best-effort async send. Detach via fire-and-forget.
-                let _ = futures_block_on(async move { client.send_op(op).await });
-            }
+            let op = match target {
+                crate::state::KillTarget::Worker(id) => {
+                    pitboss_cli::control::protocol::ControlOp::CancelWorker { task_id: id }
+                }
+                crate::state::KillTarget::Run => {
+                    pitboss_cli::control::protocol::ControlOp::CancelRun
+                }
+            };
+            spawn_control_op(state, op);
             state.mode = Mode::Normal;
         }
         _ => state.mode = Mode::Normal,
@@ -436,13 +438,13 @@ fn handle_prompt_reprompt(state: &mut AppState, code: KeyCode, modifiers: KeyMod
         KeyCode::Enter if modifiers.contains(KeyModifiers::CONTROL) => {
             // Ctrl+Enter: submit.
             if !draft.is_empty() {
-                if let Some(client) = state.control_client.clone() {
-                    let op = pitboss_cli::control::protocol::ControlOp::RepromptWorker {
+                spawn_control_op(
+                    state,
+                    pitboss_cli::control::protocol::ControlOp::RepromptWorker {
                         task_id: task_id.clone(),
                         prompt: draft.clone(),
-                    };
-                    let _ = futures_block_on(async move { client.send_op(op).await });
-                }
+                    },
+                );
             }
             state.mode = Mode::Normal;
             return Action::Continue;
@@ -580,29 +582,32 @@ fn send_approve(
     comment: Option<String>,
     edited_summary: Option<String>,
 ) {
-    if let Some(client) = state.control_client.clone() {
-        let op = pitboss_cli::control::protocol::ControlOp::Approve {
+    spawn_control_op(
+        state,
+        pitboss_cli::control::protocol::ControlOp::Approve {
             request_id: request_id.to_string(),
             approved,
             comment,
             edited_summary,
-        };
-        let _ = futures_block_on(async move { client.send_op(op).await });
-    }
+        },
+    );
 }
 
-// The TUI event loop runs outside any tokio runtime context (crossterm polls
-// synchronously). For fire-and-forget control-socket sends we use a tiny
-// single-threaded runtime per call. The operation is short — one writeln —
-// so the overhead is acceptable. If it ever becomes hot, migrate to a
-// persistent runtime handle threaded through AppState.
-fn futures_block_on<F>(fut: F) -> F::Output
-where
-    F: std::future::Future,
-{
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("build tokio rt")
-        .block_on(fut)
+// Fire-and-forget dispatch of a control op onto the runtime the
+// `ControlClient` was built under. Earlier versions built a fresh
+// `new_current_thread()` runtime per call — that ran the socket write
+// through a reactor that didn't own the writer half, so every op hung
+// silently. We now spawn on the original handle (kept alive in AppState).
+// If either the client or runtime handle is missing (observe-only mode,
+// tests), the call is a no-op.
+fn spawn_control_op(state: &AppState, op: pitboss_cli::control::protocol::ControlOp) {
+    let (Some(client), Some(handle)) =
+        (state.control_client.clone(), state.runtime_handle.as_ref())
+    else {
+        return;
+    };
+    // Detach the JoinHandle — fire-and-forget send; send_op handles its own errors.
+    std::mem::drop(handle.spawn(async move {
+        let _ = client.send_op(op).await;
+    }));
 }

--- a/crates/pitboss-tui/src/state.rs
+++ b/crates/pitboss-tui/src/state.rs
@@ -136,6 +136,12 @@ pub struct AppState {
     /// whenever any line wraps — scroll must use this to map 1:1 with
     /// what's painted. 0 until the first render.
     pub detail_log_total_rows: std::sync::atomic::AtomicUsize,
+    /// Handle to the tokio runtime that owns the `ControlClient`. Must be
+    /// used to spawn any future that touches the control socket — building
+    /// a fresh `new_current_thread()` runtime per call would run the write
+    /// from the wrong reactor and async I/O would silently hang. `None`
+    /// only in tests where no control socket is in play.
+    pub runtime_handle: Option<tokio::runtime::Handle>,
 }
 
 /// Summary of a worker's worktree diff vs its base branch.
@@ -163,6 +169,7 @@ impl AppState {
             cached_git_diff: std::collections::HashMap::new(),
             detail_log_viewport: std::sync::atomic::AtomicUsize::new(0),
             detail_log_total_rows: std::sync::atomic::AtomicUsize::new(0),
+            runtime_handle: None,
         }
     }
 

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -566,7 +566,7 @@ fn render_detail_view(
     render_detail_log(frame, body[1], state, scroll);
 
     // --- Status bar ---
-    let hint = " [jk Ctrl-D/U gG] scroll log  [Esc] back  [q] quit";
+    let hint = " [jk 1 / JK 5 / Ctrl-D/U 10 / gG] scroll log  [Esc] back  [q] quit";
     let status_para = Paragraph::new(hint).style(theme::muted_style());
     frame.render_widget(status_para, outer[2]);
 }

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -1167,6 +1167,7 @@ mod tests {
             cached_git_diff: std::collections::HashMap::new(),
             detail_log_viewport: std::sync::atomic::AtomicUsize::new(0),
             detail_log_total_rows: std::sync::atomic::AtomicUsize::new(0),
+            runtime_handle: None,
         }
     }
 

--- a/crates/pitboss-tui/src/watcher.rs
+++ b/crates/pitboss-tui/src/watcher.rs
@@ -287,17 +287,25 @@ fn build_tile(
                 TileStatus::Pending
             }
         });
+        // Mid-flight tiles don't have a summary record yet. Scan the log
+        // directly to surface running token totals and (for dynamic
+        // workers not in resolved.json) the model. Without this scan the
+        // Detail view showed all zeros + "model ?" for up to the full
+        // worker runtime on slow tasks.
+        let (live_model, live_usage) = scan_live_stats(&log_path);
         TileState {
             id: id.to_string(),
             status,
             duration_ms: None,
-            token_usage_input: 0,
-            token_usage_output: 0,
-            cache_read: 0,
-            cache_creation: 0,
+            token_usage_input: live_usage.input,
+            token_usage_output: live_usage.output,
+            cache_read: live_usage.cache_read,
+            cache_creation: live_usage.cache_creation,
             exit_code: None,
             log_path,
-            model,
+            // Prefer the manifest-declared model (present for static tasks
+            // + lead) and fall back to the log-derived one (dynamic workers).
+            model: model.or(live_model),
             worktree_path: None,
             parent_task_id: if is_dynamic {
                 parent_task_id_fallback.map(str::to_string)
@@ -306,6 +314,63 @@ fn build_tile(
             },
         }
     }
+}
+
+/// Full-file scan of a worker's stdout.log for mid-flight stats:
+///   - model: from the first assistant message's `message.model`
+///   - usage: summed token counts across every assistant message's
+///     `message.usage` (each entry is per-turn, not cumulative).
+///
+/// O(log-size) on every snapshot tick — typical worker logs are well
+/// under 1 MB so this stays in the tens of microseconds. If logs ever
+/// grow past ~10 MB this should be promoted to a streaming scan with
+/// a per-tile watermark so we only parse new bytes each tick.
+fn scan_live_stats(path: &Path) -> (Option<String>, pitboss_core::parser::TokenUsage) {
+    let Ok(file) = std::fs::File::open(path) else {
+        return (None, pitboss_core::parser::TokenUsage::default());
+    };
+    let reader = BufReader::new(file);
+    let mut model: Option<String> = None;
+    let mut usage = pitboss_core::parser::TokenUsage::default();
+    for line in reader.lines().map_while(Result::ok) {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Ok(val) = serde_json::from_str::<serde_json::Value>(trimmed) else {
+            continue;
+        };
+        if val.get("type").and_then(|v| v.as_str()) != Some("assistant") {
+            continue;
+        }
+        let Some(msg) = val.get("message") else {
+            continue;
+        };
+        if model.is_none() {
+            if let Some(m) = msg.get("model").and_then(|v| v.as_str()) {
+                model = Some(m.to_string());
+            }
+        }
+        if let Some(u) = msg.get("usage") {
+            usage.input += u
+                .get("input_tokens")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0);
+            usage.output += u
+                .get("output_tokens")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0);
+            usage.cache_read += u
+                .get("cache_read_input_tokens")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0);
+            usage.cache_creation += u
+                .get("cache_creation_input_tokens")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0);
+        }
+    }
+    (model, usage)
 }
 
 // ---------------------------------------------------------------------------
@@ -691,6 +756,56 @@ mod tests {
         );
         let live_tile = snap.tasks.iter().find(|t| t.id == "worker-live").unwrap();
         assert_eq!(live_tile.parent_task_id.as_deref(), Some("lead"));
+    }
+
+    #[test]
+    fn scan_live_stats_extracts_model_and_summed_usage() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("stdout.log");
+        // Two assistant turns with per-turn usage — expect sum. Model
+        // taken from the first assistant message.
+        let body = [
+            r#"{"type":"system","subtype":"init","session_id":"s"}"#,
+            r#"{"type":"assistant","message":{"model":"claude-opus-4-7","content":[{"type":"text","text":"a"}],"usage":{"input_tokens":10,"output_tokens":5,"cache_read_input_tokens":100,"cache_creation_input_tokens":3}}}"#,
+            r#"{"type":"assistant","message":{"model":"claude-opus-4-7","content":[{"type":"text","text":"b"}],"usage":{"input_tokens":2,"output_tokens":4,"cache_read_input_tokens":200,"cache_creation_input_tokens":1}}}"#,
+        ]
+        .join("\n");
+        std::fs::write(&path, body).unwrap();
+
+        let (model, usage) = scan_live_stats(&path);
+        assert_eq!(model.as_deref(), Some("claude-opus-4-7"));
+        assert_eq!(usage.input, 12);
+        assert_eq!(usage.output, 9);
+        assert_eq!(usage.cache_read, 300);
+        assert_eq!(usage.cache_creation, 4);
+    }
+
+    #[test]
+    fn scan_live_stats_missing_file_returns_defaults() {
+        let (model, usage) = scan_live_stats(Path::new("/nonexistent/file.log"));
+        assert!(model.is_none());
+        assert_eq!(usage.input, 0);
+        assert_eq!(usage.output, 0);
+    }
+
+    #[test]
+    fn scan_live_stats_skips_malformed_and_non_assistant_lines() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("stdout.log");
+        let body = [
+            "not json at all",
+            r#"{"type":"system","subtype":"init"}"#,
+            r#"{"type":"user","message":{"content":[]}}"#,
+            r#"{"type":"assistant","message":{"model":"claude-haiku-4-5","content":[],"usage":{"input_tokens":7,"output_tokens":3}}}"#,
+            "",
+        ]
+        .join("\n");
+        std::fs::write(&path, body).unwrap();
+
+        let (model, usage) = scan_live_stats(&path);
+        assert_eq!(model.as_deref(), Some("claude-haiku-4-5"));
+        assert_eq!(usage.input, 7);
+        assert_eq!(usage.output, 3);
     }
 
     #[test]

--- a/crates/pitboss-tui/src/watcher.rs
+++ b/crates/pitboss-tui/src/watcher.rs
@@ -13,8 +13,10 @@ use serde::Deserialize;
 use crate::state::{AppSnapshot, TileState, TileStatus};
 
 const POLL_INTERVAL_MS: u64 = 250;
-/// Number of parsed focus-pane lines to keep.
-const TAIL_LINES: usize = 500;
+/// Number of parsed focus-pane lines to keep. Deep scroll-back on long
+/// runs is worth a few extra megabytes of in-memory state per focus
+/// change (each line is ~1 KB on average).
+const TAIL_LINES: usize = 2000;
 /// Maximum bytes to read off the end of a log file when tailing. Chosen so
 /// that even a verbose stream-json run has >> `TAIL_LINES` rendered events
 /// within this window, without re-parsing multi-megabyte logs every poll.
@@ -467,14 +469,13 @@ fn tail_log(path: &Path, n: usize) -> Vec<String> {
 }
 
 /// Per-event display caps. Originally tight for pre-word-wrap terminals;
-/// the v0.4.1.x word-wrap pass means long lines take more visual rows
-/// instead of falling off the right edge, so it's safe to show more per
-/// event. Snap-in mode (`Enter` to full-screen the focus log) uses the
-/// same formatter; if you need the untruncated stream-json, read
-/// `<run-dir>/tasks/<id>/stdout.log` directly.
-const CAP_ASSISTANT_TEXT: usize = 400;
-const CAP_TOOL_INPUT: usize = 240;
-const CAP_TOOL_RESULT: usize = 480;
+/// word-wrap + visual-row scroll now handle long lines correctly, so the
+/// caps can be generous. Truncated events get a `… +N chars` marker so
+/// operators know there's more content than shown — full untruncated
+/// stream-json is always in `<run-dir>/tasks/<id>/stdout.log`.
+const CAP_ASSISTANT_TEXT: usize = 2000;
+const CAP_TOOL_INPUT: usize = 1000;
+const CAP_TOOL_RESULT: usize = 3000;
 
 /// Parse one stream-json line and return a display string, or `None` to skip.
 fn format_event(bytes: &[u8]) -> Option<String> {
@@ -482,18 +483,18 @@ fn format_event(bytes: &[u8]) -> Option<String> {
     match event {
         Event::AssistantText { text } => {
             let first_line = text.lines().find(|l| !l.trim().is_empty()).unwrap_or(&text);
-            let capped = cap_str(first_line, CAP_ASSISTANT_TEXT);
+            let capped = cap_with_marker(first_line, CAP_ASSISTANT_TEXT);
             Some(format!("> {capped}"))
         }
         Event::AssistantToolUse {
             tool_name,
             input_summary,
         } => {
-            let summary = cap_str(&input_summary, CAP_TOOL_INPUT);
+            let summary = cap_with_marker(&input_summary, CAP_TOOL_INPUT);
             Some(format!("* {tool_name} {summary}"))
         }
         Event::ToolResult { content_summary } => {
-            let capped = cap_str(&content_summary, CAP_TOOL_RESULT);
+            let capped = cap_with_marker(&content_summary, CAP_TOOL_RESULT);
             Some(format!("< {capped}"))
         }
         Event::Result {
@@ -523,7 +524,8 @@ fn format_event(bytes: &[u8]) -> Option<String> {
     }
 }
 
-/// Truncate `s` to at most `max_chars` characters, appending "..." if cut.
+/// Truncate `s` to at most `max_chars` characters (unchanged if shorter).
+/// Primary use is `cap_with_marker`; kept as a raw-truncate primitive.
 fn cap_str(s: &str, max_chars: usize) -> &str {
     // Find the byte offset of the `max_chars`-th char boundary.
     let mut chars = s.char_indices();
@@ -532,6 +534,19 @@ fn cap_str(s: &str, max_chars: usize) -> &str {
     } else {
         s
     }
+}
+
+/// Truncate with an explicit ` … +N chars` marker when content is cut, so
+/// operators see that more content exists without having to guess.
+/// Returns an owned String so callers can format without lifetime acrobatics.
+fn cap_with_marker(s: &str, max_chars: usize) -> String {
+    let char_count = s.chars().count();
+    if char_count <= max_chars {
+        return s.to_string();
+    }
+    let head = cap_str(s, max_chars);
+    let extra = char_count - max_chars;
+    format!("{head} … +{extra} chars")
 }
 
 #[cfg(test)]
@@ -551,6 +566,24 @@ mod tests {
     #[test]
     fn cap_str_above_limit() {
         assert_eq!(cap_str("hello world", 5), "hello");
+    }
+
+    #[test]
+    fn cap_with_marker_below_limit_is_unchanged() {
+        assert_eq!(cap_with_marker("hello", 10), "hello");
+    }
+
+    #[test]
+    fn cap_with_marker_above_limit_appends_count() {
+        // "hello world" is 11 chars, cap at 5 → 6 trimmed.
+        assert_eq!(cap_with_marker("hello world", 5), "hello … +6 chars");
+    }
+
+    #[test]
+    fn cap_with_marker_counts_chars_not_bytes() {
+        // Non-ASCII: each "→" is 1 char but 3 bytes.
+        let s = "→→→→→"; // 5 chars, 15 bytes
+        assert_eq!(cap_with_marker(s, 3), "→→→ … +2 chars");
     }
 
     #[test]
@@ -627,15 +660,17 @@ mod tests {
 
     #[test]
     fn format_event_truncates_long_text() {
-        let long = "a".repeat(1000);
+        // Build content longer than the cap so we know truncation fires.
+        let over = CAP_ASSISTANT_TEXT + 100;
+        let long = "a".repeat(over);
         let line = format!(
             r#"{{"type":"assistant","message":{{"content":[{{"type":"text","text":"{long}"}}]}}}}"#
         );
         let out = format_event(line.as_bytes()).unwrap();
-        // "> " prefix (2 chars) + at most CAP_ASSISTANT_TEXT chars of content.
-        assert!(out.chars().count() <= 2 + CAP_ASSISTANT_TEXT);
-        // Must actually have truncated (input is longer than the cap).
-        assert!(out.chars().count() < 2 + 1000);
+        // Output should contain the `… +N chars` marker and report the
+        // correct delta (100 trimmed chars).
+        assert!(out.contains("… +100 chars"), "expected marker, got: {out}");
+        assert!(out.starts_with("> "));
     }
 
     #[test]

--- a/crates/pitboss-tui/src/watcher.rs
+++ b/crates/pitboss-tui/src/watcher.rs
@@ -266,6 +266,13 @@ fn build_tile(
             }
             _ => {}
         }
+        // Dynamic workers aren't in resolved.json, and TaskRecord doesn't
+        // carry the model. For those the model_map returns None and the
+        // Detail view would render "model ?". Pull the model out of the
+        // first assistant event via an early-out scan — cheap relative
+        // to the full scan_live_stats (which sums usage across every
+        // assistant message and scales with log size).
+        let model = model.or_else(|| scan_first_model(&log_path));
         TileState {
             id: id.to_string(),
             status: TileStatus::Done(rec.status.clone()),
@@ -316,6 +323,36 @@ fn build_tile(
             },
         }
     }
+}
+
+/// Early-out scan: return the model from the first assistant message
+/// in the log, or `None`. O(prefix-of-file) — stops as soon as the
+/// first usable `{"type":"assistant", ...}` line is seen. Used for
+/// completed tiles where the full usage is already in the `TaskRecord`
+/// but the model wasn't carried.
+fn scan_first_model(path: &Path) -> Option<String> {
+    let file = std::fs::File::open(path).ok()?;
+    let reader = BufReader::new(file);
+    for line in reader.lines().map_while(Result::ok) {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Ok(val) = serde_json::from_str::<serde_json::Value>(trimmed) else {
+            continue;
+        };
+        if val.get("type").and_then(|v| v.as_str()) != Some("assistant") {
+            continue;
+        }
+        if let Some(m) = val
+            .get("message")
+            .and_then(|m| m.get("model"))
+            .and_then(|v| v.as_str())
+        {
+            return Some(m.to_string());
+        }
+    }
+    None
 }
 
 /// Full-file scan of a worker's stdout.log for mid-flight stats:
@@ -821,6 +858,28 @@ mod tests {
         assert!(model.is_none());
         assert_eq!(usage.input, 0);
         assert_eq!(usage.output, 0);
+    }
+
+    #[test]
+    fn scan_first_model_returns_first_seen_model() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("stdout.log");
+        let body = [
+            r#"{"type":"system","subtype":"init"}"#,
+            r#"{"type":"assistant","message":{"model":"claude-sonnet-4-6","content":[]}}"#,
+            r#"{"type":"assistant","message":{"model":"claude-opus-4-7","content":[]}}"#,
+        ]
+        .join("\n");
+        std::fs::write(&path, body).unwrap();
+        assert_eq!(
+            scan_first_model(&path).as_deref(),
+            Some("claude-sonnet-4-6")
+        );
+    }
+
+    #[test]
+    fn scan_first_model_missing_file_returns_none() {
+        assert!(scan_first_model(Path::new("/nonexistent.log")).is_none());
     }
 
     #[test]

--- a/examples/ketchup-p0-execute.toml
+++ b/examples/ketchup-p0-execute.toml
@@ -17,7 +17,7 @@
 #                         they go ("noticed this helper is also used in
 #                         two other files"). Other workers read before
 #                         editing. Loose coordination, not a hard lock.
-#   /peer/<id>/completed — each worker writes a structured summary at the
+#   /peer/self/completed  — each worker writes a structured summary at the
 #                         end (files touched, branch name, test status,
 #                         risks, follow-ups). Lead reads all of them and
 #                         composes a merge plan + combined PR description
@@ -127,7 +127,7 @@ kv_list, kv_wait, lease_acquire, lease_release. Plus filesystem tools
    reasonable. If there's a test command in the repo, run it.
 
 5. Before exiting, write a completion summary to
-   /peer/<your-task-id>/completed via mcp__pitboss__kv_set. Value is
+   /peer/self/completed via mcp__pitboss__kv_set. Value is
    a JSON object with: item_id (e.g., "P0.1"), files_touched (array),
    branch (your current git branch), test_status ("passed"/"skipped"/
    "failed"), summary (1-2 sentence what you did), risks (array of

--- a/examples/ketchup-p0-execute.toml
+++ b/examples/ketchup-p0-execute.toml
@@ -40,7 +40,11 @@
 
 [run]
 max_workers = 5
-budget_usd = 5.00
+# Generous budget so the full 5-worker spread completes. Last run at $5
+# stopped at 2/5 workers because Opus lead + 5 Opus-tier workers (per
+# defaults) is expensive. This is a recurring dogfood, not user-facing
+# sample — adjust if you mirror this into your own manifest.
+budget_usd = 100.00
 lead_timeout_secs = 3600
 worktree_cleanup = "never"
 dump_shared_store = true

--- a/examples/ketchup-p0-remaining.toml
+++ b/examples/ketchup-p0-remaining.toml
@@ -1,0 +1,127 @@
+# Follow-up run for the P0 items that didn't land in ketchup-p0-execute.toml.
+# The first run completed P0.1 (Extract Pipeline) and P0.2 (Consolidate
+# Citations) successfully but hit the $5 budget before it could spawn
+# P0.3 / P0.4 / P0.5. Opus lead was the culprit — it spent $18 on plan
+# synthesis alone.
+#
+# Adjustments:
+#   - Lead downgraded Opus → Sonnet (~5x cheaper, still plenty for fan-out
+#     orchestration; save Opus for synthesis-heavy or novel-reasoning work).
+#   - Budget bumped $5 → $15 with headroom for ~$3 Sonnet lead + ~$1/worker.
+#   - Only the three un-executed P0 items are spawned here.
+#
+# Merge order from the first run's final report (still applies):
+#   1. demo/ketchup-p0-1  (P0.1 Pipeline extract)  — pure move, merge first
+#   2. demo/ketchup-p0-2  (P0.2 Citation consolidate) — reconcile manually
+#   3. this run → P0.3 Parsing rules collapse
+#   4. this run → P0.4 Mistakes reorg (recompute line offsets post-P0.2)
+#   5. this run → P0.5 Plugin consolidate (update SKILL-PIPELINE-GUIDE xref)
+#
+# Workers branch off the current HEAD of feature/pitboss-refactor-analysis.
+
+[run]
+max_workers = 3
+budget_usd = 15.00
+lead_timeout_secs = 2400
+worktree_cleanup = "never"
+dump_shared_store = true
+
+[defaults]
+model = "claude-haiku-4-5"
+use_worktree = true
+
+[[lead]]
+id = "ketchup-p0-remaining"
+directory = "/run/media/system/Dos/Projects/ketchup"
+branch = "demo/ketchup-p0-remaining-lead"
+# Sonnet for the coordinator — enough reasoning for 3-way fan-out + synthesis
+# without Opus's token cost.
+model = "claude-sonnet-4-6"
+
+prompt = """
+You are executing three remaining P0 refactor items on the Ketchup
+repository, after an earlier run completed P0.1 (Pipeline extract) and
+P0.2 (Citation consolidate). Your toolbelt includes spawn_worker,
+wait_for_worker, wait_for_any, kv_set, kv_get, kv_list, kv_wait,
+kv_cas, lease_acquire, lease_release.
+
+CONTEXT — a prior pitboss run generated refactor-analysis/REFACTOR-PLAN.md.
+Items P0.3, P0.4, and P0.5 were not executed due to budget exhaustion.
+
+STEP 1 — Publish shared context.
+
+Read refactor-analysis/REFACTOR-PLAN.md and extract ONLY the P0.3, P0.4,
+P0.5 sections. Write a condensed summary to /ref/plan-summary via
+mcp__pitboss__kv_set. Keep it tight — this run is budget-sensitive.
+
+Also publish /ref/conventions with a 10-line summary of the repo's
+style conventions (formatting, citation format, YAML frontmatter use).
+
+NOTE: An earlier run's P0.2 shifted the Common Mistakes section in
+SKILL.md by ~9 lines. Any P0.4 line-number references in the plan are
+relative to the pre-P0.2 state. The P0.4 worker should find the section
+by header name ("Common Mistakes") rather than relying on absolute line
+numbers.
+
+STEP 2 — Spawn three workers IN PARALLEL (one spawn_worker call each,
+back-to-back, do NOT wait between them). Each worker uses this template:
+
+WORKER PROMPT TEMPLATE:
+---
+You are worker P0.{N} ({TITLE}). You have access to: kv_get, kv_set,
+kv_cas, kv_list, kv_wait, lease_acquire, lease_release, plus standard
+filesystem tools.
+
+1. mcp__pitboss__kv_get path="/ref/plan-summary" to read the plan.
+2. Your target files: {FILES}.
+3. Execute the refactor per the plan. You are in your own worktree.
+   Read the target files first, then apply the refactor matching the
+   repo's conventions (kv_get "/ref/conventions" to confirm).
+4. If you notice anything that affects OTHER P0 items, kv_set a finding
+   at /shared/findings/{N}-<short-slug>.
+5. Verify: run `ls skills/ketchup/` and eyeball file sizes. If a test
+   command exists in the repo, run it.
+6. kv_set /peer/self/completed with JSON:
+     {item_id, files_touched, branch, test_status, summary, risks, follow_ups}
+7. Exit without committing or pushing.
+---
+
+Substitutions:
+  Worker P0.3: TITLE="Collapse 16 parsing rules into 8"
+               FILES="skills/ketchup/SKILL.md (Parsing Rules section)"
+  Worker P0.4: TITLE="Reorganize mistakes: remove phase-based duplication"
+               FILES="skills/ketchup/SKILL.md (Common Mistakes section — locate by header, not line#)"
+  Worker P0.5: TITLE="Consolidate plugin references — single source of truth"
+               FILES="skills/ketchup/plugin-registry.yaml, skills/ketchup/SKILL.md (remove duplicate plugin listings), skills/ketchup/SKILL-PIPELINE-GUIDE.md (P0.1 created this; update Step 1.5 plugin-discovery cross-reference if needed)"
+
+STEP 3 — Wait for all three via mcp__pitboss__wait_for_worker.
+
+STEP 4 — Aggregate: kv_list /shared/findings/*, kv_list /peer/*/completed,
+read each entry.
+
+STEP 5 — Print the final report in this exact format:
+
+  === Merge Plan (remaining P0) ===
+  P0.3 (branch=<worker-3-branch>): <1-sentence summary>
+    Files: <files_touched>
+    Test: <test_status>
+    Risks: <risks or "none">
+
+  P0.4 ...
+  P0.5 ...
+
+  === Cross-cutting findings ===
+  <each from /shared/findings/*>
+
+  === Combined merge order (with prior run) ===
+  1. demo/ketchup-p0-1 (P0.1)  — from prior run, merge first
+  2. demo/ketchup-p0-2 (P0.2)  — from prior run, manual reconciliation
+  3. <P0.3 branch>
+  4. <P0.4 branch>
+  5. <P0.5 branch>
+
+  === Follow-ups ===
+  <consolidated from workers>
+
+Then exit.
+"""

--- a/scripts/reset-ketchup-p0-dogfood.sh
+++ b/scripts/reset-ketchup-p0-dogfood.sh
@@ -22,7 +22,10 @@ set -euo pipefail
 
 KETCHUP_DIR="/run/media/system/Dos/Projects/ketchup"
 BASELINE_TAG="dogfood/p0-baseline"
-WORKTREE_GLOB_PREFIX="/run/media/system/Dos/Projects/ketchup-pitboss-"
+# Any worktree whose checked-out branch starts with one of these is a
+# pitboss-dogfood worktree. Multiple prefixes to cover old + current
+# naming conventions (`demo/ketchup-p0-*` today; possible future adds).
+BRANCH_PREFIXES=("demo/ketchup-p0-")
 
 if [[ ! -d "$KETCHUP_DIR/.git" ]]; then
     echo "error: $KETCHUP_DIR is not a git repository" >&2
@@ -39,11 +42,19 @@ fi
 
 echo "== ketchup baseline: $(git rev-parse --short "$BASELINE_TAG")"
 
-# Discover + remove pitboss-managed worktrees. --force so uncommitted
-# worker changes are blown away; that's the whole point of the reset.
-mapfile -t worktrees < <(git worktree list --porcelain \
-    | awk '/^worktree / {print $2}' \
-    | grep -F "$WORKTREE_GLOB_PREFIX" || true)
+# Discover + remove pitboss-managed worktrees. Match by BRANCH prefix
+# rather than path — old dogfood runs used different path conventions
+# (ketchup-p0-N-lead vs ketchup-pitboss-*) and we want to clean up all
+# of them. --force so uncommitted worker changes are blown away;
+# that's the whole point of the reset.
+mapfile -t worktrees < <(git worktree list --porcelain | awk -v prefixes="$(IFS='|'; echo "${BRANCH_PREFIXES[*]}")" '
+    BEGIN { split(prefixes, ps, "|") }
+    /^worktree / { path = $2 }
+    /^branch refs\/heads\// {
+        br = substr($0, length("branch refs/heads/") + 1)
+        for (i in ps) if (index(br, ps[i]) == 1) { print path; break }
+    }
+')
 
 if [[ ${#worktrees[@]} -eq 0 ]]; then
     echo "no pitboss worktrees to remove"
@@ -60,7 +71,12 @@ fi
 
 # Delete demo/ketchup-p0-* local branches. -D since the branches diverge
 # from main via uncommitted-in-worktree changes that are now gone.
-mapfile -t branches < <(git branch --list 'demo/ketchup-p0-*' | sed 's/^[* ]*//')
+# Use for-each-ref to get clean branch names across all prefixes.
+mapfile -t branches < <(
+    for prefix in "${BRANCH_PREFIXES[@]}"; do
+        git for-each-ref --format='%(refname:short)' "refs/heads/${prefix}*"
+    done
+)
 if [[ ${#branches[@]} -eq 0 ]]; then
     echo "no demo/ketchup-p0-* branches to delete"
 else

--- a/scripts/reset-ketchup-p0-dogfood.sh
+++ b/scripts/reset-ketchup-p0-dogfood.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Reset the ketchup-pitboss dogfood to the baseline tag so we can re-run
+# examples/ketchup-p0-execute.toml from a clean slate.
+#
+# What this does:
+#   1. Removes every `ketchup-pitboss-{worker,lead}-*` worktree pitboss
+#      has spawned under /run/media/system/Dos/Projects/.
+#   2. Deletes any `demo/ketchup-p0-*` branches those worktrees pointed at.
+#   3. Resets the main ketchup checkout to the baseline tag
+#      `dogfood/p0-baseline`.
+#   4. Leaves the tag in place so subsequent resets keep working.
+#
+# Safe to run repeatedly. Nothing is pushed to origin.
+#
+# After this, re-dispatch with:
+#   ./target/release/pitboss dispatch examples/ketchup-p0-execute.toml
+#
+# Usage:
+#   scripts/reset-ketchup-p0-dogfood.sh
+
+set -euo pipefail
+
+KETCHUP_DIR="/run/media/system/Dos/Projects/ketchup"
+BASELINE_TAG="dogfood/p0-baseline"
+WORKTREE_GLOB_PREFIX="/run/media/system/Dos/Projects/ketchup-pitboss-"
+
+if [[ ! -d "$KETCHUP_DIR/.git" ]]; then
+    echo "error: $KETCHUP_DIR is not a git repository" >&2
+    exit 1
+fi
+
+cd "$KETCHUP_DIR"
+
+if ! git rev-parse -q --verify "refs/tags/$BASELINE_TAG" >/dev/null; then
+    echo "error: tag $BASELINE_TAG does not exist in $KETCHUP_DIR" >&2
+    echo "       create it first with: git tag $BASELINE_TAG <commit>" >&2
+    exit 1
+fi
+
+echo "== ketchup baseline: $(git rev-parse --short "$BASELINE_TAG")"
+
+# Discover + remove pitboss-managed worktrees. --force so uncommitted
+# worker changes are blown away; that's the whole point of the reset.
+mapfile -t worktrees < <(git worktree list --porcelain \
+    | awk '/^worktree / {print $2}' \
+    | grep -F "$WORKTREE_GLOB_PREFIX" || true)
+
+if [[ ${#worktrees[@]} -eq 0 ]]; then
+    echo "no pitboss worktrees to remove"
+else
+    for wt in "${worktrees[@]}"; do
+        echo "-- removing worktree: $wt"
+        git worktree remove --force "$wt" 2>/dev/null || {
+            echo "   fallback: rm -rf $wt"
+            rm -rf "$wt"
+        }
+    done
+    git worktree prune
+fi
+
+# Delete demo/ketchup-p0-* local branches. -D since the branches diverge
+# from main via uncommitted-in-worktree changes that are now gone.
+mapfile -t branches < <(git branch --list 'demo/ketchup-p0-*' | sed 's/^[* ]*//')
+if [[ ${#branches[@]} -eq 0 ]]; then
+    echo "no demo/ketchup-p0-* branches to delete"
+else
+    for b in "${branches[@]}"; do
+        echo "-- deleting branch: $b"
+        git branch -D "$b"
+    done
+fi
+
+# Reset the main checkout (whatever branch it's on) back to baseline.
+# If it's on a non-main branch like feature/pitboss-refactor-analysis,
+# this still works — we hard-reset that branch to the tag.
+current_branch=$(git branch --show-current)
+if [[ -z "$current_branch" ]]; then
+    echo "warn: ketchup HEAD is detached; leaving as-is"
+else
+    echo "-- resetting $current_branch to $BASELINE_TAG"
+    git reset --hard "$BASELINE_TAG"
+fi
+
+echo
+echo "== reset complete"
+git worktree list


### PR DESCRIPTION
## Summary

Ten commits addressing issues discovered while dogfooding v0.4.1. Everything is additive or a bug fix — no behavior changes outside the shared-store MCP response shape, which is a narrow breaking change callers need to unwrap one level for.

### Shared-store MCP fixes
- **`structuredContent` must be a record.** `kv_get` / `kv_list` / `list_workers` previously returned bare `null` / arrays, which Claude Code's MCP client rejected with `invalid_type`. Wrapped as `{ entry }` / `{ entries }` / `{ workers }`. Eliminated ~32 tool failures observed in the 2026-04-18 dogfood.
- **`/peer/self/` auto-resolves to `/peer/<caller.actor_id>/`.** Workers don't have a natural way to know their own UUID actor_id. Task prompts can now say "write to `/peer/self/findings.md`" and it Just Works. Applies to all 5 `kv_*` path-taking tools.
- **Beefier `Forbidden` errors.** Include the caller's actor_id + the target peer segment + a hint pointing at `/peer/self/`, so the worker can self-correct without burning turns experimenting with paths.

### Dispatcher control fixes
- **Kill commands now actually kill.** Two compounding bugs:
  - TUI's `send_op` ran on a fresh tokio runtime per call while the `ControlClient`'s socket writer was registered with the original — cross-runtime async I/O hangs silently. Moved to a runtime handle stashed in `AppState`; fixes kill, pause, continue, reprompt, approve.
  - `CancelRun` only terminated `state.cancel` (lead-only token). Workers have per-task tokens in `state.worker_cancels` — added a cascade both in the control server and in `dispatch/hierarchical.rs` finalize so workers actually receive the terminate signal.

### TUI metadata + log improvements
- **In-flight token + model display.** Watcher now scans each worker's `stdout.log` for `message.model` + per-turn `message.usage`, so the Detail pane shows non-zero tokens from the first assistant turn instead of waiting for finalize. Dynamic workers (not in `resolved.json`) also get their model populated — both while running AND after completion (early-out scan in the completed branch; TaskRecord still doesn't carry model, which would need a data-model migration).
- **Log pane QoL pass:**
  - Per-event caps raised: `assistant_text` 400→2000, `tool_input` 240→1000, `tool_result` 480→3000. Truncated events append a `… +N chars` marker so the trim is visible.
  - `TAIL_LINES` 500 → 2000 for deeper scroll-back.
  - Scroll cadence: `jk`=1 (vim-native, unchanged), `JK`=5 (new), Ctrl-D/U=10, mouse wheel 3→5. Status-bar hint updated.

### Dogfood infrastructure
- `scripts/reset-ketchup-p0-dogfood.sh` — tears down pitboss-managed worktrees + `demo/ketchup-p0-*` branches, resets the ketchup checkout to the `dogfood/p0-baseline` tag. Manual-invocation only (costs real API dollars).
- `examples/ketchup-p0-execute.toml` budget bumped 5 → 100 so the full 5-worker Opus spread can complete. Previously stopped at 2/5.
- Example TOMLs (`ketchup-p0-{execute,remaining}.toml`) now use `/peer/self/completed` to demonstrate the alias.

## Test Plan

- [x] Workspace tests: **408 passing** (up from 388; +20 new).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo build --release --workspace` clean
- [x] Dogfood run at $5 budget (partial): zero `invalid_type` errors, `/peer/self/` writes succeeded, 3 workers + lead Success.
- [x] Dogfood run at $100 budget (full 5-worker): zero `invalid_type` errors, all 5 workers + lead Success.
- [ ] Manual kill-run / kill-worker test against a live dispatch (fresh binary with the runtime fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)