### PR TITLE
feat: bundle AGENTS.md into binary + container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@ target/
 *.md
 !README.md
 !CHANGELOG.md
+!AGENTS.md
 docs/
 .cache/
 scripts/smoke-logs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`pitboss agents-md` subcommand** — prints the bundled AGENTS.md
+  reference document to stdout. The content is compiled into the binary
+  via `include_str!`, so agents orchestrating pitboss from installed
+  binaries, containers, or CI runners (anywhere the git repo isn't
+  reachable) get the same doc as reading `AGENTS.md` from the repo.
+  Container images also ship a copy at `/usr/share/doc/pitboss/AGENTS.md`
+  for shell-first discovery — both routes serve identical bytes.
 - **Container variant `pitboss-with-claude`**: a new multi-arch container image published at `ghcr.io/sds-mode/pitboss-with-claude` bundling pitboss + a pinned Claude Code CLI (`2.1.114`). Operators consume host OAuth via a bind-mount of `~/.claude`. See the [Using Claude in a container](book/src/operator-guide/using-claude-in-container.md) book page for auth setup, UID alignment (rootless podman: `--userns=keep-id`), SELinux caveats (`:z` on all bind mounts), and macOS fallbacks.
 - CI smoke-test job that verifies `claude --version`, `pitboss --version`, and the bundled ATTRIBUTION file on both architectures post-merge.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,12 @@ RUN useradd --create-home --shell /bin/bash --uid 1000 pitboss
 COPY --from=builder /build/target/release/pitboss     /usr/local/bin/pitboss
 COPY --from=builder /build/target/release/pitboss-tui /usr/local/bin/pitboss-tui
 
+# Bundled agent-facing reference doc. Mirrors `pitboss agents-md` output at
+# a standard filesystem path so shell-first agents can discover it without
+# invoking the binary. Both routes serve identical content — the binary's
+# `AGENTS_MD` const is `include_str!`'d from the same source file.
+COPY AGENTS.md /usr/share/doc/pitboss/AGENTS.md
+
 USER pitboss
 WORKDIR /home/pitboss
 

