### PR TITLE
feat: headless-mode hardening (lessons-learned fixes + Path A permission default)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,6 +262,132 @@ Compares two runs side-by-side. Useful for A/B testing prompts or models.
 
 ---
 
+## Headless mode (agents dispatching pitboss without a terminal)
+
+If you (the agent) are dispatching pitboss without a terminal attached —
+running in a container, under systemd, from another orchestrator — the
+behavior diverges from interactive TUI use in several ways. Read this
+section before writing manifests for headless dispatch.
+
+### Permission model
+
+As of v0.7, pitboss auto-sets `CLAUDE_CODE_ENTRYPOINT=sdk-ts` on every
+spawned claude subprocess. This tells claude to bypass its built-in
+interactive permission gate; pitboss becomes the sole approval authority
+via `approval_policy` and `[[approval_policy]]` rules. Without this fix,
+sub-leads in headless dispatch would exit in ~7 seconds reporting
+`Success` with no output (claude apologizing that it can't get
+permission to write files, then giving up cleanly).
+
+You can override this per-actor by setting `[defaults.env.CLAUDE_CODE_ENTRYPOINT]`
+to a different value in the manifest, but for headless dispatch you
+almost certainly want the default.
+
+### Approval policy — set `auto_approve` (or use rules)
+
+Without a TUI to approve things, pitboss's own approval mechanisms hang
+forever (or until timeout) if not configured. Set:
+
+```toml
+[run]
+approval_policy = "auto_approve"  # or "auto_reject" for strict dry-run dispatch
+```
+
+For finer control, use `[[approval_policy]]` rules with `ttl_secs`
+fallbacks. Pitboss now emits a startup warning to stderr when it detects
+`approval_policy = "block"` (or unset) AND no TTY on stdout — read it
+before assuming a hang is something else.
+
+### `require_plan_approval = true` is usually wrong headless
+
+Setting `[run].require_plan_approval = true` blocks the run until an
+operator approves the lead's first `propose_plan` call. In headless mode
+this hangs unless the lead's `propose_plan` includes a `ttl_secs` +
+`fallback`. If you see a task land with `status: "ApprovalRejected"` (v0.7+)
+or `"ApprovalTimedOut"` (when queue-TTL plumbing lands), this gate is
+the most likely cause.
+
+### Hierarchical mode requires a git repo even with `use_worktree = false`
+
+Lead setup runs a git-repo check regardless of the worktree setting.
+Before dispatching a hierarchical manifest in a fresh workspace:
+
+```bash
+git init /workspace
+git -C /workspace commit --allow-empty -m "init"
+```
+
+Flat mode (`[[task]]` only, no `[[lead]]`) does not have this requirement.
+
+### Reading run status without the TUI
+
+There is no `pitboss status` subcommand (yet). Use:
+
+- `pitboss attach <run-prefix> <task-id>` — follow a specific worker's stream-json
+- `cat <run-dir>/summary.jsonl` — completed tasks (streamed append-only)
+- `cat <run-dir>/summary.json` — full summary on clean finalize
+- `ls <run-dir>/tasks/` — all spawned task directories
+
+The root lead's logs live at `<run-dir>/tasks/<lead-id>/stdout.log`.
+Workers and sub-leads live at `<run-dir>/tasks/<task-id>/` and
+`<run-dir>/tasks/<sublead-id>/` respectively. Sub-lead ids are
+`sublead-<uuid>` — they don't match the manifest's `[lead].id`. Use
+the UUID form from `summary.jsonl` when calling `pitboss attach`.
+
+### Terminal-state classification (v0.7+)
+
+A task that exited because an approval returned negative is classified
+distinctly from a task that succeeded:
+
+| Status | Meaning |
+|--------|---------|
+| `Success` | Task completed work and exited cleanly |
+| `Failed` | Task exited with non-zero status |
+| `TimedOut` | Task exceeded `timeout_secs` |
+| `Cancelled` | Task was explicitly cancelled by operator or cascade |
+| `SpawnFailed` | Task never started (worktree prep, claude not found, etc.) |
+| `ApprovalRejected` | Task's last approval returned `{approved: false}` from operator action or `[[approval_policy]]` auto_reject rule, then exited shortly after |
+| `ApprovalTimedOut` | Reserved for queue-TTL fallback (today fires only via the `from_ttl: true` codepath which is not yet wired end-to-end; treat as an intent variant) |
+
+Before v0.7, both new statuses were reported as `Success` because the
+claude subprocess exited 0. If you see `ApprovalRejected` in
+`summary.json`, your manifest's `approval_policy` (or operator action)
+denied the actor's request — revisit the approval configuration.
+
+### Customizing sub-lead env and tools per spawn (v0.7+)
+
+`spawn_sublead` accepts optional `env` and `tools` parameters:
+
+```
+spawn_sublead(
+  prompt: "...",
+  model: "claude-sonnet-4-6",
+  budget_usd: 2.0,
+  max_workers: 4,
+  env: { "MY_VAR": "value" },        // merged over pitboss defaults
+  tools: ["Read", "Bash"]            // adds to standard sublead toolset
+)
+```
+
+Both fields are optional. Operator-supplied `env` keys override pitboss
+defaults (including `CLAUDE_CODE_ENTRYPOINT` if you really want claude's
+own gate back for that sub-lead). Operator-supplied `tools` are added
+to the standard sublead MCP toolset; pitboss orchestration tools are
+always present regardless of override.
+
+### Offline access to this doc
+
+```bash
+pitboss agents-md                                    # from any binary
+cat /usr/share/doc/pitboss/AGENTS.md                  # from a container
+```
+
+Both routes serve the same bytes — `AGENTS.md` is `include_str!`'d into
+the binary at compile time and `COPY`'d into the container image.
+`pitboss_version` in the frontmatter matches the binary version.
+
+---
+
 ## Interpreting a run directory
 
 After `pitboss dispatch` finishes, find the run via:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Two new terminal statuses: `TaskStatus::ApprovalRejected` +
+  `TaskStatus::ApprovalTimedOut`** (and matching `SubleadOutcome`
+  variants) — tasks that exit because their last `request_approval` /
+  `propose_plan` returned `{approved: false}` (operator-rejected,
+  policy auto-rejected) are now classified distinctly from genuine
+  `Success`. Previously both looked like `Success` because the claude
+  subprocess exited 0. SQLite store + JSON wire format extended with
+  the two new strings; old records deserialize unchanged.
+  `ApprovalTimedOut` is reserved for queue-TTL fallback (defined and
+  ready to wire when the queue-TTL → response path lands).
+- **`spawn_sublead` MCP tool gains optional `env` and `tools`
+  parameters** — sub-leads can now receive per-spawn environment
+  variables and a `--allowedTools` override. Operator env layers over
+  pitboss defaults (`CLAUDE_CODE_ENTRYPOINT=sdk-ts` etc.); tools merge
+  with the standard sublead MCP toolset (de-duplicated). `mcp__pitboss__*`
+  tools are always present so the sub-lead can still orchestrate workers
+  regardless of override.
+- **Dispatch-time warning when approval gates would block headless
+  runs.** If stdout is not a TTY and the manifest has
+  `require_plan_approval = true`, `approval_policy = "block"` (or
+  unset), or any `[[approval_policy]]` rule with `action = "block"`,
+  pitboss prints a stderr warning listing each gate before any claude
+  subprocess launches. Silent on TTY (interactive operators have the
+  TUI to approve).
 - **`pitboss agents-md` subcommand** — prints the bundled AGENTS.md
   reference document to stdout. The content is compiled into the binary
   via `include_str!`, so agents orchestrating pitboss from installed
@@ -21,6 +45,25 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Sub-lead claude subprocesses spawned with empty env** — previously
+  `spawn_sublead_session` constructed its `SpawnCmd` with `env:
+  Default::default()` (empty map). For headless dispatch this meant
+  sub-leads couldn't inherit `CLAUDE_CODE_ENTRYPOINT` even when the
+  operator set it via `[defaults.env]`. Now seeded with pitboss's own
+  defaults plus any operator env from the new `spawn_sublead` `env`
+  parameter. Closes the P0 half of lessons-learned items #1 and #6.
+- **Tasks that exited because their last approval was rejected showed
+  as `Success`** — the claude subprocess exited 0 (its work was simply
+  blocked by the rejection), and pitboss had no way to distinguish this
+  from a real success. New `ApprovalRejected` terminal status, plus a
+  per-actor `last_approval_response` map on `DispatchState`, plus a
+  reclassification check at every termination site (worker /
+  continue-worker / sublead / root lead) that flips Success →
+  ApprovalRejected when the actor's most recent approval (within 30s
+  of termination) returned negative. Sub-leads in headless dispatch
+  with `[[approval_policy]] action = "auto_reject"` rules will now
+  surface as `ApprovalRejected` in `summary.json` instead of misleading
+  Success. Closes lessons-learned item #3.
 - **Run-global leases leaked on connection drop when `run_lease_acquire`
   was the only tool called on a connection.** `note_actor` was missing
   from the `run_lease_acquire` and `run_lease_release` MCP handlers, so
