### PR TITLE
fix(dispatch): defaults.env plumbing + orchestration allowlist gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,21 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **`[defaults]` block silently dropped in single-table `[lead]`
+  manifests.** The `SingleLeadManifest` parser had no `defaults` field
+  and no `deny_unknown_fields`, so the entire `[defaults]` section
+  (including `[defaults.env]`) was silently discarded at parse time —
+  a manifest setting `[defaults.env.WORK_DIR] = "/tmp/foo"` would never
+  see that variable reach the lead subprocess. The lead also wasn't
+  merging defaults for `model`, `tools`, `effort`, `timeout_secs`, or
+  `use_worktree` in this form; the single-lead path used only
+  `[lead]`-level values plus a hardcoded fallback, in contrast with
+  the array-form `[[lead]]` path which has done the merge correctly
+  since v0.3. Fixed: `SingleLeadManifest` now carries `defaults`,
+  `resolve_lead_spec` merges the same way `resolve_lead` (array form)
+  does, and `deny_unknown_fields` is on so the next silent-drop bug
+  fails loud at parse time. The `[default]` (singular, common typo
+  for `[defaults]`) is now rejected with an actionable parse error.
 - **`pitboss validate` now catches the `allow_subleads = true` +
   no-fallback footgun.** A manifest with `[lead] allow_subleads = true`
   but no `[lead.sublead_defaults]` would pass `validate` and then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,33 @@ This project uses [Semantic Versioning](https://semver.org/).
   does, and `deny_unknown_fields` is on so the next silent-drop bug
   fails loud at parse time. The `[default]` (singular, common typo
   for `[defaults]`) is now rejected with an actionable parse error.
+- **Root-lead `--allowedTools` was missing four real MCP tools, causing
+  silent orchestration stalls.** `PITBOSS_MCP_TOOLS` omitted
+  `wait_actor`, `propose_plan`, `run_lease_acquire`, and
+  `run_lease_release` — all registered by the MCP server since v0.5/v0.6
+  but never added to the CLI allowlist. In headless dispatches this
+  manifested as a lead that successfully spawned subleads, then tripped
+  Claude's own permission gate on the very next call (`"Claude requested
+  permissions to use mcp__pitboss__wait_actor, but you haven't granted
+  it yet"`) and quietly exited. The interactive prompt cannot be
+  answered under `-p`, so the tool call fails and the orchestration
+  plan collapses. `SUBLEAD_MCP_TOOLS` had the same gaps. Fixed by
+  pre-allowing the missing tools on both root and sublead paths. Also
+  removed a phantom `wait_for_sublead` allowlist entry that was
+  masking the `wait_actor` omission during review (no such server tool
+  exists — sublead waits go through `wait_actor` / `wait_for_worker`).
+- **`[defaults.env]` did not propagate from the lead to subleads.**
+  Once PR #45 plumbed `[defaults.env]` through to the root lead, the
+  env still stopped there: `spawn_sublead`'s sublead env came solely
+  from the `env:` param of the MCP tool call, so project-level path
+  blocks (e.g. `WORK_DIR`, `ARTIFACTS_DIR`) defined in `[defaults.env]`
+  were invisible to subleads unless the lead remembered to re-pass them
+  on every `spawn_sublead`. Fixed by seeding sublead env from the root
+  lead's resolved env (which already carries the merged `[defaults.env]`
+  + `[lead.env]`) before layering the operator's per-spawn env on top.
+  Precedence: lead env → operator env → pitboss defaults (gap-fill).
+  Applies to both the initial spawn and the kill+resume path used when
+  a synthetic reprompt arrives.
 - **`pitboss validate` now catches the `allow_subleads = true` +
   no-fallback footgun.** A manifest with `[lead] allow_subleads = true`
   but no `[lead.sublead_defaults]` would pass `validate` and then

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -541,12 +541,14 @@ pub const PITBOSS_MCP_TOOLS: &[&str] = &[
     "mcp__pitboss__worker_status",
     "mcp__pitboss__wait_for_worker",
     "mcp__pitboss__wait_for_any",
+    "mcp__pitboss__wait_actor",
     "mcp__pitboss__list_workers",
     "mcp__pitboss__cancel_worker",
     "mcp__pitboss__pause_worker",
     "mcp__pitboss__continue_worker",
     "mcp__pitboss__request_approval",
     "mcp__pitboss__reprompt_worker",
+    "mcp__pitboss__propose_plan",
     // Shared-store tools (v0.5+). Leads can read/write the per-run
     // coordination surface alongside workers; without these in the
     // allowlist, claude stalls at the permission prompt the first time
@@ -558,6 +560,10 @@ pub const PITBOSS_MCP_TOOLS: &[&str] = &[
     "mcp__pitboss__kv_wait",
     "mcp__pitboss__lease_acquire",
     "mcp__pitboss__lease_release",
+    // Run-global leases (v0.6+). For cross-sub-tree resource coordination
+    // (e.g., serializing access to an operator-facing filesystem dir).
+    "mcp__pitboss__run_lease_acquire",
+    "mcp__pitboss__run_lease_release",
 ];
 
 /// Sub-lead tools: all root-lead tools EXCEPT `spawn_sublead` and
@@ -571,12 +577,14 @@ pub const SUBLEAD_MCP_TOOLS: &[&str] = &[
     "mcp__pitboss__worker_status",
     "mcp__pitboss__wait_for_worker",
     "mcp__pitboss__wait_for_any",
+    "mcp__pitboss__wait_actor",
     "mcp__pitboss__list_workers",
     "mcp__pitboss__cancel_worker",
     "mcp__pitboss__pause_worker",
     "mcp__pitboss__continue_worker",
     "mcp__pitboss__request_approval",
     "mcp__pitboss__reprompt_worker",
+    "mcp__pitboss__propose_plan",
     // Shared-store tools (v0.5+).
     "mcp__pitboss__kv_get",
     "mcp__pitboss__kv_set",
@@ -585,7 +593,10 @@ pub const SUBLEAD_MCP_TOOLS: &[&str] = &[
     "mcp__pitboss__kv_wait",
     "mcp__pitboss__lease_acquire",
     "mcp__pitboss__lease_release",
-    // NOTE: spawn_sublead and wait_for_sublead are intentionally NOT included.
+    // Run-global leases (v0.6+) for cross-sub-tree resource coordination.
+    "mcp__pitboss__run_lease_acquire",
+    "mcp__pitboss__run_lease_release",
+    // NOTE: spawn_sublead is intentionally NOT included (depth-2 cap).
 ];
 
 /// Builds the argv for spawning the lead subprocess, including the
@@ -615,7 +626,6 @@ pub fn lead_spawn_args(
     // list_tools already gates visibility; this only widens the CLI allowlist.
     if lead.allow_subleads {
         allowed.push("mcp__pitboss__spawn_sublead".into());
-        allowed.push("mcp__pitboss__wait_for_sublead".into());
     }
     args.push("--allowedTools".into());
     args.push(allowed.join(","));
@@ -657,7 +667,6 @@ pub fn lead_resume_spawn_args(
     }
     if lead.allow_subleads {
         allowed.push("mcp__pitboss__spawn_sublead".into());
-        allowed.push("mcp__pitboss__wait_for_sublead".into());
     }
     args.push("--allowedTools".into());
     args.push(allowed.join(","));
@@ -1334,6 +1343,81 @@ mod tests {
                 list.contains(t),
                 "expected {t} in allowedTools, got: {list}"
             );
+        }
+    }
+
+    #[test]
+    fn lead_spawn_args_allows_depth2_orchestration_tools() {
+        // Regression: prior to this test, the root-lead allowlist omitted
+        // wait_actor, propose_plan, and run_lease_*, so claude's own
+        // --allowedTools gate denied them at call time ("Claude requested
+        // permissions to use mcp__pitboss__wait_actor, but you haven't
+        // granted it yet"). These tools MUST be pre-allowed.
+        use crate::manifest::resolve::ResolvedLead;
+        use std::path::PathBuf;
+        let lead = ResolvedLead {
+            id: "l".into(),
+            directory: PathBuf::from("/tmp"),
+            prompt: "p".into(),
+            branch: None,
+            model: "m".into(),
+            effort: crate::manifest::schema::Effort::High,
+            tools: vec!["Read".into()],
+            timeout_secs: 60,
+            use_worktree: false,
+            env: Default::default(),
+            resume_session_id: None,
+            allow_subleads: true,
+            max_subleads: None,
+            max_sublead_budget_usd: None,
+            max_workers_across_tree: None,
+            sublead_defaults: None,
+        };
+        let args = lead_spawn_args(&lead, &PathBuf::from("/tmp/cfg.json"));
+        let idx = args.iter().position(|a| a == "--allowedTools").unwrap();
+        let list = &args[idx + 1];
+        for t in [
+            "mcp__pitboss__wait_actor",
+            "mcp__pitboss__propose_plan",
+            "mcp__pitboss__run_lease_acquire",
+            "mcp__pitboss__run_lease_release",
+            // spawn_sublead only appears when allow_subleads=true (our fixture).
+            "mcp__pitboss__spawn_sublead",
+        ] {
+            assert!(list.contains(t), "expected {t} in allowedTools, got: {list}");
+        }
+        // Phantom entry removed: `wait_for_sublead` is not a real server tool.
+        // Keeping it in the allowlist masked the `wait_actor` omission during
+        // review, and the string is load-bearing noise on the CLI.
+        assert!(
+            !list.contains("mcp__pitboss__wait_for_sublead"),
+            "phantom wait_for_sublead should not be in allowedTools, got: {list}"
+        );
+    }
+
+    #[test]
+    fn sublead_spawn_args_allows_depth2_orchestration_tools() {
+        // Subleads wait on their own workers (wait_actor), propose plans
+        // when the root has require_plan_approval set, and coordinate across
+        // sub-trees via run_lease_*. All must be pre-allowed to avoid the
+        // same Claude permission-prompt failure mode the root lead hit.
+        let args = sublead_spawn_args(
+            "test-sublead-id",
+            "do some work",
+            "claude-opus-4-1",
+            &PathBuf::from("/tmp/sublead-cfg.json"),
+            None,
+            None,
+        );
+        let idx = args.iter().position(|a| a == "--allowedTools").unwrap();
+        let list = &args[idx + 1];
+        for t in [
+            "mcp__pitboss__wait_actor",
+            "mcp__pitboss__propose_plan",
+            "mcp__pitboss__run_lease_acquire",
+            "mcp__pitboss__run_lease_release",
+        ] {
+            assert!(list.contains(t), "expected {t} in sublead allowedTools, got: {list}");
         }
     }
 

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -1384,7 +1384,10 @@ mod tests {
             // spawn_sublead only appears when allow_subleads=true (our fixture).
             "mcp__pitboss__spawn_sublead",
         ] {
-            assert!(list.contains(t), "expected {t} in allowedTools, got: {list}");
+            assert!(
+                list.contains(t),
+                "expected {t} in allowedTools, got: {list}"
+            );
         }
         // Phantom entry removed: `wait_for_sublead` is not a real server tool.
         // Keeping it in the allowlist masked the `wait_actor` omission during
@@ -1417,7 +1420,10 @@ mod tests {
             "mcp__pitboss__run_lease_acquire",
             "mcp__pitboss__run_lease_release",
         ] {
-            assert!(list.contains(t), "expected {t} in sublead allowedTools, got: {list}");
+            assert!(
+                list.contains(t),
+                "expected {t} in sublead allowedTools, got: {list}"
+            );
         }
     }
 

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -20,6 +20,30 @@ use crate::shared_store::SharedStore;
 use pitboss_core::session::CancelToken;
 use pitboss_core::worktree::CleanupPolicy;
 
