### PR TITLE
feat(tui): shared-store activity counters per tile

### DIFF
--- a/crates/pitboss-cli/src/control/protocol.rs
+++ b/crates/pitboss-cli/src/control/protocol.rs
@@ -84,6 +84,20 @@ pub enum ControlEvent {
     RunFinished {
         summary: RunFinishedSummary,
     },
+    /// Periodic broadcast of per-actor shared-store activity. Emitted
+    /// once per `STORE_ACTIVITY_INTERVAL` (~1 s) while there's an active
+    /// TUI connection. TUI uses this to render `kv:N lease:M` inside
+    /// each grid tile so operators can see store utilization at a glance.
+    StoreActivity {
+        counters: Vec<ActorActivityEntry>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActorActivityEntry {
+    pub actor_id: String,
+    pub kv_ops: u64,
+    pub lease_ops: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -274,5 +288,27 @@ mod tests {
             },
         };
         assert_eq!(roundtrip_event(&rf), rf);
+    }
+
+    #[test]
+    fn store_activity_roundtrips() {
+        let ev = ControlEvent::StoreActivity {
+            counters: vec![
+                ActorActivityEntry {
+                    actor_id: "worker-A".into(),
+                    kv_ops: 42,
+                    lease_ops: 3,
+                },
+                ActorActivityEntry {
+                    actor_id: "lead".into(),
+                    kv_ops: 7,
+                    lease_ops: 0,
+                },
+            ],
+        };
+        let s = serde_json::to_string(&ev).unwrap();
+        assert!(s.contains("\"event\":\"store_activity\""));
+        assert!(s.contains("\"worker-A\""));
+        assert_eq!(roundtrip_event(&ev), ev);
     }
 }

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -226,6 +226,41 @@ async fn serve_connection(
         }
     });
 
