### PR TITLE
feat(tui): in-flight git-diff + tile signifiers + tail run-id

### DIFF
--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -162,6 +162,16 @@ pub async fn run_hierarchical(
     let lead_log_path = lead_task_dir.join("stdout.log");
     let lead_stderr_path = lead_task_dir.join("stderr.log");
 
+    // Persist the lead's worktree path so the TUI can run mid-flight
+    // git-diff against it (same pattern as workers — see mcp/tools.rs).
+    if lead.use_worktree {
+        let _ = tokio::fs::write(
+            lead_task_dir.join("worktree.path"),
+            lead_cwd.to_string_lossy().as_bytes(),
+        )
+        .await;
+    }
+
     let spawn_cmd = pitboss_core::process::SpawnCmd {
         program: claude_binary.clone(),
         args: crate::dispatch::runner::lead_spawn_args(lead, &mcp_config_path),

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -326,6 +326,15 @@ async fn run_worker(
         match state.wt_mgr.prepare(&directory, &name, branch.as_deref()) {
             Ok(wt) => {
                 let p = wt.path.clone();
+                // Persist the worktree path so the TUI's Detail view can run
+                // `git diff --shortstat` against it mid-flight, not just after
+                // the TaskRecord lands. TaskRecord.worktree_path is only set
+                // on settle; writing this sidecar file closes the gap.
+                let _ = tokio::fs::write(
+                    task_dir.join("worktree.path"),
+                    p.to_string_lossy().as_bytes(),
+                )
+                .await;
                 worktree_handle = Some(wt);
                 p
             }

--- a/crates/pitboss-tui/src/state.rs
+++ b/crates/pitboss-tui/src/state.rs
@@ -234,11 +234,10 @@ impl AppState {
             return;
         };
         let task_id = tile.id.clone();
-        // Git diff is only meaningful for tasks that settled with a
-        // worktree_path recorded in summary.jsonl. For in-flight tasks
-        // the field is None (the record is written on settle), so we skip.
-        // Follow-up: add a <run-dir>/tasks/<id>/worktree.path file written
-        // at spawn time so in-flight diffs work too.
+        // worktree_path is populated for in-flight tiles via the
+        // `worktree.path` sidecar (written by the dispatcher at spawn
+        // time) and for completed tiles via TaskRecord.worktree_path —
+        // so this diff runs for both live and settled workers.
         if let Some(worktree) = tile.worktree_path.as_deref() {
             if let Some(summary) = compute_git_diff_summary(worktree) {
                 self.cached_git_diff.insert(task_id.clone(), summary);

--- a/crates/pitboss-tui/src/theme.rs
+++ b/crates/pitboss-tui/src/theme.rs
@@ -68,6 +68,35 @@ pub fn idle_border() -> Style {
     Style::default().fg(BORDER)
 }
 
+// ---------- Model-family palette ----------
+// Colors the title swatch on each tile so operators can tell at a glance
+// which model family is running where. Family matched by name prefix
+// (case-insensitive) — keep in sync with `model_family_color`.
+pub const MODEL_OPUS: Color = Color::Magenta;
+pub const MODEL_SONNET: Color = Color::Blue;
+pub const MODEL_HAIKU: Color = Color::Green;
+pub const MODEL_UNKNOWN: Color = Color::DarkGray;
+
+/// Given a model string (e.g. `"claude-opus-4-7"`), return the color
+/// for its family. Unknown families (nil, empty, non-Claude) fall back
+/// to dark-gray. Matching is substring + case-insensitive because the
+/// same family has many tags (`claude-opus-4-7`, `opus-4.7`, etc).
+pub fn model_family_color(model: Option<&str>) -> Color {
+    let Some(m) = model else {
+        return MODEL_UNKNOWN;
+    };
+    let lc = m.to_ascii_lowercase();
+    if lc.contains("opus") {
+        MODEL_OPUS
+    } else if lc.contains("sonnet") {
+        MODEL_SONNET
+    } else if lc.contains("haiku") {
+        MODEL_HAIKU
+    } else {
+        MODEL_UNKNOWN
+    }
+}
+
 // ---------- Log-line event palette ----------
 pub const LOG_ASSISTANT_TEXT: Color = Color::White; // Primary output
 pub const LOG_TOOL_USE: Color = Color::Cyan; // Model reaching out
@@ -104,6 +133,26 @@ pub fn log_line_style(line: &str) -> Style {
 mod tests {
     use super::*;
     use std::collections::HashSet;
+
+    #[test]
+    fn model_family_color_maps_opus_sonnet_haiku() {
+        assert_eq!(model_family_color(Some("claude-opus-4-7")), MODEL_OPUS);
+        assert_eq!(model_family_color(Some("claude-sonnet-4-6")), MODEL_SONNET);
+        assert_eq!(model_family_color(Some("claude-haiku-4-5")), MODEL_HAIKU);
+    }
+
+    #[test]
+    fn model_family_color_is_case_insensitive() {
+        assert_eq!(model_family_color(Some("CLAUDE-OPUS-4-7")), MODEL_OPUS);
+        assert_eq!(model_family_color(Some("Sonnet-Beta")), MODEL_SONNET);
+    }
+
+    #[test]
+    fn model_family_color_unknown_falls_back() {
+        assert_eq!(model_family_color(None), MODEL_UNKNOWN);
+        assert_eq!(model_family_color(Some("")), MODEL_UNKNOWN);
+        assert_eq!(model_family_color(Some("some-other-model")), MODEL_UNKNOWN);
+    }
 
     #[test]
     fn log_line_style_maps_event_variants() {

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -92,13 +92,13 @@ const TILE_COLS: usize = 4;
 // Percentage of mid-area height for the focus log pane (roughly 40%).
 const LOG_PANE_PCT: u16 = 40;
 
-/// Format the title string for the tile at `idx` in `state.tasks`.
-///
-/// Returns `[LEAD] {id}` if the tile is the lead (no `parent_task_id` AND at
-/// least one other tile lists it as parent), otherwise just the id.
-pub fn format_tile_title(state: &crate::state::AppState, idx: usize) -> String {
+/// Single-char role glyph for the tile title. Lead = `★`, worker = `▸`.
+/// Same lead-detection rule as `format_tile_title` (no `parent_task_id`
+/// AND at least one other tile claims this id as parent). Exposed for
+/// tests.
+pub fn tile_role_glyph(state: &crate::state::AppState, idx: usize) -> &'static str {
     let Some(tile) = state.tasks.get(idx) else {
-        return String::new();
+        return "";
     };
     let id = &tile.id;
     let is_lead = tile.parent_task_id.is_none()
@@ -107,10 +107,35 @@ pub fn format_tile_title(state: &crate::state::AppState, idx: usize) -> String {
             .iter()
             .any(|t| t.parent_task_id.as_deref() == Some(id.as_str()));
     if is_lead {
-        format!("[LEAD] {id}")
+        "\u{2605}" // ★
     } else {
-        id.clone()
+        "\u{25B8}" // ▸
     }
+}
+
+/// Format the title string for the tile at `idx` in `state.tasks`.
+/// Just the id — the role glyph + model color swatch are rendered as
+/// separate styled spans in `render_tile`.
+pub fn format_tile_title(state: &crate::state::AppState, idx: usize) -> String {
+    state
+        .tasks
+        .get(idx)
+        .map(|t| t.id.clone())
+        .unwrap_or_default()
+}
+
+/// Whether the tile at `idx` represents the run's lead. Used by the
+/// render layer for border-styling and by tests.
+pub fn tile_is_lead(state: &crate::state::AppState, idx: usize) -> bool {
+    let Some(tile) = state.tasks.get(idx) else {
+        return false;
+    };
+    let id = &tile.id;
+    tile.parent_task_id.is_none()
+        && state
+            .tasks
+            .iter()
+            .any(|t| t.parent_task_id.as_deref() == Some(id.as_str()))
 }
 
 /// Format the subtitle string for the tile at `idx` in `state.tasks`.
@@ -227,12 +252,23 @@ pub fn render(frame: &mut Frame, state: &AppState) {
 // Title bar
 // ---------------------------------------------------------------------------
 
+/// Return the most-distinguishing short form of a UUID-shaped run id.
+/// For `UUIDv7` (our format), the last hyphen-delimited segment is the
+/// random tail — sibling runs from the same minute share a common
+/// time-prefix, so showing `…146e21f77dd8` is much more useful than
+/// the lead 8 chars. Falls back to the full string when no hyphen
+/// is present (custom run ids, tests).
+fn short_run_id(run_id: &str) -> &str {
+    run_id.rsplit_once('-').map_or(run_id, |(_, tail)| tail)
+}
+
 fn render_title(frame: &mut Frame, area: Rect, state: &AppState) {
-    let short_id = if state.run_id.len() > 8 {
-        &state.run_id[..8]
-    } else {
-        &state.run_id
-    };
+    // Display the LAST segment of the UUID (random tail) rather than the
+    // leading 8 chars. UUIDv7 time-prefixes are similar across runs created
+    // close together; the tail is the actually-discriminating part, so
+    // "…146e21f77dd8" tells you which run you're looking at where
+    // "019da1b8…" looks the same as every sibling run from the same minute.
+    let short_id = short_run_id(&state.run_id);
 
     let total = state.tasks.len();
     let done = state
@@ -288,7 +324,7 @@ fn render_title(frame: &mut Frame, area: Rect, state: &AppState) {
     };
 
     let title_text = format!(
-        " Pitboss TUI — run {short_id}… — {done}/{total} done, {failed} failed{token_part}{cost_part}{duration_part}{workers_part} "
+        " Pitboss TUI — run …{short_id} — {done}/{total} done, {failed} failed{token_part}{cost_part}{duration_part}{workers_part} "
     );
 
     let para = Paragraph::new(title_text)
@@ -371,7 +407,8 @@ fn render_tile(frame: &mut Frame, area: Rect, state: &AppState, tile_idx: usize,
     let (icon, icon_color) = status_icon(&tile.status);
 
     let tile_title = format_tile_title(state, tile_idx);
-    let is_lead = tile_title.starts_with("[LEAD]");
+    let is_lead = tile_is_lead(state, tile_idx);
+    let role_glyph = tile_role_glyph(state, tile_idx);
 
     // Spec §8: focused and lead tiles both render with a distinct cyan + bold
     // border. The focused branch stays first for semantic clarity even though
@@ -382,9 +419,32 @@ fn render_tile(frame: &mut Frame, area: Rect, state: &AppState, tile_idx: usize,
         theme::idle_border()
     };
 
+    // Title: `▎ ★ {id}` — color swatch (model family) + role glyph + id.
+    // The swatch is a left-half-block char (`▎`) painted in the model's
+    // family color so tiles sharing a model are glanceable as a group.
+    // The role glyph replaces the old `[LEAD]` prefix (2 chars vs 7, and
+    // visually distinct without reading text).
+    let swatch_color = theme::model_family_color(tile.model.as_deref());
+    let title_spans = vec![
+        Span::raw(" "),
+        Span::styled("\u{258E}", Style::default().fg(swatch_color)),
+        Span::raw(" "),
+        Span::styled(
+            role_glyph,
+            Style::default().fg(if is_lead {
+                theme::BORDER_FOCUSED
+            } else {
+                theme::TEXT_SECONDARY
+            }),
+        ),
+        Span::raw(" "),
+        Span::raw(tile_title.clone()),
+        Span::raw(" "),
+    ];
+
     let mut block = Block::default()
         .borders(Borders::ALL)
-        .title(format!(" {tile_title} "))
+        .title(Line::from(title_spans))
         .border_style(border_style);
 
     // For worker tiles, append a dim parent annotation on the bottom border
@@ -1210,6 +1270,21 @@ mod tests {
     }
 
     #[test]
+    fn short_run_id_returns_tail_of_uuidv7() {
+        // Real UUIDv7 shape — want the last segment, not the time-prefix.
+        assert_eq!(
+            short_run_id("019da1b8-7820-7d73-92ea-146e21f77dd8"),
+            "146e21f77dd8"
+        );
+    }
+
+    #[test]
+    fn short_run_id_no_hyphen_returns_whole_string() {
+        assert_eq!(short_run_id("test-run"), "run");
+        assert_eq!(short_run_id("literal"), "literal");
+    }
+
+    #[test]
     fn run_stats_sums_done_tiles() {
         let s = state(vec![
             tile(
@@ -1398,22 +1473,26 @@ mod tests {
     }
 
     #[test]
-    fn render_tile_title_for_lead() {
+    fn tile_role_distinguishes_lead_from_worker() {
         // The lead is the tile whose parent_task_id is None and whose id
-        // appears as a parent of at least one other tile. Pitboss TUI renders
-        // its title with [LEAD] prefix.
+        // appears as a parent of at least one other tile. Replaced the old
+        // `[LEAD]` text prefix with a single glyph (`★`) that renders as a
+        // separate styled span in the title bar.
         let tiles = vec![
             tile("triage-lead", TileStatus::Running, None, 0, 0),
             tile_with_parent("worker-1", TileStatus::Running, Some("triage-lead".into())),
         ];
         let s = state(tiles);
-        let title = crate::tui::format_tile_title(&s, 0);
-        assert!(title.contains("[LEAD]"));
-        assert!(title.contains("triage-lead"));
 
-        let worker_title = crate::tui::format_tile_title(&s, 1);
-        assert!(!worker_title.contains("[LEAD]"));
-        assert!(worker_title.contains("worker-1"));
+        // Title is just the id now — role is communicated via glyph span.
+        assert_eq!(crate::tui::format_tile_title(&s, 0), "triage-lead");
+        assert_eq!(crate::tui::format_tile_title(&s, 1), "worker-1");
+
+        assert!(crate::tui::tile_is_lead(&s, 0));
+        assert!(!crate::tui::tile_is_lead(&s, 1));
+
+        assert_eq!(crate::tui::tile_role_glyph(&s, 0), "\u{2605}"); // ★
+        assert_eq!(crate::tui::tile_role_glyph(&s, 1), "\u{25B8}"); // ▸
     }
 
     #[test]

--- a/crates/pitboss-tui/src/watcher.rs
+++ b/crates/pitboss-tui/src/watcher.rs
@@ -282,10 +282,16 @@ fn build_tile(
             cache_read: rec.token_usage.cache_read,
             cache_creation: rec.token_usage.cache_creation,
             exit_code: rec.exit_code,
-            log_path,
+            log_path: log_path.clone(),
             model,
             parent_task_id: rec.parent_task_id.clone(),
-            worktree_path: rec.worktree_path.clone(),
+            // Prefer TaskRecord.worktree_path (canonical for completed
+            // tasks); fall back to the sidecar if the record didn't
+            // capture it (unlikely, but defensive).
+            worktree_path: rec
+                .worktree_path
+                .clone()
+                .or_else(|| log_path.parent().and_then(read_worktree_sidecar)),
         }
     } else {
         // Decide between Pending and Running by checking log freshness.
@@ -302,6 +308,12 @@ fn build_tile(
         // Detail view showed all zeros + "model ?" for up to the full
         // worker runtime on slow tasks.
         let (live_model, live_usage) = scan_live_stats(&log_path);
+        // The task dir holds a `worktree.path` sidecar written at spawn
+        // time by the dispatcher (mcp/tools.rs + dispatch/hierarchical.rs),
+        // so the Detail view can run mid-flight git-diff against it
+        // without waiting for the TaskRecord to land on settle.
+        let task_dir = log_path.parent().map(std::path::Path::to_path_buf);
+        let worktree_path = task_dir.as_ref().and_then(|d| read_worktree_sidecar(d));
         TileState {
             id: id.to_string(),
             status,
@@ -315,7 +327,7 @@ fn build_tile(
             // Prefer the manifest-declared model (present for static tasks
             // + lead) and fall back to the log-derived one (dynamic workers).
             model: model.or(live_model),
-            worktree_path: None,
+            worktree_path,
             parent_task_id: if is_dynamic {
                 parent_task_id_fallback.map(str::to_string)
             } else {
@@ -323,6 +335,19 @@ fn build_tile(
             },
         }
     }
+}
+
+/// Read the `worktree.path` sidecar file written at spawn time.
+/// Returns `None` when the file is missing (`use_worktree=false` task,
+/// or an old run from before the sidecar was introduced) or empty.
+fn read_worktree_sidecar(task_dir: &Path) -> Option<PathBuf> {
+    let bytes = std::fs::read(task_dir.join("worktree.path")).ok()?;
+    let s = String::from_utf8(bytes).ok()?;
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(trimmed))
 }
 
 /// Early-out scan: return the model from the first assistant message
@@ -880,6 +905,34 @@ mod tests {
     #[test]
     fn scan_first_model_missing_file_returns_none() {
         assert!(scan_first_model(Path::new("/nonexistent.log")).is_none());
+    }
+
+    #[test]
+    fn read_worktree_sidecar_returns_path_when_present() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("worktree.path"), "/some/worktree/path").unwrap();
+        let got = read_worktree_sidecar(dir.path()).unwrap();
+        assert_eq!(got, PathBuf::from("/some/worktree/path"));
+    }
+
+    #[test]
+    fn read_worktree_sidecar_trims_trailing_whitespace() {
+        // Dispatcher writes the raw path without a newline, but be
+        // forgiving — handwritten or shell-piped values might have one.
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("worktree.path"), "/some/path\n").unwrap();
+        assert_eq!(
+            read_worktree_sidecar(dir.path()),
+            Some(PathBuf::from("/some/path"))
+        );
+    }
+
+    #[test]
+    fn read_worktree_sidecar_none_when_missing_or_empty() {
+        let dir = tempfile::TempDir::new().unwrap();
+        assert!(read_worktree_sidecar(dir.path()).is_none());
+        std::fs::write(dir.path().join("worktree.path"), "").unwrap();
+        assert!(read_worktree_sidecar(dir.path()).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three grid-view improvements, all discovered while dogfooding PR #12:

### In-flight git diff
- **Problem:** Detail view's GIT DIFF section showed "unavailable" for every still-running worker. TaskRecord.worktree_path only lands at finalize, so live tasks rendered a blank diff even though the worktree existed on disk.
- **Fix:** dispatcher writes `<run-dir>/tasks/<task-id>/worktree.path` at spawn time (both `mcp/tools.rs` for workers + `dispatch/hierarchical.rs` for the lead); TUI watcher reads the sidecar and populates `tile.worktree_path` for in-flight tiles. Falls back to the sidecar for completed tiles too when `TaskRecord.worktree_path` is missing.
- Enter the Detail pane on a running worker — live files-changed / +lines / -lines via `git diff --shortstat`.

### Tile signifiers
- **Model-family color swatch** (`▎` glyph) prepended to every tile title, keyed to the model. Opus = magenta, Sonnet = blue, Haiku = green, unknown = dark-gray. Centralized in `theme::model_family_color` with case-insensitive matching.
- **Role glyph** replaces the `[LEAD]` text prefix. Lead = `★`, worker = `▸`. Saves ~5 chars in each title and renders a distinct visual hierarchy without reading.
- `tile_is_lead` + `tile_role_glyph` helpers factor the lead-detection predicate.

### Tail-segment run id
- **Problem:** Top status bar showed `run 019da1b8…` — the leading 8 chars of a UUIDv7. Sibling runs from the same minute share that time-prefix, so it's not discriminating.
- **Fix:** show the last hyphen-delimited segment: `run …146e21f77dd8`. That's the random tail, which is what actually differentiates runs.

## Test Plan

- [x] Workspace tests: **416 passing** (+8: sidecar ×3, model_family_color ×3, short_run_id ×2; plus replaced the old `render_tile_title_for_lead` with a glyph-based assertion).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo build --release --workspace` clean
- [ ] Manual TUI verification against a live dispatch: swatch colors distinct per model, ★/▸ render, Detail GIT DIFF shows live diff mid-flight

🤖 Generated with [Claude Code](https://claude.com/claude-code)