### PR TITLE
chore: four stacked cleanups (rmcp lease drop + prices + schema sync + resume guard)

### DIFF
--- a/crates/pitboss-cli/src/dispatch/resume.rs
+++ b/crates/pitboss-cli/src/dispatch/resume.rs
@@ -143,6 +143,24 @@ pub fn build_resume_hierarchical(run_dir: &Path) -> Result<ResolvedManifest> {
         .clone()
         .ok_or_else(|| anyhow!("lead has no claude_session_id — cannot resume"))?;
 
+    // Guard: if the prior run used a worktree that's since been cleaned,
+    // `claude --resume` will fail to find its session data (claude keys
+    // session storage by cwd hash). Fail fast with a clear message that
+    // points at `worktree_cleanup = "never"` — otherwise the user would
+    // see a cryptic claude-level error after we've already re-spawned.
+    if let Some(wt) = &lead_record.worktree_path {
+        if !wt.exists() {
+            anyhow::bail!(
+                "cannot resume: the lead's worktree was cleaned ({}).\n\
+                 claude --resume needs the original worktree directory to\n\
+                 find its session data. Re-run the original manifest with\n\
+                 `[run] worktree_cleanup = \"never\"` so future resumes\n\
+                 stay possible.",
+                wt.display()
+            );
+        }
+    }
+
     lead.resume_session_id = Some(session_id);
 
     // Workers are dispatched dynamically by the lead — the `tasks` vec
@@ -456,5 +474,106 @@ mod tests {
 
         // Silence unused warning on the un-reserialized resolved.
         let _ = resolved.lead.take();
+    }
+
+    /// Regression: when the lead's worktree has been cleaned, resume must
+    /// fail fast with a clear error rather than respawning claude in a
+    /// new directory and letting `claude --resume <session>` mysteriously
+    /// fail to find its session data.
+    #[test]
+    fn resume_fails_clearly_when_lead_worktree_missing() {
+        use crate::manifest::resolve::{ResolvedLead, ResolvedManifest};
+        use crate::manifest::schema::{Effort, WorktreeCleanup};
+        use std::path::PathBuf;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let run_dir = tmp.path();
+
+        // Write a bare-bones resolved.json.
+        let resolved = ResolvedManifest {
+            max_parallel: 4,
+            halt_on_failure: false,
+            run_dir: run_dir.to_path_buf(),
+            worktree_cleanup: WorktreeCleanup::OnSuccess,
+            emit_event_stream: false,
+            tasks: vec![],
+            lead: Some(ResolvedLead {
+                id: "triage".into(),
+                directory: PathBuf::from("/tmp"),
+                prompt: "original".into(),
+                branch: None,
+                model: "claude-haiku-4-5".into(),
+                effort: Effort::High,
+                tools: vec![],
+                timeout_secs: 600,
+                use_worktree: true,
+                env: Default::default(),
+                resume_session_id: None,
+            }),
+            max_workers: Some(4),
+            budget_usd: Some(5.0),
+            lead_timeout_secs: None,
+            approval_policy: None,
+            notifications: vec![],
+            dump_shared_store: false,
+        };
+        std::fs::write(
+            run_dir.join("resolved.json"),
+            serde_json::to_vec_pretty(&resolved).unwrap(),
+        )
+        .unwrap();
+
+        // Lead record points at a worktree path that does NOT exist — as
+        // if cleanup fired and removed it.
+        let missing_wt = tmp.path().join("already-gone");
+        assert!(!missing_wt.exists());
+        let lead_record = TaskRecord {
+            task_id: "triage".into(),
+            status: TaskStatus::Success,
+            exit_code: Some(0),
+            started_at: chrono::Utc::now(),
+            ended_at: chrono::Utc::now(),
+            duration_ms: 0,
+            worktree_path: Some(missing_wt.clone()),
+            log_path: PathBuf::new(),
+            token_usage: Default::default(),
+            claude_session_id: Some("session-gone".into()),
+            final_message_preview: None,
+            parent_task_id: None,
+            pause_count: 0,
+            reprompt_count: 0,
+            approvals_requested: 0,
+            approvals_approved: 0,
+            approvals_rejected: 0,
+            model: None,
+        };
+        let summary = RunSummary {
+            run_id: Uuid::now_v7(),
+            manifest_path: PathBuf::new(),
+            pitboss_version: "0.4.3".into(),
+            claude_version: None,
+            started_at: chrono::Utc::now(),
+            ended_at: chrono::Utc::now(),
+            total_duration_ms: 0,
+            tasks_total: 1,
+            tasks_failed: 0,
+            was_interrupted: false,
+            tasks: vec![lead_record],
+        };
+        std::fs::write(
+            run_dir.join("summary.json"),
+            serde_json::to_vec_pretty(&summary).unwrap(),
+        )
+        .unwrap();
+
+        let err = build_resume_hierarchical(run_dir).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("worktree was cleaned"),
+            "expected worktree-cleaned guidance, got: {msg}"
+        );
+        assert!(
+            msg.contains("worktree_cleanup = \"never\""),
+            "expected remediation hint, got: {msg}"
+        );
     }
 }

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -48,10 +48,17 @@ pub struct McpServer {
 
 /// The rmcp `ServerHandler` that exposes the six pitboss tools to the lead
 /// Hobbit via a per-connection MCP session.
+///
+/// Holds an `Arc<Mutex<Option<String>>>` that records the first actor_id
+/// observed in this connection's `_meta` fields. Used for per-connection
+/// lease cleanup: on disconnect, we call
+/// `SharedStore::release_all_for_actor(actor_id)` so dropped bridges
+/// don't leave their leases held until TTL expiry.
 #[derive(Clone)]
 pub struct PitbossHandler {
     state: Arc<DispatchState>,
     tool_router: ToolRouter<Self>,
+    connection_actor: Arc<tokio::sync::Mutex<Option<String>>>,
 }
 
 impl PitbossHandler {
@@ -59,6 +66,38 @@ impl PitbossHandler {
         Self {
             state,
             tool_router: Self::tool_router(),
+            connection_actor: Arc::new(tokio::sync::Mutex::new(None)),
+        }
+    }
+
+    /// Return a fresh handler instance for a new MCP connection — same
+    /// shared dispatcher state and tool router, but a dedicated
+    /// `connection_actor` slot so different connections don't trample
+    /// each other's identity tracking.
+    pub fn for_connection(&self) -> Self {
+        Self {
+            state: self.state.clone(),
+            tool_router: self.tool_router.clone(),
+            connection_actor: Arc::new(tokio::sync::Mutex::new(None)),
+        }
+    }
+
+    /// Handle to the per-connection actor_id slot. Caller holds an
+    /// `Arc::clone` so it can read the observed actor_id after the
+    /// session ends (for `release_all_for_actor` cleanup).
+    pub fn connection_actor_handle(&self) -> Arc<tokio::sync::Mutex<Option<String>>> {
+        self.connection_actor.clone()
+    }
+
+    /// Record the actor_id on the first MCP tool call that carries one.
+    /// Later calls on the same connection are no-ops (first-seen wins).
+    async fn note_actor(&self, actor_id: &str) {
+        if actor_id.is_empty() {
+            return;
+        }
+        let mut slot = self.connection_actor.lock().await;
+        if slot.is_none() {
+            *slot = Some(actor_id.to_string());
         }
     }
 }
@@ -194,6 +233,9 @@ impl PitbossHandler {
         &self,
         Parameters(args): Parameters<crate::shared_store::tools::KvGetArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        if let Some(m) = &args.meta {
+            self.note_actor(&m.actor_id).await;
+        }
         match crate::shared_store::tools::handle_kv_get(&self.state.shared_store, args).await {
             // Wrap Option<Entry> in an object so structuredContent is a
             // record (per MCP spec). A bare null was rejected by the
@@ -210,6 +252,7 @@ impl PitbossHandler {
         &self,
         Parameters(args): Parameters<crate::shared_store::tools::KvSetArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        self.note_actor(&args.meta.actor_id).await;
         match crate::shared_store::tools::handle_kv_set(&self.state.shared_store, args).await {
             Ok(v) => to_structured_result(&v),
             Err(e) => Err(shared_store_err(&e)),
@@ -223,6 +266,7 @@ impl PitbossHandler {
         &self,
         Parameters(args): Parameters<crate::shared_store::tools::KvCasArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        self.note_actor(&args.meta.actor_id).await;
         match crate::shared_store::tools::handle_kv_cas(&self.state.shared_store, args).await {
             Ok(v) => to_structured_result(&v),
             Err(e) => Err(shared_store_err(&e)),
@@ -236,6 +280,9 @@ impl PitbossHandler {
         &self,
         Parameters(args): Parameters<crate::shared_store::tools::KvListArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        if let Some(m) = &args.meta {
+            self.note_actor(&m.actor_id).await;
+        }
         match crate::shared_store::tools::handle_kv_list(&self.state.shared_store, args).await {
             // Wrap Vec<ListMetadata> in an object — MCP spec requires
             // structuredContent to be a record.
@@ -251,6 +298,9 @@ impl PitbossHandler {
         &self,
         Parameters(args): Parameters<crate::shared_store::tools::KvWaitArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        if let Some(m) = &args.meta {
+            self.note_actor(&m.actor_id).await;
+        }
         match crate::shared_store::tools::handle_kv_wait(&self.state.shared_store, args).await {
             Ok(v) => to_structured_result(&v),
             Err(e) => Err(shared_store_err(&e)),
@@ -264,6 +314,7 @@ impl PitbossHandler {
         &self,
         Parameters(args): Parameters<crate::shared_store::tools::LeaseAcquireArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        self.note_actor(&args.meta.actor_id).await;
         match crate::shared_store::tools::handle_lease_acquire(&self.state.shared_store, args).await
         {
             Ok(v) => to_structured_result(&v),
@@ -278,6 +329,7 @@ impl PitbossHandler {
         &self,
         Parameters(args): Parameters<crate::shared_store::tools::LeaseReleaseArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        self.note_actor(&args.meta.actor_id).await;
         match crate::shared_store::tools::handle_lease_release(&self.state.shared_store, args).await
         {
             Ok(()) => Ok(CallToolResult::structured(serde_json::json!({"ok": true}))),
@@ -367,7 +419,13 @@ impl McpServer {
                     accept = listener.accept() => {
                         match accept {
                             Ok((stream, _addr)) => {
-                                let h = handler.clone();
+                                // `for_connection` gives this session its own
+                                // `connection_actor` slot; cloning the Arc lets
+                                // the cleanup branch below read it after `serve`
+                                // returns without racing the moved handler.
+                                let h = handler.for_connection();
+                                let actor_slot = h.connection_actor_handle();
+                                let store_for_cleanup = h.state.shared_store.clone();
                                 let cancel_inner = cancel_outer.clone();
                                 // Track the spawned session task so Drop can signal cancellation
                                 // to per-connection tasks without waiting for MCP session timeouts.
@@ -386,6 +444,17 @@ impl McpServer {
                                                 }
                                             }
                                         } => {}
+                                    }
+                                    // Connection-drop cleanup: release every
+                                    // lease held by this session's actor.
+                                    // Until this hook existed, dropped bridges
+                                    // left leases held until TTL expiry —
+                                    // fine for short TTLs, but blocked other
+                                    // workers on long-held leases when a
+                                    // worker crashed.
+                                    let actor = actor_slot.lock().await.clone();
+                                    if let Some(id) = actor {
+                                        store_for_cleanup.release_all_for_actor(&id).await;
                                     }
                                 });
                             }

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -41,6 +41,60 @@ pub struct TokenUsageSchema {
     pub cache_creation: u64,
 }
 
+// Compile-time structural parity guards between TokenUsageSchema and
+// pitboss_core::parser::TokenUsage. If someone renames, adds, or removes
+// a field on either struct, these `From` impls won't compile — the
+// schema and the upstream type diverge loudly instead of silently.
+//
+// Previously these two structs could drift (the schema reported the
+// wrong shape), because the `#[schemars(with = ...)]` attribute on
+// WorkerStatus.partial_usage is a string reference checked only at
+// schema-generation time, not at field-layout time.
+impl From<pitboss_core::parser::TokenUsage> for TokenUsageSchema {
+    fn from(u: pitboss_core::parser::TokenUsage) -> Self {
+        let pitboss_core::parser::TokenUsage {
+            input,
+            output,
+            cache_read,
+            cache_creation,
+        } = u;
+        Self {
+            input,
+            output,
+            cache_read,
+            cache_creation,
+        }
+    }
+}
+
+impl From<TokenUsageSchema> for pitboss_core::parser::TokenUsage {
+    fn from(s: TokenUsageSchema) -> Self {
+        let TokenUsageSchema {
+            input,
+            output,
+            cache_read,
+            cache_creation,
+        } = s;
+        Self {
+            input,
+            output,
+            cache_read,
+            cache_creation,
+        }
+    }
+}
+
+// Size equality is not proof of field-shape equality (renames would
+// still pass), but it's a cheap extra signal — breaks loudly if a new
+// field lands on one side but not the other.
+const _TOKEN_USAGE_SCHEMA_SIZE_CHECK: () = {
+    assert!(
+        std::mem::size_of::<TokenUsageSchema>()
+            == std::mem::size_of::<pitboss_core::parser::TokenUsage>(),
+        "TokenUsageSchema and pitboss_core::parser::TokenUsage must stay in sync"
+    );
+};
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct WorkerStatus {
     pub state: String,

--- a/crates/pitboss-cli/tests/shared_store_flows.rs
+++ b/crates/pitboss-cli/tests/shared_store_flows.rs
@@ -394,18 +394,132 @@ async fn release_all_for_actor_clears_held_leases() {
 // Deferred: real rmcp-driven connection-drop
 // ---------------------------------------------------------------------------
 
-/// TODO(shared-store): wire SharedStore::release_all_for_actor into the rmcp
-/// server's per-connection lifecycle (fire it when a connection's tool-call
-/// stream ends). Until that lands, lease cleanup relies on TTL expiration.
+/// End-to-end test of the per-connection lease-cleanup hook:
+///   1. Session A (worker-A) acquires lease "job-1" with a long TTL.
+///   2. Session A closes.
+///   3. Session B (worker-B) can immediately acquire "job-1" — because
+///      `SharedStore::release_all_for_actor("worker-A")` fired as part of
+///      the connection-drop cleanup, not because the TTL elapsed.
 ///
-/// The shape of the future test:
-///   1. Spawn a `pitboss mcp-bridge --actor-id worker-A --actor-role worker`
-///      subprocess that acquires a long-TTL lease.
-///   2. Kill the bridge process.
-///   3. Assert worker-B's lease_acquire for the same name succeeds within a
-///      short wait window (well before the TTL would naturally expire).
+/// Without the cleanup hook, worker-B's acquire would return `acquired=false`
+/// until the 3600-second TTL expired — the pre-v0.4.3 behavior we shipped
+/// with a `#[ignore]` guard on this test.
 #[tokio::test]
-#[ignore]
 async fn lease_released_when_mcp_connection_drops() {
-    panic!("not yet implemented — requires rmcp per-connection lifecycle wiring");
+    use fake_mcp_client::FakeMcpClient;
+    use pitboss_cli::dispatch::state::{ApprovalPolicy, DispatchState};
+    use pitboss_cli::manifest::resolve::{ResolvedLead, ResolvedManifest};
+    use pitboss_cli::manifest::schema::{Effort, WorktreeCleanup};
+    use pitboss_cli::mcp::{socket_path_for_run, McpServer};
+    use pitboss_core::process::fake::{FakeScript, FakeSpawner};
+    use pitboss_core::process::ProcessSpawner;
+    use pitboss_core::session::CancelToken;
+    use pitboss_core::store::{JsonFileStore, SessionStore};
+    use pitboss_core::worktree::{CleanupPolicy, WorktreeManager};
+    use serde_json::json;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+    use uuid::Uuid;
+
+    // Minimal dispatch state wrapping a SharedStore. Lead + spawner are
+    // placeholders — we only drive lease_acquire, which doesn't touch
+    // worker machinery.
+    let dir = TempDir::new().unwrap();
+    let lead = ResolvedLead {
+        id: "lead".into(),
+        directory: PathBuf::from("/tmp"),
+        prompt: "p".into(),
+        branch: None,
+        model: "claude-haiku-4-5".into(),
+        effort: Effort::Low,
+        tools: vec![],
+        timeout_secs: 60,
+        use_worktree: false,
+        env: Default::default(),
+        resume_session_id: None,
+    };
+    let manifest = ResolvedManifest {
+        max_parallel: 4,
+        halt_on_failure: false,
+        run_dir: dir.path().to_path_buf(),
+        worktree_cleanup: WorktreeCleanup::OnSuccess,
+        emit_event_stream: false,
+        tasks: vec![],
+        lead: Some(lead),
+        max_workers: Some(4),
+        budget_usd: Some(5.0),
+        lead_timeout_secs: None,
+        approval_policy: None,
+        notifications: vec![],
+        dump_shared_store: false,
+    };
+    let store_trait: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().into()));
+    let run_id = Uuid::now_v7();
+    let spawner: Arc<dyn ProcessSpawner> = Arc::new(FakeSpawner::new(FakeScript::new()));
+    let state = Arc::new(DispatchState::new(
+        run_id,
+        manifest,
+        store_trait,
+        CancelToken::new(),
+        "lead".into(),
+        spawner,
+        PathBuf::from("claude"),
+        Arc::new(WorktreeManager::new()),
+        CleanupPolicy::Never,
+        dir.path().join(run_id.to_string()),
+        ApprovalPolicy::Block,
+        None,
+        Arc::new(SharedStore::new()),
+    ));
+
+    let socket = socket_path_for_run(state.run_id, &state.manifest.run_dir);
+    let _server = McpServer::start(socket.clone(), state.clone())
+        .await
+        .unwrap();
+
+    // Session A: acquire with a very long TTL so only the connection-drop
+    // cleanup can release it within the test timeframe.
+    let mut client_a = FakeMcpClient::connect(&socket).await.unwrap();
+    let acq_a = client_a
+        .call_tool(
+            "lease_acquire",
+            json!({
+                "name": "job-1",
+                "ttl_secs": 3600,
+                "_meta": { "actor_id": "worker-A", "actor_role": "worker" }
+            }),
+        )
+        .await
+        .unwrap();
+    assert!(
+        acq_a["acquired"].as_bool().unwrap_or(false),
+        "session A should get the lease: {acq_a}"
+    );
+
+    client_a.close().await.unwrap();
+
+    // Give the server a beat to process the disconnect. The cleanup fires
+    // after `running.waiting()` returns in the accept-loop task, and that's
+    // one tokio task hop away from our test thread.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Session B: should be able to take the lease — it's free because A
+    // disconnected, not because 3600s elapsed.
+    let mut client_b = FakeMcpClient::connect(&socket).await.unwrap();
+    let acq_b = client_b
+        .call_tool(
+            "lease_acquire",
+            json!({
+                "name": "job-1",
+                "ttl_secs": 60,
+                "_meta": { "actor_id": "worker-B", "actor_role": "worker" }
+            }),
+        )
+        .await
+        .unwrap();
+    assert!(
+        acq_b["acquired"].as_bool().unwrap_or(false),
+        "lease should be free after session A dropped: {acq_b}"
+    );
+    client_b.close().await.unwrap();
 }

--- a/crates/pitboss-core/src/prices.rs
+++ b/crates/pitboss-core/src/prices.rs
@@ -14,32 +14,39 @@ struct Rates {
     cache_write: f64,
 }
 
-/// Pricing as of 2026-04 for supported Claude Code models. Unknown models
-/// return `None` — callers should treat that as "cost unknown" in the UI.
+/// Pricing as of 2026-04 for supported Claude Code models. Match on
+/// family prefix (opus / sonnet / haiku) rather than exact revision
+/// strings — same-family revisions share pricing, so a new "claude-opus-4-8"
+/// dropping tomorrow should still cost-estimate correctly without a
+/// code change. Unknown families return `None` — callers render "—".
+///
+/// If Anthropic ever splits pricing within a family, add a more specific
+/// branch BEFORE the generic family match.
 fn rates_for(model: &str) -> Option<Rates> {
-    // Normalize: trim any trailing "-20NN1001"-style revision suffix.
-    // Model names have 4 segments (e.g. "claude-haiku-4-5"); take exactly 4.
-    let base = model.split('-').take(4).collect::<Vec<_>>().join("-");
-    match base.as_str() {
-        "claude-opus-4-7" => Some(Rates {
+    let lc = model.to_ascii_lowercase();
+    if lc.contains("opus") {
+        Some(Rates {
             input: 15.0,
             output: 75.0,
             cache_read: 1.50,
             cache_write: 18.75,
-        }),
-        "claude-sonnet-4-6" => Some(Rates {
+        })
+    } else if lc.contains("sonnet") {
+        Some(Rates {
             input: 3.0,
             output: 15.0,
             cache_read: 0.30,
             cache_write: 3.75,
-        }),
-        "claude-haiku-4-5" => Some(Rates {
+        })
+    } else if lc.contains("haiku") {
+        Some(Rates {
             input: 0.80,
             output: 4.0,
             cache_read: 0.08,
             cache_write: 1.00,
-        }),
-        _ => None,
+        })
+    } else {
+        None
     }
 }
 
@@ -102,13 +109,34 @@ mod tests {
 
     #[test]
     fn unknown_model_returns_none() {
-        assert!(cost_usd("claude-unknown-x-y", &usage(100, 200)).is_none());
+        assert!(cost_usd("gpt-4", &usage(100, 200)).is_none());
+        assert!(cost_usd("llama-3", &usage(100, 200)).is_none());
     }
 
     #[test]
     fn dated_model_suffix_normalizes() {
         // e.g., "claude-haiku-4-5-20251001" should match the base rate.
         assert!(cost_usd("claude-haiku-4-5-20251001", &usage(100, 200)).is_some());
+    }
+
+    #[test]
+    fn any_family_revision_matches_same_rates() {
+        // Older + hypothetical-newer revisions should resolve to family
+        // rates without needing code updates per-release.
+        let c1 = cost_usd("claude-opus-4-7", &usage(1_000_000, 0)).unwrap();
+        let c2 = cost_usd("claude-opus-4-5", &usage(1_000_000, 0)).unwrap();
+        let c3 = cost_usd("claude-opus-4-9", &usage(1_000_000, 0)).unwrap();
+        assert!((c1 - c2).abs() < 1e-9 && (c1 - c3).abs() < 1e-9);
+
+        let s1 = cost_usd("claude-sonnet-4-6", &usage(1_000_000, 0)).unwrap();
+        let s2 = cost_usd("claude-sonnet-4-4", &usage(1_000_000, 0)).unwrap();
+        assert!((s1 - s2).abs() < 1e-9);
+    }
+
+    #[test]
+    fn case_insensitive_family_match() {
+        assert!(cost_usd("CLAUDE-OPUS-4-7", &usage(100, 200)).is_some());
+        assert!(cost_usd("Haiku-Beta", &usage(100, 200)).is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Four roadmap / code-quality items, landed as two commits on one branch.

### 1. rmcp connection-drop → release leases (`4c725a2`)

Previously `#[ignore]`'d — now wired end-to-end. `PitbossHandler` gains a per-connection `Arc<Mutex<Option<String>>>` actor slot populated by the first `_meta` the session sends; on rmcp session teardown the accept-loop snapshots the slot and calls `SharedStore::release_all_for_actor(&id)`. Leases now free up instantly on worker crash instead of waiting for TTL.

Test implementation: `lease_released_when_mcp_connection_drops` — session A acquires with `ttl_secs=3600`, drops, session B acquires the same lease within 200 ms → proves cleanup fired on disconnect, not TTL expiry.

### 2. Prices family-match (`a711541`)

`rates_for` matched exact revisions like `claude-opus-4-7` — `claude-opus-4-5` returned None even though pricing is identical. Switched to case-insensitive substring on family names (opus/sonnet/haiku) so any past-or-future revision within a family resolves automatically. If Anthropic ever splits pricing within a family, add a more specific branch first.

### 3. `TokenUsageSchema` compile-time parity (`a711541`)

Bidirectional `From` impls with exhaustive destructuring + a `const _` size-eq assertion between `TokenUsageSchema` (pitboss-cli, has schemars derive) and `pitboss_core::parser::TokenUsage` (core, no schemars dep). Either one diverging — added/removed/renamed field — breaks the build loudly. Addresses the old Tier-3 review note.

### 4. Resume-with-cleaned-worktree guard (`a711541`)

`build_resume_hierarchical` now checks whether the lead's worktree path from the prior `TaskRecord` still exists. If cleanup removed it, fail fast with a clear error pointing at `[run] worktree_cleanup = "never"` — otherwise users see a cryptic `claude --resume` failure after the re-spawn already lands. Regression test pins the message shape.

## Test Plan
- [x] Workspace tests: **431 passing** (+4 since main: prices family revisions, case-insensitive match, resume-guard, rmcp lease drop).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo build --release --workspace` clean
- [ ] Manual: kill a worker with a long-TTL lease and confirm the next worker can acquire it immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)