### PR TITLE
docs: refresh README + AGENTS + CHANGELOG for v0.5.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ hierarchical.**
 |---|---|
 | **Pitboss** | The `pitboss` binary you invoke. |
 | **Run** | One `pitboss dispatch` invocation. Produces `~/.local/share/pitboss/runs/<run-id>/`. |
-| **Lead** | In hierarchical mode, the first claude subprocess. Receives the operator's prompt + six MCP tools. Decides how many workers to spawn. |
+| **Lead** | In hierarchical mode, the first claude subprocess. Receives the operator's prompt + the full MCP orchestration toolset. Decides how many workers to spawn. |
 | **Worker** | A claude subprocess executing a single task, either declared in `[[task]]` (flat) or dynamically spawned by the lead (hierarchical). |
 | **House rules** | Hierarchical guardrails: `max_workers` (≤16), `budget_usd`, `lead_timeout_secs`. |
 | **Worktree** | A per-task git worktree under a fresh branch, isolating concurrent work. `use_worktree = true` by default. |
@@ -97,6 +97,9 @@ TOML, typically named `pitboss.toml`. Every field annotated below.
 | `max_workers` | int | only if `[[lead]]` present | unset | Hierarchical: hard cap on concurrent + queued workers (1–16). |
 | `budget_usd` | float | only if `[[lead]]` present | unset | Hierarchical: soft cap with reservation accounting. Worker spawns fail with `budget exceeded` once `spent + reserved + next_estimate > budget`. |
 | `lead_timeout_secs` | int | only if `[[lead]]` present | 3600 (fallback) | Hierarchical: wall-clock cap on the lead. No upper bound — set generously for multi-hour orchestration plans (e.g. `21600` for a 6-hour plan executor). The 3600s fallback is tuned for single-task leads, not plan drivers. |
+| `approval_policy` | `"block"` \| `"auto_approve"` \| `"auto_reject"` | no | `"block"` | Hierarchical: how `request_approval` / `propose_plan` behave when no TUI is attached. See the `approval_policy` section below. |
+| `require_plan_approval` | bool | no | false | Hierarchical (v0.5.0+): when true, `spawn_worker` refuses until a plan submitted via `propose_plan` has been operator-approved. Opt-in; runs without it behave identically to v0.4.x. |
+| `dump_shared_store` | bool | no | false | Hierarchical: at run finalize, write `shared-store.json` into the run dir for post-mortem inspection. |
 
 ### `[defaults]`
 
@@ -167,6 +170,21 @@ original `claude_session_id`. For hierarchical runs, only the lead resumes
 **Gotcha:** if the original run used `worktree_cleanup = "on_success"` (the
 default), the worktrees are gone — claude can't find its sessions by cwd.
 Use `worktree_cleanup = "never"` on runs you know you want to resume.
+
+### Attach (v0.5.0+)
+
+```bash
+pitboss attach <run-id> <task-id>
+pitboss attach <run-id> <task-id> --raw            # stream raw stream-json
+pitboss attach <run-id> <task-id> --lines 200      # larger backfill
+```
+
+Follow-mode log viewer for a single worker. Run-id is resolved by
+prefix; first 8 chars are plenty when unique. Formatted output matches
+the TUI focus pane; `--raw` dumps the underlying jsonl. Exits on
+Ctrl-C or when the worker emits its terminal `Event::Result`. Use
+this when you want to watch one worker interactively without pulling
+up the whole TUI.
 
 ### Diff
 
@@ -241,10 +259,12 @@ Lead records have `parent_task_id: null`. Worker records have
 
 ---
 
-## The 6 MCP tools the lead has
+## The MCP tools the lead has
 
 When running hierarchical, the lead's `--allowedTools` is automatically
 populated with these. You (the operator) don't list them explicitly.
+
+### Orchestration tools
 
 | Tool | Args | Returns |
 |---|---|---|
@@ -254,7 +274,11 @@ populated with these. You (the operator) don't list them explicitly.
 | `mcp__pitboss__wait_for_any` | `{task_ids: [...], timeout_secs?}` | `{task_id, record}` on first settle |
 | `mcp__pitboss__list_workers` | `{}` | `{workers: [{task_id, state, prompt_preview, started_at}, ...]}` |
 | `mcp__pitboss__cancel_worker` | `{task_id}` | `{ok: bool}` |