+/// Build the env for a sub-lead's claude subprocess.
+///
+/// Precedence (lowest → highest):
+/// 1. `lead_env` — the root lead's resolved env (already contains
+///    `[defaults.env]` merged with `[lead.env]`). Propagating this to
+///    subleads means project-level path blocks (e.g. `WORK_DIR`,
+///    `ARTIFACTS_DIR`) reach sub-leads automatically without the root
+///    lead having to re-pass them in every `spawn_sublead` MCP call.
+/// 2. `operator_env` — per-spawn env passed explicitly by the caller of
+///    the `spawn_sublead` MCP tool. Wins over the lead-inherited env for
+///    collisions (operator override wins).
+/// 3. Pitboss defaults (e.g. `CLAUDE_CODE_ENTRYPOINT=sdk-ts`) —
+///    `entry().or_insert()` semantics, so these only fill gaps left by the
+///    two higher-priority sources.
+pub fn compose_sublead_env(
+    lead_env: &HashMap<String, String>,
+    operator_env: &HashMap<String, String>,
+) -> HashMap<String, String> {
+    let mut out = lead_env.clone();
+    out.extend(operator_env.clone());
+    crate::dispatch::runner::apply_pitboss_env_defaults(&mut out);
+    out
+}
+
 /// Outcome classification for a terminated sub-lead session.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SubleadOutcome {
