### PR TITLE
release: v0.7.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 ---
 document: pitboss-agent-instructions
 schema_version: 1
-pitboss_version: 0.6.0
+pitboss_version: 0.7.0
 last_updated: 2026-04-20
 audience: ai-agent
 canonical_url: https://github.com/SDS-Mode/pitboss/blob/main/AGENTS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+*(nothing yet)*
+
+## [0.7.0] — 2026-04-20
+
+The headless-mode hardening release. Closes the silent "7-second
+success" failure modes that an external operator hit running pitboss
+under another agent. Also ships the bundled-claude container variant,
+native multi-arch CI (no more QEMU), bundled AGENTS.md reference,
+GitHub Action bumps for Node 24 compatibility, and a security-review
+follow-up (run-global lease connection-drop cleanup).
+
+Highlights:
+- **`ghcr.io/sds-mode/pitboss-with-claude`** — new multi-arch container
+  variant bundling a pinned Claude Code CLI. Run pitboss without
+  installing claude on the host; consume OAuth via a `~/.claude` mount.
+- **Path A permission default** — `CLAUDE_CODE_ENTRYPOINT=sdk-ts` auto-set
+  on every spawned claude subprocess. Eliminates silent sub-lead failures
+  where claude asked for permission from a non-existent operator and
+  exited cleanly with no output.
+- **Approval-driven terminal states** — `ApprovalRejected` and
+  `ApprovalTimedOut` distinguish "task exited because its approval was
+  denied" from a real `Success`. Previously both looked like Success.
+- **`spawn_sublead` gains `env` and `tools`** — sub-leads can now
+  receive per-spawn environment variables and allowlist overrides,
+  matching `spawn_worker`'s shape.
+- **Headless-dispatch warning** — stderr warning at startup when
+  approval gates would block without a TTY.
+- **`pitboss agents-md`** — prints the AGENTS.md reference document
+  bundled into the binary. Same content at
+  `/usr/share/doc/pitboss/AGENTS.md` in container images.
+- **CI elapsed time 62 min → 5 min** — native `ubuntu-24.04-arm`
+  runners with matrix + merge pipeline. No QEMU emulation.
+
 ### Added
 
 - **Two new terminal statuses: `TaskStatus::ApprovalRejected` +

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1337,7 +1337,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitboss-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "pitboss-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "pitboss-tui"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version     = "0.6.0"
+version     = "0.7.0"
 edition     = "2021"
 rust-version = "1.82"
 license     = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -16,19 +16,23 @@ To browse offline:
     cargo install mdbook  # one time
     mdbook serve --open
 
