### PR TITLE
Plan approval flow: pre-flight operator gate via propose_plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`pitboss attach <run-id> <task-id>`.** Follow-mode log viewer for a
+  single worker, resolved by run-id prefix. `--raw` streams the
+  underlying jsonl; without it, lines are formatted like the TUI focus
+  pane. Exits on Ctrl-C or when the worker's terminal `Event::Result`
+  arrives.
+- **SIGSTOP freeze-pause as opt-in pause mode.** `pause_worker` now
+  takes a `mode` ("cancel" / "freeze"). Default stays at cancel-style
+  (terminate + `claude --resume`, zero state loss on the Claude side).
+  Freeze SIGSTOPs the subprocess in place; `continue_worker` SIGCONTs
+  to resume — useful for short pauses where respawning would cost a
+  context reload, risky for long pauses (Anthropic may drop the HTTP
+  session). New `WorkerState::Frozen` variant tracked alongside Paused.
+- **Structured approval schema.** `request_approval` now accepts an
+  optional typed `ApprovalPlan` (rationale / resources / risks /
+  rollback). TUI modal renders the structured fields as labeled
+  sections, with risks in the warning color. Bare-summary approvals
+  still work unchanged.
+- **Plan approval flow (`propose_plan`).** New MCP tool the lead calls
+  *before* `spawn_worker`. When `[run].require_plan_approval = true`,
+  spawn_worker refuses until a plan submitted via propose_plan has
+  been operator-approved. Reuses the structured-approval modal with a
+  `[PRE-FLIGHT PLAN]` vs `[IN-FLIGHT ACTION]` badge in the title so
+  operators can tell the two kinds apart. On rejection, the plan gate
+  stays closed so the lead can revise and retry. Runs without the
+  opt-in flag behave identically to before.
+
 ## [0.4.4] — 2026-04-18
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,46 +3,14 @@
 Capture of deferred work. Items here are scoped but unscheduled — grab
 one when you're ready, or file issues to formalize priority.
 
-**Last refresh: v0.4.4 (2026-04-18).** Everything shipped through
-v0.4.4 has been removed from this file — check `CHANGELOG.md` for
+**Last refresh: v0.4.5 (2026-04-19).** Everything shipped through
+v0.4.5 has been removed from this file — check `CHANGELOG.md` for
 per-version history. If you're about to add an item, slot it into one
 of the tiered sections below (biggest effort first).
 
 ---
 
 ## Flagship feature bucket (targeting v0.5.0)
-
-### `pitboss attach <run-id> <task-id>`
-
-Live TTY relay using `portable-pty`. Narrow-scope escape hatch for
-"I want to watch a worker interactively" — the one use case that the
-hierarchical dispatch model doesn't naturally cover. No persistent
-sessions, no tmux dependency; sits on top of v0.4.0 control-socket
-primitives. **Status:** designed, not started.
-
-### SIGSTOP freeze-pause
-
-Alternative / addition to the v0.4.0 cancel-with-resume pause model.
-Freezes a worker's process without tearing down + re-spawning — safer
-for very-long-running workers where losing the claude session mid-flight
-is expensive. Coexists with existing `pause_worker` semantics behind a
-flag. **Status:** parked; value depends on real-world pause frequency.
-
-### Structured approval schema
-
-Today the approval modal sends a freeform `summary` string and
-optionally an edited summary back. A typed schema (`{plan, rationale,
-resources, rollback_plan, ...}`) with in-TUI field-level editing would
-make the flow much more reviewable for non-trivial approvals.
-**Status:** parked pending design.
-
-### Plan approval flow
-
-Lead proposes a full execution plan, operator approves in the TUI (or
-via a new `pitboss plan` subcommand) BEFORE any workers dispatch —
-distinct from the in-flight `request_approval` tool, which gates
-individual actions mid-run. UX question: modal-in-TUI vs. separate
-subcommand. **Status:** parked, no design doc.
 
 ### Full end-to-end `fake-claude` integration test
 

--- a/crates/pitboss-cli/src/control/protocol.rs
+++ b/crates/pitboss-cli/src/control/protocol.rs
@@ -42,6 +42,28 @@ fn is_default_pause_mode(m: &PauseMode) -> bool {
     matches!(m, PauseMode::Cancel)
 }
 
+/// Discriminator on an approval request: does the operator's y/n gate
+/// a single in-flight action, or the whole run's pre-flight plan?
+///
+/// `Action` (default) = `request_approval` tool. Mid-run, per-action.
+/// `Plan` = `propose_plan` tool. Pre-flight, gates `spawn_worker` when
+/// `[run].require_plan_approval = true`.
+///
+/// Field is `#[serde(default)]` so pre-v0.4.5 TUI clients that don't
+/// know about `kind` still parse `ApprovalRequest` events and render
+/// the modal exactly as before (as `Action`).
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ApprovalKind {
+    #[default]
+    Action,
+    Plan,
+}
+
+fn is_default_approval_kind(k: &ApprovalKind) -> bool {
+    matches!(k, ApprovalKind::Action)
+}
+
 /// An operation sent from the TUI (client) to the dispatcher (server).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "op", rename_all = "snake_case")]
@@ -120,6 +142,10 @@ pub enum ControlEvent {
         /// pre-v0.4.5 dispatchers + simple approvals still work.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         plan: Option<ApprovalPlanWire>,
+        /// Action (in-flight) vs Plan (pre-flight). Defaults to Action
+        /// on the wire when absent, so pre-v0.4.5 dispatchers roundtrip.
+        #[serde(default, skip_serializing_if = "is_default_approval_kind")]
+        kind: ApprovalKind,
     },
     WorkersSnapshot {
         workers: Vec<WorkerSnapshotEntry>,
@@ -304,6 +330,7 @@ mod tests {
             task_id: "lead".into(),
             summary: "spawn 3 workers".into(),
             plan: None,
+            kind: ApprovalKind::default(),
         };
         assert_eq!(roundtrip_event(&ev), ev);
 
@@ -319,8 +346,63 @@ mod tests {
                 risks: vec!["slow to rebuild if live reads hit it".into()],
                 rollback: Some("restore from nightly snapshot".into()),
             }),
+            kind: ApprovalKind::Action,
         };
         assert_eq!(roundtrip_event(&ev2), ev2);