+| `mcp__pitboss__pause_worker` | `{task_id, mode?}` — `mode` is `"cancel"` (default) or `"freeze"` | `{ok: bool}` |
+| `mcp__pitboss__continue_worker` | `{task_id, prompt?}` | `{ok: bool}` |
 | `mcp__pitboss__reprompt_worker` | `{task_id, prompt}` | `{ok: bool}` — mid-flight course-correct via `claude --resume` |
+| `mcp__pitboss__request_approval` | `{summary, timeout_secs?, plan?: ApprovalPlan}` | `{approved, comment?, edited_summary?}` |
+| `mcp__pitboss__propose_plan` | `{plan: ApprovalPlan, timeout_secs?}` | `{approved, comment?, edited_summary?}` |
 
 All tool responses returning a collection are wrapped in a record
 (`{workers: [...]}`, `{entries: [...]}`, `{entry: ...}`) — MCP spec
@@ -298,22 +322,70 @@ layer.
 
 ### `mcp__pitboss__pause_worker`
 
-Pause a running worker. Snapshots its `claude_session_id` so
-`continue_worker` can resume. Args: `{task_id: string}`.
-Fails if worker is not in `Running` state with an initialized session.
+Pause a running worker. Two modes, distinguished by `mode`:
+
+- `mode: "cancel"` (default, v0.4.1+) — terminates the subprocess and
+  snapshots `claude_session_id` so `continue_worker` can respawn via
+  `claude --resume`. Zero context loss on Anthropic's side; some
+  reload cost on resume.
+- `mode: "freeze"` (v0.5.0+) — SIGSTOPs the subprocess in place.
+  `continue_worker` SIGCONTs to resume. No state loss at all, but
+  long freezes risk Anthropic dropping the HTTP session on their
+  side — use for short pauses only.
+
+Args: `{task_id: string, mode?: "cancel" | "freeze"}`. Fails if
+worker is not in `Running` state with an initialized session.
 
 ### `mcp__pitboss__continue_worker`
 
-Continue a previously-paused worker. Spawns `claude --resume <id>`
-under the hood. Args: `{task_id: string, prompt?: string}` (default
-prompt "continue").
+Continue a previously-paused or frozen worker. For paused workers,
+spawns `claude --resume <id>`; for frozen workers, SIGCONTs. Args:
+`{task_id: string, prompt?: string}` (prompt ignored for frozen
+workers — use `reprompt_worker` after continue if you want to
+redirect a frozen worker).
 
 ### `mcp__pitboss__request_approval`
 
-Block the lead until the operator approves, rejects, or edits.
-Args: `{summary: string, timeout_secs?: number}`. Returns
-`{approved: bool, comment?: string, edited_summary?: string}`.
+Gate a *single in-flight action* on operator approval. Block the lead
+until the operator approves, rejects, or edits. Args:
+`{summary: string, timeout_secs?: number, plan?: ApprovalPlan}`.
+Returns `{approved: bool, comment?: string, edited_summary?: string}`.
 Policy-gated: see `approval_policy` below.
+
+`ApprovalPlan` (v0.5.0+) is a typed structured schema that the TUI
+renders as labeled sections:
+
+```
+{
+  summary: string,              // required; appears in the modal title
+  rationale?: string,           // why this action should be taken
+  resources?: [string, ...],    // files / APIs / PRs that will be touched
+  risks?: [string, ...],        // known failure modes; TUI highlights in warning color
+  rollback?: string,            // how to undo if something goes wrong
+}
+```
+
+Populate `plan` for any non-trivial approval (deletions, multi-file
+edits, irreversible ops). The bare `summary` form still works for
+simple approvals.
+
+### `mcp__pitboss__propose_plan`
+
+Gate the *entire run* on operator pre-flight approval. Distinct from
+`request_approval`, which gates individual actions mid-run. Args:
+`{plan: ApprovalPlan, timeout_secs?: number}`. Returns the same
+shape as `request_approval`.
+
+When `[run].require_plan_approval = true`, `spawn_worker` refuses
+with `plan approval required: call propose_plan ...` until a plan
+submitted via this tool has been operator-approved. The TUI modal
+shows `[PRE-FLIGHT PLAN]` in its title (vs `[IN-FLIGHT ACTION]` for
+`request_approval`) so operators can tell them apart at a glance. On
+rejection, the gate stays closed so the lead can revise and retry.
+
+When `require_plan_approval = false` (the default), calling
+`propose_plan` is still valid but purely informational — `spawn_worker`
+never checks the result.
 
 ---
 
