### PR TITLE
docs: ROADMAP.md refresh for post-v0.4.4 state

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,97 +3,100 @@
 Capture of deferred work. Items here are scoped but unscheduled — grab
 one when you're ready, or file issues to formalize priority.
 
-## v0.4.1 — Attach (escape hatch)
-
-Remaining feature stages. Prerequisites (fake-claude MCP-client mode +
-e2e flow tests, `mcp__pitboss__reprompt_worker`, `lead_timeout_secs`
-flexibility) are all resolved and merged to main.
-
-- `pitboss attach <run-id> <task-id>` — live TTY relay using
-  `portable-pty`. Narrow-scope: no persistent sessions, no tmux
-  dependency. Sits on top of v0.4.0 control-socket primitives.
-- True SIGSTOP freeze-pause (alternative / addition to
-  cancel-with-resume).
-- Out-of-TUI notifications: webhooks / Slack / email for approval
-  requests and run completion.
-- Structured approval schema (JSON-in-TUI plan editing).
+**Last refresh: v0.4.4 (2026-04-18).** Everything shipped through
+v0.4.4 has been removed from this file — check `CHANGELOG.md` for
+per-version history. If you're about to add an item, slot it into one
+of the tiered sections below (biggest effort first).
 
 ---
 
-## Near-term (small, shippable)
+## Flagship feature bucket (targeting v0.5.0)
 
-The original "TUI kill" near-term item has been absorbed into the v0.4.0
-scope; this section is currently empty. Add items here as they're
-identified.
+### `pitboss attach <run-id> <task-id>`
 
----
+Live TTY relay using `portable-pty`. Narrow-scope escape hatch for
+"I want to watch a worker interactively" — the one use case that the
+hierarchical dispatch model doesn't naturally cover. No persistent
+sessions, no tmux dependency; sits on top of v0.4.0 control-socket
+primitives. **Status:** designed, not started.
 
-## Medium-term — deferred from earlier versions
+### SIGSTOP freeze-pause
 
-### Broadcast mode (`pitboss b "<prompt>"`)
+Alternative / addition to the v0.4.0 cancel-with-resume pause model.
+Freezes a worker's process without tearing down + re-spawning — safer
+for very-long-running workers where losing the claude session mid-flight
+is expensive. Coexists with existing `pause_worker` semantics behind a
+flag. **Status:** parked; value depends on real-world pause frequency.
 
-Send the same prompt to every running tile. From the v0.2.1 roadmap.
-Depends on interactive snap-in (deferred indefinitely — see below).
-**Status:** parked. No design doc.
+### Structured approval schema
 
-### Depth > 1 hierarchies
-
-A worker can itself be a lead. Needs recursion guardrails, a nested
-socket addressing scheme, and a product decision: *should this exist at
-all, or is "I want a deeper tree" a code smell for a flatter
-decomposition?* **Status:** parked pending need.
-
-### Peer messaging
-
-Workers pass results to siblings without the lead in the middle. Would
-need a new MCP surface or a shared blackboard. Risk: contention /
-ordering complexity for marginal benefit. **Status:** parked.
+Today the approval modal sends a freeform `summary` string and
+optionally an edited summary back. A typed schema (`{plan, rationale,
+resources, rollback_plan, ...}`) with in-TUI field-level editing would
+make the flow much more reviewable for non-trivial approvals.
+**Status:** parked pending design.
 
 ### Plan approval flow
 
-Lead proposes a plan, human operator approves in the TUI (or via
-`pitboss plan`) before workers actually dispatch. UX question:
-modal-in-TUI vs. separate subcommand. **Status:** parked.
+Lead proposes a full execution plan, operator approves in the TUI (or
+via a new `pitboss plan` subcommand) BEFORE any workers dispatch —
+distinct from the in-flight `request_approval` tool, which gates
+individual actions mid-run. UX question: modal-in-TUI vs. separate
+subcommand. **Status:** parked, no design doc.
 
 ### Full end-to-end `fake-claude` integration test
 
 Task 26 of the v0.3 plan left a placeholder. Requires `fake-claude` to
-speak real MCP. Medium lift; pays off once more hierarchical features
-land. **Status:** would take 1–2 days.
+speak real MCP end-to-end (including streaming responses), not just
+canned JSON lines. Medium lift; pays off as more hierarchical features
+land and e2e coverage gets more valuable. **Status:** ~1-2 days.
 
 ---
 
-## Long-term / explicitly retired
+## Ops / infra polish
 
-### Interactive snap-in (keystroke passthrough)
-
-Forwarding keystrokes from a focused TUI tile into a running claude
-subprocess. Analyzed in v0.3.4 as part of "AGENTS.md week" and
-**retired** — hierarchical mode is the correct abstraction for the
-"operator can't watch 16 workers" problem. Keeping view-only snap-in;
-not building interactive.
+- **`cargo-dist` migration.** Current release workflow is a manual
+  cross-compile matrix. `cargo-dist` adds installers (`curl | sh`),
+  auto-updater binaries, and Homebrew formula publishing. Worth the
+  switch once we add more target triples.
+- **Dockerfile / container image.** Deployment convenience + a
+  canonical runtime environment for CI reproduction.
+- **MCP protocol extensions.** We only implement `tools`. Adding
+  `resources` + `prompts` would be cheap and makes pitboss a more
+  complete MCP citizen — useful if we ever expose it to non-claude
+  MCP clients.
+- **Opt-in telemetry.** Aggregate run counts + token totals (no
+  prompt content). Default off; explicit config key to enable.
+- **systemd unit.** For long-lived dispatcher mode (`pitboss
+  dispatch` as a service rather than a one-shot).
+- **`cargo publish` to crates.io.** Once we want third-party
+  library consumers.
 
 ---
 