+
+        // Plan-kind form — pre-flight approval.
+        let ev3 = ControlEvent::ApprovalRequest {
+            request_id: "req-3".into(),
+            task_id: "lead".into(),
+            summary: "phase-1 migration plan".into(),
+            plan: Some(ApprovalPlanWire {
+                summary: "phase-1 migration plan".into(),
+                rationale: Some("prep before workers fan out".into()),
+                resources: vec!["3 worktrees".into()],
+                risks: vec![],
+                rollback: Some("no changes land yet".into()),
+            }),
+            kind: ApprovalKind::Plan,
+        };
+        assert_eq!(roundtrip_event(&ev3), ev3);
+    }
+
+    #[test]
+    fn approval_kind_defaults_and_omits_on_serialize() {
+        // Absence of `kind` on the wire must deserialize to Action.
+        let raw = r#"{"event":"approval_request","request_id":"r","task_id":"lead","summary":"s"}"#;
+        let ev: ControlEvent = serde_json::from_str(raw).unwrap();
+        match ev {
+            ControlEvent::ApprovalRequest { kind, .. } => {
+                assert_eq!(kind, ApprovalKind::Action);
+            }
+            _ => panic!("expected ApprovalRequest"),
+        }
+
+        // Default Action must be omitted on serialize (backward compat).
+        let ev = ControlEvent::ApprovalRequest {
+            request_id: "r".into(),
+            task_id: "lead".into(),
+            summary: "s".into(),
+            plan: None,
+            kind: ApprovalKind::Action,
+        };
+        let s = serde_json::to_string(&ev).unwrap();
+        assert!(!s.contains("\"kind\""), "default kind must be elided: {s}");
+
+        // Non-default Plan must appear.
+        let ev = ControlEvent::ApprovalRequest {
+            request_id: "r".into(),
+            task_id: "lead".into(),
+            summary: "s".into(),
+            plan: None,
+            kind: ApprovalKind::Plan,
+        };
+        let s = serde_json::to_string(&ev).unwrap();
+        assert!(
+            s.contains("\"kind\":\"plan\""),
+            "plan kind must be set: {s}"
+        );
     }
 
     #[test]

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -822,6 +822,7 @@ mod tests {
             approval_policy: None,
             notifications: vec![],
             dump_shared_store: false,
+            require_plan_approval: false,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -213,6 +213,7 @@ async fn serve_connection(
                 task_id: q.task_id,
                 summary: q.summary,
                 plan: q.plan.map(crate::mcp::approval::approval_plan_to_wire),
+                kind: q.kind,
             });
         }
     }

--- a/crates/pitboss-cli/src/dispatch/resume.rs
+++ b/crates/pitboss-cli/src/dispatch/resume.rs
@@ -421,6 +421,7 @@ mod tests {
             approval_policy: None,
             notifications: vec![],
             dump_shared_store: false,
+            require_plan_approval: false,
         };
         std::fs::write(
             run_dir.join("resolved.json"),
@@ -515,6 +516,7 @@ mod tests {
             approval_policy: None,
             notifications: vec![],
             dump_shared_store: false,
+            require_plan_approval: false,
         };
         std::fs::write(
             run_dir.join("resolved.json"),

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -567,6 +567,7 @@ mod tests {
             approval_policy: None,
             notifications: vec![],
             dump_shared_store: false,
+            require_plan_approval: false,
         };
 
         // Script: first call succeeds, second call fails. FakeSpawner is single-shot,
@@ -653,6 +654,7 @@ mod tests {
             approval_policy: None,
             notifications: vec![],
             dump_shared_store: false,
+            require_plan_approval: false,
         };
 
         let spawner = Arc::new(CyclingFake(
@@ -752,6 +754,7 @@ mod tests {
             approval_policy: None,
             notifications: vec![],
             dump_shared_store: false,
+            require_plan_approval: false,
         };
 
         let spawner = Arc::new(CyclingFake(

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -91,6 +91,10 @@ pub struct QueuedApproval {
     /// for simple summary-only approvals, so pre-v0.4.5 queuers still
     /// round-trip through this struct without issue.
     pub plan: Option<crate::mcp::tools::ApprovalPlan>,
+    /// Discriminator between in-flight action approvals and pre-flight
+    /// plan approvals. Carried through the queue so the TUI renders
+    /// the right modal header when the queue drains.
+    pub kind: crate::control::protocol::ApprovalKind,
     pub responder: oneshot::Sender<ApprovalResponse>,
 }
 
@@ -165,6 +169,13 @@ pub struct DispatchState {
     /// after we've already moved the handle). Value 0 means "not yet
     /// spawned" (pre-init) — callers skip signaling in that state.
     pub worker_pids: RwLock<HashMap<String, std::sync::Arc<std::sync::atomic::AtomicU32>>>,
+    /// Plan-approval gate. Starts `false`. Flipped to `true` when
+    /// `propose_plan` returns an approved response. `spawn_worker`
+    /// checks this atomic when `manifest.require_plan_approval` is set
+    /// and bails with a helpful error until the operator approves.
+    /// Always `false` when `require_plan_approval` is off; nothing
+    /// reads it in that case.
+    pub plan_approved: std::sync::atomic::AtomicBool,
 }
 
 impl DispatchState {
@@ -212,6 +223,7 @@ impl DispatchState {
             notification_router,
             shared_store,
             worker_pids: RwLock::new(HashMap::new()),
+            plan_approved: std::sync::atomic::AtomicBool::new(false),
         }
     }
 

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -264,6 +264,7 @@ mod tests {
             approval_policy: None,
             notifications: vec![],
             dump_shared_store: false,
+            require_plan_approval: false,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/src/manifest/resolve.rs
+++ b/crates/pitboss-cli/src/manifest/resolve.rs
@@ -66,6 +66,10 @@ pub struct ResolvedManifest {
     // NEW in v0.4.2:
     #[serde(default)]
     pub dump_shared_store: bool,
+    // NEW in v0.4.5 — when true, gate `spawn_worker` on an approved
+    // plan submitted via the `propose_plan` MCP tool.
+    #[serde(default)]
+    pub require_plan_approval: bool,
 }
 
 const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
@@ -125,6 +129,7 @@ pub fn resolve(manifest: Manifest, env_max_parallel: Option<u32>) -> Result<Reso
         approval_policy: manifest.run.approval_policy,
         notifications,
         dump_shared_store: manifest.run.dump_shared_store,
+        require_plan_approval: manifest.run.require_plan_approval,
     })
 }
 

--- a/crates/pitboss-cli/src/manifest/schema.rs
+++ b/crates/pitboss-cli/src/manifest/schema.rs
@@ -50,6 +50,12 @@ pub struct RunConfig {
     // NEW in v0.4.2 — write shared-store.json on finalize for post-mortem.
     #[serde(default)]
     pub dump_shared_store: bool,
+
+    // NEW in v0.4.5 — when true, the lead must call `propose_plan` and have
+    // the resulting plan approved before any `spawn_worker` call succeeds.
+    // Default off so existing runs behave unchanged.
+    #[serde(default)]
+    pub require_plan_approval: bool,
 }
 
 impl Default for RunConfig {
@@ -65,6 +71,7 @@ impl Default for RunConfig {
             lead_timeout_secs: None,
             approval_policy: None,
             dump_shared_store: false,
+            require_plan_approval: false,
         }
     }
 }
@@ -282,6 +289,35 @@ mod tests {
             m.run.approval_policy,
             Some(crate::dispatch::state::ApprovalPolicy::AutoApprove)
         );
+    }
+
+    #[test]
+    fn parses_require_plan_approval() {
+        let toml_src = r#"
+            [run]
+            require_plan_approval = true
+
+            [[lead]]
+            id = "triage"
+            directory = "/tmp"
+            prompt = "p"
+        "#;
+        let m: Manifest = toml::from_str(toml_src).unwrap();
+        assert!(m.run.require_plan_approval);
+    }
+
+    #[test]
+    fn require_plan_approval_defaults_false() {
+        let toml_src = r#"
+            [run]
+
+            [[task]]
+            id = "x"
+            directory = "/tmp"
+            prompt = "p"
+        "#;
+        let m: Manifest = toml::from_str(toml_src).unwrap();
+        assert!(!m.run.require_plan_approval);
     }
 
     #[test]

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -247,6 +247,7 @@ mod tests {
             approval_policy: None,
             notifications: vec![],
             dump_shared_store: false,
+            require_plan_approval: false,
         }
     }
 
@@ -269,6 +270,7 @@ mod tests {
             approval_policy: None,
             notifications: vec![],
             dump_shared_store: false,
+            require_plan_approval: false,
         };
         f(&mut m);
         m
@@ -347,6 +349,7 @@ mod tests {
             approval_policy: None,
             notifications: vec![],
             dump_shared_store: false,
+            require_plan_approval: false,
         };
         let err = validate(&r).unwrap_err().to_string();
         assert!(
@@ -372,6 +375,7 @@ mod tests {
             approval_policy: None,
             notifications: vec![],
             dump_shared_store: false,
+            require_plan_approval: false,
         };
         let err = validate(&r).unwrap_err().to_string();
         assert!(err.contains("max_workers"), "got: {err}");
@@ -394,6 +398,7 @@ mod tests {
             approval_policy: None,
             notifications: vec![],
             dump_shared_store: false,
+            require_plan_approval: false,
         };
         assert!(validate(&r).is_err());
     }
@@ -415,6 +420,7 @@ mod tests {
             approval_policy: None,
             notifications: vec![],
             dump_shared_store: false,
+            require_plan_approval: false,
         };
         assert!(validate(&r).is_err());
     }
