### PR TITLE
feat(dispatch): SIGSTOP freeze-pause as opt-in pause mode

### DIFF
--- a/crates/pitboss-cli/Cargo.toml
+++ b/crates/pitboss-cli/Cargo.toml
@@ -47,6 +47,7 @@ reqwest            = { workspace = true }
 lru                = { workspace = true }
 glob               = { workspace = true }
 base64             = { workspace = true }
+libc               = { workspace = true }
 
 [dev-dependencies]
 # Note: pitboss-core's test-support feature is pulled in directly here so

--- a/crates/pitboss-cli/src/control/protocol.rs
+++ b/crates/pitboss-cli/src/control/protocol.rs
@@ -9,6 +9,22 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Pause-mode selector shared with the MCP tool schema. Duplicated here
+/// so the control protocol doesn't depend on `mcp::tools`. Kept in sync
+/// by hand; if these diverge you'll notice because the wire values stop
+/// round-tripping.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum PauseMode {
+    #[default]
+    Cancel,
+    Freeze,
+}
+
+fn is_default_pause_mode(m: &PauseMode) -> bool {
+    matches!(m, PauseMode::Cancel)
+}
+
 /// An operation sent from the TUI (client) to the dispatcher (server).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "op", rename_all = "snake_case")]
@@ -22,6 +38,11 @@ pub enum ControlOp {
     CancelRun,
     PauseWorker {
         task_id: String,
+        /// Optional pause mode: `"cancel"` (default, backward-compat) or
+        /// `"freeze"`. Absent on the wire for pre-v0.4.5 TUI clients —
+        /// `#[serde(default)]` yields `Cancel`.
+        #[serde(default, skip_serializing_if = "is_default_pause_mode")]
+        mode: PauseMode,
     },
     ContinueWorker {
         task_id: String,
@@ -166,6 +187,11 @@ mod tests {
         for op in [
             ControlOp::PauseWorker {
                 task_id: "w".into(),
+                mode: PauseMode::default(),
+            },
+            ControlOp::PauseWorker {
+                task_id: "w".into(),
+                mode: PauseMode::Freeze,
             },
             ControlOp::ContinueWorker {
                 task_id: "w".into(),

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -285,6 +285,33 @@ async fn serve_connection(
     activity_pump.abort();
 }
 
+/// Best-effort SIGCONT helper: if `task_id` is currently `Frozen`,
+/// send SIGCONT so a follow-up SIGTERM / SIGKILL can actually be
+/// delivered. No-op if the worker isn't frozen or the pid slot is
+/// empty. Errors are logged and swallowed — cancel paths must not
+/// fail because of signal cleanup.
+async fn thaw_if_frozen(state: &Arc<crate::dispatch::state::DispatchState>, task_id: &str) {
+    let is_frozen = matches!(
+        state.workers.read().await.get(task_id),
+        Some(crate::dispatch::state::WorkerState::Frozen { .. })
+    );
+    if !is_frozen {
+        return;
+    }
+    let pid = state
+        .worker_pids
+        .read()
+        .await
+        .get(task_id)
+        .map(|slot| slot.load(std::sync::atomic::Ordering::Relaxed))
+        .unwrap_or(0);
+    if pid > 0 {
+        if let Err(e) = crate::dispatch::signals::resume_stopped(pid) {
+            tracing::debug!(task_id, pid, "pre-cancel SIGCONT failed: {e}");
+        }
+    }
+}
+
 /// Period between `StoreActivity` broadcasts on the control socket.
 /// Tuned for TUI poll cadence (250 ms) — faster than 1 s is noise,
 /// slower feels laggy. Constant so tests can match expected payloads.
@@ -326,6 +353,11 @@ async fn dispatch_op(
             task_id: None,
         },
         ControlOp::CancelWorker { task_id } => {
+            // If this worker is currently Frozen (SIGSTOP'd), we must
+            // SIGCONT it first so the subsequent SIGTERM is actually
+            // deliverable — a stopped process can't drain signals until
+            // it's running again. Harmless for non-frozen workers.
+            thaw_if_frozen(state, &task_id).await;
             let cancels = state.worker_cancels.read().await;
             if let Some(tok) = cancels.get(&task_id) {
                 tok.terminate();
@@ -342,12 +374,25 @@ async fn dispatch_op(
             }
         }
         ControlOp::CancelRun => {
-            // Cascade the cancel into every live worker's own token FIRST, then
-            // flip the run-level flag. The run-level `state.cancel` is only
-            // observed by the lead's SessionHandle; workers have independent
-            // per-task tokens and would otherwise keep running after the lead
-            // dies. Without this cascade, users saw "kill run" ack but ps
-            // still showed live claude workers.
+            // SIGCONT any frozen workers first — see CancelWorker above
+            // for the rationale. Also iterates every per-worker cancel
+            // token before flipping the run-level flag (run-level cancel
+            // is only observed by the lead's SessionHandle).
+            {
+                let workers = state.workers.read().await;
+                let pids = state.worker_pids.read().await;
+                for (id, w) in workers.iter() {
+                    if matches!(w, crate::dispatch::state::WorkerState::Frozen { .. }) {
+                        let pid = pids
+                            .get(id)
+                            .map(|slot| slot.load(std::sync::atomic::Ordering::Relaxed))
+                            .unwrap_or(0);
+                        if pid > 0 {
+                            let _ = crate::dispatch::signals::resume_stopped(pid);
+                        }
+                    }
+                }
+            }
             {
                 let cancels = state.worker_cancels.read().await;
                 for tok in cancels.values() {
@@ -360,7 +405,7 @@ async fn dispatch_op(
                 task_id: None,
             }
         }
-        ControlOp::PauseWorker { task_id } => {
+        ControlOp::PauseWorker { task_id, mode } => {
             let mut workers = state.workers.write().await;
             let Some(entry) = workers.get(&task_id).cloned() else {
                 return ControlEvent::OpFailed {
@@ -371,21 +416,56 @@ async fn dispatch_op(
             };
             match entry {
                 crate::dispatch::state::WorkerState::Running {
+                    started_at,
                     session_id: Some(sid),
-                    ..
                 } => {
-                    let cancels = state.worker_cancels.read().await;
-                    if let Some(tok) = cancels.get(&task_id) {
-                        tok.terminate();
+                    match mode {
+                        crate::control::protocol::PauseMode::Cancel => {
+                            let cancels = state.worker_cancels.read().await;
+                            if let Some(tok) = cancels.get(&task_id) {
+                                tok.terminate();
+                            }
+                            workers.insert(
+                                task_id.clone(),
+                                crate::dispatch::state::WorkerState::Paused {
+                                    session_id: sid,
+                                    paused_at: chrono::Utc::now(),
+                                    prior_token_usage: Default::default(),
+                                },
+                            );
+                        }
+                        crate::control::protocol::PauseMode::Freeze => {
+                            let pid = state
+                                .worker_pids
+                                .read()
+                                .await
+                                .get(&task_id)
+                                .map(|slot| slot.load(std::sync::atomic::Ordering::Relaxed))
+                                .unwrap_or(0);
+                            if pid == 0 {
+                                return ControlEvent::OpFailed {
+                                    op: "pause_worker".into(),
+                                    task_id: Some(task_id),
+                                    error: "pid slot empty; cannot freeze".into(),
+                                };
+                            }
+                            if let Err(e) = crate::dispatch::signals::freeze(pid) {
+                                return ControlEvent::OpFailed {
+                                    op: "pause_worker".into(),
+                                    task_id: Some(task_id),
+                                    error: format!("freeze failed: {e}"),
+                                };
+                            }
+                            workers.insert(
+                                task_id.clone(),
+                                crate::dispatch::state::WorkerState::Frozen {
+                                    session_id: sid,
+                                    frozen_at: chrono::Utc::now(),
+                                    started_at,
+                                },
+                            );
+                        }
                     }
-                    workers.insert(
-                        task_id.clone(),
-                        crate::dispatch::state::WorkerState::Paused {
-                            session_id: sid,
-                            paused_at: chrono::Utc::now(),
-                            prior_token_usage: Default::default(),
-                        },
-                    );
                     let _ = crate::dispatch::events::append_event(
                         &state.run_subdir,
                         &task_id,
@@ -419,6 +499,13 @@ async fn dispatch_op(
                         op: "pause_worker".into(),
                         task_id,
                         current_state: "paused".into(),
+                    }
+                }
+                crate::dispatch::state::WorkerState::Frozen { .. } => {
+                    ControlEvent::OpUnknownState {
+                        op: "pause_worker".into(),
+                        task_id,
+                        current_state: "frozen".into(),
                     }
                 }
                 crate::dispatch::state::WorkerState::Pending => ControlEvent::OpUnknownState {
@@ -469,6 +556,46 @@ async fn dispatch_op(
                             task_id: Some(task_id),
                             error: e.to_string(),
                         },
+                    }
+                }
+                Some(crate::dispatch::state::WorkerState::Frozen {
+                    session_id,
+                    started_at,
+                    ..
+                }) => {
+                    // SIGCONT the frozen process. `prompt` is ignored —
+                    // freeze-mode preserves state and has no resume point.
+                    let pid = state
+                        .worker_pids
+                        .read()
+                        .await
+                        .get(&task_id)
+                        .map(|slot| slot.load(std::sync::atomic::Ordering::Relaxed))
+                        .unwrap_or(0);
+                    if pid == 0 {
+                        return ControlEvent::OpFailed {
+                            op: "continue_worker".into(),
+                            task_id: Some(task_id),
+                            error: "pid slot empty; cannot thaw".into(),
+                        };
+                    }
+                    if let Err(e) = crate::dispatch::signals::resume_stopped(pid) {
+                        return ControlEvent::OpFailed {
+                            op: "continue_worker".into(),
+                            task_id: Some(task_id),
+                            error: format!("SIGCONT failed: {e}"),
+                        };
+                    }
+                    state.workers.write().await.insert(
+                        task_id.clone(),
+                        crate::dispatch::state::WorkerState::Running {
+                            started_at,
+                            session_id: Some(session_id),
+                        },
+                    );
+                    ControlEvent::OpAcked {
+                        op: "continue_worker".into(),
+                        task_id: Some(task_id),
                     }
                 }
                 Some(_) => ControlEvent::OpUnknownState {
@@ -572,6 +699,15 @@ async fn dispatch_op(
                         } => (
                             "paused".to_string(),
                             Some(paused_at.to_rfc3339()),
+                            Some(session_id.clone()),
+                        ),
+                        crate::dispatch::state::WorkerState::Frozen {
+                            frozen_at,
+                            session_id,
+                            ..
+                        } => (
+                            "frozen".to_string(),
+                            Some(frozen_at.to_rfc3339()),
                             Some(session_id.clone()),
                         ),
                         crate::dispatch::state::WorkerState::Done(rec) => (

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -293,7 +293,8 @@ pub async fn run_hierarchical(
                 crate::dispatch::state::WorkerState::Done(rec) => rec.clone(),
                 crate::dispatch::state::WorkerState::Pending
                 | crate::dispatch::state::WorkerState::Running { .. }
-                | crate::dispatch::state::WorkerState::Paused { .. } => {
+                | crate::dispatch::state::WorkerState::Paused { .. }
+                | crate::dispatch::state::WorkerState::Frozen { .. } => {
                     let now = Utc::now();
                     pitboss_core::store::TaskRecord {
                         task_id: id.clone(),

--- a/crates/pitboss-cli/src/dispatch/signals.rs
+++ b/crates/pitboss-cli/src/dispatch/signals.rs
@@ -1,8 +1,53 @@
 use std::time::Duration;
 
+use anyhow::{bail, Result};
 use pitboss_core::session::CancelToken;
 
 const SECOND_SIGINT_WINDOW: Duration = Duration::from_secs(5);
+
+// ---------------------------------------------------------------------
+// SIGSTOP / SIGCONT for freeze-pause
+// ---------------------------------------------------------------------
+//
+// `pause_worker` supports two modes: the classic `cancel` (which
+// terminates the claude subprocess and snapshots the session so
+// `continue_worker` can re-spawn via `claude --resume`) and the newer
+// `freeze` (which SIGSTOP's the process in place and SIGCONT's it
+// back). Freeze preserves in-flight state (no token replay, no session
+// re-init) but risks Anthropic dropping the HTTP session if the pause
+// runs past their server-side idle window. Use cancel for long pauses,
+// freeze for quick ones.
+//
+// We use raw libc::kill rather than the `nix` crate — libc is already a
+// transitive dep and this is a two-function use case. Pitboss is
+// Linux/macOS only so POSIX signal semantics are available
+// unconditionally.
+
+/// Suspend the process with `pid` using SIGSTOP. Returns an error for
+/// `pid == 0` (slot not yet populated) or if the syscall fails
+/// (process already exited, permission denied, etc).
+pub fn freeze(pid: u32) -> Result<()> {
+    send_signal(pid, libc::SIGSTOP, "SIGSTOP")
+}
+
+/// Resume a previously-frozen process with SIGCONT.
+pub fn resume_stopped(pid: u32) -> Result<()> {
+    send_signal(pid, libc::SIGCONT, "SIGCONT")
+}
+
+fn send_signal(pid: u32, sig: libc::c_int, name: &'static str) -> Result<()> {
+    if pid == 0 {
+        bail!("{name}: pid is 0 (worker not yet spawned?)");
+    }
+    // SAFETY: `kill(2)` accepts any pid_t + valid signo; no memory is
+    // dereferenced. The cast is libc's expected pid_t shape.
+    let rc = unsafe { libc::kill(pid as libc::pid_t, sig) };
+    if rc == 0 {
+        return Ok(());
+    }
+    let err = std::io::Error::last_os_error();
+    bail!("{name} to pid {pid} failed: {err}")
+}
 
 /// Spawn a task that watches for Ctrl-C in two phases:
 ///   1st SIGINT within window → drain
@@ -29,4 +74,65 @@ pub fn install_ctrl_c_watcher(cancel: CancelToken) {
             }
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn freeze_rejects_pid_zero() {
+        let err = freeze(0).unwrap_err();
+        assert!(err.to_string().contains("pid is 0"));
+    }
+
+    #[test]
+    fn resume_rejects_pid_zero() {
+        let err = resume_stopped(0).unwrap_err();
+        assert!(err.to_string().contains("pid is 0"));
+    }
+
+    /// End-to-end: spawn a sleeping child, SIGSTOP it, confirm
+    /// /proc reports stopped state, SIGCONT, confirm runnable,
+    /// then clean up. Linux-only because /proc isn't available on
+    /// macOS CI.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn freeze_then_resume_flips_proc_state() {
+        use std::process::Command;
+        use std::time::Duration;
+
+        let mut child = Command::new("sleep").arg("30").spawn().unwrap();
+        let pid = child.id();
+
+        freeze(pid).unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+        let state = read_proc_state(pid);
+        assert!(
+            matches!(state, Some('T' | 't')),
+            "expected stopped state, got {state:?}"
+        );
+
+        resume_stopped(pid).unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+        let state = read_proc_state(pid);
+        assert!(
+            matches!(state, Some('S' | 'R')),
+            "expected sleeping/running after SIGCONT, got {state:?}"
+        );
+
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    #[cfg(target_os = "linux")]
+    fn read_proc_state(pid: u32) -> Option<char> {
+        let s = std::fs::read_to_string(format!("/proc/{pid}/status")).ok()?;
+        for line in s.lines() {
+            if let Some(rest) = line.strip_prefix("State:") {
+                return rest.trim().chars().next();
+            }
+        }
+        None
+    }
 }

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -36,6 +36,21 @@ pub enum WorkerState {
         /// TaskRecord knows what the prior subprocess cost.
         prior_token_usage: pitboss_core::parser::TokenUsage,
     },
+    /// Frozen by SIGSTOP — claude subprocess is still alive but
+    /// suspended at the kernel level. Distinct from Paused because
+    /// `continue_worker` just SIGCONT's instead of respawning via
+    /// `claude --resume`. Suitable for short pauses; long freezes risk
+    /// Anthropic dropping the HTTP session on their side.
+    Frozen {
+        /// Session id captured at freeze time (same field semantics as
+        /// Paused). Populated so `worker_status` still reports it and
+        /// so callers that want to fall back to cancel-style resume can.
+        session_id: String,
+        frozen_at: chrono::DateTime<chrono::Utc>,
+        /// Saved `started_at` from the Running state so `continue_worker`
+        /// can transition back to Running without losing elapsed time.
+        started_at: chrono::DateTime<chrono::Utc>,
+    },
     Done(TaskRecord),
 }
 
@@ -139,6 +154,13 @@ pub struct DispatchState {
     pub notification_router: Option<std::sync::Arc<crate::notify::NotificationRouter>>,
     /// In-memory shared store for hub-mediated lead ↔ worker coordination.
     pub shared_store: std::sync::Arc<crate::shared_store::SharedStore>,
+    /// Per-worker OS pid, published by the SessionHandle as soon as the
+    /// child is spawned. Used by the SIGSTOP freeze-pause path to
+    /// signal the process directly without going through the
+    /// `ChildProcess` interface (the Box lives inside the session task
+    /// after we've already moved the handle). Value 0 means "not yet
+    /// spawned" (pre-init) — callers skip signaling in that state.
+    pub worker_pids: RwLock<HashMap<String, std::sync::Arc<std::sync::atomic::AtomicU32>>>,
 }
 
 impl DispatchState {
@@ -185,6 +207,7 @@ impl DispatchState {
             worker_counters: RwLock::new(HashMap::new()),
             notification_router,
             shared_store,
+            worker_pids: RwLock::new(HashMap::new()),
         }
     }
 
@@ -196,7 +219,10 @@ impl DispatchState {
             .filter(|w| {
                 matches!(
                     w,
-                    WorkerState::Pending | WorkerState::Running { .. } | WorkerState::Paused { .. }
+                    WorkerState::Pending
+                        | WorkerState::Running { .. }
+                        | WorkerState::Paused { .. }
+                        | WorkerState::Frozen { .. }
                 )
             })
             .count()

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -19,8 +19,9 @@ use crate::dispatch::state::DispatchState;
 use crate::mcp::tools::{
     handle_cancel_worker, handle_continue_worker, handle_list_workers, handle_pause_worker,
     handle_reprompt_worker, handle_request_approval, handle_spawn_worker, handle_wait_for_any,
-    handle_wait_for_worker, handle_worker_status, ContinueWorkerArgs, RepromptWorkerArgs,
-    RequestApprovalArgs, SpawnWorkerArgs, TaskIdArgs, WaitForAnyArgs, WaitForWorkerArgs,
+    handle_wait_for_worker, handle_worker_status, ContinueWorkerArgs, PauseWorkerArgs,
+    RepromptWorkerArgs, RequestApprovalArgs, SpawnWorkerArgs, TaskIdArgs, WaitForAnyArgs,
+    WaitForWorkerArgs,
 };
 
 /// Compute the socket path for a given run. Falls back to the run_dir if
@@ -175,20 +176,20 @@ impl PitbossHandler {
     }
 
     #[tool(
-        description = "Pause a running worker. Snapshots its session id so continue_worker can resume."
+        description = "Pause a running worker. Two modes: \"cancel\" (default — terminates subprocess, snapshots session_id; continue_worker re-spawns via claude --resume) or \"freeze\" (SIGSTOP the process in place; continue_worker SIGCONTs — zero state loss but risks dropped HTTP session on long pauses)."
     )]
     async fn pause_worker(
         &self,
-        Parameters(args): Parameters<TaskIdArgs>,
+        Parameters(args): Parameters<PauseWorkerArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        match handle_pause_worker(&self.state, &args.task_id).await {
+        match handle_pause_worker(&self.state, &args.task_id, args.mode).await {
             Ok(res) => to_structured_result(&res),
             Err(e) => Err(ErrorData::invalid_request(e.to_string(), None)),
         }
     }
 
     #[tool(
-        description = "Continue a previously-paused worker. Spawns claude --resume under the hood."
+        description = "Continue a previously-paused worker. For Paused (cancel-mode): spawns claude --resume with prompt (default \"continue\"). For Frozen (freeze-mode): SIGCONT — prompt is ignored."
     )]
     async fn continue_worker(
         &self,

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -130,6 +130,30 @@ pub struct TaskIdArgs {
     pub task_id: String,
 }
 
+/// Pause-mode selector.
+///
+/// - `Cancel` (default): terminates the claude subprocess, snapshots
+///   its session_id. `continue_worker` re-spawns via `claude --resume`.
+///   Works for arbitrarily long pauses; loses any in-flight state.
+/// - `Freeze`: SIGSTOP's the process in place. `continue_worker` just
+///   SIGCONT's. Zero state loss + instant resume, but Anthropic may
+///   drop the HTTP session if the pause runs past their server-side
+///   idle window — prefer for quick pauses (seconds to low minutes).
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum PauseMode {
+    #[default]
+    Cancel,
+    Freeze,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct PauseWorkerArgs {
+    pub task_id: String,
+    #[serde(default)]
+    pub mode: PauseMode,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct WaitForWorkerArgs {
     pub task_id: String,
@@ -488,13 +512,25 @@ async fn run_worker(
                 }
             }
         });
+        // Register a pid slot so the SIGSTOP freeze-pause path can
+        // signal this worker directly. Populated inside
+        // `run_to_completion` right after the spawn succeeds.
+        let pid_slot = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+        state
+            .worker_pids
+            .write()
+            .await
+            .insert(task_id.clone(), pid_slot.clone());
         let outcome = SessionHandle::new(task_id.clone(), Arc::clone(&state.spawner), cmd)
             .with_log_path(log_path.clone())
             .with_stderr_log_path(stderr_path)
             .with_session_id_tx(session_id_tx)
+            .with_pid_slot(pid_slot)
             .run_to_completion(cancel, Duration::from_secs(timeout_secs))
             .await;
         promote_task.abort();
+        // Clean up the pid slot — the worker is done, the pid is stale.
+        state.worker_pids.write().await.remove(&task_id);
         outcome
     };
 
@@ -722,6 +758,14 @@ pub async fn spawn_resume_worker(
     let log_path = task_dir.join("stdout.log");
     let stderr_path = task_dir.join("stderr.log");
     let resume_model = model.clone();
+    // Register a pid slot for the resumed subprocess too, so
+    // freeze-pause works across continue_worker boundaries.
+    let resume_pid_slot = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+    state
+        .worker_pids
+        .write()
+        .await
+        .insert(task_id.clone(), resume_pid_slot.clone());
 
     tokio::spawn(async move {
         use pitboss_core::store::{TaskRecord, TaskStatus};
@@ -732,8 +776,11 @@ pub async fn spawn_resume_worker(
         )
         .with_log_path(log_path.clone())
         .with_stderr_log_path(stderr_path)
+        .with_pid_slot(resume_pid_slot)
         .run_to_completion(worker_cancel, std::time::Duration::from_secs(timeout_secs))
         .await;
+        // Clean up the pid slot when the resumed subprocess exits.
+        state_bg.worker_pids.write().await.remove(&task_id_bg);
         let status = match outcome.final_state {
             pitboss_core::session::SessionState::Completed => TaskStatus::Success,
             pitboss_core::session::SessionState::Failed { .. } => TaskStatus::Failed,
@@ -834,6 +881,9 @@ pub async fn handle_list_workers(state: &Arc<DispatchState>) -> Vec<WorkerSummar
                 WorkerState::Paused { paused_at, .. } => {
                     ("Paused".to_string(), Some(paused_at.to_rfc3339()))
                 }
+                WorkerState::Frozen { started_at, .. } => {
+                    ("Frozen".to_string(), Some(started_at.to_rfc3339()))
+                }
                 WorkerState::Done(rec) => (
                     match rec.status {
                         pitboss_core::store::TaskStatus::Success => "Completed",
@@ -888,6 +938,15 @@ pub async fn handle_worker_status(
             *prior_token_usage,
             None,
         ),
+        WorkerState::Frozen { started_at, .. } => (
+            "Frozen".to_string(),
+            Some(started_at.to_rfc3339()),
+            // The child is still alive and its counters haven't been
+            // snapshotted at freeze time (partial_usage is populated by
+            // Done records). Report zeros rather than inventing a value.
+            pitboss_core::parser::TokenUsage::default(),
+            None,
+        ),
         WorkerState::Done(rec) => (
             match rec.status {
                 pitboss_core::store::TaskStatus::Success => "Completed",
@@ -933,6 +992,7 @@ pub async fn handle_cancel_worker(
 pub async fn handle_pause_worker(
     state: &Arc<DispatchState>,
     task_id: &str,
+    mode: PauseMode,
 ) -> Result<CancelResult> {
     let mut workers = state.workers.write().await;
     let Some(entry) = workers.get(task_id).cloned() else {
@@ -940,27 +1000,54 @@ pub async fn handle_pause_worker(
     };
     match entry {
         WorkerState::Running {
+            started_at,
             session_id: Some(sid),
-            ..
-        } => {
-            let cancels = state.worker_cancels.read().await;
-            if let Some(tok) = cancels.get(task_id) {
-                tok.terminate();
+        } => match mode {
+            PauseMode::Cancel => {
+                let cancels = state.worker_cancels.read().await;
+                if let Some(tok) = cancels.get(task_id) {
+                    tok.terminate();
+                }
+                workers.insert(
+                    task_id.to_string(),
+                    WorkerState::Paused {
+                        session_id: sid,
+                        paused_at: chrono::Utc::now(),
+                        prior_token_usage: Default::default(),
+                    },
+                );
+                Ok(CancelResult { ok: true })
             }
-            workers.insert(
-                task_id.to_string(),
-                WorkerState::Paused {
-                    session_id: sid,
-                    paused_at: chrono::Utc::now(),
-                    prior_token_usage: Default::default(),
-                },
-            );
-            Ok(CancelResult { ok: true })
-        }
+            PauseMode::Freeze => {
+                // Read the pid slot. If 0 (subprocess hasn't spawned
+                // yet), fail — freeze is meaningless without a pid.
+                let pid = state
+                    .worker_pids
+                    .read()
+                    .await
+                    .get(task_id)
+                    .map(|slot| slot.load(std::sync::atomic::Ordering::Relaxed))
+                    .unwrap_or(0);
+                if pid == 0 {
+                    anyhow::bail!("cannot freeze {task_id}: worker pid unknown (race with spawn?)");
+                }
+                crate::dispatch::signals::freeze(pid)?;
+                workers.insert(
+                    task_id.to_string(),
+                    WorkerState::Frozen {
+                        session_id: sid,
+                        frozen_at: chrono::Utc::now(),
+                        started_at,
+                    },
+                );
+                Ok(CancelResult { ok: true })
+            }
+        },
         WorkerState::Running {
             session_id: None, ..
         } => anyhow::bail!("worker not yet initialized (no session_id)"),
         WorkerState::Paused { .. } => anyhow::bail!("worker already paused"),
+        WorkerState::Frozen { .. } => anyhow::bail!("worker already frozen"),
         _ => anyhow::bail!("worker not in a pausable state"),
     }
 }
@@ -974,6 +1061,41 @@ pub async fn handle_continue_worker(
         Some(WorkerState::Paused { session_id, .. }) => {
             let prompt = args.prompt.unwrap_or_else(|| "continue".into());
             spawn_resume_worker(state, args.task_id, prompt, session_id).await?;
+            Ok(CancelResult { ok: true })
+        }
+        Some(WorkerState::Frozen {
+            session_id,
+            started_at,
+            ..
+        }) => {
+            // SIGCONT the process in place — no respawn, no session
+            // replay. The subprocess picks up exactly where it left
+            // off. `prompt` is silently ignored in freeze mode (it's
+            // a resume-only concept); clients that want to inject a
+            // new prompt should thaw + reprompt as two steps.
+            let pid = state
+                .worker_pids
+                .read()
+                .await
+                .get(&args.task_id)
+                .map(|slot| slot.load(std::sync::atomic::Ordering::Relaxed))
+                .unwrap_or(0);
+            if pid == 0 {
+                anyhow::bail!(
+                    "cannot thaw {}: pid slot empty (race with exit?)",
+                    args.task_id
+                );
+            }
+            crate::dispatch::signals::resume_stopped(pid)?;
+            // Transition back to Running, preserving the ORIGINAL
+            // started_at so wall-clock duration stays accurate.
+            state.workers.write().await.insert(
+                args.task_id.clone(),
+                WorkerState::Running {
+                    started_at,
+                    session_id: Some(session_id),
+                },
+            );
             Ok(CancelResult { ok: true })
         }
         Some(_) => anyhow::bail!("worker not paused"),
@@ -1001,6 +1123,9 @@ pub async fn handle_reprompt_worker(
             sid
         }
         Some(WorkerState::Paused { session_id, .. }) => session_id,
+        Some(WorkerState::Frozen { .. }) => {
+            anyhow::bail!("worker is frozen; continue_worker (SIGCONT) it first before reprompting")
+        }
         Some(WorkerState::Running {
             session_id: None, ..
         }) => anyhow::bail!("worker not yet initialized (no session_id)"),
@@ -1862,7 +1987,9 @@ mod tests {
                 session_id: Some("sess".into()),
             },
         );
-        let res = handle_pause_worker(&state, "w-1").await.unwrap();
+        let res = handle_pause_worker(&state, "w-1", PauseMode::Cancel)
+            .await
+            .unwrap();
         assert!(res.ok);
         assert!(worker_token.is_terminated());
         let workers = state.workers.read().await;
@@ -1870,6 +1997,85 @@ mod tests {
             workers.get("w-1").unwrap(),
             WorkerState::Paused { .. }
         ));
+    }
+
+    /// End-to-end freeze: spawn a real sleeping child, register its pid
+    /// slot + a Running WorkerState, call handle_pause_worker(Freeze),
+    /// verify Frozen state + that /proc (on Linux) sees the process as
+    /// stopped. Then handle_continue_worker to thaw.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn freeze_and_thaw_transition_via_handler() {
+        use std::process::Command;
+
+        let state = test_state().await;
+
+        // Spawn a real long-sleep child we can safely SIGSTOP/SIGCONT.
+        let child = Command::new("sleep").arg("30").spawn().unwrap();
+        let pid = child.id();
+
+        // Register the pid + Running state.
+        let slot = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(pid));
+        state
+            .worker_pids
+            .write()
+            .await
+            .insert("w-freeze".into(), slot);
+        state
+            .worker_cancels
+            .write()
+            .await
+            .insert("w-freeze".into(), pitboss_core::session::CancelToken::new());
+        state.workers.write().await.insert(
+            "w-freeze".into(),
+            WorkerState::Running {
+                started_at: chrono::Utc::now(),
+                session_id: Some("sess-freeze".into()),
+            },
+        );
+
+        // Freeze.
+        let res = handle_pause_worker(&state, "w-freeze", PauseMode::Freeze)
+            .await
+            .unwrap();
+        assert!(res.ok);
+        assert!(matches!(
+            state.workers.read().await.get("w-freeze").unwrap(),
+            WorkerState::Frozen { .. }
+        ));
+
+        // /proc should show 'T' (stopped).
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        let status = std::fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+        let state_line = status
+            .lines()
+            .find(|l| l.starts_with("State:"))
+            .unwrap_or("State: ?");
+        assert!(
+            state_line.contains('T'),
+            "expected stopped state, got {state_line}"
+        );
+
+        // Thaw via continue_worker (no prompt — freeze path ignores it).
+        let cres = handle_continue_worker(
+            &state,
+            ContinueWorkerArgs {
+                task_id: "w-freeze".into(),
+                prompt: None,
+            },
+        )
+        .await
+        .unwrap();
+        assert!(cres.ok);
+        assert!(matches!(
+            state.workers.read().await.get("w-freeze").unwrap(),
+            WorkerState::Running { .. }
+        ));
+
+        // Cleanup.
+        let mut owned = child;
+        let _ = owned.kill();
+        let _ = owned.wait();
     }
 
     #[tokio::test]

--- a/crates/pitboss-cli/tests/control_flows.rs
+++ b/crates/pitboss-cli/tests/control_flows.rs
@@ -96,6 +96,7 @@ async fn pause_op_writes_events_jsonl() {
     client
         .send(&ControlOp::PauseWorker {
             task_id: "w-1".into(),
+            mode: pitboss_cli::control::protocol::PauseMode::default(),
         })
         .await
         .unwrap();

--- a/crates/pitboss-core/src/session/handle.rs
+++ b/crates/pitboss-core/src/session/handle.rs
@@ -20,6 +20,7 @@ pub struct SessionHandle {
     log_path: Option<PathBuf>,
     stderr_log_path: Option<PathBuf>,
     session_id_tx: Option<tokio::sync::mpsc::Sender<String>>,
+    pid_slot: Option<Arc<std::sync::atomic::AtomicU32>>,
 }
 
 impl SessionHandle {
@@ -35,6 +36,7 @@ impl SessionHandle {
             log_path: None,
             stderr_log_path: None,
             session_id_tx: None,
+            pid_slot: None,
         }
     }
 
@@ -53,6 +55,19 @@ impl SessionHandle {
     #[must_use]
     pub fn with_session_id_tx(mut self, tx: tokio::sync::mpsc::Sender<String>) -> Self {
         self.session_id_tx = Some(tx);
+        self
+    }
+
+    /// Provide a shared atomic slot that `run_to_completion` will populate
+    /// with the child's OS pid immediately after spawn. Used by the
+    /// dispatcher's SIGSTOP freeze-pause path — it needs the raw pid
+    /// to send signals without going through the `ChildProcess`
+    /// interface (which takes `&mut self`, and we've already moved the
+    /// handle into the session task). Slot value of 0 means "not yet
+    /// spawned"; any non-zero value is the real pid.
+    #[must_use]
+    pub fn with_pid_slot(mut self, slot: Arc<std::sync::atomic::AtomicU32>) -> Self {
+        self.pid_slot = Some(slot);
         self
     }
 
@@ -82,6 +97,15 @@ impl SessionHandle {
                 };
             }
         };
+
+        // Publish the child pid so the dispatcher's SIGSTOP freeze-pause
+        // path can signal it directly. No-op if the caller didn't install
+        // a slot (tests, flat mode without pause support).
+        if let Some(slot) = &self.pid_slot {
+            if let Some(pid) = child.pid() {
+                slot.store(pid, std::sync::atomic::Ordering::Relaxed);
+            }
+        }
 
         let stdout = child.take_stdout().expect("stdout piped");
         let reader = BufReader::new(stdout).lines();

--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -342,7 +342,10 @@ fn handle_normal(state: &mut AppState, code: KeyCode) -> Action {
             if let Some(tile) = state.focused_tile().cloned() {
                 spawn_control_op(
                     state,
-                    pitboss_cli::control::protocol::ControlOp::PauseWorker { task_id: tile.id },
+                    pitboss_cli::control::protocol::ControlOp::PauseWorker {
+                        task_id: tile.id,
+                        mode: pitboss_cli::control::protocol::PauseMode::default(),
+                    },
                 );
             }
         }


### PR DESCRIPTION
## Summary

Adds a `freeze` pause mode alongside the existing (default) `cancel` pause. Freeze-mode SIGSTOPs the claude subprocess in place instead of terminating + respawning on resume.

| Mode | Behavior | Best for |
|---|---|---|
| `cancel` (default) | kill + snapshot session → `claude --resume` on continue | long pauses; state loss acceptable |
| `freeze` (new) | SIGSTOP → SIGCONT on continue, zero state loss | short pauses (seconds–low minutes) |

Tradeoffs called out in the `PauseMode` docstring — long freezes risk Anthropic dropping the HTTP session on their side, so we don't default to it.

### Architecture

- **`SessionHandle::with_pid_slot(Arc<AtomicU32>)`** publishes the child pid immediately after spawn. Caller stores the Arc in `DispatchState.worker_pids` so freeze/thaw can signal the process directly, without punching a channel back through the already-moved session task.
- **`WorkerState::Frozen`** variant preserves the original `started_at` so `continue_worker` transitions back to Running without losing wall-clock duration.
- **`dispatch::signals::{freeze, resume_stopped}`** wraps `libc::kill`. libc is already transitive; no new dep.
- **`PauseMode`** enum lives in two places — `mcp::tools` for the tool schema, `control::protocol` for the TUI wire. Duplicated to keep the protocol module free of MCP deps; docstring calls out the sync requirement.
- **Kill paths** (`CancelWorker`, `CancelRun`) now SIGCONT any Frozen workers BEFORE firing SIGTERM. Stopped processes can't drain signals until runnable again, so the kill would otherwise hang.
- **Exhaustive-match cleanup** across `hierarchical.rs` finalize synthesis, `server.rs` list handlers, `mcp/tools.rs` status + reprompt (which refuses frozen workers with a clear error pointing to continue_worker-first).

### Test Plan
- [x] Workspace tests: **435 passing** (+4: signals primitives reject pid=0, real Linux sleep child flips /proc State 'S' → 'T' → 'S' across freeze/SIGCONT, end-to-end via `handle_pause_worker(Freeze)` + `handle_continue_worker` on a real PID).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo build --release --workspace` clean
- [ ] Manual smoke: freeze a live Opus worker mid-turn, confirm no tokens accrue during freeze, thaw, confirm it resumes exactly where it stopped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)