@@ -455,11 +479,22 @@ async fn spawn_sublead_session(
 
     // 5. Build the spawn command. CWD is root's run_subdir (sub-leads don't
     //    get separate worktrees in v0.6 — revisit in future).
-    //    Env precedence (lowest → highest): pitboss defaults
-    //    (`CLAUDE_CODE_ENTRYPOINT=sdk-ts`) → operator-supplied env from the
-    //    `spawn_sublead` MCP call. Operator wins for collisions.
-    let mut sublead_env: std::collections::HashMap<String, String> = operator_env.clone();
-    crate::dispatch::runner::apply_pitboss_env_defaults(&mut sublead_env);
+    //    Env precedence (lowest → highest): root lead's resolved env (which
+    //    already merges [defaults.env] + [lead.env]) → operator-supplied env
+    //    from the `spawn_sublead` MCP call → pitboss defaults
+    //    (`CLAUDE_CODE_ENTRYPOINT=sdk-ts`, only fills gaps).
+    //    Inheriting the lead's env means project-level path blocks like
+    //    `[defaults.env]` (WORK_DIR/ARTIFACTS_DIR/etc.) reach subleads
+    //    automatically, matching operator expectations; the lead doesn't
+    //    have to re-pass them in every spawn_sublead call.
+    let lead_env = state
+        .root
+        .manifest
+        .lead
+        .as_ref()
+        .map(|l| l.env.clone())
+        .unwrap_or_default();
+    let sublead_env = compose_sublead_env(&lead_env, &operator_env);
     let initial_cmd = SpawnCmd {
         program: sub_layer.claude_binary.clone(),
         args,
@@ -601,11 +636,16 @@ async fn spawn_sublead_session(
                         Some(sid.as_str()),
                         tools_for_resume,
                     );
-                    // Same env precedence as the initial spawn: operator first,
-                    // pitboss defaults fill gaps.
-                    let mut resume_env: std::collections::HashMap<String, String> =
-                        operator_env_bg.clone();
-                    crate::dispatch::runner::apply_pitboss_env_defaults(&mut resume_env);
+                    // Same env precedence as the initial spawn (see
+                    // compose_sublead_env): lead → operator → pitboss defaults.
+                    let lead_env_resume = state_bg
+                        .root
+                        .manifest
+                        .lead
+                        .as_ref()
+                        .map(|l| l.env.clone())
+                        .unwrap_or_default();
+                    let resume_env = compose_sublead_env(&lead_env_resume, &operator_env_bg);
                     current_cmd = SpawnCmd {
                         program: sub_layer_bg.claude_binary.clone(),
                         args: resume_args,
@@ -819,4 +859,78 @@ pub async fn reconcile_terminated_sublead(
     let _ = state.root.done_tx.send(sublead_id.to_string());
 
     Ok(())
+}
+
+#[cfg(test)]
+mod env_composition_tests {
+    use super::*;
+
+    fn env(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn lead_env_propagates_to_sublead() {
+        // Regression: operator reported [defaults.env] reaching the lead
+        // but not the subleads. Lead-env must be the base layer.
+        let lead = env(&[
+            ("WORK_DIR", "/run/work"),
+            ("ARTIFACTS_DIR", "/run/artifacts"),
+            ("ADVENTURE_OUT", "/run/out"),
+        ]);
+        let out = compose_sublead_env(&lead, &HashMap::new());
+        assert_eq!(out.get("WORK_DIR").map(String::as_str), Some("/run/work"));
+        assert_eq!(
+            out.get("ARTIFACTS_DIR").map(String::as_str),
+            Some("/run/artifacts")
+        );
+        assert_eq!(
+            out.get("ADVENTURE_OUT").map(String::as_str),
+            Some("/run/out")
+        );
+    }
+
+    #[test]
+    fn operator_env_wins_over_lead_env() {
+        // Spawn-site override beats inherited lead env. Lets a lead steer a
+        // specific sublead to a different WORK_DIR without editing the manifest.
+        let lead = env(&[("WORK_DIR", "/lead/path")]);
+        let operator = env(&[("WORK_DIR", "/operator/path")]);
+        let out = compose_sublead_env(&lead, &operator);
+        assert_eq!(
+            out.get("WORK_DIR").map(String::as_str),
+            Some("/operator/path")
+        );
+    }
+
+    #[test]
+    fn pitboss_defaults_fill_gaps_only() {
+        // CLAUDE_CODE_ENTRYPOINT is only set when neither lead nor operator
+        // supplied it. If either did, that value wins.
+        let empty = HashMap::new();
+        let out = compose_sublead_env(&empty, &empty);
+        assert_eq!(
+            out.get("CLAUDE_CODE_ENTRYPOINT").map(String::as_str),
+            Some("sdk-ts")
+        );
+
+        let lead = env(&[("CLAUDE_CODE_ENTRYPOINT", "cli")]);
+        let out = compose_sublead_env(&lead, &HashMap::new());
+        assert_eq!(
+            out.get("CLAUDE_CODE_ENTRYPOINT").map(String::as_str),
+            Some("cli"),
+            "lead's explicit CLAUDE_CODE_ENTRYPOINT must not be clobbered by defaults"
+        );
+    }
+
+    #[test]
+    fn empty_lead_env_still_applies_pitboss_defaults() {
+        // No [defaults.env] and no operator env → sublead still gets
+        // CLAUDE_CODE_ENTRYPOINT so the MCP permission bypass engages.
+        let out = compose_sublead_env(&HashMap::new(), &HashMap::new());
+        assert!(out.contains_key("CLAUDE_CODE_ENTRYPOINT"));
+    }
 }

--- a/crates/pitboss-cli/src/manifest/resolve.rs
+++ b/crates/pitboss-cli/src/manifest/resolve.rs
@@ -278,7 +278,7 @@ pub fn resolve_single_lead(
     env_max_parallel: Option<u32>,
 ) -> Result<ResolvedManifest> {
     let lead = if let Some(spec) = manifest.lead {
-        Some(resolve_lead_spec(&spec, &manifest.run)?)
+        Some(resolve_lead_spec(&spec, &manifest.run, &manifest.defaults)?)
     } else {
         None
     };
@@ -326,13 +326,31 @@ pub fn resolve_single_lead(
 }
 
 /// Resolve a `LeadSpec` (single-table `[lead]`) into a `ResolvedLead`.
-fn resolve_lead_spec(spec: &LeadSpec, run: &RunConfig) -> Result<ResolvedLead> {
+///
+/// `defaults` carries any `[defaults]` block from the manifest; its fields
+/// are merged into the `LeadSpec` so the single-table form has the same
+/// inheritance behavior the array-form `[[lead]]` already had via `resolve`.
+/// Per-lead values override defaults on collision; for env, defaults are
+/// applied first then per-lead env entries layered on top.
+fn resolve_lead_spec(
+    spec: &LeadSpec,
+    run: &RunConfig,
+    defaults: &Defaults,
+) -> Result<ResolvedLead> {
+    // Timeout cascade matches `resolve_lead` (array form):
+    // per-lead → [run].lead_timeout_secs → [defaults].timeout_secs → DEFAULT.
     let timeout_secs = spec
         .timeout_secs
         .or(run.lead_timeout_secs)
+        .or(defaults.timeout_secs)
         .unwrap_or(DEFAULT_TIMEOUT_SECS);
 
     let sublead_defaults = spec.sublead_defaults.as_ref().map(resolve_sublead_defaults);
+
+    // Env merge: defaults first, lead-level entries override on collision.
+    // Mirrors the array-form pattern in `resolve` (around line 184).
+    let mut env = defaults.env.clone();
+    env.extend(spec.env.clone());
 
     Ok(ResolvedLead {
         // id and directory are not present in the [lead] single-table format
@@ -347,12 +365,17 @@ fn resolve_lead_spec(spec: &LeadSpec, run: &RunConfig) -> Result<ResolvedLead> {
         model: spec
             .model
             .clone()
+            .or_else(|| defaults.model.clone())
             .unwrap_or_else(|| DEFAULT_MODEL.to_string()),
-        effort: spec.effort.unwrap_or(DEFAULT_EFFORT),
-        tools: spec.tools.clone().unwrap_or_else(default_tools),
+        effort: spec.effort.or(defaults.effort).unwrap_or(DEFAULT_EFFORT),
+        tools: spec
+            .tools
+            .clone()
+            .or_else(|| defaults.tools.clone())
+            .unwrap_or_else(default_tools),
         timeout_secs,
-        use_worktree: spec.use_worktree.unwrap_or(true),
-        env: spec.env.clone(),
+        use_worktree: spec.use_worktree.or(defaults.use_worktree).unwrap_or(true),
+        env,
         resume_session_id: None,
         // v0.6 depth-2 fields:
         allow_subleads: spec.allow_subleads,
@@ -464,6 +487,125 @@ mod tests {
 
     fn man(src: &str) -> Manifest {
         toml::from_str(src).unwrap()
+    }
+
+    fn slm(src: &str) -> SingleLeadManifest {
+        toml::from_str(src).unwrap()
+    }
+
+    #[test]
+    fn single_lead_merges_defaults_env_into_lead() {
+        // Regression test: the user's manifest had `[defaults.env]` set with
+        // ARTIFACTS_DIR / WORK_DIR / ADVENTURE_OUT, but the lead spawned with
+        // an empty env because `SingleLeadManifest` had no `defaults` field
+        // (silent drop) and `resolve_lead_spec` didn't read defaults anyway.
+        let m = slm(r#"
+            [run]
+            budget_usd = 1.0
+            max_workers = 2
+
+            [defaults]
+            model = "claude-sonnet-4-6"
+
+            [defaults.env]
+            WORK_DIR = "/tmp/foo"
+            ARTIFACTS_DIR = "/tmp/bar"
+
+            [lead]
+            prompt = "test"
+            allow_subleads = true
+
+            [lead.sublead_defaults]
+            read_down = true
+            "#);
+        let r = resolve_single_lead(m, None).unwrap();
+        let lead = r.lead.as_ref().unwrap();
+        assert_eq!(
+            lead.env.get("WORK_DIR"),
+            Some(&"/tmp/foo".to_string()),
+            "defaults.env.WORK_DIR must propagate to the lead"
+        );
+        assert_eq!(
+            lead.env.get("ARTIFACTS_DIR"),
+            Some(&"/tmp/bar".to_string()),
+            "defaults.env.ARTIFACTS_DIR must propagate to the lead"
+        );
+    }
+
+    #[test]
+    fn single_lead_merges_defaults_model_when_lead_omits() {
+        let m = slm(r#"
+            [defaults]
+            model = "claude-sonnet-4-6"
+
+            [lead]
+            prompt = "x"
+            "#);
+        let r = resolve_single_lead(m, None).unwrap();
+        assert_eq!(r.lead.as_ref().unwrap().model, "claude-sonnet-4-6");
+    }
+
+    #[test]
+    fn single_lead_lead_model_overrides_defaults_model() {
+        let m = slm(r#"
+            [defaults]
+            model = "claude-haiku-4-5"
+
+            [lead]
+            prompt = "x"
+            model = "claude-opus-4-7"
+            "#);
+        let r = resolve_single_lead(m, None).unwrap();
+        assert_eq!(r.lead.as_ref().unwrap().model, "claude-opus-4-7");
+    }
+
+    #[test]
+    fn single_lead_lead_env_overrides_defaults_env_on_collision() {
+        let m = slm(r#"
+            [defaults.env]
+            SHARED = "default-value"
+
+            [lead]
+            prompt = "x"
+
+            [lead.env]
+            SHARED = "lead-override"
+            EXTRA = "lead-only"
+            "#);
+        let r = resolve_single_lead(m, None).unwrap();
+        let env = &r.lead.as_ref().unwrap().env;
+        assert_eq!(env.get("SHARED"), Some(&"lead-override".to_string()));
+        assert_eq!(env.get("EXTRA"), Some(&"lead-only".to_string()));
+    }
+
+    #[test]
+    fn single_lead_merges_defaults_tools_when_lead_omits() {
+        let m = slm(r#"
+            [defaults]
+            tools = ["Read", "Bash"]
+
+            [lead]
+            prompt = "x"
+            "#);
+        let r = resolve_single_lead(m, None).unwrap();
+        assert_eq!(r.lead.as_ref().unwrap().tools, vec!["Read", "Bash"]);
+    }
+
+    #[test]
+    fn single_lead_unknown_top_level_section_rejected() {
+        // [default] (singular) is a common typo for [defaults]. With
+        // deny_unknown_fields, this fails at parse instead of silently
+        // dropping the operator's intent.
+        let result: Result<SingleLeadManifest, _> = toml::from_str(
+            r#"
+            [default]
+            model = "claude-sonnet-4-6"
+
+            [lead]
+            prompt = "x"
+            "#,
+        );
+        assert!(result.is_err(), "expected parse error for [default] typo");
     }
 
     #[test]

--- a/crates/pitboss-cli/src/manifest/schema.rs
+++ b/crates/pitboss-cli/src/manifest/schema.rs
@@ -185,10 +185,21 @@ pub struct Lead {
 /// the TOML author writes `[lead]` (one table) instead of `[[lead]]` (array).
 /// Carries all per-run settings under `[run]` and per-lead settings (including
 /// depth-2 caps) under `[lead]`.
+///
+/// `deny_unknown_fields` is intentional: without it, a typo'd top-level
+/// section (e.g. `[default]` instead of `[defaults]`) silently disappears
+/// at parse time and the operator only finds out at dispatch — too late.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SingleLeadManifest {
     #[serde(default)]
     pub run: RunConfig,
+    /// Per-actor defaults (model, env, tools, etc.). Merged into `[lead]`
+    /// during resolution; `[lead]` values override on collision. The
+    /// array-form `Manifest` already carries this; the single-table form
+    /// gained it in the same release that added the `[lead]` form.
+    #[serde(default)]
+    pub defaults: Defaults,
     /// Single-table `[lead]` block.
     pub lead: Option<LeadSpec>,
     /// Notification sinks (v0.4.1+). Parsed as [[notification]] sections.


### PR DESCRIPTION
## Summary

Bundled postmortem for the D&D-adventure dispatch that died early despite a $300 / 8h budget. Three independent bugs in `spawn_sublead`'s end-to-end path, each fully masking the next:

1. `[defaults]` silently dropped in single-table `[lead]` manifests (original PR scope)
2. Root-lead `--allowedTools` missing four real MCP tools (added in this PR)
3. `[defaults.env]` not inherited by subleads (added in this PR)

Individually any one of these is a soft-fail with no operator-visible signal. Stacked, the dispatch exits after ~13 minutes marked `Success` with nothing to diagnose except silent sublead directories.

## Fix 1 — [defaults] block dropped in single-table [lead] form

- `SingleLeadManifest` had no `defaults` field and no `deny_unknown_fields`; operator's entire `[defaults]` block was silently discarded at parse
- `resolve_lead_spec` never merged defaults into the lead the way the array-form `resolve_lead` does
- Adds `defaults` + `deny_unknown_fields`, merges env / model / effort / tools / use_worktree / timeout_secs, aligns timeout cascade with array form

## Fix 2 — Orchestration allowlist gaps

`PITBOSS_MCP_TOOLS` and `SUBLEAD_MCP_TOOLS` were missing four server tools:
- `mcp__pitboss__wait_actor`
- `mcp__pitboss__propose_plan`
- `mcp__pitboss__run_lease_acquire`
- `mcp__pitboss__run_lease_release`

Observable failure: lead successfully spawns subleads, then the very next `wait_actor` call returns `"Claude requested permissions to use mcp__pitboss__wait_actor, but you haven't granted it yet"` — Claude's own permission prompt, unanswerable under `-p`. Lead gives up, dispatch marks Success, four orphan subleads on disk.

Also removed a phantom `mcp__pitboss__wait_for_sublead` entry that's not a real server tool — it was masking the `wait_actor` omission during review.

## Fix 3 — [defaults.env] not inherited by subleads

After Fix 1, `[defaults.env]` reaches the root lead but `spawn_sublead`'s sublead env came solely from the tool-call `env:` param. Project-level path blocks defined once in `[defaults.env]` were invisible to subleads unless the lead remembered to re-pass them on every spawn.

New precedence (captured in `compose_sublead_env` helper):
1. Root lead's resolved env (`[defaults.env]` + `[lead.env]` already merged)
2. Operator env from the `spawn_sublead` MCP call
3. Pitboss defaults (`CLAUDE_CODE_ENTRYPOINT=sdk-ts`) — gap-fill only

Applied at both initial spawn and the kill+resume path used for synthetic reprompts.

## Tests

- 6 single-lead manifest tests (defaults merge, singular typo rejection, etc.) — Fix 1
- 2 allowlist regression tests (root lead + sublead) — Fix 2
- 4 env composition tests (lead propagation, operator-wins, defaults-gap-fill) — Fix 3
- Full suite: **309 passed**, fmt + clippy clean

## Behavior change note

Single-table manifests that "worked" before by accident (e.g. relying on hardcoded defaults matching `[defaults]`) now use the merged values. Correct behavior per the array-form contract. Worth a callout in the v0.7.1 release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)