### PR TITLE
fake-claude bridge mode + e2e coverage for v0.4.5 features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,21 @@ This project uses [Semantic Versioning](https://semver.org/).
   operators can tell the two kinds apart. On rejection, the plan gate
   stays closed so the lead can revise and retry. Runs without the
   opt-in flag behave identically to before.
+- **fake-claude ↔ mcp-bridge end-to-end test coverage.** fake-claude
+  now supports an opt-in bridge mode
+  (`PITBOSS_FAKE_MCP_BRIDGE_CMD` + `PITBOSS_FAKE_ACTOR_ID` +
+  `PITBOSS_FAKE_ACTOR_ROLE`) that spawns `pitboss mcp-bridge` as a
+  child and speaks stdio JSON-RPC to it — the same path a real
+  claude subprocess takes. New integration tests exercise:
+  - `_meta` injection end-to-end (bridge → dispatcher) via `kv_set`;
+  - pre-flight `propose_plan` gate with a real lead subprocess + real
+    control-socket operator;
+  - `pause_worker(mode="freeze")` / `continue_worker` with an actual
+    worker subprocess (via a test-only `FakeClaudeWorkerSpawner` that
+    rewrites `spawn_worker`'s command to fake-claude with the right
+    env overlay).
+  Closes the v0.3 Task 26 placeholder in `hierarchical_flows.rs` —
+  the empty `#[tokio::test]` stub has been removed.
 
 ## [0.4.4] — 2026-04-18
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -881,7 +881,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1255,6 +1255,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1338,7 +1350,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1476,6 +1488,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "process-wrap"
+version = "8.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ef4f2f0422f23a82ec9f628ea2acd12871c81a9362b02c43c1aa86acfc3ba1"
+dependencies = [
+ "futures",
+ "indexmap",
+ "nix",
+ "tokio",
+ "tracing",
+ "windows",
 ]
 
 [[package]]
@@ -1736,6 +1762,7 @@ dependencies = [
  "futures",
  "paste",
  "pin-project-lite",
+ "process-wrap",
  "rmcp-macros",
  "schemars",
  "serde",
@@ -2729,6 +2756,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2736,9 +2798,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -2765,9 +2838,34 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-result"
@@ -2775,7 +2873,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -2784,7 +2891,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2820,7 +2927,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2845,7 +2952,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -2854,6 +2961,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,12 +12,9 @@ of the tiered sections below (biggest effort first).
 
 ## Flagship feature bucket (targeting v0.5.0)
 
-### Full end-to-end `fake-claude` integration test
-
-Task 26 of the v0.3 plan left a placeholder. Requires `fake-claude` to
-speak real MCP end-to-end (including streaming responses), not just
-canned JSON lines. Medium lift; pays off as more hierarchical features
-land and e2e coverage gets more valuable. **Status:** ~1-2 days.
+_Empty — all v0.5.0 flagship items have shipped. v0.5.0 release can
+cut whenever we're ready. Post-v0.5.0 items live in the tiered
+sections below._
 
 ---
 

--- a/crates/pitboss-cli/tests/e2e_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_flows.rs
@@ -24,7 +24,7 @@ use pitboss_cli::manifest::resolve::{ResolvedLead, ResolvedManifest};
 use pitboss_cli::manifest::schema::{Effort, WorktreeCleanup};
 use pitboss_cli::mcp::{socket_path_for_run, McpServer};
 use pitboss_core::process::fake::{FakeScript, FakeSpawner};
-use pitboss_core::process::{ProcessSpawner, SpawnCmd, TokioSpawner};
+use pitboss_core::process::{ChildProcess, ProcessSpawner, SpawnCmd, TokioSpawner};
 use pitboss_core::session::{CancelToken, SessionHandle, SessionOutcome};
 use pitboss_core::store::{JsonFileStore, SessionStore};
 use pitboss_core::worktree::{CleanupPolicy, WorktreeManager};
@@ -107,6 +107,45 @@ async fn run_fake_claude_lead(
     cancel: CancelToken,
     timeout: Duration,
 ) -> SessionOutcome {
+    run_fake_claude_lead_impl(cwd, script_path, mcp_sock, None, cancel, timeout).await
+}
+
+/// Variant of `run_fake_claude_lead` that wires fake-claude through a
+/// spawned `pitboss mcp-bridge` subprocess instead of connecting to the
+/// socket directly. `actor_id` / `actor_role` get injected into every
+/// `tools/call` via `_meta` by the bridge.
+async fn run_fake_claude_lead_via_bridge(
+    cwd: &std::path::Path,
+    script_path: &std::path::Path,
+    mcp_sock: &std::path::Path,
+    actor_id: &str,
+    actor_role: &str,
+    cancel: CancelToken,
+    timeout: Duration,
+) -> SessionOutcome {
+    run_fake_claude_lead_impl(
+        cwd,
+        script_path,
+        mcp_sock,
+        Some((
+            support::pitboss_binary(),
+            actor_id.into(),
+            actor_role.into(),
+        )),
+        cancel,
+        timeout,
+    )
+    .await
+}
+
+async fn run_fake_claude_lead_impl(
+    cwd: &std::path::Path,
+    script_path: &std::path::Path,
+    mcp_sock: &std::path::Path,
+    bridge: Option<(PathBuf, String, String)>,
+    cancel: CancelToken,
+    timeout: Duration,
+) -> SessionOutcome {
     let mut env = HashMap::new();
     env.insert(
         "PITBOSS_FAKE_SCRIPT".to_string(),
@@ -116,6 +155,14 @@ async fn run_fake_claude_lead(
         "PITBOSS_FAKE_MCP_SOCKET".to_string(),
         mcp_sock.to_string_lossy().to_string(),
     );
+    if let Some((pitboss_bin, actor_id, actor_role)) = bridge {
+        env.insert(
+            "PITBOSS_FAKE_MCP_BRIDGE_CMD".to_string(),
+            pitboss_bin.to_string_lossy().to_string(),
+        );
+        env.insert("PITBOSS_FAKE_ACTOR_ID".to_string(), actor_id);
+        env.insert("PITBOSS_FAKE_ACTOR_ROLE".to_string(), actor_role);
+    }
     let cmd = SpawnCmd {
         program: fake_claude_path(),
         args: vec![],
@@ -686,4 +733,411 @@ async fn e2e_run_finished_notifies_webhook() {
     // Fire-and-forget — wait briefly for the tokio::spawn'd emit.
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     mock.verify().await;
+}
+
+/// End-to-end plan-approval flow with a real lead subprocess.
+/// `require_plan_approval = true` means spawn_worker fails until an
+/// operator approves a plan via the TUI. We drive it as a real lead
+/// (fake-claude) + a real control-socket client: lead calls
+/// `propose_plan`, background FCC auto-approves, lead then calls
+/// `spawn_worker` successfully.
+#[tokio::test]
+async fn e2e_lead_propose_plan_gate_unblocks_spawn() {
+    support::ensure_built();
+
+    let dir = TempDir::new().unwrap();
+    let run_id = Uuid::now_v7();
+
+    // Build a state with `require_plan_approval = true`.
+    let lead = ResolvedLead {
+        id: "lead".into(),
+        directory: PathBuf::from("/tmp"),
+        prompt: "lead prompt".into(),
+        branch: None,
+        model: "claude-haiku-4-5".into(),
+        effort: Effort::High,
+        tools: vec![],
+        timeout_secs: 3600,
+        use_worktree: false,
+        env: Default::default(),
+        resume_session_id: None,
+    };
+    let manifest = ResolvedManifest {
+        max_parallel: 4,
+        halt_on_failure: false,
+        run_dir: dir.path().to_path_buf(),
+        worktree_cleanup: WorktreeCleanup::OnSuccess,
+        emit_event_stream: false,
+        tasks: vec![],
+        lead: Some(lead),
+        max_workers: Some(4),
+        budget_usd: Some(5.0),
+        lead_timeout_secs: None,
+        approval_policy: Some(ApprovalPolicy::Block),
+        notifications: vec![],
+        dump_shared_store: false,
+        require_plan_approval: true,
+    };
+    let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
+    let worker_script = FakeScript::new()
+        .stdout_line(r#"{"type":"system","subtype":"init","session_id":"worker-sess"}"#)
+        .stdout_line(
+            r#"{"type":"result","session_id":"worker-sess","usage":{"input_tokens":1,"output_tokens":1}}"#,
+        )
+        .exit_code(0);
+    let spawner: Arc<dyn ProcessSpawner> = Arc::new(FakeSpawner::new(worker_script));
+    let wt_mgr = Arc::new(WorktreeManager::new());
+    let run_subdir = dir.path().join(run_id.to_string());
+    tokio::fs::create_dir_all(&run_subdir).await.unwrap();
+    let state = Arc::new(DispatchState::new(
+        run_id,
+        manifest,
+        store,
+        CancelToken::new(),
+        "lead".into(),
+        spawner,
+        PathBuf::from("claude"),
+        wt_mgr,
+        CleanupPolicy::Never,
+        run_subdir,
+        ApprovalPolicy::Block,
+        None,
+        std::sync::Arc::new(pitboss_cli::shared_store::SharedStore::new()),
+    ));
+
+    let mcp_sock = socket_path_for_run(run_id, &state.manifest.run_dir);
+    let _mcp_server = McpServer::start(mcp_sock.clone(), state.clone())
+        .await
+        .unwrap();
+    let ctrl_sock = pitboss_cli::control::control_socket_path(run_id, &state.manifest.run_dir);
+    let _ctrl_server = pitboss_cli::control::server::start_control_server(
+        ctrl_sock.clone(),
+        "0.4.5".into(),
+        run_id.to_string(),
+        "hierarchical".into(),
+        state.clone(),
+    )
+    .await
+    .unwrap();
+
+    // Background FCC: poll for queued plan approval, connect, approve.
+    let ctrl_sock_bg = ctrl_sock.clone();
+    let state_for_fcc = state.clone();
+    let fcc_task = tokio::spawn(async move {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+        loop {
+            if !state_for_fcc.approval_queue.lock().await.is_empty() {
+                break;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                panic!("FCC timed out waiting for queued plan approval");
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        let mut client =
+            fake_control_client::FakeControlClient::connect(&ctrl_sock_bg, "0.4.5-fcc")
+                .await
+                .unwrap();
+        match client.recv_timeout(Duration::from_secs(5)).await.unwrap() {
+            Some(pitboss_cli::control::protocol::ControlEvent::ApprovalRequest {
+                request_id,
+                kind,
+                ..
+            }) => {
+                assert_eq!(
+                    kind,
+                    pitboss_cli::control::protocol::ApprovalKind::Plan,
+                    "expected kind=Plan for propose_plan request"
+                );
+                client
+                    .send(&pitboss_cli::control::protocol::ControlOp::Approve {
+                        request_id,
+                        approved: true,
+                        comment: None,
+                        edited_summary: None,
+                    })
+                    .await
+                    .unwrap();
+            }
+            other => panic!("expected ApprovalRequest, got {other:?}"),
+        }
+    });
+
+    // Lead script: propose_plan, then spawn_worker. The spawn_worker
+    // line would fail with "plan approval required" if it came before
+    // the plan approval; success here proves the full flow works.
+    let script = dir.path().join("script.jsonl");
+    let script_body = r#"{"stdout":"{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"lead-sess\"}"}
+{"mcp_call":{"name":"propose_plan","args":{"plan":{"summary":"phase-1","rationale":"prep work","resources":["worktrees"],"risks":[],"rollback":"drop worktrees"},"timeout_secs":10},"bind":"plan"}}
+{"mcp_call":{"name":"spawn_worker","args":{"prompt":"go"},"bind":"w1"}}
+{"stdout":"{\"type\":\"result\",\"subtype\":\"success\",\"session_id\":\"lead-sess\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}"}
+"#;
+    tokio::fs::write(&script, script_body).await.unwrap();
+
+    let outcome = run_fake_claude_lead(
+        dir.path(),
+        &script,
+        &mcp_sock,
+        CancelToken::new(),
+        Duration::from_secs(30),
+    )
+    .await;
+
+    fcc_task.await.expect("FCC task panicked");
+
+    assert_eq!(
+        outcome.exit_code,
+        Some(0),
+        "lead exit non-zero: outcome={outcome:?}"
+    );
+
+    // plan_approved latched true, one worker spawned successfully.
+    assert!(state
+        .plan_approved
+        .load(std::sync::atomic::Ordering::Acquire));
+    let workers = state.workers.read().await;
+    assert_eq!(
+        workers.len(),
+        1,
+        "expected one worker post-approval, got {}",
+        workers.len()
+    );
+
+    state.cancel.terminate();
+}
+
+/// Full-stack bridge test: fake-claude lead spawns `pitboss mcp-bridge`
+/// and speaks stdio JSON-RPC to it. The bridge injects `_meta` on every
+/// `tools/call` and forwards to the unix socket. We call `kv_set` with
+/// a value and then verify the stored entry's `written_by` field equals
+/// the actor_id the bridge was launched with — proving the whole
+/// lead → bridge (subprocess) → unix-socket → dispatcher → tool-handler
+/// path works end-to-end, including the `_meta` injection that the
+/// existing direct-socket e2e tests skip.
+#[tokio::test]
+async fn e2e_lead_through_mcp_bridge_injects_meta() {
+    support::ensure_built();
+
+    let dir = TempDir::new().unwrap();
+    let (run_id, state) = mk_state(dir.path(), ApprovalPolicy::Block);
+
+    let sock = socket_path_for_run(run_id, &state.manifest.run_dir);
+    let _server = McpServer::start(sock.clone(), state.clone()).await.unwrap();
+
+    // Lead script: init, kv_set on /shared/bridge_probe, result.
+    // kv_set carries `_meta` as a required field — the bridge's job is
+    // to populate it, so a direct-socket fake-claude would fail this
+    // call. Bridge mode succeeds; the stored entry's `written_by` is
+    // the actor_id the bridge was configured with.
+    let script = dir.path().join("script.jsonl");
+    // kv_set's `value` is a Vec<u8>; serde_json encodes byte-arrays as a
+    // JSON array of numbers by default. "ok" => [111, 107].
+    let script_body = r#"{"stdout":"{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"lead-sess\"}"}
+{"mcp_call":{"name":"kv_set","args":{"path":"/shared/bridge_probe","value":[111,107]},"bind":"res"}}
+{"stdout":"{\"type\":\"result\",\"subtype\":\"success\",\"session_id\":\"lead-sess\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}"}
+"#;
+    tokio::fs::write(&script, script_body).await.unwrap();
+
+    let outcome = run_fake_claude_lead_via_bridge(
+        dir.path(),
+        &script,
+        &sock,
+        "lead", // actor_id the bridge will inject
+        "lead", // actor_role
+        CancelToken::new(),
+        Duration::from_secs(30),
+    )
+    .await;
+
+    assert_eq!(
+        outcome.exit_code,
+        Some(0),
+        "fake-claude via bridge exited non-zero: outcome={outcome:?}"
+    );
+    assert!(matches!(
+        outcome.final_state,
+        pitboss_core::session::SessionState::Completed
+    ));
+
+    // Assertion: the stored entry MUST reflect the bridge's injected
+    // actor_id. If _meta failed to arrive, kv_set would either reject
+    // the call (missing required _meta) or write with a different
+    // actor_id — both caught here.
+    let entry = state
+        .shared_store
+        .get("/shared/bridge_probe")
+        .await
+        .expect("kv_set should have persisted the entry");
+    assert_eq!(
+        entry.written_by, "lead",
+        "bridge-injected actor_id did not reach the tool handler; \
+         written_by = {:?}",
+        entry.written_by
+    );
+
+    state.cancel.terminate();
+}
+
+/// Test-only ProcessSpawner that rewrites each spawn to run fake-claude
+/// with a specific env overlay. Needed because the MCP `spawn_worker`
+/// path builds `SpawnCmd { env: HashMap::new(), ... }` (no per-worker
+/// env plumbing), but fake-claude needs `PITBOSS_FAKE_SCRIPT` +
+/// `PITBOSS_FAKE_HOLD` to act as a long-lived worker. This spawner
+/// rewrites `program` to fake-claude and drops the claude-shaped `args`
+/// (fake-claude ignores them).
+struct FakeClaudeWorkerSpawner {
+    inner: TokioSpawner,
+    fake_claude: PathBuf,
+    env_overlay: HashMap<String, String>,
+}
+
+#[async_trait::async_trait]
+impl ProcessSpawner for FakeClaudeWorkerSpawner {
+    async fn spawn(
+        &self,
+        mut cmd: SpawnCmd,
+    ) -> Result<Box<dyn ChildProcess>, pitboss_core::error::SpawnError> {
+        cmd.program = self.fake_claude.clone();
+        cmd.args = vec![];
+        for (k, v) in &self.env_overlay {
+            cmd.env.insert(k.clone(), v.clone());
+        }
+        self.inner.spawn(cmd).await
+    }
+}
+
+/// Real-subprocess freeze-pause e2e. Workers are spawned as actual
+/// fake-claude processes (via FakeClaudeWorkerSpawner) so `worker_pids`
+/// gets populated and `pause_worker(Freeze)` can send SIGSTOP.
+#[tokio::test]
+async fn e2e_freeze_pause_and_continue_real_subprocess_worker() {
+    support::ensure_built();
+
+    let dir = TempDir::new().unwrap();
+    let run_id = Uuid::now_v7();
+
+    // Worker script: emit init + result, then hold. init drives
+    // session_id capture (required for pause_worker); HOLD=1 keeps
+    // the process alive so freeze has something to SIGSTOP.
+    let worker_script_path = dir.path().join("worker-script.jsonl");
+    tokio::fs::write(
+        &worker_script_path,
+        r#"{"stdout":"{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"worker-sess\"}"}
+{"stdout":"{\"type\":\"result\",\"subtype\":\"success\",\"session_id\":\"worker-sess\",\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}"}
+"#,
+    )
+    .await
+    .unwrap();
+
+    let mut env_overlay = HashMap::new();
+    env_overlay.insert(
+        "PITBOSS_FAKE_SCRIPT".into(),
+        worker_script_path.to_string_lossy().to_string(),
+    );
+    env_overlay.insert("PITBOSS_FAKE_HOLD".into(), "1".into());
+
+    let lead = ResolvedLead {
+        id: "lead".into(),
+        directory: PathBuf::from("/tmp"),
+        prompt: "lead prompt".into(),
+        branch: None,
+        model: "claude-haiku-4-5".into(),
+        effort: Effort::High,
+        tools: vec![],
+        timeout_secs: 3600,
+        use_worktree: false,
+        env: Default::default(),
+        resume_session_id: None,
+    };
+    let manifest = ResolvedManifest {
+        max_parallel: 4,
+        halt_on_failure: false,
+        run_dir: dir.path().to_path_buf(),
+        worktree_cleanup: WorktreeCleanup::OnSuccess,
+        emit_event_stream: false,
+        tasks: vec![],
+        lead: Some(lead),
+        max_workers: Some(4),
+        budget_usd: Some(5.0),
+        lead_timeout_secs: None,
+        approval_policy: Some(ApprovalPolicy::Block),
+        notifications: vec![],
+        dump_shared_store: false,
+        require_plan_approval: false,
+    };
+    let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
+    let spawner: Arc<dyn ProcessSpawner> = Arc::new(FakeClaudeWorkerSpawner {
+        inner: TokioSpawner::new(),
+        fake_claude: fake_claude_path(),
+        env_overlay,
+    });
+    let wt_mgr = Arc::new(WorktreeManager::new());
+    let run_subdir = dir.path().join(run_id.to_string());
+    tokio::fs::create_dir_all(&run_subdir).await.unwrap();
+    let state = Arc::new(DispatchState::new(
+        run_id,
+        manifest,
+        store,
+        CancelToken::new(),
+        "lead".into(),
+        spawner,
+        // claude_binary placeholder: the FakeClaudeWorkerSpawner
+        // rewrites `program` to fake-claude on every spawn.
+        PathBuf::from("claude"),
+        wt_mgr,
+        CleanupPolicy::Never,
+        run_subdir,
+        ApprovalPolicy::Block,
+        None,
+        std::sync::Arc::new(pitboss_cli::shared_store::SharedStore::new()),
+    ));
+
+    let mcp_sock = socket_path_for_run(run_id, &state.manifest.run_dir);
+    let _server = McpServer::start(mcp_sock.clone(), state.clone())
+        .await
+        .unwrap();
+
+    // Lead script: spawn, wait for init, freeze, continue, cancel.
+    let script = dir.path().join("lead-script.jsonl");
+    let script_body = r#"{"stdout":"{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"lead-sess\"}"}
+{"mcp_call":{"name":"spawn_worker","args":{"prompt":"do a thing"},"bind":"w1"}}
+{"sleep_ms":500}
+{"mcp_call":{"name":"pause_worker","args":{"task_id":"$w1.task_id","mode":"freeze"},"bind":"pause_res"}}
+{"sleep_ms":200}
+{"mcp_call":{"name":"continue_worker","args":{"task_id":"$w1.task_id"},"bind":"cont_res"}}
+{"sleep_ms":200}
+{"mcp_call":{"name":"cancel_worker","args":{"task_id":"$w1.task_id"},"bind":"cancel_res"}}
+{"stdout":"{\"type\":\"result\",\"subtype\":\"success\",\"session_id\":\"lead-sess\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}"}
+"#;
+    tokio::fs::write(&script, script_body).await.unwrap();
+
+    let outcome = run_fake_claude_lead(
+        dir.path(),
+        &script,
+        &mcp_sock,
+        CancelToken::new(),
+        Duration::from_secs(30),
+    )
+    .await;
+
+    assert_eq!(
+        outcome.exit_code,
+        Some(0),
+        "lead exit non-zero: outcome={outcome:?}"
+    );
+
+    // Proof of a working freeze→continue→cancel cycle: the lead
+    // subprocess exited 0 above, which means *every* mcp_call
+    // succeeded (pause_worker with mode=freeze, continue_worker,
+    // cancel_worker). Any failure would have bubbled out of fake-claude
+    // as exit code 5. The pause_worker call in particular requires a
+    // live worker pid, which requires a real TokioSpawner subprocess
+    // — so this test also proves the FakeClaudeWorkerSpawner wiring
+    // populates `worker_pids` correctly. No further assertions needed.
+    //
+    // We do wait a tick for the worker background task to settle so
+    // the test's Drop teardown doesn't race a live subprocess.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    state.cancel.terminate();
+    tokio::time::sleep(Duration::from_millis(200)).await;
 }

--- a/crates/pitboss-cli/tests/hierarchical_flows.rs
+++ b/crates/pitboss-cli/tests/hierarchical_flows.rs
@@ -218,18 +218,9 @@ async fn mcp_spawn_while_draining_returns_error() {
     client.close().await.unwrap();
 }
 
-#[tokio::test]
-async fn hierarchical_run_with_one_worker_end_to_end() {
-    // This test doesn't spin up a real claude; it uses fake-claude as both
-    // the lead and the worker. The fake lead emits a pitboss__spawn_worker
-    // tool_use, waits for the result, then exits. The dispatcher wires the
-    // MCP tool_result back to the fake lead via a scripted transcript.
-
-    // FIXME: The full round-trip requires the fake-claude binary to
-    // interact with the pitboss MCP server through the MCP protocol. Since
-    // fake-claude doesn't speak MCP, this end-to-end case is deferred to
-    // the manual smoke test until a full MCP-aware fake lead is built.
-    //
-    // Task 26 keeps the placeholder here so the plan records the intent.
-    // Implementation of the full loop comes in v0.3.1 hardening.
-}
+// Task 26 of the v0.3 plan left a placeholder here; the full
+// hierarchical end-to-end coverage landed in v0.4.1's e2e_flows.rs and
+// was extended in v0.4.5 (`e2e_lead_spawns_worker_via_real_subprocess`,
+// `e2e_lead_propose_plan_gate_unblocks_spawn`,
+// `e2e_lead_through_mcp_bridge_injects_meta`, and others). The empty
+// placeholder test has been removed.

--- a/tests-support/fake-claude/Cargo.toml
+++ b/tests-support/fake-claude/Cargo.toml
@@ -11,6 +11,6 @@ path = "src/main.rs"
 
 [dependencies]
 serde_json = { workspace = true }
-rmcp       = { workspace = true, features = ["client", "transport-io"] }
+rmcp       = { workspace = true, features = ["client", "transport-io", "transport-child-process"] }
 tokio      = { workspace = true, features = ["macros", "rt-multi-thread", "net", "io-util", "sync", "process", "fs", "time"] }
 anyhow     = { workspace = true }

--- a/tests-support/fake-claude/src/main.rs
+++ b/tests-support/fake-claude/src/main.rs
@@ -51,10 +51,14 @@ fn main() {
             .expect("build tokio runtime");
 
         // Open an MCP client if the socket env var is set. Unset => None.
+        // When PITBOSS_FAKE_MCP_BRIDGE_CMD + ACTOR_ID + ACTOR_ROLE are also
+        // set, the client spawns `pitboss mcp-bridge` as a child and speaks
+        // stdio to it — exercising the same `_meta` injection path that a
+        // real claude subprocess uses in production.
         let client = match std::env::var("PITBOSS_FAKE_MCP_SOCKET") {
             Ok(sock) => {
                 let path = std::path::PathBuf::from(sock);
-                match rt.block_on(mcp_client::McpClient::connect(&path)) {
+                match rt.block_on(mcp_client::McpClient::connect_from_env(&path)) {
                     Ok(c) => Some(c),
                     Err(e) => {
                         eprintln!("fake-claude: mcp connect {}: {e:#}", path.display());

--- a/tests-support/fake-claude/src/mcp_client.rs
+++ b/tests-support/fake-claude/src/mcp_client.rs
@@ -5,16 +5,26 @@
 //! of `fake-mcp-client/src/lib.rs` — the two crates have different roles
 //! (one drives the server as a test peer; the other emulates a lead
 //! subprocess), and inlining avoids a test-support dependency cycle.
+//!
+//! Two connection modes:
+//! - [`McpClient::connect`] — opens the pitboss unix socket directly.
+//!   Fast for test setups that don't care about the bridge layer.
+//! - [`McpClient::connect_via_bridge`] — spawns
+//!   `<pitboss> mcp-bridge <socket> --actor-id <id> --actor-role <role>`
+//!   and speaks stdio JSON-RPC to it. Exercises the `_meta` injection
+//!   path that a real claude subprocess uses in production.
 
 #![allow(dead_code)]
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use rmcp::model::{CallToolRequestParam, CallToolResult};
 use rmcp::service::{RoleClient, RunningService};
+use rmcp::transport::TokioChildProcess;
 use rmcp::ServiceExt;
 use serde_json::Value;
+use tokio::process::Command;
 
 pub struct McpClient {
     inner: RunningService<RoleClient, ()>,
@@ -22,7 +32,8 @@ pub struct McpClient {
 
 impl McpClient {
     /// Connect to a pitboss MCP server on `socket` and complete the MCP
-    /// initialization handshake.
+    /// initialization handshake. Direct unix-socket mode — skips the
+    /// bridge's `_meta` injection.
     pub async fn connect(socket: &Path) -> Result<Self> {
         let stream = tokio::net::UnixStream::connect(socket)
             .await
@@ -32,6 +43,59 @@ impl McpClient {
             .await
             .with_context(|| format!("mcp init handshake on {}", socket.display()))?;
         Ok(Self { inner })
+    }
+
+    /// Connect via a spawned `pitboss mcp-bridge` subprocess. Mirrors
+    /// how a real claude subprocess talks to pitboss: the bridge reads
+    /// JSON-RPC from stdin, injects `_meta: {actor_id, actor_role}` on
+    /// every `tools/call`, and forwards to the unix socket.
+    ///
+    /// `pitboss_bin` must point at a `pitboss` binary that exposes the
+    /// `mcp-bridge` subcommand.
+    pub async fn connect_via_bridge(
+        pitboss_bin: &Path,
+        socket: &Path,
+        actor_id: &str,
+        actor_role: &str,
+    ) -> Result<Self> {
+        let mut cmd = Command::new(pitboss_bin);
+        cmd.arg("mcp-bridge")
+            .arg(socket)
+            .arg("--actor-id")
+            .arg(actor_id)
+            .arg("--actor-role")
+            .arg(actor_role);
+        let transport = TokioChildProcess::new(cmd).with_context(|| {
+            format!(
+                "spawn mcp-bridge via {} (sock={}, actor={}/{})",
+                pitboss_bin.display(),
+                socket.display(),
+                actor_id,
+                actor_role,
+            )
+        })?;
+        let inner = ()
+            .serve(transport)
+            .await
+            .with_context(|| format!("mcp init handshake via bridge on {}", socket.display()))?;
+        Ok(Self { inner })
+    }
+
+    /// Helper: read the trio of bridge env vars and pick the right
+    /// connection mode. Returns `None` if no MCP is configured at all,
+    /// the direct-socket path if only `PITBOSS_FAKE_MCP_SOCKET` is set,
+    /// and the bridge path if all three bridge vars are set.
+    pub async fn connect_from_env(socket: &Path) -> Result<Self> {
+        let bridge_cmd = std::env::var_os("PITBOSS_FAKE_MCP_BRIDGE_CMD");
+        if let Some(cmd) = bridge_cmd {
+            let actor_id = std::env::var("PITBOSS_FAKE_ACTOR_ID")
+                .context("PITBOSS_FAKE_MCP_BRIDGE_CMD set but PITBOSS_FAKE_ACTOR_ID missing")?;
+            let actor_role = std::env::var("PITBOSS_FAKE_ACTOR_ROLE")
+                .context("PITBOSS_FAKE_MCP_BRIDGE_CMD set but PITBOSS_FAKE_ACTOR_ROLE missing")?;
+            return Self::connect_via_bridge(&PathBuf::from(cmd), socket, &actor_id, &actor_role)
+                .await;
+        }
+        Self::connect(socket).await
     }
 
     /// Call a tool and return its structured content as JSON. Pitboss


### PR DESCRIPTION
## Summary

Closes roadmap item #5. v0.5.0 flagship bucket is now empty.

This PR extends `fake-claude` to optionally go through `pitboss mcp-bridge` (just like a real claude subprocess does), and adds three new end-to-end tests that fill the coverage gap for features shipped since v0.4.1 — structured approval, plan approval, and SIGSTOP freeze-pause.

**Bridge plumbing (B)**
- `fake-claude`: new `McpClient::connect_via_bridge(pitboss_bin, sock, actor_id, actor_role)` that spawns `pitboss mcp-bridge` as a child via rmcp's `TokioChildProcess` transport and speaks stdio JSON-RPC. Selected by three env vars (`PITBOSS_FAKE_MCP_BRIDGE_CMD`, `PITBOSS_FAKE_ACTOR_ID`, `PITBOSS_FAKE_ACTOR_ROLE`). Direct-socket mode stays default, so every existing e2e test passes unchanged.

**New e2e tests (C)**
1. **`e2e_lead_through_mcp_bridge_injects_meta`** — proves the full bridge path end-to-end. Lead calls `kv_set /shared/probe`; asserts the stored entry's `written_by` matches the actor_id the bridge was configured with. The direct-socket e2e tests skip this layer.
2. **`e2e_lead_propose_plan_gate_unblocks_spawn`** — real lead + real FakeControlClient. Lead calls `propose_plan`, FCC observes `ApprovalRequest{kind:Plan}` and approves, lead's subsequent `spawn_worker` succeeds.
3. **`e2e_freeze_pause_and_continue_real_subprocess_worker`** — requires a real worker pid for SIGSTOP to target. New test-only `FakeClaudeWorkerSpawner` rewrites `spawn_worker`'s command to fake-claude with the right env overlay. Lead script drives spawn → freeze → continue → cancel all via MCP.

**Cleanup**
- Removed the empty `hierarchical_run_with_one_worker_end_to_end` placeholder left over from v0.3 Task 26. The comment that replaces it points at the e2e tests that now cover the same intent.
- ROADMAP: flagship bucket empty — v0.5.0 release can cut.
- CHANGELOG: adds the fake-claude/bridge coverage entry under `[Unreleased]`.

## Test Plan

- [x] `cargo test --workspace` — 456 passed, 0 failed (up from 453)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo build --release --workspace` clean
- [x] All three new tests pass individually
- [x] `fake-claude --version` smoke still works
- [x] Direct-socket e2e tests unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)