### PR TITLE
ci(container): migrate to native multi-arch (no QEMU)

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -114,3 +114,52 @@ jobs:
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
+
+  merge:
+    name: Merge manifest
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: github.event_name != 'pull_request'
+    steps:
+      - name: Download digest artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (final tags)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect final manifest
+        run: |
+          docker buildx imagetools inspect \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -73,6 +73,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Compute image name (lowercase for GHCR)
+        id: image
+        run: |
+          REPO_LC=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          echo "name=${{ env.REGISTRY }}/${REPO_LC}" >> "$GITHUB_OUTPUT"
+
       - name: Log in to GHCR
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
@@ -85,7 +91,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ steps.image.outputs.name }}
 
       - name: Build and push by digest
         id: build
@@ -95,7 +101,7 @@ jobs:
           target: runtime
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          outputs: type=image,name=${{ steps.image.outputs.name }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
           cache-from: type=gha,scope=build-${{ matrix.platform_pair }}
           cache-to: type=gha,mode=max,scope=build-${{ matrix.platform_pair }}
 
@@ -121,6 +127,12 @@ jobs:
     needs: [build]
     if: github.event_name != 'pull_request'
     steps:
+      - name: Compute image name (lowercase for GHCR)
+        id: image
+        run: |
+          REPO_LC=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          echo "name=${{ env.REGISTRY }}/${REPO_LC}" >> "$GITHUB_OUTPUT"
+
       - name: Download digest artifacts
         uses: actions/download-artifact@v4
         with:
@@ -142,7 +154,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ steps.image.outputs.name }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -157,9 +169,9 @@ jobs:
         run: |
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+            $(printf '${{ steps.image.outputs.name }}@sha256:%s ' *)
 
       - name: Inspect final manifest
         run: |
           docker buildx imagetools inspect \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+            ${{ steps.image.outputs.name }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,4 +1,5 @@
-# Build + publish the pitboss container image to GitHub Container Registry.
+# Build + publish the pitboss container image to GitHub Container Registry
+# using a matrix + merge pipeline on native runners (no QEMU).
 #
 # Triggers:
 #   push to main   -> `ghcr.io/sds-mode/pitboss:main` + `:latest`
@@ -6,13 +7,14 @@
 #                     also updates `:latest` on tag push
 #   pull_request   -> build-only (no push) so PR authors see build failures.
 #
-# Platforms: linux/amd64 + linux/arm64 (matches the cargo-dist target
-# matrix that ships the standalone binaries).
+# Platforms: linux/amd64 (ubuntu-latest) + linux/arm64 (ubuntu-24.04-arm).
+# The arm64 cell runs natively on GitHub's free arm64 hosted runner.
 #
-# Security note: the only ${{ ... }} expressions used in `run:` contexts
-# are build-tool arguments consumed by trusted actions (docker/*). The
-# human-content vectors (commit messages, PR titles, etc.) are never
-# interpolated into shell. No `env:` escape hatches needed.
+# Architecture:
+#   Job `build` (matrix of {platform, runner}): builds + pushes by digest,
+#     uploads digest as artifact.
+#   Job `merge` (single job, push events only): downloads digests, creates
+#     multi-arch manifest via `docker buildx imagetools create`.
 
 name: Container
 
@@ -20,10 +22,6 @@ on:
   push:
     branches: [main]
     tags: ['v*']
-    # Skip the (slow, QEMU-emulated) container rebuild when a commit
-    # touches ONLY documentation. A commit touching docs AND code (e.g.
-    # the v0.6.0 release commit, which updates Cargo.toml + CHANGELOG.md)
-    # still triggers because not all changed paths match the ignore list.
     paths-ignore:
       - '**.md'
       - 'book/**'
@@ -45,21 +43,32 @@ permissions:
   contents: read
   packages: write
 
+concurrency:
+  group: container-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+  build:
+    name: Build (${{ matrix.platform_pair }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            platform_pair: linux-amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            platform_pair: linux-arm64
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -72,31 +81,36 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata
+      - name: Extract metadata (for labels only at this stage)
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          # Tags:
-          #   - semver: v0.5.0 -> 0.5.0, 0.5, 0
-          #   - branch: main -> main
-          #   - latest on default-branch push OR any release tag
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
-      - name: Build and push
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          target: runtime
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          cache-from: type=gha,scope=build-${{ matrix.platform_pair }}
+          cache-to: type=gha,mode=max,scope=build-${{ matrix.platform_pair }}
+
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.platform_pair }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1


### PR DESCRIPTION
## Summary

Replaces the current QEMU-emulated single-job container build with a matrix + merge pipeline on native runners (`ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64). Image contents, tags, and layer digests are unchanged.

This is **PR1 of 2** from the approved design at `docs/superpowers/specs/2026-04-20-claude-bundled-container-variant-design.md` (local-only spec). PR2 will add a \`pitboss-with-claude\` variant on top of this new matrix pattern.

### Why

Current CI takes ~60 minutes per push due to QEMU-emulated arm64 Rust compilation. Native arm64 runners cut that to an expected ~3-5 minutes (~12× speedup measured on the baseline run). This is also a prerequisite for adding the bundled-claude variant — doubling the QEMU matrix would push runtime past 2 hours.

### Architecture

- **build** job, matrix of \`{platform, runner}\`: builds + pushes by digest, uploads digest as artifact.
- **merge** job (push events only): downloads digests, \`docker buildx imagetools create\` assembles the multi-arch manifest, inspects the result.
- GHA cache scoped per-platform (\`build-linux-amd64\` / \`build-linux-arm64\`) so amd64 and arm64 don't stomp on each other.

## Test plan

- [ ] Both matrix cells (amd64 + arm64) run in parallel on native runners
- [ ] PR build is build-only (no image pushed)
- [ ] Elapsed time under 5 minutes
- [ ] After merge: \`docker buildx imagetools inspect ghcr.io/sds-mode/pitboss:main\` shows both architectures
- [ ] \`docker run --rm ghcr.io/sds-mode/pitboss:main pitboss --version\` matches pre-migration baseline (\`pitboss 0.6.0\`)
- [ ] arm64 cell logs show \`ubuntu-24.04-arm\` runner label (not QEMU)
- [ ] \`grep qemu .github/workflows/container.yml\` returns nothing

## Rollback

If arm64 native runners are unavailable or the merge pattern misbehaves, revert the PR. The existing image stays pulled by any prior \`:latest\` / \`:main\` tags until the next manifest push.