### PR TITLE
feat(tui): click-to-select (tile + picker) + right-click exits Detail

### DIFF
--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -150,31 +150,43 @@ pub fn run(run_dir: PathBuf, run_id: String) -> anyhow::Result<()> {
                     }
                 }
                 Event::Mouse(mouse) => {
-                    match (state.mode.clone(), mouse.kind) {
-                        // Wheel scroll inside Detail view — 5 rows/tick,
-                        // matches J/K shift-scroll cadence.
-                        (Mode::Detail { .. }, MouseEventKind::ScrollDown) => {
-                            state.detail_scroll_down(5, DETAIL_VISIBLE_ROWS);
+                    let prev_focus = state.focus;
+                    let prev_mode_disc = std::mem::discriminant(&state.mode);
+                    let action = handle_mouse(&mut state, mouse);
+                    match action {
+                        Action::Quit => break,
+                        Action::SwitchRun { run_dir, run_id } => {
+                            // Same transition as the keyboard-driven
+                            // SwitchRun path above — restart the watcher
+                            // and reset run-local state.
+                            let (new_rx, new_tx) = spawn_watcher(run_dir.clone());
+                            snapshot_rx = new_rx;
+                            focus_tx = new_tx;
+                            state.run_dir = run_dir;
+                            state.run_id = run_id;
+                            state.tasks = vec![];
+                            state.focus = 0;
+                            state.run_list.clear();
+                            state.mode = Mode::Normal;
+                            let _ = focus_tx.send(String::new());
+                            dirty = true;
+                            continue;
                         }
-                        (Mode::Detail { .. }, MouseEventKind::ScrollUp) => {
-                            state.detail_scroll_up(5);
-                        }
-                        // Left-click on a tile in the grid view: focus it
-                        // and enter Detail (equivalent to hjkl-nav + Enter).
-                        // Clicking the already-focused tile also enters
-                        // Detail — same muscle memory as double-click on
-                        // desktop icons.
-                        (Mode::Normal, MouseEventKind::Down(MouseButton::Left)) => {
-                            if let Some(idx) = state.tile_at(mouse.column, mouse.row) {
-                                state.focus = idx;
-                                if let Some(tile) = state.focused_tile() {
-                                    let _ = focus_tx.send(tile.id.clone());
-                                }
-                                state.enter_detail();
-                                dirty = true;
-                            }
-                        }
-                        _ => {}
+                        Action::Continue => {}
+                    }
+
+                    // Mouse clicks can change focus + mode (tile click →
+                    // Detail, right-click → exit Detail). Mirror the
+                    // key-path's post-handler bookkeeping so the watcher
+                    // tails the new focus and the terminal clears on
+                    // mode transitions.
+                    if prev_focus != state.focus
+                        || prev_mode_disc != std::mem::discriminant(&state.mode)
+                    {
+                        dirty = true;
+                    }
+                    if let Some(tile) = state.focused_tile() {
+                        let _ = focus_tx.send(tile.id.clone());
                     }
                 }
                 _ => {}
@@ -219,6 +231,58 @@ enum Action {
 /// for the handler. The render pass also calls `detail_auto_scroll` with the
 /// real `visible_rows`.
 const DETAIL_VISIBLE_ROWS: usize = 40;
+
+/// Handle a single mouse event. Returns the same [`Action`] type as
+/// `handle_key` so the event-loop's existing `SwitchRun` dispatch can
+/// handle picker-click → open-run in one place.
+fn handle_mouse(state: &mut AppState, mouse: crossterm::event::MouseEvent) -> Action {
+    match (state.mode.clone(), mouse.kind) {
+        // Wheel scroll inside Detail view — 5 rows/tick, matches J/K
+        // shift-scroll cadence.
+        (Mode::Detail { .. }, MouseEventKind::ScrollDown) => {
+            state.detail_scroll_down(5, DETAIL_VISIBLE_ROWS);
+        }
+        (Mode::Detail { .. }, MouseEventKind::ScrollUp) => {
+            state.detail_scroll_up(5);
+        }
+        // Right-click inside Detail view exits back to the grid —
+        // symmetric with Esc, easier than reaching for the keyboard.
+        (Mode::Detail { .. }, MouseEventKind::Down(MouseButton::Right)) => {
+            state.exit_detail();
+        }
+        // Left-click on a tile in the grid: focus + enter Detail
+        // (equivalent to hjkl + Enter). Clicks on the already-focused
+        // tile also enter Detail.
+        (Mode::Normal, MouseEventKind::Down(MouseButton::Left)) => {
+            if let Some(idx) = state.tile_at(mouse.column, mouse.row) {
+                state.focus = idx;
+                if let Some(tile) = state.focused_tile() {
+                    // The focus_tx is owned by run(); we can't touch it
+                    // from this helper. Caller observes Action::Continue
+                    // + re-reads focused_tile in the normal focus-notify
+                    // path at the top of the event loop.
+                    let _ = tile;
+                }
+                state.enter_detail();
+            }
+        }
+        // Left-click on a picker row: open that run (equivalent to
+        // highlighting + pressing Enter). The event-loop dispatches
+        // `SwitchRun` — same transition as keyboard select.
+        (Mode::PickingRun { .. }, MouseEventKind::Down(MouseButton::Left)) => {
+            if let Some(idx) = state.picker_row_at(mouse.column, mouse.row) {
+                if let Some(entry) = state.run_list.get(idx) {
+                    return Action::SwitchRun {
+                        run_dir: entry.run_dir.clone(),
+                        run_id: entry.run_id.clone(),
+                    };
+                }
+            }
+        }
+        _ => {}
+    }
+    Action::Continue
+}
 
 /// Handle a single key press. Returns an [`Action`] describing what to do next.
 fn handle_key(state: &mut AppState, code: KeyCode, modifiers: KeyModifiers) -> Action {

--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -5,7 +5,7 @@ use std::sync::mpsc;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crossterm::event::{self, Event, KeyCode, KeyModifiers, MouseEventKind};
+use crossterm::event::{self, Event, KeyCode, KeyModifiers, MouseButton, MouseEventKind};
 
 use crate::state::{AppSnapshot, AppState, Mode};
 use crate::watcher;
@@ -150,22 +150,31 @@ pub fn run(run_dir: PathBuf, run_id: String) -> anyhow::Result<()> {
                     }
                 }
                 Event::Mouse(mouse) => {
-                    // Only wire wheel scroll in the detail view for now.
-                    // Tile grid mouse clicks, drag-select, etc. can be
-                    // added later if useful.
-                    if matches!(state.mode, Mode::Detail { .. }) {
-                        match mouse.kind {
-                            // Wheel scroll: 5 rows/tick — matches `J`/`K`
-                            // shift-scroll cadence and feels natural for
-                            // quick log navigation without overshooting.
-                            MouseEventKind::ScrollDown => {
-                                state.detail_scroll_down(5, DETAIL_VISIBLE_ROWS);
-                            }
-                            MouseEventKind::ScrollUp => {
-                                state.detail_scroll_up(5);
-                            }
-                            _ => {}
+                    match (state.mode.clone(), mouse.kind) {
+                        // Wheel scroll inside Detail view — 5 rows/tick,
+                        // matches J/K shift-scroll cadence.
+                        (Mode::Detail { .. }, MouseEventKind::ScrollDown) => {
+                            state.detail_scroll_down(5, DETAIL_VISIBLE_ROWS);
                         }
+                        (Mode::Detail { .. }, MouseEventKind::ScrollUp) => {
+                            state.detail_scroll_up(5);
+                        }
+                        // Left-click on a tile in the grid view: focus it
+                        // and enter Detail (equivalent to hjkl-nav + Enter).
+                        // Clicking the already-focused tile also enters
+                        // Detail — same muscle memory as double-click on
+                        // desktop icons.
+                        (Mode::Normal, MouseEventKind::Down(MouseButton::Left)) => {
+                            if let Some(idx) = state.tile_at(mouse.column, mouse.row) {
+                                state.focus = idx;
+                                if let Some(tile) = state.focused_tile() {
+                                    let _ = focus_tx.send(tile.id.clone());
+                                }
+                                state.enter_detail();
+                                dirty = true;
+                            }
+                        }
+                        _ => {}
                     }
                 }
                 _ => {}

--- a/crates/pitboss-tui/src/state.rs
+++ b/crates/pitboss-tui/src/state.rs
@@ -148,6 +148,12 @@ pub struct AppState {
     /// `TileState.id` for the lead + each worker). Empty until the first
     /// broadcast arrives (~1 s after TUI connects).
     pub store_activity: std::collections::HashMap<String, StoreActivityCounters>,
+    /// Bounding rectangles of each tile, populated by `render_tile_grid`
+    /// each frame. Used by the mouse-click handler to hit-test which
+    /// tile a click landed on. Wrapped in a Mutex so the render pass
+    /// (which has `&AppState`) can update it via interior mutability —
+    /// same pattern as `detail_log_viewport`.
+    pub tile_hit_rects: std::sync::Mutex<Vec<(usize, ratatui::layout::Rect)>>,
 }
 
 /// Mirrors `pitboss_cli::control::protocol::ActorActivityEntry` but
@@ -186,7 +192,23 @@ impl AppState {
             detail_log_total_rows: std::sync::atomic::AtomicUsize::new(0),
             runtime_handle: None,
             store_activity: std::collections::HashMap::new(),
+            tile_hit_rects: std::sync::Mutex::new(Vec::new()),
         }
+    }
+
+    /// Hit-test: find the tile index whose render rect contains `(col, row)`.
+    /// Populated by `render_tile_grid`; reads the cache under its Mutex.
+    /// Returns `None` if no tile matches (click outside the grid) or the
+    /// cache is empty (no render has run yet).
+    pub fn tile_at(&self, col: u16, row: u16) -> Option<usize> {
+        let rects = self.tile_hit_rects.lock().ok()?;
+        rects.iter().find_map(|(idx, r)| {
+            if col >= r.x && col < r.x + r.width && row >= r.y && row < r.y + r.height {
+                Some(*idx)
+            } else {
+                None
+            }
+        })
     }
 
     /// Returns the currently focused tile, if any.
@@ -982,6 +1004,46 @@ mod tests {
             "got {:?}",
             state.mode
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // tile_at hit-test
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn tile_at_returns_tile_containing_click() {
+        use ratatui::layout::Rect;
+        let state = make_state();
+        // Two tiles side by side in a 40×10 area:
+        //   tile 0: x=0..20, y=0..10
+        //   tile 1: x=20..40, y=0..10
+        *state.tile_hit_rects.lock().unwrap() =
+            vec![(0, Rect::new(0, 0, 20, 10)), (1, Rect::new(20, 0, 20, 10))];
+        assert_eq!(state.tile_at(5, 5), Some(0));
+        assert_eq!(state.tile_at(19, 9), Some(0));
+        assert_eq!(state.tile_at(20, 0), Some(1));
+        assert_eq!(state.tile_at(39, 9), Some(1));
+    }
+
+    #[test]
+    fn tile_at_returns_none_outside_any_rect() {
+        use ratatui::layout::Rect;
+        let state = make_state();
+        *state.tile_hit_rects.lock().unwrap() = vec![(0, Rect::new(10, 10, 20, 10))];
+        // Left of the rect.
+        assert_eq!(state.tile_at(5, 15), None);
+        // Below the rect.
+        assert_eq!(state.tile_at(15, 25), None);
+        // Right edge is exclusive (x + width is one past the last column).
+        assert_eq!(state.tile_at(30, 15), None);
+    }
+
+    #[test]
+    fn tile_at_empty_cache_returns_none() {
+        // Before the first render the cache is empty; any click is a miss.
+        let state = make_state();
+        assert!(state.tile_hit_rects.lock().unwrap().is_empty());
+        assert_eq!(state.tile_at(0, 0), None);
     }
 
     // -----------------------------------------------------------------------

--- a/crates/pitboss-tui/src/state.rs
+++ b/crates/pitboss-tui/src/state.rs
@@ -154,6 +154,11 @@ pub struct AppState {
     /// (which has `&AppState`) can update it via interior mutability —
     /// same pattern as `detail_log_viewport`.
     pub tile_hit_rects: std::sync::Mutex<Vec<(usize, ratatui::layout::Rect)>>,
+    /// Bounding rectangles of each run-picker row (y coords are absolute
+    /// terminal rows). Populated by `render_run_picker_overlay` whenever
+    /// the picker is visible; used by the mouse click handler to open
+    /// a run with one click.
+    pub picker_hit_rects: std::sync::Mutex<Vec<(usize, ratatui::layout::Rect)>>,
 }
 
 /// Mirrors `pitboss_cli::control::protocol::ActorActivityEntry` but
@@ -193,7 +198,23 @@ impl AppState {
             runtime_handle: None,
             store_activity: std::collections::HashMap::new(),
             tile_hit_rects: std::sync::Mutex::new(Vec::new()),
+            picker_hit_rects: std::sync::Mutex::new(Vec::new()),
         }
+    }
+
+    /// Hit-test: find the picker row index whose render rect contains
+    /// `(col, row)`. Same shape as `tile_at`. Returns `None` when the
+    /// picker isn't open or the click fell on empty space (run list
+    /// shorter than the picker area).
+    pub fn picker_row_at(&self, col: u16, row: u16) -> Option<usize> {
+        let rects = self.picker_hit_rects.lock().ok()?;
+        rects.iter().find_map(|(idx, r)| {
+            if col >= r.x && col < r.x + r.width && row >= r.y && row < r.y + r.height {
+                Some(*idx)
+            } else {
+                None
+            }
+        })
     }
 
     /// Hit-test: find the tile index whose render rect contains `(col, row)`.
@@ -1044,6 +1065,25 @@ mod tests {
         let state = make_state();
         assert!(state.tile_hit_rects.lock().unwrap().is_empty());
         assert_eq!(state.tile_at(0, 0), None);
+    }
+
+    #[test]
+    fn picker_row_at_returns_row_index() {
+        use ratatui::layout::Rect;
+        let state = make_state();
+        // Three picker rows stacked vertically: y=5,6,7.
+        *state.picker_hit_rects.lock().unwrap() = vec![
+            (0, Rect::new(2, 5, 40, 1)),
+            (1, Rect::new(2, 6, 40, 1)),
+            (2, Rect::new(2, 7, 40, 1)),
+        ];
+        assert_eq!(state.picker_row_at(10, 5), Some(0));
+        assert_eq!(state.picker_row_at(10, 6), Some(1));
+        assert_eq!(state.picker_row_at(10, 7), Some(2));
+        // Below last row.
+        assert_eq!(state.picker_row_at(10, 8), None);
+        // Left of picker.
+        assert_eq!(state.picker_row_at(0, 5), None);
     }
 
     // -----------------------------------------------------------------------

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -385,6 +385,10 @@ fn render_tile_grid(frame: &mut Frame, area: Rect, state: &AppState) {
         .constraints(row_constraints)
         .split(area);
 
+    // Refresh the hit-test cache for mouse click → tile lookup. Cleared
+    // each render so it reflects the current layout even after a resize.
+    let mut hit_rects: Vec<(usize, Rect)> = Vec::with_capacity(n);
+
     for row in 0..rows {
         let cols_layout = Layout::default()
             .direction(Direction::Horizontal)
@@ -397,8 +401,14 @@ fn render_tile_grid(frame: &mut Frame, area: Rect, state: &AppState) {
                 break;
             }
             let focused = tile_idx == state.focus;
-            render_tile(frame, cols_layout[col], state, tile_idx, focused);
+            let tile_rect = cols_layout[col];
+            render_tile(frame, tile_rect, state, tile_idx, focused);
+            hit_rects.push((tile_idx, tile_rect));
         }
+    }
+
+    if let Ok(mut cache) = state.tile_hit_rects.lock() {
+        *cache = hit_rects;
     }
 }
 
@@ -1246,6 +1256,7 @@ mod tests {
             detail_log_total_rows: std::sync::atomic::AtomicUsize::new(0),
             runtime_handle: None,
             store_activity: std::collections::HashMap::new(),
+            tile_hit_rects: std::sync::Mutex::new(Vec::new()),
         }
     }
 

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -1079,6 +1079,19 @@ fn render_run_picker_overlay(frame: &mut Frame, area: Rect, state: &AppState, se
     list_state.select(Some(selected));
 
     frame.render_stateful_widget(list, inner, &mut list_state);
+
+    // Populate the picker hit-cache so mouse clicks resolve to row
+    // indices. Rows are laid out top-to-bottom starting at `inner.y`;
+    // we clip to the inner height so clicks below the last run land
+    // on no row (returns None from `picker_row_at`).
+    if let Ok(mut cache) = state.picker_hit_rects.lock() {
+        cache.clear();
+        let max_rows = inner.height as usize;
+        for (idx, _) in state.run_list.iter().enumerate().take(max_rows) {
+            let y = inner.y + u16::try_from(idx).unwrap_or(u16::MAX);
+            cache.push((idx, ratatui::layout::Rect::new(inner.x, y, inner.width, 1)));
+        }
+    }
 }
 
 fn render_confirm_kill(frame: &mut Frame, area: Rect, target: &crate::state::KillTarget) {
@@ -1257,6 +1270,7 @@ mod tests {
             runtime_handle: None,
             store_activity: std::collections::HashMap::new(),
             tile_hit_rects: std::sync::Mutex::new(Vec::new()),
+            picker_hit_rects: std::sync::Mutex::new(Vec::new()),
         }
     }
 


### PR DESCRIPTION
## Summary

Three mouse additions, all small:

### 1. Left-click a grid tile
Focuses it and enters Detail. Equivalent to hjkl-nav + Enter. Clicking the already-focused tile also enters Detail — desktop-icon muscle memory.

- `AppState.tile_hit_rects` — `Mutex<Vec<(usize, Rect)>>` cache populated by `render_tile_grid` each frame (interior mutability, same pattern as `detail_log_viewport`).
- `AppState::tile_at(col, row)` — iterate cache, return containing index. Resize-safe (cache refreshes every render).

### 2. Left-click a run in the picker overlay
Opens that run. Equivalent to highlighting + Enter.

- `AppState.picker_hit_rects` — parallel cache for picker rows.
- `AppState::picker_row_at(col, row)` — mirror of `tile_at`.
- Click handler returns `Action::SwitchRun` so the event loop's existing keyboard-SwitchRun transition (watcher swap + state reset) fires for clicks too.

### 3. Right-click in Detail view
Exits back to the grid — symmetric with Esc / `q`, quicker when you're already on the mouse.

### Refactor
- `Event::Mouse` branch moved into a standalone `handle_mouse` that returns `Action`, mirroring `handle_key`.
- Post-handler bookkeeping (focus-notify to watcher, dirty flag on mode or focus change) shared between mouse and keyboard paths.

### Test Plan
- [x] Workspace tests: **427 passing** (+4 hit-test: tile inside, tile outside, tile empty, picker row hit / out-of-bounds).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo build --release --workspace` clean
- [ ] Manual TUI verification: click tiles, click picker rows, right-click in Detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)