-## Code-quality follow-ups (Tier 3/4 from earlier reviews)
+## Medium-term — deferred, lower priority
 
-- `TokenUsageSchema` compile-time sync check with `TokenUsage`
-  (e.g., `static_assertions::assert_fields!`). Currently two structs
-  can diverge silently.
-- Resume + worktree cleanup interaction — `pitboss resume` loses the
-  claude session if the original worktree was cleaned. Either default
-  hierarchical to `worktree_cleanup = "never"` or reuse the original
-  worktree path on resume.
-- More Claude models in `prices.rs` as they ship.
-- `cargo-dist` migration — current release workflow is manual cross-
-  compile. `cargo-dist` adds installers (`curl|sh`), updater binaries,
-  Homebrew formula publishing. Worth it once we add more targets.
-- Dockerfile / container image.
-- MCP protocol extensions (we only implement tools; resources + prompts
-  would be cheap adds).
-- Opt-in telemetry (aggregate run counts, token totals).
-- systemd unit for running as a long-lived dispatcher.
-- `cargo publish` once we want crates.io distribution.
+### Broadcast mode (`pitboss b "<prompt>"`)
+
+Send the same prompt to every running tile. From the v0.2.1 roadmap.
+Depends on interactive snap-in (retired — see below). **Status:**
+parked; probably needs a different UX surface now.
+
+### Depth > 1 hierarchies
+
+A worker can itself be a lead. Needs recursion guardrails, a nested
+socket addressing scheme, and a real product decision: *should this
+exist at all, or is "I want a deeper tree" a code smell for a flatter
+decomposition?* **Status:** parked pending need.
+
+### Peer messaging
+
+Workers pass results to siblings without the lead in the middle.
+Considered and implemented differently in v0.4.2 — the worker shared
+store (`/shared/*` namespace) covers the most common case via a hub
+model. Lateral MCP calls between workers remain a non-goal (see
+below). **Status:** partially subsumed by shared store; MCP-channel
+form explicitly retired.
 
 ---
 
@@ -103,16 +106,27 @@ not building interactive.
 
 Specifically: don't let workers spawn sub-workers or send tool calls
 laterally. Depth = 1 is a design invariant, not an accidental limit.
-Breaking it re-introduces contention + ordering complexity that
-pitboss was built to avoid.
+Breaking it re-introduces the contention + ordering complexity that
+pitboss was built to avoid. If you need workers to share data, use
+the shared store (`/shared/*` or `/peer/<id>/*` namespaces — see
+`AGENTS.md`).
+
+### Interactive snap-in (keystroke passthrough)
+
+Forwarding keystrokes from a focused TUI tile into a running claude
+subprocess. Analyzed in v0.3.4 and **retired** — hierarchical mode is
+the correct abstraction for the "operator can't watch 16 workers"
+problem. The `pitboss attach` escape hatch (above) covers the narrow
+cases where view-only isn't enough. View-only Detail view stays.
 
 ### Windows-native builds
 
 Pitboss relies on unix sockets + SIGTERM for cancellation. Porting to
 Windows would mean a named-pipe abstraction + different process
-signaling. The current target audience runs on Linux + macOS; supporting
-Windows would materially expand the surface area for zero incremental
-use cases we know about. Happy to revisit if a concrete need emerges.
+signaling. The current target audience runs on Linux + macOS;
+supporting Windows would materially expand the surface area for zero
+incremental use cases we know about. Revisit if a concrete need
+emerges.
 
 ### Heavy dependency-manager features
 


### PR DESCRIPTION
## Summary

Everything shipped through v0.4.4 removed from ROADMAP.md. Added a \"Last refresh\" line so future readers can see when it drifts.

**Removed (shipped):**
- Notifications plugin system (v0.4.1)
- TokenUsageSchema compile-time sync (v0.4.4)
- Prices family-match (v0.4.4)
- Resume+worktree cleanup interaction (v0.4.4)
- rmcp lease drop on connection close (v0.4.4)

**Restructured:**
- Dropped the mislabeled "v0.4.1 — Attach" section; merged the 4 remaining feature items with the parked ones into a single "Flagship feature bucket (targeting v0.5.0)" section.
- Ops/infra polish lifted to its own tier (cargo-dist, Dockerfile, MCP extensions, telemetry, systemd, crates.io).
- "Peer messaging" annotated as partially subsumed by the v0.4.2 shared store.
- Cross-references: interactive-snap-in retirement points at `pitboss attach` as the escape hatch; worker→worker MCP non-goal points at `/shared/*` + `/peer/<id>/*`.

No code changes.