@@ -34,6 +77,18 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **Default `CLAUDE_CODE_ENTRYPOINT=sdk-ts` on every spawned claude
+  subprocess** (root lead, workers, sub-leads). Pitboss is the external
+  permission authority via `approval_policy` + `[[approval_policy]]`
+  rules + the TUI; claude's own interactive permission gate is bypassed
+  to prevent silent 7-second-success failures in headless dispatch where
+  no TTY is available to approve tool calls. Operators who want claude's
+  own gate back for a specific actor restore it by setting
+  `CLAUDE_CODE_ENTRYPOINT` to a non-`sdk-ts` value via `[defaults.env]`,
+  `[lead.env]`, `[[task]].env`, or the `env` field on `spawn_sublead`.
+  See `docs/superpowers/specs/2026-04-20-path-b-permission-prompt-routing-pin.md`
+  for the deferred alternative (route claude's gate through pitboss's
+  approval queue rather than bypassing).
 - **Container CI**: migrated from QEMU-emulated multi-arch builds to
   native `ubuntu-latest` + `ubuntu-24.04-arm` runners with a matrix +
   merge pipeline. Published `ghcr.io/sds-mode/pitboss` image contents
@@ -42,6 +97,16 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Docs
 
+- **AGENTS.md: new "Headless mode" section** between "Invocation
+  patterns" and "Interpreting a run directory" — covers the v0.7
+  permission model (`CLAUDE_CODE_ENTRYPOINT=sdk-ts` default), approval
+  policy choices for unattended dispatch, the dispatch-time TTY warning,
+  the `require_plan_approval` footgun, the git-repo-required-for-
+  hierarchical-mode quirk, status reading without the TUI, the new
+  terminal-state classifications (including operator guidance for
+  `ApprovalRejected` debugging), the new `spawn_sublead` env/tools
+  parameters, and the offline access patterns (`pitboss agents-md` +
+  the container doc path).
 - **AGENTS.md**: added YAML frontmatter (`document`, `schema_version`,
   `pitboss_version`, `audience`, `canonical_url`, `last_updated`) so
   agents can filter for applicability without scanning the whole doc.

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -719,6 +719,12 @@ async fn dispatch_op(
                                 pitboss_core::store::TaskStatus::TimedOut => "done_timed_out",
                                 pitboss_core::store::TaskStatus::Cancelled => "done_cancelled",
                                 pitboss_core::store::TaskStatus::SpawnFailed => "done_spawn_failed",
+                                pitboss_core::store::TaskStatus::ApprovalRejected => {
+                                    "done_approval_rejected"
+                                }
+                                pitboss_core::store::TaskStatus::ApprovalTimedOut => {
+                                    "done_approval_timed_out"
+                                }
                             }
                             .to_string(),
                             Some(rec.started_at.to_rfc3339()),

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -337,26 +337,35 @@ pub async fn run_hierarchical(
         .unwrap_or_default();
     // Merge the loop's own reprompt_count into the counter-based one.
     let total_reprompt_count = lead_counters.reprompt_count + reprompt_count;
+    // Compute initial status from session state, then reclassify if the
+    // root lead exited shortly after a rejected approval (lessons-learned:
+    // require_plan_approval = true + auto_reject by policy → lead exits 0
+    // → would otherwise be Success). See `mcp::tools::run_worker` for the
+    // same pattern.
+    let mut lead_status = match final_outcome.final_state {
+        pitboss_core::session::SessionState::Completed => pitboss_core::store::TaskStatus::Success,
+        pitboss_core::session::SessionState::Failed { .. } => {
+            pitboss_core::store::TaskStatus::Failed
+        }
+        pitboss_core::session::SessionState::TimedOut => pitboss_core::store::TaskStatus::TimedOut,
+        pitboss_core::session::SessionState::Cancelled => {
+            pitboss_core::store::TaskStatus::Cancelled
+        }
+        pitboss_core::session::SessionState::SpawnFailed { .. } => {
+            pitboss_core::store::TaskStatus::SpawnFailed
+        }
+        _ => pitboss_core::store::TaskStatus::Failed,
+    };
+    if matches!(lead_status, pitboss_core::store::TaskStatus::Success) {
+        if let Some(crate::dispatch::state::ApprovalTerminationKind::Rejected) =
+            state.approval_driven_termination(&lead.id).await
+        {
+            lead_status = pitboss_core::store::TaskStatus::ApprovalRejected;
+        }
+    }
     let lead_record = pitboss_core::store::TaskRecord {
         task_id: lead.id.clone(),
-        status: match final_outcome.final_state {
-            pitboss_core::session::SessionState::Completed => {
-                pitboss_core::store::TaskStatus::Success
-            }
-            pitboss_core::session::SessionState::Failed { .. } => {
-                pitboss_core::store::TaskStatus::Failed
-            }
-            pitboss_core::session::SessionState::TimedOut => {
-                pitboss_core::store::TaskStatus::TimedOut
-            }
-            pitboss_core::session::SessionState::Cancelled => {
-                pitboss_core::store::TaskStatus::Cancelled
-            }
-            pitboss_core::session::SessionState::SpawnFailed { .. } => {
-                pitboss_core::store::TaskStatus::SpawnFailed
-            }
-            _ => pitboss_core::store::TaskStatus::Failed,
-        },
+        status: lead_status,
         exit_code: final_outcome.exit_code,
         started_at: overall_started_at,
         ended_at: final_outcome.ended_at,

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -200,11 +200,13 @@ pub async fn run_hierarchical(
     //     identical behaviour to the v0.5 single-shot. The extra state
     //     (last_session_id, overall_started_at, total_token_usage) adds no
     //     overhead on the common path.
+    let mut lead_env = lead.env.clone();
+    crate::dispatch::runner::apply_pitboss_env_defaults(&mut lead_env);
     let initial_cmd = pitboss_core::process::SpawnCmd {
         program: claude_binary.clone(),
         args: crate::dispatch::runner::lead_spawn_args(lead, &mcp_config_path),
         cwd: lead_cwd.clone(),
-        env: lead.env.clone(),
+        env: lead_env,
     };
 
     state.workers.write().await.insert(
@@ -286,11 +288,13 @@ pub async fn run_hierarchical(
                     sid,
                     &new_prompt,
                 );
+                let mut resume_env = lead.env.clone();
+                crate::dispatch::runner::apply_pitboss_env_defaults(&mut resume_env);
                 current_cmd = pitboss_core::process::SpawnCmd {
                     program: claude_binary.clone(),
                     args: resume_args,
                     cwd: lead_cwd.clone(),
-                    env: lead.env.clone(),
+                    env: resume_env,
                 };
                 // Reset the workers map entry to Running (session_id TBD).
                 state.workers.write().await.insert(

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -27,6 +27,11 @@ pub async fn run_hierarchical(
     run_dir_override: Option<PathBuf>,
     dry_run: bool,
 ) -> Result<i32> {
+    // Surface headless approval-gate mis-configurations early, before any
+    // claude subprocess launches. Runs silently if stdout is a TTY (the
+    // operator has the TUI to approve things).
+    crate::dispatch::runner::print_headless_warnings_if_applicable(&resolved);
+
     let run_id = Uuid::now_v7();
     let run_dir = run_dir_override.unwrap_or_else(|| resolved.run_dir.clone());
     tokio::fs::create_dir_all(&run_dir).await.ok();

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -690,12 +690,17 @@ pub fn lead_resume_spawn_args(
 /// - `model`: The model name (e.g., "claude-opus-4-1")
 /// - `mcp_config_path`: Path to the per-sublead mcp-config file
 /// - `resume_session_id`: Optional session ID to resume from
+/// - `tools_override`: When `Some(&[...])`, the listed tools are added to
+///   the allow-list alongside the standard sublead MCP toolset. When
+///   `None`, only the MCP toolset is included (preserves v0.6 behavior).
+///   De-duplicated to keep the resulting `--allowedTools` flag tidy.
 pub fn sublead_spawn_args(
     _sublead_id: &str,
     prompt: &str,
     model: &str,
     mcp_config_path: &std::path::Path,
     resume_session_id: Option<&str>,
+    tools_override: Option<&[String]>,
 ) -> Vec<String> {
     let mut args = vec![
         "--output-format".into(),
@@ -703,8 +708,19 @@ pub fn sublead_spawn_args(
         "--verbose".into(),
     ];
 
-    // Build the allowed-tools set: sublead tools (no user tools, no depth-2 tools).
-    let allowed: Vec<String> = SUBLEAD_MCP_TOOLS.iter().map(|t| t.to_string()).collect();
+    // Build the allowed-tools set. Operator-supplied tools (if any) are
+    // listed first; pitboss MCP tools always appended so the sub-lead can
+    // still orchestrate workers regardless of the override.
+    let mut allowed: Vec<String> = match tools_override {
+        Some(ts) => ts.to_vec(),
+        None => Vec::new(),
+    };
+    for t in SUBLEAD_MCP_TOOLS {
+        allowed.push((*t).to_string());
+    }
+    // De-duplicate while preserving order.
+    let mut seen = std::collections::HashSet::new();
+    allowed.retain(|t| seen.insert(t.clone()));
     args.push("--allowedTools".into());
     args.push(allowed.join(","));
 
@@ -1329,6 +1345,7 @@ mod tests {
             "claude-opus-4-1",
             &PathBuf::from("/tmp/sublead-cfg.json"),
             None,
+            None,
         );
         let idx = args.iter().position(|a| a == "--allowedTools").unwrap();
         let list = &args[idx + 1];
@@ -1352,6 +1369,7 @@ mod tests {
             "claude-opus-4-1",
             &PathBuf::from("/tmp/sublead-cfg.json"),
             None,
+            None,
         );
         let idx = args.iter().position(|a| a == "--allowedTools").unwrap();
         let list = &args[idx + 1];
@@ -1370,6 +1388,7 @@ mod tests {
             "claude-opus-4-1",
             &PathBuf::from("/tmp/sublead-cfg.json"),
             Some("resume-session-123"),
+            None,
         );
         // Verify the basic arg structure is correct
         assert!(args.contains(&"--output-format".to_string()));
@@ -1383,5 +1402,47 @@ mod tests {
         assert!(args.contains(&"resume-session-123".to_string()));
         assert!(args.contains(&"-p".to_string()));
         assert!(args.contains(&"do some work".to_string()));
+    }
+
+    #[test]
+    fn sublead_spawn_args_honors_tools_override() {
+        let custom = ["Read".to_string(), "Bash".to_string()];
+        let args = sublead_spawn_args(
+            "test-sublead-id",
+            "do some work",
+            "claude-opus-4-1",
+            &PathBuf::from("/tmp/sublead-cfg.json"),
+            None,
+            Some(&custom),
+        );
+        let idx = args.iter().position(|a| a == "--allowedTools").unwrap();
+        let list = &args[idx + 1];
+        // Operator-supplied tools must be present.
+        assert!(list.contains("Read"), "Read missing from {list}");
+        assert!(list.contains("Bash"), "Bash missing from {list}");
+        // pitboss MCP tools must still be present (override doesn't remove them).
+        assert!(
+            list.contains("mcp__pitboss__"),
+            "pitboss MCP tools missing from {list}"
+        );
+    }
+
+    #[test]
+    fn sublead_spawn_args_dedups_when_override_overlaps_mcp_tools() {
+        // Operator passes a pitboss MCP tool already in the standard set.
+        // Result should not contain duplicates.
+        let custom = ["mcp__pitboss__spawn_worker".to_string()];
+        let args = sublead_spawn_args(
+            "test-sublead-id",
+            "do some work",
+            "claude-opus-4-1",
+            &PathBuf::from("/tmp/sublead-cfg.json"),
+            None,
+            Some(&custom),
+        );
+        let idx = args.iter().position(|a| a == "--allowedTools").unwrap();
+        let list = &args[idx + 1];
+        let count = list.matches("mcp__pitboss__spawn_worker").count();
+        assert_eq!(count, 1, "spawn_worker appears {count} times in {list}");
     }
 }

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -40,6 +40,94 @@ pub fn apply_pitboss_env_defaults(env: &mut std::collections::HashMap<String, St
         .or_insert_with(|| "sdk-ts".to_string());
 }
 
+/// Check whether a manifest has approval gates that will block indefinitely
+/// in a headless (no-TUI) dispatch. Returns warning strings describing each
+/// gate; empty if the manifest can run cleanly headless. Callers typically
+/// print the warnings to stderr at dispatch startup.
+///
+/// Gates checked:
+/// - `[run].require_plan_approval = true` → lead's `propose_plan` will hang
+///   on the operator queue with no TUI to respond.
+/// - `[run].approval_policy = "block"` (or unset — the default) → unmatched
+///   `request_approval` calls will sit in the queue.
+/// - Any `[[approval_policy]]` rule with `action = "block"` → policy-matched
+///   approvals will force into the queue.
+///
+/// The warning is orthogonal to the Path A env-default fix — Path A stops
+/// claude's OWN permission gate from firing, but pitboss's own approval
+/// layer is still operator-driven by default. An operator expecting headless
+/// dispatch should set `approval_policy = "auto_approve"` (or use
+/// `[[approval_policy]]` rules with `ttl_secs` + `fallback`).
+pub fn headless_approval_gate_warnings(manifest: &ResolvedManifest) -> Vec<String> {
+    let mut warnings = Vec::new();
+
+    if manifest.require_plan_approval {
+        warnings.push(
+            "`[run].require_plan_approval = true` — lead will hang on `propose_plan` \
+             with no TUI to approve. Set `false` or add a `ttl_secs` + `fallback` \
+             on the `propose_plan` call for headless use."
+                .to_string(),
+        );
+    }
+
+    // `approval_policy` defaults to `Block` when unset, so both None and
+    // Some(Block) trigger the warning.
+    let policy_blocks = matches!(
+        manifest.approval_policy,
+        None | Some(crate::dispatch::state::ApprovalPolicy::Block)
+    );
+    if policy_blocks {
+        warnings.push(
+            "`[run].approval_policy` is `block` (or unset — defaults to block) — \
+             unmatched `request_approval` / `propose_plan` calls will sit in \
+             the operator queue. Set `auto_approve` or `auto_reject` for \
+             headless use."
+                .to_string(),
+        );
+    }
+
+    let blocking_rule_count = manifest
+        .approval_rules
+        .iter()
+        .filter(|r| matches!(r.action, crate::mcp::policy::ApprovalAction::Block))
+        .count();
+    if blocking_rule_count > 0 {
+        warnings.push(format!(
+            "{} `[[approval_policy]]` rule(s) use `action = \"block\"` — matched \
+             approvals will force into the operator queue. Change to \
+             `auto_approve` / `auto_reject`, or attach a TUI.",
+            blocking_rule_count
+        ));
+    }
+
+    warnings
+}
+
+/// Emit headless-approval-gate warnings to stderr when stdout is not a
+/// terminal. Operators running pitboss interactively won't see spurious
+/// warnings; headless operators see them prominently before any claude
+/// subprocess launches.
+pub fn print_headless_warnings_if_applicable(manifest: &ResolvedManifest) {
+    if atty::is(atty::Stream::Stdout) {
+        return;
+    }
+    let warnings = headless_approval_gate_warnings(manifest);
+    if warnings.is_empty() {
+        return;
+    }
+    eprintln!(
+        "pitboss: WARNING — dispatching without a TUI surface but the manifest \
+         has approval gates that will block:"
+    );
+    for w in &warnings {
+        eprintln!("  - {}", w);
+    }
+    eprintln!(
+        "See https://sds-mode.github.io/pitboss/operator-guide/approvals.html \
+         for the headless approval patterns."
+    );
+}
+
 fn cleanup_policy_from(w: crate::manifest::schema::WorktreeCleanup) -> CleanupPolicy {
     match w {
         crate::manifest::schema::WorktreeCleanup::Always => CleanupPolicy::Always,
@@ -58,6 +146,10 @@ pub async fn run_dispatch_inner(
     run_dir_override: Option<PathBuf>,
     dry_run: bool,
 ) -> Result<i32> {
+    // Flat manifests rarely use `[[approval_policy]]` or `propose_plan`,
+    // but if they do, the same headless-gate warnings apply. Silent on TTY.
+    print_headless_warnings_if_applicable(&resolved);
+
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
     let run_dir = run_dir_override.unwrap_or_else(|| resolved.run_dir.clone());
     tokio::fs::create_dir_all(&run_dir).await.ok();
@@ -733,6 +825,85 @@ mod tests {
             env.get("CLAUDE_CODE_ENTRYPOINT"),
             Some(&"sdk-ts".to_string())
         );
+    }
+
+    fn minimal_manifest() -> ResolvedManifest {
+        ResolvedManifest {
+            max_parallel: 1,
+            halt_on_failure: false,
+            run_dir: PathBuf::from("/tmp/pitboss-test"),
+            worktree_cleanup: crate::manifest::schema::WorktreeCleanup::OnSuccess,
+            emit_event_stream: false,
+            tasks: vec![],
+            lead: None,
+            max_workers: None,
+            budget_usd: None,
+            lead_timeout_secs: None,
+            approval_policy: Some(crate::dispatch::state::ApprovalPolicy::AutoApprove),
+            notifications: vec![],
+            dump_shared_store: false,
+            require_plan_approval: false,
+            approval_rules: vec![],
+        }
+    }
+
+    #[test]
+    fn headless_warnings_empty_for_clean_manifest() {
+        let manifest = minimal_manifest();
+        let warnings = headless_approval_gate_warnings(&manifest);
+        assert!(
+            warnings.is_empty(),
+            "clean manifest should not warn: {:?}",
+            warnings
+        );
+    }
+
+    #[test]
+    fn headless_warnings_flag_require_plan_approval() {
+        let mut manifest = minimal_manifest();
+        manifest.require_plan_approval = true;
+        let warnings = headless_approval_gate_warnings(&manifest);
+        assert_eq!(warnings.len(), 1, "expected one warning: {:?}", warnings);
+        assert!(warnings[0].contains("require_plan_approval"));
+    }
+
+    #[test]
+    fn headless_warnings_flag_block_default_when_unset() {
+        let mut manifest = minimal_manifest();
+        manifest.approval_policy = None;
+        let warnings = headless_approval_gate_warnings(&manifest);
+        assert_eq!(warnings.len(), 1, "expected one warning: {:?}", warnings);
+        assert!(warnings[0].contains("approval_policy"));
+    }
+
+    #[test]
+    fn headless_warnings_flag_block_policy_explicit() {
+        let mut manifest = minimal_manifest();
+        manifest.approval_policy = Some(crate::dispatch::state::ApprovalPolicy::Block);
+        let warnings = headless_approval_gate_warnings(&manifest);
+        assert_eq!(warnings.len(), 1, "expected one warning: {:?}", warnings);
+        assert!(warnings[0].contains("approval_policy"));
+    }
+
+    #[test]
+    fn headless_warnings_flag_block_rule() {
+        let mut manifest = minimal_manifest();
+        manifest.approval_rules = vec![crate::mcp::policy::ApprovalRule {
+            r#match: crate::mcp::policy::ApprovalMatch::default(),
+            action: crate::mcp::policy::ApprovalAction::Block,
+        }];
+        let warnings = headless_approval_gate_warnings(&manifest);
+        assert_eq!(warnings.len(), 1, "expected one warning: {:?}", warnings);
+        assert!(warnings[0].contains("approval_policy") && warnings[0].contains("rule"));
+    }
+
+    #[test]
+    fn headless_warnings_stack_when_multiple_gates_present() {
+        let mut manifest = minimal_manifest();
+        manifest.require_plan_approval = true;
+        manifest.approval_policy = Some(crate::dispatch::state::ApprovalPolicy::Block);
+        let warnings = headless_approval_gate_warnings(&manifest);
+        assert_eq!(warnings.len(), 2, "expected two warnings: {:?}", warnings);
     }
 
     fn init_repo(root: &std::path::Path) {

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -17,6 +17,29 @@ use uuid::Uuid;
 
 use crate::manifest::resolve::{ResolvedManifest, ResolvedTask};
 
+/// Seed an env map with pitboss's own defaults for spawned claude subprocesses.
+/// Currently: set `CLAUDE_CODE_ENTRYPOINT=sdk-ts` if not already present.
+///
+/// Rationale: pitboss is the external permission authority (via
+/// `approval_policy`, `[[approval_policy]]` rules, and the TUI). Claude's
+/// own interactive permission gate is redundant under pitboss orchestration
+/// and causes silent 7-second-success failures in headless dispatch when no
+/// operator is present to approve each tool call.
+///
+/// The `sdk-ts` value tells claude "you're running under an SDK runtime that
+/// manages permissions externally — don't prompt the TTY." Operators who want
+/// claude's own gate back for a specific actor can override via
+/// `[defaults.env]`, `[lead.env]`, `[[task]].env`, or the `env` field on
+/// `spawn_sublead`.
+///
+/// See `docs/superpowers/specs/2026-04-20-path-b-permission-prompt-routing-pin.md`
+/// for the deferred alternative (routing claude's gate through pitboss's
+/// approval queue rather than bypassing it).
+pub fn apply_pitboss_env_defaults(env: &mut std::collections::HashMap<String, String>) {
+    env.entry("CLAUDE_CODE_ENTRYPOINT".to_string())
+        .or_insert_with(|| "sdk-ts".to_string());
+}
+
 fn cleanup_policy_from(w: crate::manifest::schema::WorktreeCleanup) -> CleanupPolicy {
     match w {
         crate::manifest::schema::WorktreeCleanup::Always => CleanupPolicy::Always,
@@ -336,11 +359,13 @@ async fn execute_task(
         task.directory.clone()
     };
 
+    let mut cmd_env = task.env.clone();
+    apply_pitboss_env_defaults(&mut cmd_env);
     let cmd = SpawnCmd {
         program: claude.to_path_buf(),
         args: spawn_args(task),
         cwd: cwd.clone(),
-        env: task.env.clone(),
+        env: cmd_env,
     };
 
     table.lock().await.mark_running(&task.id);
@@ -671,8 +696,44 @@ async fn expire_approvals(state: &Arc<crate::dispatch::state::DispatchState>) {
 mod tests {
     use super::*;
     use pitboss_core::process::fake::{FakeScript, FakeSpawner};
+    use std::collections::HashMap;
     use std::process::Command;
     use tempfile::TempDir;
+
+    #[test]
+    fn apply_pitboss_env_defaults_sets_entrypoint_when_absent() {
+        let mut env: HashMap<String, String> = HashMap::new();
+        apply_pitboss_env_defaults(&mut env);
+        assert_eq!(
+            env.get("CLAUDE_CODE_ENTRYPOINT"),
+            Some(&"sdk-ts".to_string()),
+            "default should be applied to an empty env"
+        );
+    }
+
+    #[test]
+    fn apply_pitboss_env_defaults_honors_operator_override() {
+        let mut env: HashMap<String, String> = HashMap::new();
+        env.insert("CLAUDE_CODE_ENTRYPOINT".to_string(), "cli".to_string());
+        apply_pitboss_env_defaults(&mut env);
+        assert_eq!(
+            env.get("CLAUDE_CODE_ENTRYPOINT"),
+            Some(&"cli".to_string()),
+            "operator-set value must not be overwritten"
+        );
+    }
+
+    #[test]
+    fn apply_pitboss_env_defaults_preserves_other_keys() {
+        let mut env: HashMap<String, String> = HashMap::new();
+        env.insert("FOO".to_string(), "bar".to_string());
+        apply_pitboss_env_defaults(&mut env);
+        assert_eq!(env.get("FOO"), Some(&"bar".to_string()));
+        assert_eq!(
+            env.get("CLAUDE_CODE_ENTRYPOINT"),
+            Some(&"sdk-ts".to_string())
+        );
+    }
 
     fn init_repo(root: &std::path::Path) {
         Command::new("git")

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -107,6 +107,36 @@ pub struct ApprovalResponse {
     pub reason: Option<String>,
 }
 
+/// Most recent approval response delivered to a given actor. Populated by
+/// `handle_request_approval` and `handle_propose_plan` immediately before
+/// they return to the MCP caller. Consulted at actor-termination time by
+/// `approval_driven_termination` to reclassify "silent exit after a
+/// rejected approval" as `TaskStatus::ApprovalRejected` rather than the
+/// misleading `Success`.
+///
+/// Entries are kept for the duration of the run — the map is small (one
+/// per actor that ever requested an approval) and termination
+/// reclassification can happen seconds to minutes after the last
+/// approval.
+#[derive(Debug, Clone)]
+pub struct LastApprovalResponse {
+    pub approved: bool,
+    pub received_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Why an actor's terminal status should be reclassified from `Success`.
+/// Returned by `DispatchState::approval_driven_termination`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApprovalTerminationKind {
+    /// Last approval returned `{approved: false}` from an operator action
+    /// or a `[[approval_policy]]` `auto_reject` rule.
+    Rejected,
+    // Future: TimedOut variant when queue-TTL fallback is wired through to
+    // an actual {approved: false} response (today's expire_approvals removes
+    // the entry without responding, so the actor sees a bridge timeout
+    // rather than a clean rejection — that's a separate fix).
+}
+
 #[derive(Default, Clone, Debug)]
 pub struct WorkerCounters {
     pub pause_count: u32,
@@ -234,6 +264,12 @@ pub struct DispatchState {
     /// Run-global lease registry for cross-sub-tree resource coordination.
     /// Distinct from per-layer /leases/* stored in each layer's KvStore.
     pub run_leases: Arc<RunLeaseRegistry>,
+    /// Most-recent approval response per actor id. Populated by the
+    /// approval MCP handlers when they return; consulted at actor-
+    /// termination time by `approval_driven_termination` to reclassify
+    /// silent exits as `TaskStatus::ApprovalRejected`. See the
+    /// `LastApprovalResponse` doc for the full lifecycle.
+    pub last_approval_response: RwLock<HashMap<String, LastApprovalResponse>>,
 }
 
 /// CAUTION: This Deref always resolves to the root layer, which is correct
@@ -308,7 +344,53 @@ impl DispatchState {
             sublead_results: RwLock::new(HashMap::new()),
             worker_layer_index: RwLock::new(HashMap::new()),
             run_leases: Arc::new(RunLeaseRegistry::new()),
+            last_approval_response: RwLock::new(HashMap::new()),
         }
+    }
+
+    /// Record the most recent approval response delivered to `actor_id`.
+    /// Called by approval MCP handlers immediately before they return to
+    /// the caller. Used downstream by `approval_driven_termination` to
+    /// reclassify silent exits.
+    pub async fn record_last_approval_response(&self, actor_id: &str, approved: bool) {
+        let mut slot = self.last_approval_response.write().await;
+        slot.insert(
+            actor_id.to_string(),
+            LastApprovalResponse {
+                approved,
+                received_at: chrono::Utc::now(),
+            },
+        );
+    }
+
+    /// If the given actor's most-recent approval response was negative and
+    /// recent (within 30 s of now), return the reclassification kind.
+    /// Returns `None` if no reclassification applies.
+    ///
+    /// Used by actor-termination paths to turn `TaskStatus::Success` into
+    /// `ApprovalRejected` when the actor clearly exited because of the
+    /// rejection rather than by completing real work after it.
+    ///
+    /// The 30-second recency window is empirical: claude subprocesses that
+    /// exit due to a rejected approval typically terminate within a few
+    /// seconds (the apology message + exit). 30 seconds gives generous
+    /// headroom while still excluding actors that received a rejection,
+    /// did substantial subsequent work, and then terminated for unrelated
+    /// reasons.
+    pub async fn approval_driven_termination(
+        &self,
+        actor_id: &str,
+    ) -> Option<ApprovalTerminationKind> {
+        let slot = self.last_approval_response.read().await;
+        let entry = slot.get(actor_id)?;
+        if entry.approved {
+            return None;
+        }
+        let age = chrono::Utc::now() - entry.received_at;
+        if age.num_seconds() > 30 {
+            return None;
+        }
+        Some(ApprovalTerminationKind::Rejected)
     }
 
     /// Accessor for the root layer. Used where callers need an explicit

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -53,7 +53,7 @@ impl SubleadOutcome {
 }
 
 /// Configuration for a sub-lead spawn, validated against root's caps.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct SubleadSpawnRequest {
     pub prompt: String,
     pub model: String,
@@ -62,6 +62,18 @@ pub struct SubleadSpawnRequest {
     pub lead_timeout_secs: Option<u64>,
     pub initial_ref: HashMap<String, Value>,
     pub read_down: bool,
+    /// Operator-supplied env vars passed to the sub-lead's claude
+    /// subprocess. Layered over pitboss's own defaults
+    /// (`CLAUDE_CODE_ENTRYPOINT=sdk-ts`); operator-set keys win when the
+    /// names collide. See `apply_pitboss_env_defaults` in dispatch/runner.rs
+    /// for the resolution order.
+    pub env: HashMap<String, String>,
+    /// Operator-supplied tool list override for `--allowedTools`. Empty
+    /// means "use the standard sublead toolset" (preserves v0.6 behavior).
+    /// Non-empty replaces the user-tool portion; the pitboss MCP tools
+    /// (`mcp__pitboss__*`) are always included regardless so the sub-lead
+    /// can still orchestrate workers.
+    pub tools: Vec<String>,
 }
 
 /// Validated, defaults-applied resource envelope for a sub-lead spawn.
@@ -312,6 +324,8 @@ pub async fn spawn_sublead(
             req.prompt,
             req.model,
             envelope,
+            req.env,
+            req.tools,
         )
         .await
         .context("sub-lead claude session spawn failed")?;
@@ -389,12 +403,15 @@ fn derive_sublead_manifest(
 /// by the cascade watcher from root. `SessionHandle::run_to_completion`
 /// observes it via `cancel.await_terminate()`, sends SIGTERM, then SIGKILL
 /// after TERMINATE_GRACE.
+#[allow(clippy::too_many_arguments)]
 async fn spawn_sublead_session(
     state: Arc<DispatchState>,
     sub_layer: Arc<LayerState>,
     prompt: String,
     model: String,
     envelope: ResolvedEnvelope,
+    operator_env: std::collections::HashMap<String, String>,
+    tools_override: Vec<String>,
 ) -> Result<()> {
     use crate::dispatch::hierarchical::build_sublead_mcp_config;
     use crate::dispatch::runner::sublead_spawn_args;
@@ -414,8 +431,21 @@ async fn spawn_sublead_session(
         .await
         .context("build sublead mcp-config")?;
 
-    // 3. Build the CLI args: sublead toolset, model, prompt, no --resume (v0.6).
-    let args = sublead_spawn_args(&sublead_id, &prompt, &model, &mcp_config_path, None);
+    // 3. Build the CLI args: sublead toolset (or operator override),
+    //    model, prompt, no --resume on first spawn.
+    let tools_for_args: Option<&[String]> = if tools_override.is_empty() {
+        None
+    } else {
+        Some(&tools_override)
+    };
+    let args = sublead_spawn_args(
+        &sublead_id,
+        &prompt,
+        &model,
+        &mcp_config_path,
+        None,
+        tools_for_args,
+    );
 
     // 4. Task log directory (mirrors workers' layout for consistency).
     let task_dir = sub_layer.run_subdir.join("tasks").join(&sublead_id);
@@ -425,12 +455,10 @@ async fn spawn_sublead_session(
 
     // 5. Build the spawn command. CWD is root's run_subdir (sub-leads don't
     //    get separate worktrees in v0.6 — revisit in future).
-    //    TODO(Task 5): merge manifest [defaults.env] + per-spawn env overrides
-    //    here. For now, only pitboss's own defaults (CLAUDE_CODE_ENTRYPOINT)
-    //    are seeded — operators who need `[defaults.env]` on sub-leads
-    //    spawn them from a dispatcher with the target env var already in its
-    //    ambient env (tokio Command inherits parent env for keys not explicitly set).
-    let mut sublead_env: std::collections::HashMap<String, String> = Default::default();
+    //    Env precedence (lowest → highest): pitboss defaults
+    //    (`CLAUDE_CODE_ENTRYPOINT=sdk-ts`) → operator-supplied env from the
+    //    `spawn_sublead` MCP call. Operator wins for collisions.
+    let mut sublead_env: std::collections::HashMap<String, String> = operator_env.clone();
     crate::dispatch::runner::apply_pitboss_env_defaults(&mut sublead_env);
     let initial_cmd = SpawnCmd {
         program: sub_layer.claude_binary.clone(),
@@ -462,6 +490,8 @@ async fn spawn_sublead_session(
     let sublead_id_bg = sublead_id.clone();
     let model_bg = model.clone();
     let mcp_config_path_bg = mcp_config_path.clone();
+    let operator_env_bg = operator_env;
+    let tools_override_bg = tools_override;
 
     tokio::spawn(async move {
         let mut current_cmd = initial_cmd;
@@ -557,15 +587,24 @@ async fn spawn_sublead_session(
                     reprompt_count += 1;
 
                     // Re-build args with --resume and the new prompt.
+                    // Carry forward the operator's tool override for resume too.
+                    let tools_for_resume: Option<&[String]> = if tools_override_bg.is_empty() {
+                        None
+                    } else {
+                        Some(&tools_override_bg)
+                    };
                     let resume_args = sublead_spawn_args(
                         &sublead_id_bg,
                         &new_prompt,
                         &model_bg,
                         &mcp_config_path_bg,
                         Some(sid.as_str()),
+                        tools_for_resume,
                     );
+                    // Same env precedence as the initial spawn: operator first,
+                    // pitboss defaults fill gaps.
                     let mut resume_env: std::collections::HashMap<String, String> =
-                        Default::default();
+                        operator_env_bg.clone();
                     crate::dispatch::runner::apply_pitboss_env_defaults(&mut resume_env);
                     current_cmd = SpawnCmd {
                         program: sub_layer_bg.claude_binary.clone(),

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -414,11 +414,18 @@ async fn spawn_sublead_session(
 
     // 5. Build the spawn command. CWD is root's run_subdir (sub-leads don't
     //    get separate worktrees in v0.6 — revisit in future).
+    //    TODO(Task 5): merge manifest [defaults.env] + per-spawn env overrides
+    //    here. For now, only pitboss's own defaults (CLAUDE_CODE_ENTRYPOINT)
+    //    are seeded — operators who need `[defaults.env]` on sub-leads
+    //    spawn them from a dispatcher with the target env var already in its
+    //    ambient env (tokio Command inherits parent env for keys not explicitly set).
+    let mut sublead_env: std::collections::HashMap<String, String> = Default::default();
+    crate::dispatch::runner::apply_pitboss_env_defaults(&mut sublead_env);
     let initial_cmd = SpawnCmd {
         program: sub_layer.claude_binary.clone(),
         args,
         cwd: sub_layer.run_subdir.clone(),
-        env: Default::default(),
+        env: sublead_env,
     };
 
     // 6. Determine the lead timeout — fall back to 1 hour if the manifest
@@ -546,11 +553,14 @@ async fn spawn_sublead_session(
                         &mcp_config_path_bg,
                         Some(sid.as_str()),
                     );
+                    let mut resume_env: std::collections::HashMap<String, String> =
+                        Default::default();
+                    crate::dispatch::runner::apply_pitboss_env_defaults(&mut resume_env);
                     current_cmd = SpawnCmd {
                         program: sub_layer_bg.claude_binary.clone(),
                         args: resume_args,
                         cwd: sub_layer_bg.run_subdir.clone(),
-                        env: Default::default(),
+                        env: resume_env,
                     };
 
                     // Reset workers entry to Running with no session_id (will be

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -27,6 +27,15 @@ pub enum SubleadOutcome {
     Cancel,
     Timeout,
     Error(String),
+    /// Sub-lead exited after receiving `{approved: false}` from an
+    /// operator action or an `[[approval_policy]]` auto-reject rule.
+    /// Distinguished from `Success` because the sub-lead didn't do
+    /// meaningful work before exiting — it asked and was denied.
+    ApprovalRejected,
+    /// Sub-lead exited after its pending approval timed out (TTL
+    /// expired, fallback fired). Distinguished from `ApprovalRejected`
+    /// because no operator attention reached the approval.
+    ApprovalTimedOut,
 }
 
 impl SubleadOutcome {
@@ -37,6 +46,8 @@ impl SubleadOutcome {
             SubleadOutcome::Cancel => "cancel",
             SubleadOutcome::Timeout => "timeout",
             SubleadOutcome::Error(_) => "error",
+            SubleadOutcome::ApprovalRejected => "approval_rejected",
+            SubleadOutcome::ApprovalTimedOut => "approval_timed_out",
         }
     }
 }
@@ -613,6 +624,8 @@ async fn spawn_sublead_session(
             SubleadOutcome::Cancel => TaskStatus::Cancelled,
             SubleadOutcome::Timeout => TaskStatus::TimedOut,
             SubleadOutcome::Error(_) => TaskStatus::Failed,
+            SubleadOutcome::ApprovalRejected => TaskStatus::ApprovalRejected,
+            SubleadOutcome::ApprovalTimedOut => TaskStatus::ApprovalTimedOut,
         };
 
         // 9. Build and persist a TaskRecord for the sub-lead's compound session.

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -605,7 +605,7 @@ async fn spawn_sublead_session(
         *sub_layer_bg.reprompt_tx.lock().await = None;
 
         // 7. Classify the outcome for the terminal record.
-        let sublead_outcome = match final_outcome.final_state {
+        let mut sublead_outcome = match final_outcome.final_state {
             pitboss_core::session::SessionState::Completed => SubleadOutcome::Success,
             pitboss_core::session::SessionState::Cancelled => SubleadOutcome::Cancel,
             pitboss_core::session::SessionState::TimedOut => SubleadOutcome::Timeout,
@@ -617,6 +617,18 @@ async fn spawn_sublead_session(
             }
             _ => SubleadOutcome::Error("unknown terminal state".into()),
         };
+
+        // Reclassify silent exits driven by a recent rejected approval. A
+        // sub-lead that called propose_plan, got auto_reject, and exited
+        // would otherwise show as Success. See run_worker for the same
+        // pattern.
+        if matches!(sublead_outcome, SubleadOutcome::Success) {
+            if let Some(crate::dispatch::state::ApprovalTerminationKind::Rejected) =
+                state_bg.approval_driven_termination(&sublead_id_bg).await
+            {
+                sublead_outcome = SubleadOutcome::ApprovalRejected;
+            }
+        }
 
         // 8. Map to TaskStatus for the TaskRecord.
         let status = match &sublead_outcome {

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -51,6 +51,19 @@ struct SpawnSubleadRequest {
     /// max_workers).
     #[serde(default)]
     read_down: bool,
+    /// Environment variables to pass to the sub-lead's claude subprocess.
+    /// Merged on top of pitboss's own defaults (e.g. `CLAUDE_CODE_ENTRYPOINT
+    /// = "sdk-ts"`); operator-set keys win over defaults. Use this when a
+    /// specific sub-lead needs a different env than the root, e.g. an
+    /// `ANTHROPIC_API_KEY` override or a worker-toolset-specific flag.
+    #[serde(default)]
+    env: std::collections::HashMap<String, String>,
+    /// Tool list override for the sub-lead's `--allowedTools`. If empty, uses
+    /// the standard sublead toolset. If non-empty, the listed tools are
+    /// passed to claude verbatim; pitboss MCP tools (`mcp__pitboss__*`) are
+    /// always included on top so the sub-lead can still spawn workers etc.
+    #[serde(default)]
+    tools: Vec<String>,
     /// Caller identity injected by mcp-bridge (actor_id + actor_role).
     #[serde(rename = "_meta", default)]
     #[schemars(skip)]
@@ -315,6 +328,8 @@ impl PitbossHandler {
             lead_timeout_secs: req.lead_timeout_secs,
             initial_ref: req.initial_ref,
             read_down: req.read_down,
+            env: req.env,
+            tools: req.tools,
         };
 
         match do_spawn(&self.state, spawn_req).await {

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -1083,6 +1083,8 @@ pub async fn handle_list_workers(state: &Arc<DispatchState>) -> Vec<WorkerSummar
                         pitboss_core::store::TaskStatus::TimedOut => "TimedOut",
                         pitboss_core::store::TaskStatus::Cancelled => "Cancelled",
                         pitboss_core::store::TaskStatus::SpawnFailed => "SpawnFailed",
+                        pitboss_core::store::TaskStatus::ApprovalRejected => "ApprovalRejected",
+                        pitboss_core::store::TaskStatus::ApprovalTimedOut => "ApprovalTimedOut",
                     }
                     .to_string(),
                     Some(rec.started_at.to_rfc3339()),
@@ -1146,6 +1148,8 @@ pub async fn handle_worker_status(
                 pitboss_core::store::TaskStatus::TimedOut => "TimedOut",
                 pitboss_core::store::TaskStatus::Cancelled => "Cancelled",
                 pitboss_core::store::TaskStatus::SpawnFailed => "SpawnFailed",
+                pitboss_core::store::TaskStatus::ApprovalRejected => "ApprovalRejected",
+                pitboss_core::store::TaskStatus::ApprovalTimedOut => "ApprovalTimedOut",
             }
             .to_string(),
             Some(rec.started_at.to_rfc3339()),

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -718,7 +718,7 @@ async fn run_worker(
         outcome
     };
 
-    let status = match outcome.final_state {
+    let mut status = match outcome.final_state {
         pitboss_core::session::SessionState::Completed => TaskStatus::Success,
         pitboss_core::session::SessionState::Failed { .. } => TaskStatus::Failed,
         pitboss_core::session::SessionState::TimedOut => TaskStatus::TimedOut,
@@ -726,6 +726,20 @@ async fn run_worker(
         pitboss_core::session::SessionState::SpawnFailed { .. } => TaskStatus::SpawnFailed,
         _ => TaskStatus::Failed,
     };
+
+    // Reclassify silent exits driven by a recent rejected approval. When a
+    // worker calls request_approval / propose_plan, gets {approved: false}
+    // (operator action or [[approval_policy]] auto_reject), and exits
+    // shortly after, the claude subprocess exits 0 and we'd otherwise
+    // mark Success. Now distinguished as ApprovalRejected so headless
+    // operators can tell the difference.
+    if matches!(status, TaskStatus::Success) {
+        if let Some(crate::dispatch::state::ApprovalTerminationKind::Rejected) =
+            state.approval_driven_termination(&task_id).await
+        {
+            status = TaskStatus::ApprovalRejected;
+        }
+    }
 
     // Cleanup worktree per policy.
     if let Some(wt) = worktree_handle {
@@ -995,7 +1009,7 @@ pub async fn spawn_resume_worker(
         .await;
         // Clean up the pid slot when the resumed subprocess exits.
         state_bg.worker_pids.write().await.remove(&task_id_bg);
-        let status = match outcome.final_state {
+        let mut status = match outcome.final_state {
             pitboss_core::session::SessionState::Completed => TaskStatus::Success,
             pitboss_core::session::SessionState::Failed { .. } => TaskStatus::Failed,
             pitboss_core::session::SessionState::TimedOut => TaskStatus::TimedOut,
@@ -1003,6 +1017,15 @@ pub async fn spawn_resume_worker(
             pitboss_core::session::SessionState::SpawnFailed { .. } => TaskStatus::SpawnFailed,
             _ => TaskStatus::Failed,
         };
+        // Reclassify silent exits driven by a recent rejected approval (see
+        // run_worker for the same pattern + rationale).
+        if matches!(status, TaskStatus::Success) {
+            if let Some(crate::dispatch::state::ApprovalTerminationKind::Rejected) =
+                state_bg.approval_driven_termination(&task_id_bg).await
+            {
+                status = TaskStatus::ApprovalRejected;
+            }
+        }
         let counters = state_bg
             .worker_counters
             .read()
@@ -1462,6 +1485,9 @@ pub async fn handle_request_approval(
                         actor = %pending.requesting_actor_id,
                         "auto-approved by policy"
                     );
+                    state
+                        .record_last_approval_response(&pending.requesting_actor_id, true)
+                        .await;
                     return Ok(ApprovalToolResponse {
                         approved: true,
                         comment: Some("auto-approved by policy".into()),
@@ -1474,6 +1500,9 @@ pub async fn handle_request_approval(
                         actor = %pending.requesting_actor_id,
                         "auto-rejected by policy"
                     );
+                    state
+                        .record_last_approval_response(&pending.requesting_actor_id, false)
+                        .await;
                     return Ok(ApprovalToolResponse {
                         approved: false,
                         comment: Some("auto-rejected by policy".into()),
@@ -1493,6 +1522,7 @@ pub async fn handle_request_approval(
             .or(state.manifest.lead_timeout_secs)
             .unwrap_or(3600),
     );
+    let caller_id_for_record = caller_id.clone();
     let bridge = crate::mcp::approval::ApprovalBridge::new(Arc::clone(state));
     match bridge
         .request(
@@ -1504,12 +1534,17 @@ pub async fn handle_request_approval(
         )
         .await
     {
-        Ok(resp) => Ok(ApprovalToolResponse {
-            approved: resp.approved,
-            comment: resp.comment,
-            edited_summary: resp.edited_summary,
-            reason: resp.reason,
-        }),
+        Ok(resp) => {
+            state
+                .record_last_approval_response(&caller_id_for_record, resp.approved)
+                .await;
+            Ok(ApprovalToolResponse {
+                approved: resp.approved,
+                comment: resp.comment,
+                edited_summary: resp.edited_summary,
+                reason: resp.reason,
+            })
+        }
         Err(e) => anyhow::bail!("approval failed: {e}"),
     }
 }
@@ -1566,6 +1601,9 @@ pub async fn handle_propose_plan(
                     state
                         .plan_approved
                         .store(true, std::sync::atomic::Ordering::Release);
+                    state
+                        .record_last_approval_response(&pending.requesting_actor_id, true)
+                        .await;
                     return Ok(ApprovalToolResponse {
                         approved: true,
                         comment: Some("auto-approved by policy".into()),
@@ -1578,6 +1616,9 @@ pub async fn handle_propose_plan(
                         actor = %pending.requesting_actor_id,
                         "plan auto-rejected by policy"
                     );
+                    state
+                        .record_last_approval_response(&pending.requesting_actor_id, false)
+                        .await;
                     return Ok(ApprovalToolResponse {
                         approved: false,
                         comment: Some("auto-rejected by policy".into()),
@@ -1601,6 +1642,7 @@ pub async fn handle_propose_plan(
     // approval without the structured fields would be useless, but the
     // summary still anchors the audit trail.
     let summary = args.plan.summary.clone();
+    let caller_id_for_record = caller_id.clone();
     let bridge = crate::mcp::approval::ApprovalBridge::new(Arc::clone(state));
     match bridge
         .request(
@@ -1618,6 +1660,9 @@ pub async fn handle_propose_plan(
                     .plan_approved
                     .store(true, std::sync::atomic::Ordering::Release);
             }
+            state
+                .record_last_approval_response(&caller_id_for_record, resp.approved)
+                .await;
             Ok(ApprovalToolResponse {
                 approved: resp.approved,
                 comment: resp.comment,

--- a/crates/pitboss-cli/src/tui_table.rs
+++ b/crates/pitboss-cli/src/tui_table.rs
@@ -121,6 +121,8 @@ impl ProgressTable {
             Status::Done(TaskStatus::TimedOut) => "⏱ TimedOut".to_string(),
             Status::Done(TaskStatus::Cancelled) => "⊘ Cancelled".to_string(),
             Status::Done(TaskStatus::SpawnFailed) => "! SpawnFail".to_string(),
+            Status::Done(TaskStatus::ApprovalRejected) => "⊘ ApprovalRej".to_string(),
+            Status::Done(TaskStatus::ApprovalTimedOut) => "⏱ ApprovalTO".to_string(),
         };
         let time = if r.duration_ms == 0 {
             "—".to_string()

--- a/crates/pitboss-cli/tests/e2e_sublead_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_sublead_flows.rs
@@ -194,6 +194,8 @@ async fn root_spawns_sublead_which_completes() {
         lead_timeout_secs: Some(600),
         initial_ref: Default::default(),
         read_down: false,
+        env: Default::default(),
+        tools: Default::default(),
     };
     let sublead_id = spawn_sublead(&state, req)
         .await
@@ -285,6 +287,8 @@ async fn root_kill_cascades_to_sublead_workers() {
         lead_timeout_secs: Some(600),
         initial_ref: Default::default(),
         read_down: false,
+        env: Default::default(),
+        tools: Default::default(),
     };
     let sublead_id = spawn_sublead(&state, req)
         .await
@@ -646,6 +650,8 @@ async fn budget_envelope_returns_to_root_pool() {
         lead_timeout_secs: Some(600),
         initial_ref: Default::default(),
         read_down: false,
+        env: Default::default(),
+        tools: Default::default(),
     };
     let sublead_id = spawn_sublead(&state, req)
         .await
@@ -836,6 +842,8 @@ async fn sublead_session_spawns_runs_and_reconciles() {
         lead_timeout_secs: Some(30),
         initial_ref: Default::default(),
         read_down: false,
+        env: Default::default(),
+        tools: Default::default(),
     };
     let sublead_id = spawn_sublead(&state, req)
         .await

--- a/crates/pitboss-cli/tests/sublead_flows.rs
+++ b/crates/pitboss-cli/tests/sublead_flows.rs
@@ -483,6 +483,8 @@ async fn unspent_sublead_envelope_returns_to_root_pool() {
         lead_timeout_secs: Some(1800),
         initial_ref: Default::default(),
         read_down: false,
+        env: Default::default(),
+        tools: Default::default(),
     };
     let sublead_id = pitboss_cli::dispatch::sublead::spawn_sublead(&state, req)
         .await
@@ -1096,6 +1098,8 @@ async fn wait_actor_returns_for_terminated_sublead() {
         lead_timeout_secs: Some(1800),
         initial_ref: Default::default(),
         read_down: false,
+        env: Default::default(),
+        tools: Default::default(),
     };
     let sublead_id = spawn_sublead(&state, req)
         .await
@@ -1154,6 +1158,8 @@ async fn wait_actor_blocks_then_wakes_on_sublead_termination() {
         lead_timeout_secs: Some(1800),
         initial_ref: Default::default(),
         read_down: false,
+        env: Default::default(),
+        tools: Default::default(),
     };
     let sublead_id = spawn_sublead(&state, req)
         .await
@@ -1616,6 +1622,8 @@ async fn sublead_worker_budget_reserved_against_sublead_envelope() {
         lead_timeout_secs: Some(1800),
         initial_ref: Default::default(),
         read_down: false,
+        env: Default::default(),
+        tools: Default::default(),
     };
     let sublead_id = spawn_sublead(&state, req)
         .await

--- a/crates/pitboss-core/src/store/record.rs
+++ b/crates/pitboss-core/src/store/record.rs
@@ -161,9 +161,9 @@ mod tests {
             (TaskStatus::ApprovalTimedOut, "\"ApprovalTimedOut\""),
         ] {
             let s = serde_json::to_string(variant).unwrap();
-            assert_eq!(&s, expected_json, "serialize {:?}", variant);
+            assert_eq!(&s, expected_json, "serialize {variant:?}");
             let back: TaskStatus = serde_json::from_str(&s).unwrap();
-            assert_eq!(&back, variant, "round-trip {:?}", variant);
+            assert_eq!(&back, variant, "round-trip {variant:?}");
         }
     }
 

--- a/crates/pitboss-core/src/store/record.rs
+++ b/crates/pitboss-core/src/store/record.rs
@@ -14,6 +14,17 @@ pub enum TaskStatus {
     TimedOut,
     Cancelled,
     SpawnFailed,
+    /// Terminal state for a task that called `request_approval` or
+    /// `propose_plan` and received `{approved: false}` from an operator
+    /// (or a policy rule that mapped to `auto_reject`), then exited
+    /// without doing meaningful subsequent work. Previously lumped into
+    /// `Success` because claude exited 0; distinguished as of v0.7+.
+    ApprovalRejected,
+    /// Terminal state for a task whose pending approval aged past its
+    /// `ttl_secs` and was auto-resolved via its `fallback` (typically
+    /// `auto_reject`), then exited. Distinguished from `ApprovalRejected`
+    /// because no operator attention reached the approval — it timed out.
+    ApprovalTimedOut,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -141,6 +152,19 @@ mod tests {
         assert!(json.contains("parent_task_id"));
         let back: TaskRecord = serde_json::from_str(&json).unwrap();
         assert_eq!(back.parent_task_id.as_deref(), Some("lead-abc"));
+    }
+
+    #[test]
+    fn task_status_approval_variants_round_trip() {
+        for (variant, expected_json) in &[
+            (TaskStatus::ApprovalRejected, "\"ApprovalRejected\""),
+            (TaskStatus::ApprovalTimedOut, "\"ApprovalTimedOut\""),
+        ] {
+            let s = serde_json::to_string(variant).unwrap();
+            assert_eq!(&s, expected_json, "serialize {:?}", variant);
+            let back: TaskStatus = serde_json::from_str(&s).unwrap();
+            assert_eq!(&back, variant, "round-trip {:?}", variant);
+        }
     }
 
     #[test]

--- a/crates/pitboss-core/src/store/sqlite.rs
+++ b/crates/pitboss-core/src/store/sqlite.rs
@@ -243,6 +243,8 @@ fn status_to_str(s: &TaskStatus) -> &'static str {
         TaskStatus::TimedOut => "TimedOut",
         TaskStatus::Cancelled => "Cancelled",
         TaskStatus::SpawnFailed => "SpawnFailed",
+        TaskStatus::ApprovalRejected => "ApprovalRejected",
+        TaskStatus::ApprovalTimedOut => "ApprovalTimedOut",
     }
 }
 
@@ -254,6 +256,8 @@ fn status_from_str(s: &str) -> Result<TaskStatus, StoreError> {
         "TimedOut" => Ok(TaskStatus::TimedOut),
         "Cancelled" => Ok(TaskStatus::Cancelled),
         "SpawnFailed" => Ok(TaskStatus::SpawnFailed),
+        "ApprovalRejected" => Ok(TaskStatus::ApprovalRejected),
+        "ApprovalTimedOut" => Ok(TaskStatus::ApprovalTimedOut),
         other => Err(StoreError::Incomplete(format!(
             "unknown task status: {other}"
         ))),

--- a/crates/pitboss-tui/src/theme.rs
+++ b/crates/pitboss-tui/src/theme.rs
@@ -37,8 +37,14 @@ pub fn tile_status_color(status: &TileStatus) -> Color {
         TileStatus::Done(TaskStatus::Success) => STATUS_SUCCESS,
         TileStatus::Done(TaskStatus::Failed) => STATUS_FAILED,
         TileStatus::Done(TaskStatus::TimedOut) => STATUS_TIMED_OUT,
-        TileStatus::Done(TaskStatus::Cancelled) => STATUS_CANCELLED,
         TileStatus::Done(TaskStatus::SpawnFailed) => STATUS_SPAWN_FAILED,
+        // Cancelled + approval-driven terminations share a color — all three
+        // represent "actor exited because its work was blocked" rather than
+        // a pure error. Approval rejection/timeout are semantically closer
+        // to cancellation than to a Failed/TimedOut runtime error.
+        TileStatus::Done(
+            TaskStatus::Cancelled | TaskStatus::ApprovalRejected | TaskStatus::ApprovalTimedOut,
+        ) => STATUS_CANCELLED,
     }
 }
 

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -1679,14 +1679,18 @@ fn build_approval_plan_lines(
 // ---------------------------------------------------------------------------
 
 fn status_icon(status: &TileStatus) -> (&'static str, Color) {
+    // Cancelled + ApprovalRejected share the "blocked" glyph ⊘.
+    // TimedOut + ApprovalTimedOut share the clock glyph ⏱.
+    // All four are semantically "actor exited because its work was blocked
+    // or timed out" rather than a pure runtime error.
     let icon = match status {
         TileStatus::Pending => "…",
         TileStatus::Running => "●",
         TileStatus::Done(TaskStatus::Success) => "✓",
         TileStatus::Done(TaskStatus::Failed) => "✗",
-        TileStatus::Done(TaskStatus::TimedOut) => "⏱",
-        TileStatus::Done(TaskStatus::Cancelled) => "⊘",
         TileStatus::Done(TaskStatus::SpawnFailed) => "!",
+        TileStatus::Done(TaskStatus::TimedOut | TaskStatus::ApprovalTimedOut) => "⏱",
+        TileStatus::Done(TaskStatus::Cancelled | TaskStatus::ApprovalRejected) => "⊘",
     };
     (icon, theme::tile_status_color(status))
 }
@@ -1700,6 +1704,8 @@ fn status_label(status: &TileStatus) -> &'static str {
         TileStatus::Done(TaskStatus::TimedOut) => "Time",
         TileStatus::Done(TaskStatus::Cancelled) => "Canc",
         TileStatus::Done(TaskStatus::SpawnFailed) => "SpwF",
+        TileStatus::Done(TaskStatus::ApprovalRejected) => "AppR",
+        TileStatus::Done(TaskStatus::ApprovalTimedOut) => "AppT",
     }
 }
 


### PR DESCRIPTION
## Summary

Closes the headless-mode failure modes surfaced in an external lessons-learned doc from a real headless dispatch attempt. Six fixes on one branch, plus a deferred-design spec pin for the alternative we *didn't* pick.

PR-B of a 2-PR sequence. PR-A (#39) shipped the AGENTS.md binary embedding + container path; this PR ships the behavior changes that make headless dispatch actually usable.

## What changes

**Fixes the silent 7-second-success failure mode** (lessons-learned items #1, #6 — P0):
- Pitboss now auto-sets `CLAUDE_CODE_ENTRYPOINT=sdk-ts` on every claude subprocess (root lead, workers, sub-leads). Claude bypasses its own interactive permission gate; pitboss becomes the sole approval authority via existing `approval_policy` + `[[approval_policy]]` rules.
- Sub-lead claude subprocesses no longer spawn with hardcoded empty env (was `env: Default::default()`).
- New `env` and `tools` parameters on the `spawn_sublead` MCP tool — leads can customize sub-lead execution context per-spawn, matching `spawn_worker`'s shape.

**Fixes the "approval rejection looks like Success" classification hole** (lessons-learned item #3):
- New `TaskStatus::ApprovalRejected` + `TaskStatus::ApprovalTimedOut` terminal states (and matching `SubleadOutcome` variants).
- New `last_approval_response` map on `DispatchState`, populated when `request_approval` / `propose_plan` returns.
- Reclassification check at every termination site (worker, continue-worker, sublead, root lead) flips `Success → ApprovalRejected` when the actor's most recent approval (within 30s) returned negative.
- `ApprovalTimedOut` defined but not yet emitted — reserved for queue-TTL fallback path which is a separate fix.

**Surfaces approval gates that will block headless runs** at dispatch time:
- New stderr warning when stdout is not a TTY AND `require_plan_approval = true` / `approval_policy = "block"` / any rule with `action = "block"`.
- Lists each specific gate plus a doc link.
- Silent on TTY (interactive operators have the TUI).

**Documentation:**
- New "Headless mode" section in `AGENTS.md` covering all of the above plus the residual gotchas the lessons doc flagged (git-repo requirement for hierarchical mode, sub-lead id naming convention, etc.).
- CHANGELOG entries grouped under Added / Changed / Fixed / Docs.

## What's NOT in this PR

- **Path B** (route claude's permission gate through pitboss's approval queue rather than bypassing it) is pinned in `docs/superpowers/specs/2026-04-20-path-b-permission-prompt-routing-pin.md`. Path A here is the minimum viable fix; B is the more correct UX but ~1 week of focused work.
- **Queue-TTL → response wiring** so `ApprovalTimedOut` actually fires. Today `expire_approvals` removes the entry without sending a response; the actor sees a bridge timeout error. Defined the variant + reserved the slot, but the wiring is a separate concern.
- **`pitboss status` subcommand** for headless run inspection. Documented as a workaround in AGENTS.md (use `pitboss attach` + `summary.jsonl` reads); the dedicated subcommand is a future feature.

## Local validation

- `cargo test --workspace`: all green (273 + 75 + 271 + 13 + 29 + others)
- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace -- -D warnings`: clean

## Test plan

- [ ] PR CI: 4 container build cells + CI test/lint/fmt + Book build + Release plan all pass
- [ ] After merge: full push-path matrix builds, both images publish, smoke-test passes
- [ ] Manual: dispatch a headless manifest with `[[approval_policy]] action = "auto_reject"` and confirm `summary.json` shows `status: "ApprovalRejected"` instead of `Success`
- [ ] Manual: dispatch with `require_plan_approval = true` and no TTY; confirm the stderr warning fires before the lead launches
- [ ] Manual: spawn a sub-lead via the MCP tool with `env: { "FOO": "bar" }` and verify the sub-lead's environment contains `FOO=bar`

## Plan + spec references

- Plan: `docs/superpowers/plans/2026-04-20-headless-mode-hardening-plan.md` (local-only, gitignored)
- Path B pin: `docs/superpowers/specs/2026-04-20-path-b-permission-prompt-routing-pin.md` (local-only)
- Lessons-learned source: external (`/run/media/system/Dos/angrylarry/angrylarry/vault/pitboss-lessons-learned.md`)