-**v0.6.0** is the depth-2 sub-leads release. A root lead may now
-dynamically spawn sub-leads at runtime — each with its own budget
-envelope, worker cap, timeout, and isolated coordination layer —
-via the new `spawn_sublead` MCP tool. Accompanying additions: `wait_actor`
-(generalized lifecycle wait for workers or sub-leads), `run_lease_acquire`
-/ `run_lease_release` for run-global resource coordination,
-`cancel_worker(target, reason?)` delivering synthetic reprompts up the tree,
-`[[approval_policy]]` manifest blocks for deterministic (non-LLM) rule
-matching, reject-with-reason, approval TTL + fallback, a grouped TUI grid
-for sub-tree containers, and a non-modal approval list pane (`'a'` hotkey).
-455 → 536 tests, 0 failures. See `CHANGELOG.md` for the full per-version
-history and `AGENTS.md` for MCP tool reference, keybindings, and manifest
-schema.
+**v0.7.0** is the headless-mode hardening release. A new
+`ghcr.io/sds-mode/pitboss-with-claude` container variant bundles a
+pinned Claude Code CLI so you can run pitboss without installing
+claude on the host — consume OAuth via a `~/.claude` bind mount. The
+Path A permission default (`CLAUDE_CODE_ENTRYPOINT=sdk-ts` on every
+spawned claude subprocess) closes the silent "7-second success"
+failure mode where sub-leads apologized for not having permission and
+exited cleanly with no output. Approval-driven terminations are now
+distinguished from real success via new `ApprovalRejected` and
+`ApprovalTimedOut` terminal states. `spawn_sublead` gains optional
+`env` and `tools` parameters (matching `spawn_worker`). A dispatch-time
+warning fires on stderr when approval gates are configured without a
+TTY. `pitboss agents-md` prints the embedded reference doc; container
+images also carry `/usr/share/doc/pitboss/AGENTS.md`. CI elapsed time
+drops 62 min → 5 min via native arm64 runners (no QEMU). See
+`CHANGELOG.md` for the full per-version history and `AGENTS.md` for
+the MCP tool reference, keybindings, and manifest schema.
 
 Rust toolkit for running and observing parallel Claude Code sessions. A
 dispatcher (`pitboss`) fans out `claude` subprocesses under a concurrency

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,282 @@
+# Release process
+
+Pitboss releases follow a fixed checklist. This document is the canonical
+reference — if the steps here disagree with a past release's git history,
+trust the history but file a PR updating this doc.
+
+Release mechanics (tarball builds, installers, Homebrew tap publish,
+container image tags) are driven by cargo-dist and our three GitHub
+Actions workflows. Your job as release driver is the pre-flight prose +
+pushing a tag.
+
+---
+
+## When to cut a release
+
+Cut a release when `[Unreleased]` in `CHANGELOG.md` has accumulated any
+user-visible behavior change — new feature, bug fix, removal, or breaking
+change. Docs-only or CI-only changes alone do not warrant a release.
+
+Use semantic versioning:
+
+- **Major** (`X.0.0`) — breaking changes to the manifest schema, the MCP
+  tool surface, the `summary.json` wire format, or CLI subcommand shape.
+  Pitboss is still pre-1.0, so breaking changes land in minor bumps until
+  the stable-API inflection.
+- **Minor** (`0.X.0`) — new features, new MCP tools, new terminal states,
+  new subcommands. Default cadence.
+- **Patch** (`0.0.X`) — bug fixes and non-breaking doc updates that
+  couldn't wait for the next minor.
+
+---
+
+## Pre-flight checklist (run on a `release/vX.Y.Z` branch)
+
+### 1. Version bump — single source of truth
+
+```bash
+git checkout -b release/vX.Y.Z main
+# Edit Cargo.toml [workspace.package].version → "X.Y.Z"
+```
+
+The workspace-root `Cargo.toml` is the only place with a literal version
+string. Every crate under `crates/` inherits via `version = { workspace = true }`.
+
+### 2. AGENTS.md frontmatter
+
+Update the YAML frontmatter at the top of `AGENTS.md`:
+
+```yaml
+pitboss_version: X.Y.Z
+last_updated: YYYY-MM-DD
+```
+
+The `pitboss_version` field is how agents decide whether this doc applies
+to the binary they're orchestrating — it must match `CARGO_PKG_VERSION` at
+release time. The `include_str!` in `crates/pitboss-cli/src/agents_md.rs`
+bakes this file into the binary at compile time, so the version baked in
+matches the version in the frontmatter.
+
+### 3. CHANGELOG.md — promote `[Unreleased]` to the new version
+
+Replace `## [Unreleased]` with:
+
+```markdown
+## [Unreleased]
+
+*(nothing yet)*
+
+## [X.Y.Z] — YYYY-MM-DD
+
+[One-paragraph headline summarizing the release — tagline + the 2-3
+highlights most operators will care about. Keep it under 150 words.]
+
+Highlights:
+- **[feature]** — one-sentence pitch.
+- **[feature]** — one-sentence pitch.
+- **[fix]** — one-sentence pitch if it closes a notable gap.
+
+### Added
+[... existing Unreleased Added items, unchanged ...]
+
+### Changed
+[... existing Unreleased Changed items, unchanged ...]
+
+### Fixed
+[... existing Unreleased Fixed items, unchanged ...]
+
+### Docs
+[... existing Unreleased Docs items, unchanged ...]
+```
+
+The `### Added`/`### Changed`/`### Fixed`/`### Docs` subsections move
+verbatim from what was under `[Unreleased]`. Don't re-edit them — they
+were written during the feature commits and reflect shipped behavior.
+
+### 4. README.md — replace the version-highlight paragraph
+
+README has one paragraph near the top that describes the current release.
+Replace it wholesale with a new paragraph for this version. Reference
+`CHANGELOG.md` and `AGENTS.md` as always.
+
+### 5. ROADMAP.md — refresh the "Last refresh" note + adjust section titles
+
+Update the `**Last refresh:**` line at the top:
+
+```markdown
+**Last refresh: vX.Y.Z (YYYY-MM-DD).** Everything shipped through
+vX.Y.Z has been removed from this file ...
+```
+
+If you have a `## Deferred from v<prev>.0 (targeting v<prev+1>+)` section,
+rename its title to `## Deferred from vX.Y.Z (targeting v<X.Y.Z+1>+)` and
+prune/add items to reflect what actually shipped this release and what
+remains deferred.
+
+### 6. book/src/intro.md — bump "Current version" section
+
+Replace the `## Current version` paragraph with a new one for this
+release. Shorter than the README paragraph — this renders on the book
+landing page, it's operator-facing summary, not release marketing.
+
+### 7. Commit the release prep in one PR
+
+```bash
+git add Cargo.toml Cargo.lock AGENTS.md CHANGELOG.md README.md ROADMAP.md book/src/intro.md
+git commit -m "release: prep vX.Y.Z"
+git push -u origin HEAD
+gh pr create --title "release: vX.Y.Z" --body "..."
+```
+
+The PR body should link to the `[X.Y.Z]` section of `CHANGELOG.md` on
+the branch (a reader reviewing the PR can click through to the full
+change list without scrolling the diff).
+
+### 8. CI passes, merge
+
+The release-prep PR runs the full CI matrix. Wait for green, then merge
+via `gh pr merge <N> --auto --squash` (or `--admin` if you've decided
+branch protection is in the way for this specific case — see the
+[branch-protection notes](#branch-protection--merging) below).
+
+---
+
+## Tag and release
+
+Once the release-prep PR is merged to `main`:
+
+```bash
+git checkout main
+git pull --ff-only
+git tag -a vX.Y.Z -m "vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+This triggers three GitHub Actions workflows in parallel:
+
+### `.github/workflows/release.yml` (cargo-dist)
+
+Auto-generated by `cargo-dist`. Builds platform-specific tarballs +
+installers, creates a GitHub Release with the artifacts attached, and
+commits an updated formula to the [Homebrew tap](https://github.com/SDS-Mode/homebrew-pitboss).
+
+Duration: ~10-15 minutes. Watch with `gh run watch`.
+
+### `.github/workflows/container.yml`
+
+Builds and pushes multi-arch container images to
+`ghcr.io/sds-mode/pitboss:<X.Y.Z>` and
+`ghcr.io/sds-mode/pitboss-with-claude:<X.Y.Z>`. Also updates the
+`:latest` tag on both images. Includes a post-merge smoke test.
+
+Duration: ~5-7 minutes. Runs in parallel with the release workflow.
+
+### `.github/workflows/book.yml`
+
+Rebuilds the mdBook site and deploys it to GitHub Pages. The updated
+`## Current version` section appears on the landing page immediately.
+
+Duration: ~1-2 minutes.
+
+---
+
+## Post-release verification
+
+After all three workflows complete:
+
+### Container image sanity
+
+```bash
+podman pull ghcr.io/sds-mode/pitboss-with-claude:X.Y.Z
+podman inspect ghcr.io/sds-mode/pitboss-with-claude:X.Y.Z \
+  --format '{{index .Config.Labels "ai.anthropic.claude-code.version"}}'
+podman run --rm ghcr.io/sds-mode/pitboss-with-claude:X.Y.Z pitboss --version
+# → pitboss X.Y.Z
+podman run --rm ghcr.io/sds-mode/pitboss-with-claude:X.Y.Z pitboss agents-md | head -5
+# → frontmatter with pitboss_version: X.Y.Z
+```
+
+### Homebrew tap sanity
+
+```bash
+brew tap SDS-Mode/pitboss
+brew install pitboss
+pitboss --version
+# → pitboss X.Y.Z
+```
+
+### cargo-dist tarball sanity
+
+```bash
+curl -sSfL https://github.com/SDS-Mode/pitboss/releases/download/vX.Y.Z/pitboss-installer.sh | sh
+pitboss --version
+# → pitboss X.Y.Z
+```
+
+### Pages site sanity
+
+Visit <https://sds-mode.github.io/pitboss/> and confirm the "Current
+version" callout on the landing page shows `X.Y.Z`.
+
+---
+
+## Branch protection & merging
+
+`main` is protected by a ruleset requiring:
+
+- Pull request (0 approvals — solo-dev repo)
+- Required status checks: `test + lint + fmt`, and all four container
+  build cells
+- Branch up-to-date with main before merge
+- Linear history (matches squash-merge)
+- No force push, no deletion
+
+Auto-merge is enabled repo-wide; `delete-branch-on-merge` is on.
+
+**Default merge command:**
+
+```bash
+gh pr merge <N> --auto --squash
+```
+
+GitHub handles waiting for required checks, keeping the branch up-to-date,
+and merging once all conditions clear. No bypass needed.
+
+**Admin bypass** (`--admin`) is available to repository admins and should
+be reserved for genuine escape cases:
+
+- Hotfixing a broken `main` where required CI is blocked by the very
+  thing the PR fixes
+- Protection misconfiguration you're in the middle of fixing
+- NOT for "I don't want to wait" — use `--auto` instead
+
+Every admin-bypass merge generates an audit log event. For a solo-dev
+repo this is fine, but the audit pattern is useful if collaborators are
+added later.
+
+---
+
+## Rolling back a release
+
+Tags on `main` are protected (non-force, non-delete). If a release needs
+to be withdrawn:
+
+1. **Don't delete the tag.** Homebrew tap, container images, and
+   installed binaries reference it.
+2. **Publish a patch release immediately** (`vX.Y.Z+1`) that reverts the
+   problematic change.
+3. If the release introduced a catastrophic security issue, yank the
+   Homebrew formula commit in the tap and mark the GitHub Release as
+   "Draft" so casual installs stop picking it up. Existing installed
+   binaries continue to work until their next update.
+4. Document the rollback rationale in the patch release's CHANGELOG
+   entry under `### Security` or `### Changed`.
+
+---
+
+## Changes to this process
+
+If you iterate on the release flow, update this document in the same PR
+that lands the change. The goal is that a first-time releaser can follow
+this file top-to-bottom and produce a correct release without having to
+reconstruct the process from git history.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,8 +3,8 @@
 Capture of deferred work. Items here are scoped but unscheduled — grab
 one when you're ready, or file issues to formalize priority.
 
-**Last refresh: v0.6.0 (2026-04-19).** Everything shipped through
-v0.6.0 has been removed from this file — check `CHANGELOG.md` for
+**Last refresh: v0.7.0 (2026-04-20).** Everything shipped through
+v0.7.0 has been removed from this file — check `CHANGELOG.md` for
 per-version history. If you're about to add an item, slot it into one
 of the tiered sections below (biggest effort first).
 
@@ -54,29 +54,56 @@ form explicitly retired.
 
 ---
 
-## Deferred from v0.6.0 (targeting v0.7+)
+## Deferred from v0.7.0 (targeting v0.8+)
 
-Items that were scoped or considered during v0.6 development but
+Items that were scoped or considered during v0.7 development but
 explicitly deferred. These are reasonably well-understood problems,
 not blue-sky ideas.
 
+### Queue-TTL fallback → response wiring
+
+`ApprovalTimedOut` terminal state was added in v0.7 but never fires —
+`expire_approvals` (in `runner.rs`) removes expired queue entries
+without sending a `{approved: false, from_ttl: true}` response back to
+the waiting actor. The actor instead sees a bridge-timeout error and
+lands in `Failed` rather than `ApprovalTimedOut`. **Status:** variant
+defined and classification path is ready; the wiring is a ~2-3 hour
+follow-up.
+
+### `pitboss status` subcommand
+
+Headless-mode inspection currently relies on `pitboss attach` +
+manual reads of `summary.jsonl` and `tasks/`. A dedicated `pitboss
+status <run-id>` would be a natural cap on the headless-agent flow.
+**Status:** deferred; needs a small spec on columns, flags, snapshot-
+vs-tail, JSON output.
+
+### Path B — route claude's permission gate through pitboss
+
+Alternative to the v0.7 Path A default (`CLAUDE_CODE_ENTRYPOINT=sdk-ts`
+bypasses claude's own gate). Path B would route claude's per-tool
+permission requests through a new `permission_prompt` MCP tool,
+surfacing them in pitboss's approval queue + TUI. **Status:** spec
+pinned at `docs/superpowers/specs/2026-04-20-path-b-permission-prompt-routing-pin.md`;
+revisit when a concrete trigger appears.
+
 ### Per-sub-tree runners (Phase 4 ownership cleanup)
 
-In v0.6.0, the watcher cascades cancel tokens directly across sub-tree
-boundaries rather than going through a per-sub-tree runner that owns
-its workers' cancellation. This inverts the ownership model the v0.6
-spec noted for future cleanup. Current implementation works correctly
-but the ownership inversion is a known footgun for handlers that need
-to route by caller. **Status:** deferred for v0.7; tracked in codebase
-with CAUTION doc block on `DispatchState`'s `Deref` impl.
+The watcher cascades cancel tokens directly across sub-tree boundaries
+rather than going through a per-sub-tree runner that owns its workers'
+cancellation. Current implementation works correctly but the ownership
+inversion is a known footgun. Also: `terminate()` does not cascade to
+sub-tree workers (only `drain()` does); gates Phase 4 work.
+**Status:** deferred; tracked in codebase via `TODO(Phase 4)` in
+`signals.rs:222` and CAUTION doc block on `DispatchState`'s `Deref` impl.
 
 ### TUI runtime policy mutation
 
-`[[approval_policy]]` rules are manifest-only in v0.6 — the TUI can
-display and act on policy but cannot edit rules while a run is live.
-Useful for operators who want to tighten or relax auto-approve rules
-mid-run without restarting. **Status:** deferred; manifest-only is
-safe and sufficient for the v0.6 use cases.
+`[[approval_policy]]` rules are manifest-only — the TUI can display
+and act on policy but cannot edit rules while a run is live. Useful
+for operators who want to tighten or relax auto-approve rules mid-run
+without restarting. **Status:** deferred; manifest-only is safe and
+sufficient for current use cases.
 
 ### Sub-lead resume support
 
@@ -88,13 +115,21 @@ persisting sub-lead `sublead_id` → `session_id` mappings and threading
 current fallback (root lead re-spawns) is workable for the typical
 interruption+retry case.
 
-### Native-arm container runners
+### Hierarchical mode requires a git repo even with `use_worktree = false`
 
-The current multi-arch container build uses QEMU emulation for
-`linux/arm64`, which is slow. Splitting the matrix to use native arm64
-runners (GitHub's `ubuntu-24.04-arm` or self-hosted) would cut build
-time significantly. **Status:** deferred; blocked on runner availability
-and cost in the public CI budget; the QEMU build is correct if slow.
+Lead setup runs a git-repo check regardless of the `use_worktree`
+setting. Flat mode has no equivalent check — the hierarchical side is
+inconsistent. **Status:** deferred; documented in AGENTS.md "Headless
+mode" section as a known quirk. Fix is a 1-line code change or a more
+prominent book note.
+
+### Slack notification sink escaping
+
+v0.7 hardened the Discord sink (escape markdown + `allowed_mentions: []`)
+but the Slack sink wasn't audited for the same class of injection.
+If Slack sink formats untrusted fields into `mrkdwn` blocks, same
+treatment applies. **Status:** deferred; audit + fix in one small PR
+when prioritized.
 
 ---
 

--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -25,6 +25,6 @@ Language models are stochastic. A well-run pit is not.
 
 ## Current version
 
-**v0.6.0** — depth-2 sub-leads, `spawn_sublead`, `wait_actor`, run-global leases (`run_lease_acquire`/`run_lease_release`), `[[approval_policy]]` declarative matcher, kill-with-reason, reject-with-reason, approval TTL/fallback, TUI grouped grid, and approval list pane. 536 tests, zero flakes.
+**v0.7.0** — headless-mode hardening. Bundled-claude container variant (`ghcr.io/sds-mode/pitboss-with-claude`), `CLAUDE_CODE_ENTRYPOINT=sdk-ts` permission default (closes the "silent 7-second success" sub-lead failure), `ApprovalRejected`/`ApprovalTimedOut` terminal states, `spawn_sublead` gains optional `env` + `tools` parameters, dispatch-time TTY warning when approval gates are configured without an operator surface, `pitboss agents-md` subcommand + `/usr/share/doc/pitboss/AGENTS.md` in container images, native multi-arch CI (62 min → 5 min), GHA action bumps for Node 24 compatibility.
 
 See [Changelog](./reference/changelog.md) for the full version history.


### PR DESCRIPTION
## Summary

Release-prep for v0.7.0. Updates all version-carrying files in lockstep per the new [RELEASE.md](./RELEASE.md) checklist (codified in this PR).

**Headline:** headless-mode hardening, bundled-claude container variant, native multi-arch CI, and a new AGENTS.md embedding path so agents can fetch the version-matched doc from a compiled binary.

## Release notes

Full details in the `[0.7.0]` section of CHANGELOG.md. Highlights:

- **`ghcr.io/sds-mode/pitboss-with-claude`** — new multi-arch container variant bundling a pinned Claude Code CLI
- **`CLAUDE_CODE_ENTRYPOINT=sdk-ts` default** on every spawned claude subprocess (Path A from the permission design)
- **`TaskStatus::ApprovalRejected` + `TaskStatus::ApprovalTimedOut`** terminal states
- **`spawn_sublead` gains `env` + `tools`** parameters
- **Dispatch-time TTY warning** when approval gates would block headless
- **`pitboss agents-md`** subcommand + `/usr/share/doc/pitboss/AGENTS.md` in container images
- **CI elapsed time 62 min → 5 min** via native `ubuntu-24.04-arm` runners (no more QEMU)

## Files updated

- `Cargo.toml` — workspace version 0.6.0 → 0.7.0
- `AGENTS.md` — frontmatter `pitboss_version: 0.7.0`
- `CHANGELOG.md` — `[Unreleased]` → `[0.7.0]` with headline + highlights block
- `README.md` — version-highlight paragraph replaced
- `ROADMAP.md` — "Last refresh" bumped, deferred-items section refreshed
- `book/src/intro.md` — Current version section updated
- `RELEASE.md` (new) — codified release checklist; future releases update this file in the same PR that changes the flow

## Process reference

Per RELEASE.md, after this PR merges:

1. Tag: `git tag -a v0.7.0 -m "v0.7.0" && git push origin v0.7.0`
2. Three workflows auto-trigger: cargo-dist release, container build+push, book/Pages redeploy
3. Post-release verify: container tags, Homebrew tap formula, cargo-dist installer, Pages landing page

## Test plan

- [ ] CI green (all 5 required status checks)
- [ ] After merge: tag pushed, release workflow publishes tarballs + Homebrew formula
- [ ] After merge: container workflow publishes `:0.7.0` + `:latest` on both images
- [ ] Post-release: `pitboss --version` prints `pitboss 0.7.0` from each distribution channel
- [ ] Post-release: `pitboss agents-md | head -5` prints frontmatter with `pitboss_version: 0.7.0`