@@ -354,7 +426,7 @@ branch conflict, non-git directory). Check the stderr log.
 
 ---
 
-## Operator keybindings (pitboss-tui, v0.4.4+)
+## Operator keybindings (pitboss-tui, v0.5.0+)
 
 Navigation / views:
 - `h j k l` / arrows — navigate tiles
@@ -557,6 +629,6 @@ dispatch first and have to ask follow-ups, you've probably wasted budget.
 
 ## Version
 
-Written for pitboss `v0.4.4`. Schema may evolve; `pitboss validate` is the
+Written for pitboss `v0.5.0`. Schema may evolve; `pitboss validate` is the
 source of truth. This document should stay self-contained — if something
 here conflicts with the actual binary, the binary wins. File a PR.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -547,7 +547,11 @@ This project uses [Semantic Versioning](https://semver.org/).
   SIGINT terminates.
 - Part 1 offline smoke test harness (`scripts/smoke-part1.sh`, 10 tests).
 
-[Unreleased]: https://github.com/SDS-Mode/pitboss/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/SDS-Mode/pitboss/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/SDS-Mode/pitboss/compare/v0.4.4...v0.5.0
+[0.4.4]: https://github.com/SDS-Mode/pitboss/compare/v0.4.3...v0.4.4
+[0.4.3]: https://github.com/SDS-Mode/pitboss/compare/v0.4.2...v0.4.3
+[0.4.2]: https://github.com/SDS-Mode/pitboss/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/SDS-Mode/pitboss/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/SDS-Mode/pitboss/compare/v0.3.4...v0.4.0
 [0.3.4]: https://github.com/SDS-Mode/pitboss/compare/v0.3.3...v0.3.4

--- a/README.md
+++ b/README.md
@@ -6,13 +6,16 @@
 > schema reference, decision tree, canonical examples, and the rules for
 > translating natural-language requests into valid manifests.
 
-**v0.4.4** tightens the shared-store primitives and dev-infra on top of
-v0.4.3: MCP leases now release instantly on connection drop instead of
-waiting for TTL, `pitboss resume` fails fast if the lead worktree was
-cleaned (rather than letting `claude --resume` cryptically fail later),
-the price table matches by model family so future revisions cost
-correctly without a code change, and Dependabot keeps cargo + actions
-deps current. See `CHANGELOG.md` for the full list and `AGENTS.md` for
+**v0.5.0** ships the flagship operator-control bucket: `pitboss attach
+<run-id> <task-id>` for a follow-mode log viewer on a single worker;
+SIGSTOP freeze-pause as an opt-in alternative to cancel-with-resume;
+structured `ApprovalPlan` (rationale / resources / risks / rollback)
+rendered as labeled sections in the TUI modal; a new `propose_plan`
+MCP tool + `[run].require_plan_approval` flag that gates `spawn_worker`
+on operator pre-flight approval; and `fake-claude` end-to-end test
+coverage through `pitboss mcp-bridge` that closes the v0.3 Task 26
+placeholder. 455 tests, zero flakes, full flagship bucket delivered.
+See `CHANGELOG.md` for the per-version history and `AGENTS.md` for
 MCP tool reference, keybindings, and manifest schema.
 
 Rust toolkit for running and observing parallel Claude Code sessions. A
@@ -44,7 +47,11 @@ Pre-built binaries are attached to every GitHub release.
 ```bash
 # x86_64 Linux
 mkdir -p ~/.local/bin
-curl -L https://github.com/SDS-Mode/pitboss/releases/latest/download/pitboss-v0.4.4-x86_64-unknown-linux-gnu.tar.gz \
+curl -L https://github.com/SDS-Mode/pitboss/releases/latest/download/pitboss-v0.5.0-x86_64-unknown-linux-gnu.tar.gz \
+  | tar xz -C ~/.local/bin
+
+# aarch64 macOS (Apple Silicon)
+curl -L https://github.com/SDS-Mode/pitboss/releases/latest/download/pitboss-v0.5.0-aarch64-apple-darwin.tar.gz \
   | tar xz -C ~/.local/bin
 
 pitboss version
@@ -52,8 +59,8 @@ pitboss-tui --version
 ```
 
 The tarball contains both `pitboss` and `pitboss-tui`. Put them anywhere on
-`$PATH`. Swap `x86_64-unknown-linux-gnu` for your target when more builds
-land in the matrix.
+`$PATH`. Current release matrix: `x86_64-unknown-linux-gnu` and
+`aarch64-apple-darwin` — other targets require a source build.
 
 ### From source
 
@@ -67,13 +74,19 @@ cargo install --path crates/pitboss-tui
 ## Subcommands
 
 ```
-pitboss validate <manifest>       parse + resolve + validate, exit non-zero on error
-pitboss dispatch <manifest>       deal a run
-pitboss resume <run-id>           re-deal a prior run, reusing claude_session_id
-pitboss diff <run-a> <run-b>      compare two runs side-by-side
-pitboss completions <shell>       print shell completion script
-pitboss version                   print version
+pitboss validate <manifest>          parse + resolve + validate, exit non-zero on error
+pitboss dispatch <manifest>          deal a run
+pitboss resume <run-id>              re-deal a prior run, reusing claude_session_id
+pitboss attach <run-id> <task-id>    follow-mode log viewer for a single worker
+pitboss diff <run-a> <run-b>         compare two runs side-by-side
+pitboss completions <shell>          print shell completion script
+pitboss version                      print version
 ```
+
+`pitboss attach` accepts a run-id prefix (first 8 chars are plenty when
+it's unique). `--raw` streams the raw stream-json jsonl; without it,
+lines render like the TUI focus pane. Exits on Ctrl-C or when the
+worker emits its terminal `Event::Result`.
 
 ### Shell completions
 
@@ -162,6 +175,16 @@ The lead has these MCP tools, auto-allowed in its `--allowedTools`:
 | `mcp__pitboss__wait_for_any` | Block until any of a list of workers settles |
 | `mcp__pitboss__list_workers` | Snapshot of active + completed workers |
 | `mcp__pitboss__cancel_worker` | Signal a per-worker `CancelToken` |
+| `mcp__pitboss__pause_worker` | Pause a worker — `mode="cancel"` (default, terminates + snapshots session) or `mode="freeze"` (SIGSTOPs the subprocess in place) |
+| `mcp__pitboss__continue_worker` | Resume a paused/frozen worker (`claude --resume` or SIGCONT respectively) |
+| `mcp__pitboss__reprompt_worker` | Mid-flight redirect: kill + `claude --resume <sid>` with a new prompt |
+| `mcp__pitboss__request_approval` | Gate a single in-flight action on operator approval; accepts an optional typed `ApprovalPlan` |
+| `mcp__pitboss__propose_plan` | Pre-flight gate: submit an execution plan for approval; required before `spawn_worker` when `[run].require_plan_approval = true` |
+
+Workers additionally get the 7 shared-store tools (`kv_get`, `kv_set`,
+`kv_cas`, `kv_list`, `kv_wait`, `lease_acquire`, `lease_release`) for
+hub-mediated coordination without breaking the depth-1 invariant. See
+`AGENTS.md` for full schemas.
 
 ### House rules
 
@@ -229,14 +252,15 @@ guarantee any single hand — it guarantees you can inspect it.
 
 ## Status
 
-`v0.4.4` — shared-store + resume polish: leases free on MCP
-disconnect, resume-guard against cleaned worktrees, family-based
-pricing, Dependabot. Builds on v0.4.3's worker shared store, TUI
-Detail view, and mouse affordances, and v0.4.1's control plane
-(cancel/pause/continue/reprompt, operator approvals, notification
-sinks). 431 tests pass under `cargo test --workspace --features
-pitboss-core/test-support`. See [`CHANGELOG.md`](CHANGELOG.md) for
-the per-version history.
+`v0.5.0` — the flagship operator-control bucket shipped:
+`pitboss attach` follow-mode viewer, SIGSTOP freeze-pause, structured
+`ApprovalPlan`, pre-flight `propose_plan` gate, and a full
+fake-claude-through-`mcp-bridge` e2e test harness. Builds on v0.4.4's
+shared-store + resume polish, v0.4.3's worker shared store, and
+v0.4.1's control plane (cancel/pause/continue/reprompt, operator
+approvals, notification sinks). 455 tests pass under `cargo test
+--workspace --features pitboss-core/test-support`. See
+[`CHANGELOG.md`](CHANGELOG.md) for the per-version history.
 
 ## Manual smoke testing
 
@@ -253,7 +277,7 @@ Requires `claude` authenticated via its normal subscription config (no
 
 ```bash
 cargo build --workspace
-cargo test --workspace --features pitboss-core/test-support    # 431 tests
+cargo test --workspace --features pitboss-core/test-support    # 455 tests
 cargo lint                                                     # clippy -D warnings
 cargo fmt --all -- --check
 ```
@@ -286,6 +310,7 @@ scripts/smoke-part3-tui.sh      # 7 non-interactive TUI tests
 The tag push triggers `.github/workflows/release.yml`, which builds release
 binaries for every target in the matrix, packages them as
 `pitboss-vX.Y.Z-<target>.tar.gz`, and attaches them to the auto-created
-GitHub release. Current matrix: `x86_64-unknown-linux-gnu`. Adding more
-targets (macOS, Windows, aarch64) is a matrix-entry addition in the
-workflow.
+GitHub release. Current matrix: `x86_64-unknown-linux-gnu` and
+`aarch64-apple-darwin` (Apple Silicon). Adding more targets (Windows,
+`x86_64-apple-darwin` for older Intel Macs, aarch64 linux) is a
+matrix-entry addition in the workflow.


### PR DESCRIPTION
## Summary

v0.5.0 shipped but the human-facing docs still pointed at v0.4.4. This PR brings them current.

**README.md**
- v0.4.4 highlights paragraph replaced with the v0.5.0 feature bucket (`pitboss attach`, SIGSTOP freeze-pause, structured `ApprovalPlan`, `propose_plan`, fake-claude bridge e2e).
- Download URLs bumped to `v0.5.0`; `aarch64-apple-darwin` added alongside the Linux tarball.
- `pitboss attach` added to the subcommand list with a short usage blurb.
- MCP tools table extended with `pause_worker` (+freeze mode), `continue_worker`, `reprompt_worker`, `request_approval` (with plan), `propose_plan`; cross-refs the 7 shared-store tools.
- Status section + `cargo test` command: test count 431 → 455.
- Release-matrix note mentions `aarch64-apple-darwin`.

**AGENTS.md**
- `[run]` schema table adds `approval_policy`, `require_plan_approval`, `dump_shared_store`.
- New `pitboss attach` invocation section.
- The stale \"6 MCP tools\" section replaced with a complete orchestration tool table.
- `pause_worker` documents freeze vs cancel modes.
- `request_approval` documents the typed `ApprovalPlan` schema.
- New `propose_plan` section explains the pre-flight vs in-flight distinction and the `[PRE-FLIGHT PLAN]` / `[IN-FLIGHT ACTION]` TUI badge.
- Version footer v0.4.4 → v0.5.0.

**CHANGELOG.md**
- Compare links at the bottom repaired: 0.4.2 / 0.4.3 / 0.4.4 / 0.5.0 added; `[Unreleased]` now compares from `v0.5.0`.

Docs-only; no code touched.

## Test Plan

- [x] `git diff` proofread for every section
- [x] CHANGELOG compare-links point at valid refs
- [x] Feature descriptions match actual behavior (verified against shipped code in #22–#26)
- [x] No emojis added, no links to nonexistent anchors

🤖 Generated with [Claude Code](https://claude.com/claude-code)