+    // Periodic shared-store activity broadcaster. Each connection gets
+    // its own ticker so when the TUI reconnects it starts from the
+    // current live counters. 1 s cadence is fast enough for the TUI's
+    // 250 ms poll to feel responsive without flooding the socket.
+    let ev_tx_activity = ev_tx.clone();
+    let state_activity = state.clone();
+    let activity_pump = tokio::spawn(async move {
+        // Delay first emission by one period. tokio::time::interval's default
+        // is to fire immediately on construction, which would race ahead of
+        // the first OpAcked in tests that send an op right after hello.
+        let period = std::time::Duration::from_millis(STORE_ACTIVITY_INTERVAL_MS);
+        let mut interval = tokio::time::interval_at(tokio::time::Instant::now() + period, period);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            interval.tick().await;
+            let snapshot = state_activity.shared_store.activity_snapshot().await;
+            let counters: Vec<crate::control::protocol::ActorActivityEntry> = snapshot
+                .into_iter()
+                .map(
+                    |(actor_id, c)| crate::control::protocol::ActorActivityEntry {
+                        actor_id,
+                        kv_ops: c.kv_ops,
+                        lease_ops: c.lease_ops,
+                    },
+                )
+                .collect();
+            if ev_tx_activity
+                .send(ControlEvent::StoreActivity { counters })
+                .is_err()
+            {
+                break;
+            }
+        }
+    });
+
     // Read loop.
     while let Ok(Some(line)) = reader.next_line().await {
         let reply = match serde_json::from_str::<ControlOp>(&line) {
@@ -247,7 +282,13 @@ async fn serve_connection(
         *cw = None;
     }
     pump.abort();
+    activity_pump.abort();
 }
+
+/// Period between `StoreActivity` broadcasts on the control socket.
+/// Tuned for TUI poll cadence (250 ms) — faster than 1 s is noise,
+/// slower feels laggy. Constant so tests can match expected payloads.
+const STORE_ACTIVITY_INTERVAL_MS: u64 = 1000;
 
 async fn send_event(
     writer: &Arc<Mutex<tokio::net::unix::OwnedWriteHalf>>,

--- a/crates/pitboss-cli/src/shared_store/mod.rs
+++ b/crates/pitboss-cli/src/shared_store/mod.rs
@@ -148,6 +148,19 @@ fn authorize_write(
     }
 }
 
+/// Per-actor activity counters surfaced to the TUI so each grid tile can
+/// show "kv:N lease:M" — a glanceable indicator of which workers are
+/// actively using the shared store vs idle. Counters are monotonically
+/// increasing for the lifetime of a run; kv covers get/set/cas/list/wait,
+/// lease covers acquire+release. Incremented for both successful and
+/// failed calls (authz/limit errors still count as "tried to use the
+/// store") so operators can see frustration loops in the numbers.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct ActivityCounters {
+    pub kv_ops: u64,
+    pub lease_ops: u64,
+}
+
 pub struct SharedStore {
     entries: RwLock<HashMap<PathBuf, Entry>>,
     limits: Limits,
@@ -155,6 +168,10 @@ pub struct SharedStore {
     cancel: CancellationToken,
     leases: LeaseRegistry,
     lease_notifier: broadcast::Sender<String>,
+    /// Per-actor activity counters, keyed by `actor_id`. Protected by a
+    /// standard RwLock (not the entries lock) so counter bumps don't
+    /// contend with reads/writes.
+    activity: RwLock<std::collections::HashMap<String, ActivityCounters>>,
 }
 
 impl SharedStore {
@@ -172,7 +189,35 @@ impl SharedStore {
             cancel: CancellationToken::new(),
             leases: LeaseRegistry::new(),
             lease_notifier,
+            activity: RwLock::new(std::collections::HashMap::new()),
         }
+    }
+
+    /// Increment the kv counter for `actor_id`. Called from each `kv_*`
+    /// MCP tool handler — no-op when the actor id is empty (defensive,
+    /// shouldn't happen in practice since the bridge stamps `_meta`).
+    pub async fn note_kv_op(&self, actor_id: &str) {
+        if actor_id.is_empty() {
+            return;
+        }
+        let mut activity = self.activity.write().await;
+        activity.entry(actor_id.to_string()).or_default().kv_ops += 1;
+    }
+
+    /// Increment the lease counter for `actor_id`. Called from
+    /// `lease_acquire` / `lease_release`.
+    pub async fn note_lease_op(&self, actor_id: &str) {
+        if actor_id.is_empty() {
+            return;
+        }
+        let mut activity = self.activity.write().await;
+        activity.entry(actor_id.to_string()).or_default().lease_ops += 1;
+    }
+
+    /// Snapshot the per-actor activity map. Used by the control server to
+    /// push periodic updates to the TUI.
+    pub async fn activity_snapshot(&self) -> std::collections::HashMap<String, ActivityCounters> {
+        self.activity.read().await.clone()
     }
 
     pub async fn get(&self, path: &str) -> Option<Entry> {
@@ -1049,5 +1094,49 @@ mod tests {
         assert!(text.contains("\"path\": \"/ref/a\""));
         assert!(text.contains("\"value_b64\":"));
         assert!(text.contains("\"name\": \"job-1\""));
+    }
+
+    // -----------------------------------------------------------------------
+    // Activity counters (v0.4.2+)
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn activity_counters_start_empty() {
+        let s = SharedStore::new();
+        assert!(s.activity_snapshot().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn note_kv_op_increments_kv_counter() {
+        let s = SharedStore::new();
+        s.note_kv_op("worker-A").await;
+        s.note_kv_op("worker-A").await;
+        s.note_kv_op("worker-B").await;
+        let snap = s.activity_snapshot().await;
+        assert_eq!(snap.get("worker-A").unwrap().kv_ops, 2);
+        assert_eq!(snap.get("worker-A").unwrap().lease_ops, 0);
+        assert_eq!(snap.get("worker-B").unwrap().kv_ops, 1);
+    }
+
+    #[tokio::test]
+    async fn note_lease_op_increments_lease_counter_independently() {
+        let s = SharedStore::new();
+        s.note_lease_op("worker-A").await;
+        s.note_kv_op("worker-A").await;
+        let snap = s.activity_snapshot().await;
+        let counters = snap.get("worker-A").unwrap();
+        assert_eq!(counters.kv_ops, 1);
+        assert_eq!(counters.lease_ops, 1);
+    }
+
+    #[tokio::test]
+    async fn note_ops_ignore_empty_actor_id() {
+        // Defensive: the bridge always stamps `_meta` so this shouldn't
+        // happen in practice, but an empty actor_id would otherwise
+        // create a bogus "" entry in the activity map.
+        let s = SharedStore::new();
+        s.note_kv_op("").await;
+        s.note_lease_op("").await;
+        assert!(s.activity_snapshot().await.is_empty());
     }
 }

--- a/crates/pitboss-cli/src/shared_store/tools.rs
+++ b/crates/pitboss-cli/src/shared_store/tools.rs
@@ -150,10 +150,20 @@ fn require_identity_for_self(path: &str, meta: Option<&MetaField>) -> Result<Str
 
 // ---------- Handlers ----------
 
+// Counter-bump policy: every tool call that carries an actor identity
+// bumps the matching counter EXACTLY ONCE at entry, BEFORE authz or
+// execution. That way "tried and got denied" still shows up in the TUI
+// — often the most useful signal when debugging a worker that's spinning
+// on bad paths. For tools where identity is optional (Option<MetaField>
+// — reads), we only bump when it's actually present.
+
 pub async fn handle_kv_get(
     store: &Arc<SharedStore>,
     args: KvGetArgs,
 ) -> Result<Option<Entry>, StoreError> {
+    if let Some(m) = &args.meta {
+        store.note_kv_op(&m.actor_id).await;
+    }
     let path = require_identity_for_self(&args.path, args.meta.as_ref())?;
     Ok(store.get(&path).await)
 }
@@ -162,6 +172,7 @@ pub async fn handle_kv_set(
     store: &Arc<SharedStore>,
     args: KvSetArgs,
 ) -> Result<KvSetResult, StoreError> {
+    store.note_kv_op(&args.meta.actor_id).await;
     let caller: CallerIdentity = args.meta.into();
     let path = resolve_peer_self(&args.path, &caller.id);
     let version = store
@@ -174,6 +185,7 @@ pub async fn handle_kv_cas(
     store: &Arc<SharedStore>,
     args: KvCasArgs,
 ) -> Result<super::CasResult, StoreError> {
+    store.note_kv_op(&args.meta.actor_id).await;
     let caller: CallerIdentity = args.meta.into();
     let path = resolve_peer_self(&args.path, &caller.id);
     store
@@ -191,6 +203,9 @@ pub async fn handle_kv_list(
     store: &Arc<SharedStore>,
     args: KvListArgs,
 ) -> Result<Vec<ListMetadata>, StoreError> {
+    if let Some(m) = &args.meta {
+        store.note_kv_op(&m.actor_id).await;
+    }
     let glob = require_identity_for_self(&args.glob, args.meta.as_ref())?;
     store.list(&glob).await
 }
@@ -199,6 +214,9 @@ pub async fn handle_kv_wait(
     store: &Arc<SharedStore>,
     args: KvWaitArgs,
 ) -> Result<Entry, StoreError> {
+    if let Some(m) = &args.meta {
+        store.note_kv_op(&m.actor_id).await;
+    }
     let path = require_identity_for_self(&args.path, args.meta.as_ref())?;
     store
         .wait(
@@ -213,6 +231,7 @@ pub async fn handle_lease_acquire(
     store: &Arc<SharedStore>,
     args: LeaseAcquireArgs,
 ) -> Result<AcquireResult, StoreError> {
+    store.note_lease_op(&args.meta.actor_id).await;
     let caller: CallerIdentity = args.meta.into();
     store
         .lease_acquire(
@@ -228,6 +247,7 @@ pub async fn handle_lease_release(
     store: &Arc<SharedStore>,
     args: LeaseReleaseArgs,
 ) -> Result<(), StoreError> {
+    store.note_lease_op(&args.meta.actor_id).await;
     let caller: CallerIdentity = args.meta.into();
     store.lease_release(&args.lease_id, &caller).await
 }

--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -408,6 +408,22 @@ fn apply_control_event(state: &mut AppState, ev: pitboss_cli::control::protocol:
         E::Superseded | E::RunFinished { .. } => {
             state.control_connected = false;
         }
+        E::StoreActivity { counters } => {
+            // Rebuild the map from scratch each broadcast — the server
+            // sends the full snapshot, so we don't need to merge.
+            state.store_activity = counters
+                .into_iter()
+                .map(|e| {
+                    (
+                        e.actor_id,
+                        crate::state::StoreActivityCounters {
+                            kv_ops: e.kv_ops,
+                            lease_ops: e.lease_ops,
+                        },
+                    )
+                })
+                .collect();
+        }
         _ => {}
     }
 }

--- a/crates/pitboss-tui/src/state.rs
+++ b/crates/pitboss-tui/src/state.rs
@@ -142,6 +142,21 @@ pub struct AppState {
     /// from the wrong reactor and async I/O would silently hang. `None`
     /// only in tests where no control socket is in play.
     pub runtime_handle: Option<tokio::runtime::Handle>,
+    /// Per-actor shared-store activity counters received via the control
+    /// socket's periodic `StoreActivity` broadcast. Rendered as
+    /// `kv:N lease:M` on each grid tile. Keyed by `actor_id` (matches
+    /// `TileState.id` for the lead + each worker). Empty until the first
+    /// broadcast arrives (~1 s after TUI connects).
+    pub store_activity: std::collections::HashMap<String, StoreActivityCounters>,
+}
+
+/// Mirrors `pitboss_cli::control::protocol::ActorActivityEntry` but
+/// kept as a separate TUI-owned type so the state module doesn't depend
+/// on the wire protocol's serde derives.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct StoreActivityCounters {
+    pub kv_ops: u64,
+    pub lease_ops: u64,
 }
 
 /// Summary of a worker's worktree diff vs its base branch.
@@ -170,6 +185,7 @@ impl AppState {
             detail_log_viewport: std::sync::atomic::AtomicUsize::new(0),
             detail_log_total_rows: std::sync::atomic::AtomicUsize::new(0),
             runtime_handle: None,
+            store_activity: std::collections::HashMap::new(),
         }
     }
 

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -477,7 +477,21 @@ fn render_tile(frame: &mut Frame, area: Rect, state: &AppState, tile_idx: usize,
         },
     );
 
-    let lines = vec![
+    // Shared-store activity line: `kv:N lease:M`. Skip when both are 0
+    // (almost all tiles during the first second + the lead in flat-mode
+    // runs), so quiet tiles don't waste a row on a useless "kv:0 lease:0".
+    let activity_line = state
+        .store_activity
+        .get(&tile.id)
+        .filter(|c| c.kv_ops > 0 || c.lease_ops > 0)
+        .map(|c| {
+            Line::from(Span::styled(
+                format!("kv:{} lease:{}", c.kv_ops, c.lease_ops),
+                theme::muted_style(),
+            ))
+        });
+
+    let mut lines = vec![
         Line::from(vec![
             Span::styled(icon, Style::default().fg(icon_color)),
             Span::raw(" "),
@@ -493,6 +507,9 @@ fn render_tile(frame: &mut Frame, area: Rect, state: &AppState, tile_idx: usize,
         )),
         Line::from(Span::styled(cost_str, theme::muted_style())),
     ];
+    if let Some(line) = activity_line {
+        lines.push(line);
+    }
 
     let para = Paragraph::new(lines).wrap(Wrap { trim: false });
     frame.render_widget(para, inner);
@@ -1228,6 +1245,7 @@ mod tests {
             detail_log_viewport: std::sync::atomic::AtomicUsize::new(0),
             detail_log_total_rows: std::sync::atomic::AtomicUsize::new(0),
             runtime_handle: None,
+            store_activity: std::collections::HashMap::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

Each grid tile now shows a `kv:N lease:M` row reflecting per-actor shared-store activity. Glanceable signal for which workers are hammering the store vs idle, and — since the counter bumps happen BEFORE authz/execution — failed attempts show up too, which is the most useful signal when a worker is spinning on bad paths.

### Wire
- **`SharedStore.activity`** — `RwLock<HashMap<actor_id, ActivityCounters>>` with `note_kv_op` / `note_lease_op` methods and an `activity_snapshot()` reader. No contention with store reads/writes (separate lock).
- **Handler bumps** — every `handle_kv_*` and `handle_lease_*` MCP handler bumps its counter at entry, BEFORE `authorized_*` or `require_identity_for_self`. Covers get/set/cas/list/wait + lease acquire/release.
- **`ControlEvent::StoreActivity`** — new variant carrying `Vec<ActorActivityEntry>` broadcast once per second per connection while a TUI is attached. First emission delayed one period via `tokio::time::interval_at` so the tick doesn't race ahead of `OpAcked` replies in existing tests.
- **TUI** — new `AppState.store_activity` map, updated from the broadcast, rendered in `render_tile` as a dim 5th row when at least one counter is non-zero.

### Test Plan
- [x] Workspace tests: **423 passing** (+5: 4 counter primitives, 1 protocol roundtrip).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo build --release --workspace` clean
- [ ] Manual TUI verification against a live dispatch: during a shared-store-heavy run (ketchup-p0-execute), tiles should show increasing `kv:N` counts that match what's visible in each worker's log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)