@@ -435,6 +441,7 @@ mod tests {
             approval_policy: None,
             notifications: vec![],
             dump_shared_store: false,
+            require_plan_approval: false,
         };
         let err = validate(&r).unwrap_err().to_string();
         assert!(err.contains("empty manifest"), "got: {err}");

--- a/crates/pitboss-cli/src/mcp/approval.rs
+++ b/crates/pitboss-cli/src/mcp/approval.rs
@@ -58,11 +58,15 @@ impl ApprovalBridge {
     /// responds, (b) the policy auto-resolves, or (c) `timeout` elapses.
     /// `plan` carries the typed structured fields (rationale, resources,
     /// risks, rollback); pass `None` for simple summary-only approvals.
+    /// `kind` distinguishes `request_approval` (in-flight, `Action`) from
+    /// `propose_plan` (pre-flight, `Plan`) — passed through to the TUI
+    /// modal so the operator can tell them apart.
     pub async fn request(
         &self,
         task_id: String,
         summary: String,
         plan: Option<crate::mcp::tools::ApprovalPlan>,
+        kind: crate::control::protocol::ApprovalKind,
         timeout: Duration,
     ) -> Result<ApprovalResponse, ApprovalError> {
         let request_id = format!("req-{}", Uuid::now_v7());
@@ -109,6 +113,7 @@ impl ApprovalBridge {
                     task_id,
                     summary,
                     plan: plan.map(approval_plan_to_wire),
+                    kind,
                 };
                 // Best-effort send.
                 let _ = w.send(ev);
@@ -141,6 +146,7 @@ impl ApprovalBridge {
                             task_id,
                             summary,
                             plan,
+                            kind,
                             responder: tx,
                         });
                 }
@@ -268,6 +274,7 @@ mod tests {
                 "lead".into(),
                 "spawn 2".into(),
                 None,
+                crate::control::protocol::ApprovalKind::Action,
                 Duration::from_secs(1),
             )
             .await
@@ -284,6 +291,7 @@ mod tests {
                 "lead".into(),
                 "spawn 2".into(),
                 None,
+                crate::control::protocol::ApprovalKind::Action,
                 Duration::from_secs(1),
             )
             .await
@@ -301,6 +309,7 @@ mod tests {
                 "lead".into(),
                 "spawn 2".into(),
                 None,
+                crate::control::protocol::ApprovalKind::Action,
                 Duration::from_millis(50),
             )
             .await