--- a/crates/pitboss-cli/src/agents_md.rs
+++ b/crates/pitboss-cli/src/agents_md.rs
@@ -1,0 +1,46 @@
+//! `pitboss agents-md` — prints the AGENTS.md reference document bundled
+//! into this binary at compile time.
+//!
+//! Use when orchestrating pitboss from an environment without repo access
+//! (installed binary, container, CI runner). The embedded content's
+//! `pitboss_version` frontmatter is authoritative for the running binary.
+//!
+//! Parallel delivery path: the container images also copy AGENTS.md to
+//! `/usr/share/doc/pitboss/AGENTS.md` for shell-first discovery. Both
+//! routes serve the same bytes.
+
+/// Full AGENTS.md content, embedded at compile time from the repo root.
+pub const AGENTS_MD: &str = include_str!("../../../AGENTS.md");
+
+/// Write the bundled AGENTS.md document to stdout. No trailing newline
+/// is appended — the document already ends in one.
+pub fn print_agents_md() {
+    print!("{AGENTS_MD}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AGENTS_MD;
+
+    #[test]
+    fn agents_md_has_frontmatter() {
+        assert!(
+            AGENTS_MD.starts_with("---\ndocument: pitboss-agent-instructions"),
+            "AGENTS.md must open with the documented frontmatter; got first 60 chars: {:?}",
+            &AGENTS_MD[..AGENTS_MD.len().min(60)]
+        );
+    }
+
+    #[test]
+    fn agents_md_declares_pitboss_version() {
+        assert!(
+            AGENTS_MD.contains("\npitboss_version:"),
+            "frontmatter must declare pitboss_version"
+        );
+    }
+
+    #[test]
+    fn agents_md_is_not_empty() {
+        assert!(AGENTS_MD.len() > 1000, "AGENTS.md should be substantial");
+    }
+}

--- a/crates/pitboss-cli/src/cli.rs
+++ b/crates/pitboss-cli/src/cli.rs
@@ -78,6 +78,11 @@ pub enum Command {
     },
     /// Print version information.
     Version,
+    /// Print the bundled AGENTS.md reference document to stdout. Useful
+    /// for agents orchestrating pitboss from environments without repo
+    /// access (installed binary, container, CI runner). Content is
+    /// compiled in at build time and matches the running binary's version.
+    AgentsMd,
     /// Internal: proxy stdio <-> unix-socket for a claude subprocess's MCP client.
     /// Launched automatically by the `--mcp-config` file that pitboss generates
     /// per-actor. Not intended for direct human use.

--- a/crates/pitboss-cli/src/lib.rs
+++ b/crates/pitboss-cli/src/lib.rs
@@ -4,6 +4,7 @@
 //! the `pitboss` binary. The binary (`src/main.rs`) imports the same modules
 //! from this lib crate rather than re-declaring them.
 
+pub mod agents_md;
 pub mod attach;
 pub mod cli;
 pub mod control;

--- a/crates/pitboss-cli/src/main.rs
+++ b/crates/pitboss-cli/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
 
-use pitboss_cli::{attach, cli, diff, dispatch, manifest, mcp};
+use pitboss_cli::{agents_md, attach, cli, diff, dispatch, manifest, mcp};
 
 use cli::{Cli, Command};
 
@@ -12,6 +12,10 @@ fn main() -> Result<()> {
     match args.command {
         Command::Version => {
             println!("pitboss {}", env!("CARGO_PKG_VERSION"));
+            Ok(())
+        }
+        Command::AgentsMd => {
+            agents_md::print_agents_md();
             Ok(())
         }
         Command::Validate { manifest } => run_validate(&manifest),


### PR DESCRIPTION
## Summary

Adds two symmetric access paths for the agent-facing reference doc so operators orchestrating pitboss from environments without repo access (installed binary, container, CI runner) still get the doc that matches their binary version.

1. **`pitboss agents-md` subcommand** — \`include_str!\` compiles AGENTS.md into the binary; the subcommand prints it to stdout. Compile-time embedding guarantees \`pitboss_version\` in the frontmatter matches the binary version.
2. **Container filesystem path** — \`/usr/share/doc/pitboss/AGENTS.md\`, \`COPY\`'d in the Dockerfile runtime stage. Inherited by the with-claude variant. Shell-first agents discover it at a standard doc path.

Both routes serve identical bytes (verified via \`diff\` locally).

## Minor infra change

\`.dockerignore\` had a blanket \`*.md\` exclude with exceptions for only \`README.md\` and \`CHANGELOG.md\`. Added \`!AGENTS.md\` so the file reaches the build context — \`include_str!\` fails inside the container otherwise.

## Context

Lessons-learned from an operator attempting headless pitboss dispatch: an agent pulling the container or using an installed binary has no way to fetch the version-matched AGENTS.md without network access to a specific git ref. AGENTS.md's frontmatter already declares \`pitboss_version\` for applicability filtering; this PR makes the frontmatter's claim checkable against the actually-running binary.

## Test plan

- [ ] PR CI: all 4 container build cells pass (AGENTS.md now in the build context)
- [ ] \`cargo test -p pitboss-cli --lib agents_md\` green (3 tests)
- [ ] \`pitboss agents-md | head -5\` from the built binary prints the frontmatter
- [ ] After merge: \`podman run --rm ghcr.io/sds-mode/pitboss-with-claude:main pitboss agents-md | diff - <(podman run --rm --entrypoint cat ghcr.io/sds-mode/pitboss-with-claude:main /usr/share/doc/pitboss/AGENTS.md)\` is empty

## Follow-up

This is PR-A of a split from the headless-mode-hardening plan. PR-B will add the behavior changes (auto \`CLAUDE_CODE_ENTRYPOINT=sdk-ts\`, sublead env/tools plumbing, ApprovalRejected/ApprovalTimedOut terminal states, dispatch-time TTY warning, and an AGENTS.md "Headless mode" section that references the new subcommand and file path).