--- a/crates/pitboss-cli/src/mcp/approval.rs
+++ b/crates/pitboss-cli/src/mcp/approval.rs
@@ -235,6 +235,7 @@ mod tests {
             approval_policy: Some(policy),
             notifications: vec![],
             dump_shared_store: false,
+            require_plan_approval: false,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -563,6 +563,7 @@ mod tests {
             approval_policy: None,
             notifications: vec![],
             dump_shared_store: false,
+            require_plan_approval: false,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();
@@ -626,6 +627,7 @@ mod tests {
             approval_policy: None,
             notifications: vec![],
             dump_shared_store: false,
+            require_plan_approval: false,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -18,10 +18,10 @@ use rmcp::{tool, tool_handler, tool_router, ErrorData, ServerHandler};
 use crate::dispatch::state::DispatchState;
 use crate::mcp::tools::{
     handle_cancel_worker, handle_continue_worker, handle_list_workers, handle_pause_worker,
-    handle_reprompt_worker, handle_request_approval, handle_spawn_worker, handle_wait_for_any,
-    handle_wait_for_worker, handle_worker_status, ContinueWorkerArgs, PauseWorkerArgs,
-    RepromptWorkerArgs, RequestApprovalArgs, SpawnWorkerArgs, TaskIdArgs, WaitForAnyArgs,
-    WaitForWorkerArgs,
+    handle_propose_plan, handle_reprompt_worker, handle_request_approval, handle_spawn_worker,
+    handle_wait_for_any, handle_wait_for_worker, handle_worker_status, ContinueWorkerArgs,
+    PauseWorkerArgs, ProposePlanArgs, RepromptWorkerArgs, RequestApprovalArgs, SpawnWorkerArgs,
+    TaskIdArgs, WaitForAnyArgs, WaitForWorkerArgs,
 };
 
 /// Compute the socket path for a given run. Falls back to the run_dir if
@@ -222,6 +222,19 @@ impl PitbossHandler {
         Parameters(args): Parameters<RequestApprovalArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         match handle_request_approval(&self.state, args).await {
+            Ok(res) => to_structured_result(&res),
+            Err(e) => Err(ErrorData::invalid_request(e.to_string(), None)),
+        }
+    }
+
+    #[tool(
+        description = "Propose a full execution plan for pre-flight operator approval. When [run].require_plan_approval=true, spawn_worker is blocked until a plan submitted via this tool is approved. Plan carries typed rationale/resources/risks/rollback for structured review. Blocks until operator responds or timeout. Distinct from request_approval, which gates individual in-flight actions."
+    )]
+    async fn propose_plan(
+        &self,
+        Parameters(args): Parameters<ProposePlanArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        match handle_propose_plan(&self.state, args).await {
             Ok(res) => to_structured_result(&res),
             Err(e) => Err(ErrorData::invalid_request(e.to_string(), None)),
         }

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -1216,7 +1216,13 @@ pub async fn handle_request_approval(
     );
     let bridge = crate::mcp::approval::ApprovalBridge::new(Arc::clone(state));
     match bridge
-        .request(state.lead_id.clone(), args.summary, args.plan, timeout)
+        .request(
+            state.lead_id.clone(),
+            args.summary,
+            args.plan,
+            crate::control::protocol::ApprovalKind::Action,
+            timeout,
+        )
         .await
     {
         Ok(resp) => Ok(ApprovalToolResponse {

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -1373,6 +1373,7 @@ mod tests {
             approval_policy: None,
             notifications: vec![],
             dump_shared_store: false,
+            require_plan_approval: false,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();
@@ -1748,6 +1749,7 @@ mod tests {
             approval_policy: None,
             notifications: vec![],
             dump_shared_store: false,
+            require_plan_approval: false,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();
@@ -2335,6 +2337,7 @@ mod tests {
             approval_policy: Some(ApprovalPolicy::AutoApprove),
             notifications: vec![],
             dump_shared_store: false,
+            require_plan_approval: false,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let script = FakeScript::new().hold_until_signal();

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -245,6 +245,24 @@ pub struct ApprovalToolResponse {
     pub edited_summary: Option<String>,
 }
 
+/// Arguments for `propose_plan`: the lead submits a full execution plan
+/// for operator pre-flight approval. Gated by `[run].require_plan_approval`.
+/// When that flag is off, calling `propose_plan` is harmless — the plan
+/// is approved via the usual modal/policy path, but `spawn_worker` never
+/// checks the result.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ProposePlanArgs {
+    /// The typed plan to review. `summary` is required; the rest
+    /// (rationale / resources / risks / rollback) is optional but
+    /// strongly recommended — the whole point of pre-flight approval is
+    /// that the operator can evaluate *before* workers start.
+    pub plan: ApprovalPlan,
+    /// Optional per-request timeout override. Falls back to
+    /// `lead_timeout_secs`.
+    #[serde(default)]
+    pub timeout_secs: Option<u64>,
+}
+
 use std::sync::Arc;
 
 use anyhow::{bail, Result};
@@ -261,6 +279,22 @@ pub async fn handle_spawn_worker(
     // Guard 1: draining
     if state.cancel.is_draining() || state.cancel.is_terminated() {
         bail!("run is draining: no new workers accepted");
+    }
+
+    // Guard 1b: plan approval. When the manifest opts in with
+    // `[run].require_plan_approval = true`, the lead must call
+    // `propose_plan` and get operator approval before any worker
+    // dispatches. The check happens here rather than earlier so draining
+    // runs still short-circuit with their clearer error.
+    if state.manifest.require_plan_approval
+        && !state
+            .plan_approved
+            .load(std::sync::atomic::Ordering::Acquire)
+    {
+        bail!(
+            "plan approval required: call `propose_plan` and wait for \
+             operator approval before spawning workers"
+        );
     }
 
     // Guard 2: worker cap
@@ -1231,6 +1265,54 @@ pub async fn handle_request_approval(
             edited_summary: resp.edited_summary,
         }),
         Err(e) => anyhow::bail!("approval failed: {e}"),
+    }
+}
+
+/// Handle `propose_plan`: the lead submits a full execution plan for
+/// pre-flight operator approval, distinct from `request_approval`'s
+/// in-flight per-action gating. Flips `state.plan_approved` to true on
+/// approval; leaves it false on rejection (lead can revise and retry).
+///
+/// Returns the same `ApprovalToolResponse` shape as `request_approval`
+/// so leads can share response-handling code — they just dispatch on
+/// the tool name.
+pub async fn handle_propose_plan(
+    state: &Arc<DispatchState>,
+    args: ProposePlanArgs,
+) -> Result<ApprovalToolResponse> {
+    let timeout = Duration::from_secs(
+        args.timeout_secs
+            .or(state.manifest.lead_timeout_secs)
+            .unwrap_or(3600),
+    );
+    // Reuse the summary from the plan as the modal headline — a plan
+    // approval without the structured fields would be useless, but the
+    // summary still anchors the audit trail.
+    let summary = args.plan.summary.clone();
+    let bridge = crate::mcp::approval::ApprovalBridge::new(Arc::clone(state));
+    match bridge
+        .request(
+            state.lead_id.clone(),
+            summary,
+            Some(args.plan),
+            crate::control::protocol::ApprovalKind::Plan,
+            timeout,
+        )
+        .await
+    {
+        Ok(resp) => {
+            if resp.approved {
+                state
+                    .plan_approved
+                    .store(true, std::sync::atomic::Ordering::Release);
+            }
+            Ok(ApprovalToolResponse {
+                approved: resp.approved,
+                comment: resp.comment,
+                edited_summary: resp.edited_summary,
+            })
+        }
+        Err(e) => anyhow::bail!("plan approval failed: {e}"),
     }
 }
 
@@ -2378,5 +2460,185 @@ mod tests {
         .await
         .unwrap();
         assert!(resp.approved);
+    }
+
+    /// Build a `DispatchState` with the specified approval policy and
+    /// `require_plan_approval` flag. Mirrors `handle_request_approval_auto_approves`
+    /// test scaffolding but parameterized so plan-approval tests can share it.
+    async fn mk_plan_state(
+        policy: crate::dispatch::state::ApprovalPolicy,
+        require_plan_approval: bool,
+    ) -> Arc<DispatchState> {
+        use crate::dispatch::state::ApprovalPolicy;
+        use crate::manifest::resolve::{ResolvedLead, ResolvedManifest};
+        use crate::manifest::schema::{Effort, WorktreeCleanup};
+        use pitboss_core::process::fake::{FakeScript, FakeSpawner};
+        use pitboss_core::process::ProcessSpawner;
+        use pitboss_core::session::CancelToken;
+        use pitboss_core::store::{JsonFileStore, SessionStore};
+        use pitboss_core::worktree::{CleanupPolicy, WorktreeManager};
+        use std::path::PathBuf;
+        use tempfile::TempDir;
+        use uuid::Uuid;
+        let _ = ApprovalPolicy::Block; // silence unused-variant warning on import
+
+        let dir = TempDir::new().unwrap();
+        let lead = ResolvedLead {
+            id: "lead".into(),
+            directory: PathBuf::from("/tmp"),
+            prompt: "p".into(),
+            branch: None,
+            model: "claude-haiku-4-5".into(),
+            effort: Effort::High,
+            tools: vec![],
+            timeout_secs: 60,
+            use_worktree: false,
+            env: Default::default(),
+            resume_session_id: None,
+        };
+        let manifest = ResolvedManifest {
+            max_parallel: 4,
+            halt_on_failure: false,
+            run_dir: dir.path().to_path_buf(),
+            worktree_cleanup: WorktreeCleanup::OnSuccess,
+            emit_event_stream: false,
+            tasks: vec![],
+            lead: Some(lead),
+            max_workers: Some(4),
+            budget_usd: Some(1.0),
+            lead_timeout_secs: None,
+            approval_policy: Some(policy),
+            notifications: vec![],
+            dump_shared_store: false,
+            require_plan_approval,
+        };
+        let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
+        let script = FakeScript::new().hold_until_signal();
+        let spawner: Arc<dyn ProcessSpawner> = Arc::new(FakeSpawner::new(script));
+        let wt_mgr = Arc::new(WorktreeManager::new());
+        let run_id = Uuid::now_v7();
+        let run_subdir = dir.path().join(run_id.to_string());
+        std::mem::forget(dir);
+        Arc::new(DispatchState::new(
+            run_id,
+            manifest,
+            store,
+            CancelToken::new(),
+            "lead".into(),
+            spawner,
+            PathBuf::from("claude"),
+            wt_mgr,
+            CleanupPolicy::Never,
+            run_subdir,
+            policy,
+            None,
+            std::sync::Arc::new(crate::shared_store::SharedStore::new()),
+        ))
+    }
+
+    #[tokio::test]
+    async fn spawn_worker_blocks_when_plan_not_approved() {
+        let state = mk_plan_state(crate::dispatch::state::ApprovalPolicy::AutoApprove, true).await;
+        // plan_approved starts false; even with AutoApprove policy for
+        // per-action approvals, spawn_worker must refuse until a plan
+        // has actually been approved.
+        let err = handle_spawn_worker(
+            &state,
+            SpawnWorkerArgs {
+                prompt: "do work".into(),
+                directory: None,
+                branch: None,
+                tools: None,
+                timeout_secs: None,
+                model: None,
+            },
+        )
+        .await
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("plan approval required"),
+            "expected plan-approval error, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_worker_allowed_when_require_plan_approval_off() {
+        // Default behavior: runs without the opt-in flag never gate on
+        // plan_approved. Whether the spawn ultimately succeeds or fails
+        // depends on unrelated state we don't exercise here — we only
+        // assert that the plan-approval guard itself doesn't fire.
+        let state = mk_plan_state(crate::dispatch::state::ApprovalPolicy::AutoApprove, false).await;
+        let res = handle_spawn_worker(
+            &state,
+            SpawnWorkerArgs {
+                prompt: "do work".into(),
+                directory: None,
+                branch: None,
+                tools: None,
+                timeout_secs: None,
+                model: None,
+            },
+        )
+        .await;
+        match res {
+            Ok(_) => {} // guard correctly skipped
+            Err(e) => assert!(
+                !e.to_string().contains("plan approval required"),
+                "plan-approval guard should not fire when require_plan_approval=false, got: {e}"
+            ),
+        }
+    }
+
+    #[tokio::test]
+    async fn propose_plan_auto_approve_flips_flag() {
+        let state = mk_plan_state(crate::dispatch::state::ApprovalPolicy::AutoApprove, true).await;
+        assert!(!state
+            .plan_approved
+            .load(std::sync::atomic::Ordering::Acquire));
+
+        let resp = handle_propose_plan(
+            &state,
+            ProposePlanArgs {
+                plan: ApprovalPlan {
+                    summary: "phase-1".into(),
+                    rationale: Some("prep".into()),
+                    resources: vec!["3 worktrees".into()],
+                    risks: vec![],
+                    rollback: Some("none".into()),
+                },
+                timeout_secs: Some(2),
+            },
+        )
+        .await
+        .unwrap();
+        assert!(resp.approved);
+        assert!(state
+            .plan_approved
+            .load(std::sync::atomic::Ordering::Acquire));
+    }
+
+    #[tokio::test]
+    async fn propose_plan_auto_reject_leaves_flag_false() {
+        let state = mk_plan_state(crate::dispatch::state::ApprovalPolicy::AutoReject, true).await;
+        let resp = handle_propose_plan(
+            &state,
+            ProposePlanArgs {
+                plan: ApprovalPlan {
+                    summary: "phase-1".into(),
+                    ..Default::default()
+                },
+                timeout_secs: Some(2),
+            },
+        )
+        .await
+        .unwrap();
+        assert!(!resp.approved);
+        assert!(
+            !state
+                .plan_approved
+                .load(std::sync::atomic::Ordering::Acquire),
+            "rejected plan must not flip plan_approved — lead should be able to retry"
+        );
     }
 }

--- a/crates/pitboss-cli/tests/control_flows.rs
+++ b/crates/pitboss-cli/tests/control_flows.rs
@@ -334,3 +334,172 @@ async fn auto_reject_policy_responds_without_tui() {
     assert!(!resp.approved);
     assert_eq!(resp.comment.as_deref(), Some("no operator available"));
 }
+
+#[tokio::test]
+async fn propose_plan_end_to_end_unblocks_spawn_gate() {
+    use pitboss_cli::control::protocol::{ApprovalKind, ApprovalPlanWire};
+    use pitboss_cli::mcp::tools::{
+        handle_propose_plan, handle_spawn_worker, ApprovalPlan, ProposePlanArgs, SpawnWorkerArgs,
+    };
+    use std::time::Duration;
+
+    let dir = TempDir::new().unwrap();
+    let run_id = uuid::Uuid::now_v7();
+    let run_subdir = dir.path().join(run_id.to_string());
+    tokio::fs::create_dir_all(&run_subdir).await.unwrap();
+    let manifest = ResolvedManifest {
+        max_parallel: 4,
+        halt_on_failure: false,
+        run_dir: dir.path().to_path_buf(),
+        worktree_cleanup: WorktreeCleanup::OnSuccess,
+        emit_event_stream: false,
+        tasks: vec![],
+        lead: None,
+        max_workers: Some(4),
+        budget_usd: Some(1.0),
+        lead_timeout_secs: None,
+        approval_policy: Some(ApprovalPolicy::Block),
+        notifications: vec![],
+        dump_shared_store: false,
+        require_plan_approval: true,
+    };
+    let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
+    let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
+    let wt_mgr = Arc::new(WorktreeManager::new());
+    let state = Arc::new(DispatchState::new(
+        run_id,
+        manifest,
+        store,
+        CancelToken::new(),
+        "lead".into(),
+        spawner,
+        PathBuf::from("/bin/true"),
+        wt_mgr,
+        CleanupPolicy::Never,
+        run_subdir,
+        ApprovalPolicy::Block,
+        None,
+        std::sync::Arc::new(pitboss_cli::shared_store::SharedStore::new()),
+    ));
+
+    // Baseline: spawn_worker is gated.
+    let err = handle_spawn_worker(
+        &state,
+        SpawnWorkerArgs {
+            prompt: "early work".into(),
+            directory: None,
+            branch: None,
+            tools: None,
+            timeout_secs: None,
+            model: None,
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(err.to_string().contains("plan approval required"));
+
+    // Boot the control server so an operator can attach.
+    let sock = dir.path().join("plan-approval.sock");
+    let _h = pitboss_cli::control::server::start_control_server(
+        sock.clone(),
+        "0.4.5".into(),
+        run_id.to_string(),
+        "hierarchical".into(),
+        state.clone(),
+    )
+    .await
+    .unwrap();
+    let mut client = fake_control_client::FakeControlClient::connect(&sock, "0.4.5")
+        .await
+        .unwrap();
+
+    // Drive the lead's propose_plan call on a background task.
+    let state_for_plan = state.clone();
+    let plan_handle = tokio::spawn(async move {
+        handle_propose_plan(
+            &state_for_plan,
+            ProposePlanArgs {
+                plan: ApprovalPlan {
+                    summary: "phase-1 migration".into(),
+                    rationale: Some("prep worktrees before fan-out".into()),
+                    resources: vec!["3 worktrees off main".into()],
+                    risks: vec![],
+                    rollback: Some("drop worktrees; nothing committed".into()),
+                },
+                timeout_secs: Some(5),
+            },
+        )
+        .await
+    });
+
+    // Expect the TUI to receive an ApprovalRequest with kind=Plan.
+    let ev = client
+        .recv_timeout(Duration::from_secs(2))
+        .await
+        .unwrap()
+        .expect("approval_request event");
+    let (request_id, kind, plan) = match ev {
+        ControlEvent::ApprovalRequest {
+            request_id,
+            kind,
+            plan,
+            ..
+        } => (request_id, kind, plan),
+        other => panic!("expected ApprovalRequest, got {other:?}"),
+    };
+    assert_eq!(kind, ApprovalKind::Plan);
+    let plan = plan.expect("plan-kind requests must carry a structured plan");
+    assert_eq!(
+        plan,
+        ApprovalPlanWire {
+            summary: "phase-1 migration".into(),
+            rationale: Some("prep worktrees before fan-out".into()),
+            resources: vec!["3 worktrees off main".into()],
+            risks: vec![],
+            rollback: Some("drop worktrees; nothing committed".into()),
+        }
+    );
+
+    // Operator approves.
+    client
+        .send(&ControlOp::Approve {
+            request_id,
+            approved: true,
+            comment: None,
+            edited_summary: None,
+        })
+        .await
+        .unwrap();
+
+    let resp = tokio::time::timeout(Duration::from_secs(3), plan_handle)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert!(resp.approved);
+    assert!(state
+        .plan_approved
+        .load(std::sync::atomic::Ordering::Acquire));
+
+    // Now spawn_worker no longer hits the plan-approval gate. It may
+    // fail downstream (no git worktree set up) but the failure must not
+    // be the plan-approval one.
+    let res = handle_spawn_worker(
+        &state,
+        SpawnWorkerArgs {
+            prompt: "post-approval work".into(),
+            directory: None,
+            branch: None,
+            tools: None,
+            timeout_secs: None,
+            model: None,
+        },
+    )
+    .await;
+    if let Err(e) = &res {
+        assert!(
+            !e.to_string().contains("plan approval required"),
+            "plan-approval gate still firing after approval: {e}"
+        );
+    }
+}

--- a/crates/pitboss-cli/tests/control_flows.rs
+++ b/crates/pitboss-cli/tests/control_flows.rs
@@ -167,6 +167,7 @@ async fn block_policy_queue_drains_on_tui_connect() {
                 "lead".into(),
                 "spawn 3".into(),
                 None,
+                pitboss_cli::control::protocol::ApprovalKind::Action,
                 Duration::from_secs(5),
             )
             .await
@@ -270,6 +271,7 @@ async fn auto_approve_policy_responds_without_tui() {
             "lead".into(),
             "spawn".into(),
             None,
+            pitboss_cli::control::protocol::ApprovalKind::Action,
             Duration::from_millis(200),
         )
         .await
@@ -324,6 +326,7 @@ async fn auto_reject_policy_responds_without_tui() {
             "lead".into(),
             "spawn".into(),
             None,
+            pitboss_cli::control::protocol::ApprovalKind::Action,
             Duration::from_millis(200),
         )
         .await

--- a/crates/pitboss-cli/tests/control_flows.rs
+++ b/crates/pitboss-cli/tests/control_flows.rs
@@ -48,6 +48,7 @@ async fn pause_op_writes_events_jsonl() {
         approval_policy: Some(ApprovalPolicy::Block),
         notifications: vec![],
         dump_shared_store: false,
+        require_plan_approval: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -135,6 +136,7 @@ async fn block_policy_queue_drains_on_tui_connect() {
         approval_policy: Some(ApprovalPolicy::Block),
         notifications: vec![],
         dump_shared_store: false,
+        require_plan_approval: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -240,6 +242,7 @@ async fn auto_approve_policy_responds_without_tui() {
         approval_policy: Some(ApprovalPolicy::AutoApprove),
         notifications: vec![],
         dump_shared_store: false,
+        require_plan_approval: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -293,6 +296,7 @@ async fn auto_reject_policy_responds_without_tui() {
         approval_policy: Some(ApprovalPolicy::AutoReject),
         notifications: vec![],
         dump_shared_store: false,
+        require_plan_approval: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());

--- a/crates/pitboss-cli/tests/e2e_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_flows.rs
@@ -67,6 +67,7 @@ fn mk_state(
         approval_policy: Some(approval_policy),
         notifications: vec![],
         dump_shared_store: false,
+        require_plan_approval: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(run_dir.to_path_buf()));
     // Worker-side spawner: emits a complete stream-json run then exits 0.
@@ -310,6 +311,7 @@ async fn e2e_lead_cancels_worker_mid_flight() {
         approval_policy: Some(ApprovalPolicy::Block),
         notifications: vec![],
         dump_shared_store: false,
+        require_plan_approval: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let hold_script = FakeScript::new().hold_until_signal();
@@ -548,6 +550,7 @@ async fn e2e_lead_reprompts_running_worker() {
         approval_policy: Some(ApprovalPolicy::Block),
         notifications: vec![],
         dump_shared_store: false,
+        require_plan_approval: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     // Worker script emits init+result so session_id gets captured via the

--- a/crates/pitboss-cli/tests/hierarchical_flows.rs
+++ b/crates/pitboss-cli/tests/hierarchical_flows.rs
@@ -50,6 +50,7 @@ fn mk_state() -> (TempDir, Arc<DispatchState>) {
         approval_policy: None,
         notifications: vec![],
         dump_shared_store: false,
+        require_plan_approval: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/tests/shared_store_flows.rs
+++ b/crates/pitboss-cli/tests/shared_store_flows.rs
@@ -452,6 +452,7 @@ async fn lease_released_when_mcp_connection_drops() {
         approval_policy: None,
         notifications: vec![],
         dump_shared_store: false,
+        require_plan_approval: false,
     };
     let store_trait: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().into()));
     let run_id = Uuid::now_v7();

--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -474,12 +474,14 @@ fn apply_control_event(state: &mut AppState, ev: pitboss_cli::control::protocol:
             task_id,
             summary,
             plan,
+            kind,
         } => {
             state.mode = Mode::ApprovalModal {
                 request_id,
                 task_id,
                 summary,
                 plan,
+                kind,
                 sub_mode: crate::state::ApprovalSubMode::Overview,
             };
         }
@@ -569,6 +571,7 @@ struct ApprovalCtx {
     task_id: String,
     summary: String,
     plan: Option<pitboss_cli::control::protocol::ApprovalPlanWire>,
+    kind: pitboss_cli::control::protocol::ApprovalKind,
 }
 
 fn handle_approval_modal(state: &mut AppState, code: KeyCode, modifiers: KeyModifiers) -> Action {
@@ -578,6 +581,7 @@ fn handle_approval_modal(state: &mut AppState, code: KeyCode, modifiers: KeyModi
         task_id,
         summary,
         plan,
+        kind,
         sub_mode,
     } = state.mode.clone()
     else {
@@ -588,6 +592,7 @@ fn handle_approval_modal(state: &mut AppState, code: KeyCode, modifiers: KeyModi
         task_id,
         summary,
         plan,
+        kind,
     };
 
     match sub_mode {
@@ -615,6 +620,7 @@ fn handle_approval_overview(state: &mut AppState, code: KeyCode, ctx: ApprovalCt
                 task_id: ctx.task_id,
                 summary: ctx.summary,
                 plan: ctx.plan,
+                kind: ctx.kind,
                 sub_mode: ApprovalSubMode::Rejecting {
                     draft: String::new(),
                 },
@@ -627,6 +633,7 @@ fn handle_approval_overview(state: &mut AppState, code: KeyCode, ctx: ApprovalCt
                 task_id: ctx.task_id,
                 summary: ctx.summary,
                 plan: ctx.plan,
+                kind: ctx.kind,
                 sub_mode: ApprovalSubMode::Editing { draft },
             };
         }
@@ -680,6 +687,7 @@ fn handle_approval_draft(
         task_id: ctx.task_id,
         summary: ctx.summary,
         plan: ctx.plan,
+        kind: ctx.kind,
         sub_mode,
     };
 }

--- a/crates/pitboss-tui/src/state.rs
+++ b/crates/pitboss-tui/src/state.rs
@@ -48,6 +48,11 @@ pub enum Mode {
         task_id: String,
         summary: String,
         plan: Option<pitboss_cli::control::protocol::ApprovalPlanWire>,
+        /// `Action` = in-flight approval from `request_approval`;
+        /// `Plan` = pre-flight approval from `propose_plan`. Drives the
+        /// modal header badge so operators can tell them apart without
+        /// reading the summary.
+        kind: pitboss_cli::control::protocol::ApprovalKind,
         sub_mode: ApprovalSubMode,
     },
 }
@@ -1175,6 +1180,7 @@ mod tests {
             task_id: "lead".into(),
             summary: "spawn 3".into(),
             plan: None,
+            kind: pitboss_cli::control::protocol::ApprovalKind::Action,
             sub_mode: ApprovalSubMode::Overview,
         };
         assert!(matches!(m, Mode::ApprovalModal { .. }));
@@ -1192,6 +1198,7 @@ mod tests {
             task_id: "lead".into(),
             summary: "delete idx".into(),
             plan: Some(plan),
+            kind: pitboss_cli::control::protocol::ApprovalKind::Action,
             sub_mode: ApprovalSubMode::Overview,
         };
         if let Mode::ApprovalModal { plan, .. } = m2 {
@@ -1226,6 +1233,7 @@ mod tests {
             task_id: "lead".into(),
             summary: "spawn 3".into(),
             plan: None,
+            kind: pitboss_cli::control::protocol::ApprovalKind::Action,
             sub_mode: ApprovalSubMode::Overview,
         };
         // Direct transition — we don't call into app::handle_* here to avoid

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -243,6 +243,7 @@ pub fn render(frame: &mut Frame, state: &AppState) {
             task_id,
             summary,
             plan,
+            kind,
             sub_mode,
         } => render_approval_modal(
             frame,
@@ -251,6 +252,7 @@ pub fn render(frame: &mut Frame, state: &AppState) {
             task_id,
             summary,
             plan.as_ref(),
+            *kind,
             sub_mode,
         ),
         Mode::Normal | Mode::Detail { .. } => {}
@@ -1150,6 +1152,7 @@ fn render_approval_modal(
     task_id: &str,
     summary: &str,
     plan: Option<&pitboss_cli::control::protocol::ApprovalPlanWire>,
+    kind: pitboss_cli::control::protocol::ApprovalKind,
     sub_mode: &crate::state::ApprovalSubMode,
 ) {
     use crate::state::ApprovalSubMode;
@@ -1159,12 +1162,20 @@ fn render_approval_modal(
     let y = area.y + area.height.saturating_sub(modal_h) / 2;
     let modal = Rect::new(x, y, modal_w, modal_h);
     frame.render_widget(Clear, modal);
+    // Badge distinguishes pre-flight plan approvals from in-flight action
+    // approvals. Operators reading the modal need to know whether
+    // approving unblocks the *run* (Plan) or a *single action* (Action).
+    let badge = match kind {
+        pitboss_cli::control::protocol::ApprovalKind::Plan => "PRE-FLIGHT PLAN",
+        pitboss_cli::control::protocol::ApprovalKind::Action => "IN-FLIGHT ACTION",
+    };
     match sub_mode {
         ApprovalSubMode::Overview => {
             // When a typed plan is present, render structured fields as
             // a multi-section view. Plain summary otherwise.
-            let title =
-                format!(" Approval from `{task_id}` — y=approve  n=reject  e=edit  Esc=cancel ");
+            let title = format!(
+                " [{badge}] Approval from `{task_id}` — y=approve  n=reject  e=edit  Esc=cancel "
+            );
             let block = Block::default().borders(Borders::ALL).title(title);
             let lines = plan.map_or_else(
                 || {

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -1145,6 +1145,7 @@ fn render_prompt_reprompt(frame: &mut Frame, area: Rect, task_id: &str, draft: &
     frame.render_widget(para, modal);
 }
 
+#[allow(clippy::too_many_arguments)]
 fn render_approval_modal(
     frame: &mut Frame,
     area: Rect,

--- a/crates/pitboss-tui/tests/tui_control.rs
+++ b/crates/pitboss-tui/tests/tui_control.rs
@@ -67,6 +67,7 @@ fn approval_modal_overview_renders_summary() {
         task_id: "lead".into(),
         summary: "SPAWN THREE HOBBITS".into(),
         plan: None,
+        kind: pitboss_cli::control::protocol::ApprovalKind::Action,
         sub_mode: ApprovalSubMode::Overview,
     };
 
@@ -86,6 +87,66 @@ fn approval_modal_overview_renders_summary() {
     assert!(
         text.contains("SPAWN THREE HOBBITS"),
         "modal should include the summary, got:\n{text}"
+    );
+}
+
+#[test]
+fn approval_modal_shows_plan_badge_for_plan_kind() {
+    let mut state = AppState::new(std::path::PathBuf::from("/tmp"), "run-1".into());
+    state.mode = Mode::ApprovalModal {
+        request_id: "req-1".into(),
+        task_id: "lead".into(),
+        summary: "phase-1 plan".into(),
+        plan: None,
+        kind: pitboss_cli::control::protocol::ApprovalKind::Plan,
+        sub_mode: ApprovalSubMode::Overview,
+    };
+    let backend = TestBackend::new(100, 24);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| pitboss_tui::tui::render(frame, &state))
+        .unwrap();
+    let buf = terminal.backend().buffer();
+    let mut text = String::new();
+    for y in 0..24 {
+        for x in 0..100 {
+            text.push_str(buf.cell((x, y)).unwrap().symbol());
+        }
+        text.push('\n');
+    }
+    assert!(
+        text.contains("PRE-FLIGHT PLAN"),
+        "plan-kind modal should show the pre-flight badge, got:\n{text}"
+    );
+}
+
+#[test]
+fn approval_modal_shows_action_badge_for_default_kind() {
+    let mut state = AppState::new(std::path::PathBuf::from("/tmp"), "run-1".into());
+    state.mode = Mode::ApprovalModal {
+        request_id: "req-1".into(),
+        task_id: "lead".into(),
+        summary: "delete staging index".into(),
+        plan: None,
+        kind: pitboss_cli::control::protocol::ApprovalKind::Action,
+        sub_mode: ApprovalSubMode::Overview,
+    };
+    let backend = TestBackend::new(100, 24);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| pitboss_tui::tui::render(frame, &state))
+        .unwrap();
+    let buf = terminal.backend().buffer();
+    let mut text = String::new();
+    for y in 0..24 {
+        for x in 0..100 {
+            text.push_str(buf.cell((x, y)).unwrap().symbol());
+        }
+        text.push('\n');
+    }
+    assert!(
+        text.contains("IN-FLIGHT ACTION"),
+        "action-kind modal should show the in-flight badge, got:\n{text}"
     );
 }
 


### PR DESCRIPTION
## Summary

Closes roadmap item #4 in the v0.5.0 flagship bucket. Leads can now propose a full execution plan for **pre-flight** operator approval, distinct from the in-flight `request_approval` tool. Opt-in via `[run].require_plan_approval = true`; existing runs are completely unaffected.

**How it works**
- New MCP tool `propose_plan(plan, timeout_secs)` — the lead submits a typed `ApprovalPlan` (reuses the struct from #24).
- When `require_plan_approval = true`, `spawn_worker` refuses with a clear error until a plan has been operator-approved.
- Approval reuses the v0.4.5 structured-approval modal, distinguished by a **`[PRE-FLIGHT PLAN]`** vs **`[IN-FLIGHT ACTION]`** badge in the title.
- No TUI attached? Falls back to the existing `ApprovalPolicy` (auto_approve / auto_reject / block) — same knob users already understand.
- Rejected plans leave the gate closed so the lead can revise and retry.

**Backward compatibility**
- `ApprovalKind` defaults to `Action` on the wire with `skip_serializing_if`, so pre-0.4.5 TUI clients roundtrip `ApprovalRequest` events unchanged.
- `require_plan_approval` defaults to `false`; `plan_approved` is never checked when off.

**Tests**
- 4 new unit tests in `mcp::tools` covering the gate + `propose_plan` flip/reject semantics.
- 2 new TUI tests covering the modal badge.
- 2 new protocol tests (`kind` roundtrip + serde default elision).
- 1 new end-to-end integration test in `control_flows.rs` driving `propose_plan` → control-socket `ApprovalRequest` (kind=Plan, full ApprovalPlanWire) → operator approve → `plan_approved` flipped → `spawn_worker` gate unblocked.

Workspace now 453 tests (up from 443 on main). `cargo fmt` / `clippy -D warnings` / release build all clean.

## Test Plan

- [x] `cargo test --workspace` — 453 passed, 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo build --release --workspace` clean
- [ ] Manual smoke: run with `[run].require_plan_approval = true`, confirm spawn_worker is blocked, approve via TUI, confirm spawn proceeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)