### PR TITLE
post-v0.7 bundle: depth-2 hardening + TUI fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,10 @@ flamegraph.svg
 
 # Local-only operator script: hardcoded host paths, not portable.
 /scripts/reset-ketchup-p0-dogfood.sh
+
+# Local notes — NOTES-*.md at the repo root. Scratch docs (testing
+# processes, diagnostic recipes, in-flight bug postmortems) accessible
+# from the working tree without polluting git history. Format on
+# purpose: one-shot grep-target, uppercase prefix so they sort above
+# tracked docs in a directory listing.
+NOTES-*.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,17 +271,36 @@ section before writing manifests for headless dispatch.
 
 ### Permission model
 
-As of v0.7, pitboss auto-sets `CLAUDE_CODE_ENTRYPOINT=sdk-ts` on every
-spawned claude subprocess. This tells claude to bypass its built-in
-interactive permission gate; pitboss becomes the sole approval authority
-via `approval_policy` and `[[approval_policy]]` rules. Without this fix,
-sub-leads in headless dispatch would exit in ~7 seconds reporting
-`Success` with no output (claude apologizing that it can't get
-permission to write files, then giving up cleanly).
+**Pitboss is the sole permission authority for every claude subprocess
+it spawns.** As of v0.7.1 every spawned claude (lead, sub-lead, worker)
+receives:
 
-You can override this per-actor by setting `[defaults.env.CLAUDE_CODE_ENTRYPOINT]`
-to a different value in the manifest, but for headless dispatch you
-almost certainly want the default.
+1. `CLAUDE_CODE_ENTRYPOINT=sdk-ts` in env — closes claude's MCP-tool
+   permission gate. Operator-overridable via `[defaults.env]`.
+2. `--dangerously-skip-permissions` on the CLI — closes claude's
+   filesystem (read/write outside cwd), bash-with-`$VAR`-expansion, and
+   bash-with-`&&` gates. **Set unconditionally; not env-overridable.**
+
+Without (1) sub-leads in headless dispatch exited in ~7 seconds
+reporting `Success` with no output (apologizing that they couldn't get
+MCP permission). Without (2), even after the MCP gate was closed, every
+sublead's `echo x >> "$WORK_DIR/file"` returned `"Contains
+simple_expansion"` — `-p` mode has no UI to answer the prompt — and the
+orchestration plan collapsed silently with empty registries and null
+kv reads.
+
+Pitboss replaces the closed claude gates with its own approval surface:
+`[run].approval_policy` (block / auto_approve / auto_reject),
+`[[approval_policy]]` rules with TTL+fallback, the `request_approval`
+and `propose_plan` MCP tools, and the TUI's approve/reject modal. If
+you need claude's own gate fully back, do not use pitboss's headless
+dispatch — drive the claude CLI interactively instead.
+
+The trust boundary: anything you wouldn't run in your own claude
+session under `--dangerously-skip-permissions` should not be in a
+pitboss manifest. Operator-supplied prompts have full filesystem and
+shell access at the `[lead].directory` cwd. Treat manifests as
+production code.
 
 ### Approval policy — set `auto_approve` (or use rules)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,21 @@ This project uses [Semantic Versioning](https://semver.org/).
   (stays pending, press \`a\` to re-open)`. `ApprovalListItem.id`
   changed from `uuid::Uuid` to `String` to match the server's
   `req-<uuid>` wire format.
+- **Sub-leads couldn't read project files without a permission
+  prompt.** Every sub-lead's claude subprocess started with
+  `cwd = ~/.local/share/pitboss/runs/<run_id>/`, which put the operator's
+  project directory (and anything `[defaults.env]` pointed into it)
+  outside claude's cwd-rooted trust zone. Claude would prompt on every
+  read, and under `-p` headless mode the prompt is unanswerable —
+  sub-leads effectively couldn't see any project artifact. The v0.6
+  author's own comment flagged this as a placeholder ("sub-leads don't
+  get separate worktrees in v0.6 — revisit in future"). Fixed: sub-lead
+  cwd is now the root lead's manifest `directory` (not `lead_cwd` —
+  when the lead uses a worktree, sub-leads still cwd the canonical
+  project dir so they can't lose cwd mid-flight if the lead's worktree
+  is cleaned up, and they see committed project state rather than the
+  lead's in-flight edits). Applied at both initial spawn and the
+  kill+resume path.
 - **Sub-lead MCP bridge was silently broken since v0.6.** The CLI
   `ActorRoleArg` enum defined only `Lead` and `Worker`, but
   `build_sublead_mcp_config` wrote `--actor-role sublead` into every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,31 @@ This project uses [Semantic Versioning](https://semver.org/).
   (stays pending, press \`a\` to re-open)`. `ApprovalListItem.id`
   changed from `uuid::Uuid` to `String` to match the server's
   `req-<uuid>` wire format.
+- **`wait_actor` / `wait_for_worker` blocked indefinitely on
+  sub-lead-spawned workers because completion fired the wrong
+  broadcast.** Each `LayerState` carries its own `done_tx`; worker
+  termination called `layer.done_tx.send(task_id)` — for a
+  sub-lead-spawned worker that's the SUBLEAD's broadcast, not
+  root's. `wait_for_actor_internal` always subscribes via
+  `state.root.done_tx`, so the parent sub-lead's `wait_actor` on
+  its own worker missed the completion entirely and blocked until
+  the timeout (or the sub-lead's `lead_timeout_secs` SIGTERM'd it).
+  Smoke-test evidence: workers completed in ~10s, sub-leads timed
+  out at the 180s mark with `MCP error -32000: Connection closed`
+  on the wait_actor reply (the connection died when the sub-lead
+  was killed, not because the wait itself errored). Fixed by
+  fanning worker termination broadcasts to root's `done_tx` in
+  addition to the worker's own layer — applied at both the normal
+  exit path and the SpawnFailed early-exit path.
+- **`wait_for_actor_internal` had a subscribe-after-check race.**
+  Fast-path Done check + existence check ran before
+  `state.done_tx.subscribe()`; a completion that landed in the
+  microsecond gap was missed and the wait blocked until timeout.
+  In v0.5/v0.6 this was unreachable for sub-leads (which got
+  `unknown actor_id` before the cross-layer-lookup fix in d134289),
+  but the same fix exposed the race. Subscribe FIRST, then re-check
+  — guarantees no completion is lost regardless of how short the
+  worker is.
 - **Sub-lead-spawned workers SpawnFailed at `/tmp` when no
   `directory` arg was passed.** `derive_sublead_manifest` clears
   `lead` on the sub-manifest, and `handle_spawn_worker`'s fallback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,24 @@ This project uses [Semantic Versioning](https://semver.org/).
   (stays pending, press \`a\` to re-open)`. `ApprovalListItem.id`
   changed from `uuid::Uuid` to `String` to match the server's
   `req-<uuid>` wire format.
+- **Sub-lead-spawned workers SpawnFailed at `/tmp` when no
+  `directory` arg was passed.** `derive_sublead_manifest` clears
+  `lead` on the sub-manifest, and `handle_spawn_worker`'s fallback
+  chain only consulted `target_layer.manifest.lead.directory` before
+  defaulting to `/tmp`. Sub-lead callers therefore landed on `/tmp`
+  whenever they didn't supply an explicit directory — git worktree
+  creation then failed loudly with `"not inside a git work-tree:
+  /tmp"` and the worker was marked SpawnFailed. The failure was
+  visible in `summary.jsonl` but **not** in the sub-lead's
+  `wait_for_worker` reply (which sees the SpawnFailed task record
+  but doesn't surface the cwd that caused it), so a sub-lead's only
+  signal was a worker that never produced output — easy to misread
+  as a model-side problem. Fixed by extending the fallback chain
+  through the **root lead's** directory before falling back to
+  `/tmp`. Same fix applied to `tools`, `timeout_secs`, and
+  `use_worktree` resolution so sub-lead workers honor the operator's
+  root-level defaults instead of either crashing on `/tmp` or
+  silently using a different `use_worktree` setting than root.
 - **Sub-lead-spawned workers looked "unknown" to every downstream
   lookup.** `handle_list_workers`, `handle_worker_status`, and
   `wait_for_actor_internal` (the engine behind `wait_actor` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,21 @@ This project uses [Semantic Versioning](https://semver.org/).
   (stays pending, press \`a\` to re-open)`. `ApprovalListItem.id`
   changed from `uuid::Uuid` to `String` to match the server's
   `req-<uuid>` wire format.
+- **Workers spawned with an empty env — `[defaults.env]` never
+  reached them.** `run_worker` and `spawn_resume_worker` both built
+  their `SpawnCmd` with `env: Default::default()`, so manifest-level
+  env vars (e.g. `WORK_DIR`, `ARTIFACTS_DIR`) propagated lead → sublead
+  (after prior fixes) but dead-ended before hitting workers. Observable
+  symptom: a sublead asking a worker to write `"$WORK_DIR/file.md"`
+  resolved `$WORK_DIR` to empty and the worker's bash either errored
+  or wrote to an unexpected path. Same bug class as the sublead-env
+  regression; third occurrence of "env stops at layer N". Fixed by
+  re-using `compose_sublead_env` at both worker-spawn paths, seeding
+  from `layer.manifest.lead.env` (initial) / `state.manifest.lead.env`
+  (resume) so the same lead → sublead → worker env chain holds across
+  depth-2, pause/continue, and reprompt. `SpawnWorkerArgs` still has
+  no per-spawn `env` override — operator env stays at the manifest
+  level for now.
 - **Sub-leads couldn't read project files without a permission
   prompt.** Every sub-lead's claude subprocess started with
   `cwd = ~/.local/share/pitboss/runs/<run_id>/`, which put the operator's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,27 @@ This project uses [Semantic Versioning](https://semver.org/).
   does, and `deny_unknown_fields` is on so the next silent-drop bug
   fails loud at parse time. The `[default]` (singular, common typo
   for `[defaults]`) is now rejected with an actionable parse error.
+- **TUI approval modal stranded requests on `Esc`.** Hitting `Esc` to
+  dismiss an approval popup transitioned the TUI to normal mode without
+  sending any response, leaving the request pending server-side — the
+  run stayed blocked, the modal was gone, and pressing `a` to "retrieve"
+  the approval opened an empty list because `ApprovalRequest` events
+  were never populating `approval_list.items` in the first place (the
+  queue pane shipped for v0.6 but was only ever wired up in tests).
+  Operators reasonably concluded the TUI was hung and had no way to
+  proceed. Fixed: `ApprovalRequest` events now push an item into the
+  approval queue in addition to opening the modal (de-duplicated by
+  request_id to survive event replays on server restart); `Esc` from
+  any modal sub-mode drops the operator into the approval-list pane
+  with the dismissed item selected; `send_approve` removes items from
+  the queue on decision (clamping `selected_idx` when the last item
+  goes); re-opening a queued request preserves the `plan` payload and
+  `kind` discriminator so dismissed `propose_plan` approvals still
+  render as "PRE-FLIGHT PLAN" with structured plan view on re-open.
+  Modal title updated from the misleading `Esc=cancel` to `Esc=dismiss
+  (stays pending, press \`a\` to re-open)`. `ApprovalListItem.id`
+  changed from `uuid::Uuid` to `String` to match the server's
+  `req-<uuid>` wire format.
 - **Sub-lead MCP bridge was silently broken since v0.6.** The CLI
   `ActorRoleArg` enum defined only `Lead` and `Worker`, but
   `build_sublead_mcp_config` wrote `--actor-role sublead` into every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,23 @@ This project uses [Semantic Versioning](https://semver.org/).
   (stays pending, press \`a\` to re-open)`. `ApprovalListItem.id`
   changed from `uuid::Uuid` to `String` to match the server's
   `req-<uuid>` wire format.
+- **Sub-lead-spawned workers looked "unknown" to every downstream
+  lookup.** `handle_list_workers`, `handle_worker_status`, and
+  `wait_for_actor_internal` (the engine behind `wait_actor` /
+  `wait_for_worker`) all read `state.workers` — which under the
+  DispatchState → LayerState Deref resolves to the root layer's
+  workers map. Workers spawned by a sub-lead are registered in the
+  sub-lead's `LayerState.workers` via `target_layer.workers.write()`
+  in `handle_spawn_worker`, so a sub-lead calling `spawn_worker` got
+  back a valid task_id but the very next `wait_actor` on that id
+  returned `MCP error -32600: unknown actor_id: worker-...` and
+  `list_workers` returned `[]`. Silent depth-2 break since v0.6 —
+  sub-leads cannot manage their own workers. Fixed by introducing
+  `find_worker_across_layers` that scans root + every active
+  sub-lead layer, and routing all four handlers through it.
+  Confirmed via the depth-2 smoke test: before the fix, the sublead
+  got "unknown actor_id" on every wait; after, the wait completes
+  against the correct layer's worker record.
 - **Workers spawned with an empty env — `[defaults.env]` never
   reached them.** `run_worker` and `spawn_resume_worker` both built
   their `SpawnCmd` with `env: Default::default()`, so manifest-level

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,30 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Security
 
+- **`--dangerously-skip-permissions` is now passed to every spawned
+  claude (lead, sub-lead, worker).** Operators must read this entry.
+  Pitboss is the sole permission authority for orchestrated claude
+  subprocesses — see the v0.7 doc on `CLAUDE_CODE_ENTRYPOINT=sdk-ts`
+  for the original "single permission authority" rationale. The flag
+  extends that decision from MCP tools (which `sdk-ts` already
+  bypassed) to every other claude-side gate: filesystem reads/writes
+  outside cwd, bash with `$VAR` expansion, bash with `&&`. Without
+  the flag, headless dispatch silently stalls on these gates with no
+  operator-visible cause — the smoke test exposed this as empty
+  registries, null kv reads, and "no deliverable files written"
+  despite both subleads reporting `outcome=success`. Pitboss's own
+  approval surface (`approval_policy`, `[[approval_policy]]` rules,
+  TUI modal) replaces what claude's gate would have caught. The flag
+  is set unconditionally and is NOT env-overridable; operators who
+  need claude's own gate fully back should drive claude CLI
+  interactively, not via pitboss headless dispatch. **Trust
+  boundary**: anything you wouldn't run in your own claude session
+  under `--dangerously-skip-permissions` should not be in a pitboss
+  manifest. Operator-supplied prompts have full filesystem + shell
+  access at `[lead].directory`. Treat manifests as production code.
+  Locked in by regression tests — every spawn variant
+  (lead, lead-resume, sublead, sublead-resume, worker) is asserted
+  to carry the flag.
 - **SSRF / secret-exfiltration hardening on `[[notification]]` sinks.**
   See "Breaking changes" above for URL scheme / host and env-var
   substitution restrictions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,21 @@ This project uses [Semantic Versioning](https://semver.org/).
   does, and `deny_unknown_fields` is on so the next silent-drop bug
   fails loud at parse time. The `[default]` (singular, common typo
   for `[defaults]`) is now rejected with an actionable parse error.
+- **Sub-lead MCP bridge was silently broken since v0.6.** The CLI
+  `ActorRoleArg` enum defined only `Lead` and `Worker`, but
+  `build_sublead_mcp_config` wrote `--actor-role sublead` into every
+  sub-lead's mcp-config. When claude spawned the mcp-bridge subprocess
+  to talk to pitboss, clap rejected the argv (`invalid value 'sublead'
+  for '--actor-role'`), the bridge exited immediately, and claude
+  reported `pitboss: failed` in its init event — with zero pitboss MCP
+  tools registered for the sub-lead. Observable symptom: sub-leads
+  can't `kv_get`, `spawn_worker`, or any other pitboss tool; the lead
+  looks fine. The server-side `ALLOWED_ROLES` had always accepted
+  `sublead` (and `root_lead`); only the client-side argv parser was
+  rejecting valid traffic pitboss itself was emitting. Added `Sublead`
+  and `RootLead` variants, switched clap `rename_all` to `snake_case`
+  so `RootLead → root_lead`, and added a regression test pinning every
+  ActorRole variant to its server-side token.
 - **Root-lead `--allowedTools` was missing four real MCP tools, causing
   silent orchestration stalls.** `PITBOSS_MCP_TOOLS` omitted
   `wait_actor`, `propose_plan`, `run_lease_acquire`, and

--- a/crates/pitboss-cli/src/cli.rs
+++ b/crates/pitboss-cli/src/cli.rs
@@ -3,9 +3,21 @@ use std::path::PathBuf;
 use clap::{Parser, Subcommand};
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
-#[clap(rename_all = "lowercase")]
+#[clap(rename_all = "snake_case")]
 pub enum ActorRoleArg {
+    /// Legacy v0.3-v0.5 flat-lead role. Kept for compat with
+    /// `lead_spawn_args`' mcp-config emitter, which writes `--actor-role lead`.
     Lead,
+    /// Depth-2 root lead. Accepted by the mcp-bridge subcommand so the
+    /// server-side role gate can enforce depth-2 invariants (e.g. only
+    /// RootLead may call `spawn_sublead`).
+    RootLead,
+    /// Depth-2 sub-tree lead. Required so `build_sublead_mcp_config`'s
+    /// `--actor-role sublead` passes clap parsing; without this variant the
+    /// mcp-bridge subprocess rejects argv at startup and the sub-lead's
+    /// claude reports `pitboss: failed` on every MCP call. Silent depth-2
+    /// break since v0.6.
+    Sublead,
     Worker,
 }
 

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -613,6 +613,44 @@ async fn dispatch_op(
             }
         }
         ControlOp::RepromptWorker { task_id, prompt } => {
+            // Route by task_id:
+            // - Sub-lead id → deliver via the sub-lead's own
+            //   reprompt_tx channel (sub_layer.send_synthetic_reprompt).
+            //   The sub-lead's background kill+resume loop (see
+            //   dispatch/sublead.rs:642) consumes reprompt_rx and
+            //   re-launches its claude subprocess with `--resume
+            //   <session_id>` and the new prompt.
+            // - Root-layer worker id → existing spawn_resume_worker
+            //   flow (below).
+            // - Everything else → unknown task_id.
+            //
+            // Pre-fix, sub-lead reprompts returned "unknown task_id"
+            // because the handler only looked at `state.workers`
+            // (= root layer via Deref). Sub-leads live in
+            // `state.subleads`, not `state.workers`, so the check
+            // always missed.
+            {
+                let subleads = state.subleads.read().await;
+                if let Some(sub_layer) = subleads.get(&task_id).cloned() {
+                    drop(subleads);
+                    let _ = crate::dispatch::events::append_event(
+                        &state.run_subdir,
+                        &task_id,
+                        &crate::dispatch::events::TaskEvent::Reprompt {
+                            at: chrono::Utc::now(),
+                            prompt_preview: prompt.chars().take(80).collect(),
+                            prior_session_id: String::new(),
+                        },
+                    )
+                    .await;
+                    sub_layer.send_synthetic_reprompt(&prompt).await;
+                    return ControlEvent::OpAcked {
+                        op: "reprompt_worker".into(),
+                        task_id: Some(task_id),
+                    };
+                }
+            }
+
             let current = state.workers.read().await.get(&task_id).cloned();
             let session_id = match current {
                 Some(crate::dispatch::state::WorkerState::Running {

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -23,14 +23,22 @@ use crate::manifest::resolve::{ResolvedManifest, ResolvedTask};
 /// Rationale: pitboss is the external permission authority (via
 /// `approval_policy`, `[[approval_policy]]` rules, and the TUI). Claude's
 /// own interactive permission gate is redundant under pitboss orchestration
-/// and causes silent 7-second-success failures in headless dispatch when no
-/// operator is present to approve each tool call.
+/// and causes silent stalls in headless dispatch when no operator is
+/// present to answer each prompt. The `sdk-ts` value tells claude "you're
+/// running under an SDK runtime that manages permissions externally."
 ///
-/// The `sdk-ts` value tells claude "you're running under an SDK runtime that
-/// manages permissions externally — don't prompt the TTY." Operators who want
-/// claude's own gate back for a specific actor can override via
-/// `[defaults.env]`, `[lead.env]`, `[[task]].env`, or the `env` field on
-/// `spawn_sublead`.
+/// **Companion flag**: every pitboss-spawned claude (lead, sub-lead, worker)
+/// also launches with `--dangerously-skip-permissions`. Together the env
+/// var and the flag close the full permission surface (MCP tools, file I/O,
+/// bash-with-`$VAR`, bash-with-`&&`). See `lead_spawn_args` for the
+/// detailed trust-model writeup.
+///
+/// Operators who want claude's own gate back for a specific actor can
+/// override `CLAUDE_CODE_ENTRYPOINT` via `[defaults.env]`, `[lead.env]`,
+/// `[[task]].env`, or the `env` field on `spawn_sublead` — but the
+/// `--dangerously-skip-permissions` CLI flag is set unconditionally and
+/// is not env-overridable. Operators who need the claude gate fully back
+/// should not use pitboss's headless dispatch.
 ///
 /// See `docs/superpowers/specs/2026-04-20-path-b-permission-prompt-routing-pin.md`
 /// for the deferred alternative (routing claude's gate through pitboss's
@@ -606,6 +614,22 @@ pub const SUBLEAD_MCP_TOOLS: &[&str] = &[
 /// answered in `-p` (non-interactive) mode, so we always pre-allow the six
 /// pitboss MCP tools here. User-specified `tools` (from defaults / per-lead)
 /// are merged in alongside the MCP set.
+///
+/// **Trust model — `--dangerously-skip-permissions`:** every pitboss-spawned
+/// claude (lead, sub-lead, worker) launches with this flag. Pitboss is the
+/// external permission authority via `[run].approval_policy`,
+/// `[[approval_policy]]` rules, and the TUI's approve/reject modal — see
+/// `apply_pitboss_env_defaults` for the rationale we already adopted for
+/// MCP tools (CLAUDE_CODE_ENTRYPOINT=sdk-ts). The flag extends that
+/// "single permission authority" design to the rest of claude's gates
+/// (filesystem reads/writes, bash with `$VAR` expansion, bash with `&&`).
+/// Without it, headless dispatch silently stalls: under `-p`, claude's own
+/// prompts have no UI to answer them, so `echo x >> "$WORK_DIR/file"`
+/// returns "Contains simple_expansion" and the orchestration plan
+/// collapses with no operator-visible cause. Operators who want claude's
+/// own gate back for a specific run should not use pitboss's headless
+/// dispatch — they should drive the claude CLI interactively. See
+/// CHANGELOG entry under v0.7.1 for the security note.
 pub fn lead_spawn_args(
     lead: &crate::manifest::resolve::ResolvedLead,
     mcp_config: &std::path::Path,
@@ -614,6 +638,8 @@ pub fn lead_spawn_args(
         "--output-format".into(),
         "stream-json".into(),
         "--verbose".into(),
+        // Pitboss is the permission authority — see fn doc comment.
+        "--dangerously-skip-permissions".into(),
     ];
 
     // Build the allowed-tools set: user tools + pitboss MCP tools.
@@ -660,6 +686,8 @@ pub fn lead_resume_spawn_args(
         "--output-format".into(),
         "stream-json".into(),
         "--verbose".into(),
+        // Permission authority is pitboss (see lead_spawn_args doc).
+        "--dangerously-skip-permissions".into(),
     ];
     let mut allowed: Vec<String> = lead.tools.clone();
     for t in PITBOSS_MCP_TOOLS {
@@ -715,6 +743,8 @@ pub fn sublead_spawn_args(
         "--output-format".into(),
         "stream-json".into(),
         "--verbose".into(),
+        // Permission authority is pitboss (see lead_spawn_args doc).
+        "--dangerously-skip-permissions".into(),
     ];
 
     // Build the allowed-tools set. Operator-supplied tools (if any) are
@@ -1278,6 +1308,59 @@ mod tests {
             !args.iter().any(|a| a == "--resume"),
             "expected no --resume in args: {args:?}"
         );
+    }
+
+    #[test]
+    fn every_spawn_variant_passes_dangerously_skip_permissions() {
+        // Pitboss is the permission authority — every spawned claude must
+        // run with `--dangerously-skip-permissions`. Without this, headless
+        // dispatch silently stalls on bash-with-`$VAR`, file-write-outside-
+        // cwd, and every other claude-side gate that has no `-p`-mode
+        // answer. This test exists so the flag can't be dropped accidentally
+        // (the smoke-test failure mode is silent — empty registries and
+        // null kv reads, no operator-visible error).
+        use crate::manifest::resolve::ResolvedLead;
+        use std::path::PathBuf;
+        let lead = ResolvedLead {
+            id: "l".into(),
+            directory: PathBuf::from("/tmp"),
+            prompt: "p".into(),
+            branch: None,
+            model: "m".into(),
+            effort: crate::manifest::schema::Effort::High,
+            tools: vec!["Read".into()],
+            timeout_secs: 60,
+            use_worktree: false,
+            env: Default::default(),
+            resume_session_id: None,
+            allow_subleads: true,
+            max_subleads: None,
+            max_sublead_budget_usd: None,
+            max_workers_across_tree: None,
+            sublead_defaults: None,
+        };
+        let cfg = PathBuf::from("/tmp/cfg.json");
+        let cases: Vec<(&str, Vec<String>)> = vec![
+            ("lead", lead_spawn_args(&lead, &cfg)),
+            (
+                "lead_resume",
+                lead_resume_spawn_args(&lead, &cfg, "sess", "new prompt"),
+            ),
+            (
+                "sublead",
+                sublead_spawn_args("sl-id", "p", "m", &cfg, None, None),
+            ),
+            (
+                "sublead_resume",
+                sublead_spawn_args("sl-id", "p", "m", &cfg, Some("sess"), None),
+            ),
+        ];
+        for (name, argv) in cases {
+            assert!(
+                argv.iter().any(|a| a == "--dangerously-skip-permissions"),
+                "{name} spawn args missing --dangerously-skip-permissions: {argv:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -477,16 +477,37 @@ async fn spawn_sublead_session(
     let log_path = task_dir.join("stdout.log");
     let stderr_path = task_dir.join("stderr.log");
 
-    // 5. Build the spawn command. CWD is root's run_subdir (sub-leads don't
-    //    get separate worktrees in v0.6 — revisit in future).
-    //    Env precedence (lowest → highest): root lead's resolved env (which
-    //    already merges [defaults.env] + [lead.env]) → operator-supplied env
-    //    from the `spawn_sublead` MCP call → pitboss defaults
-    //    (`CLAUDE_CODE_ENTRYPOINT=sdk-ts`, only fills gaps).
-    //    Inheriting the lead's env means project-level path blocks like
-    //    `[defaults.env]` (WORK_DIR/ARTIFACTS_DIR/etc.) reach subleads
-    //    automatically, matching operator expectations; the lead doesn't
-    //    have to re-pass them in every spawn_sublead call.
+    // 5. Build the spawn command.
+    //
+    //    CWD: the root lead's manifest `directory` (not its worktree path,
+    //    even when the lead uses one). Rationale:
+    //    - Claude gates file I/O on paths outside cwd. Previous default of
+    //      `run_subdir` (under ~/.local/share/pitboss/runs/…) put every
+    //      operator artifact (project files, $WORK_DIR, $ARTIFACTS_DIR)
+    //      outside the sublead's trust zone, triggering a permission
+    //      prompt on every read. Under `-p` headless mode the prompt is
+    //      unanswerable; subleads effectively couldn't read project files.
+    //    - Using `lead.directory` (not `lead_cwd` = possibly-worktree-path)
+    //      keeps subleads independent of the lead's worktree lifecycle:
+    //      subleads won't lose cwd if the lead's worktree is cleaned up
+    //      while subleads are still running, and they see the committed
+    //      project state rather than the lead's in-flight edits.
+    //    - Workers spawned by subleads resolve their own cwd via
+    //      `args.directory` → `lead.directory` fallback → optional
+    //      per-worker worktree, so worker cwd is unchanged by this.
+    //    Falls back to `run_subdir` when the manifest has no `[lead]`
+    //    (flat-only hierarchical run — not a path that reaches
+    //    spawn_sublead in practice, but we prefer a well-defined cwd over
+    //    a panic).
+    //
+    //    Env precedence (lowest → highest): root lead's resolved env
+    //    (which already merges [defaults.env] + [lead.env]) →
+    //    operator-supplied env from the `spawn_sublead` MCP call →
+    //    pitboss defaults (`CLAUDE_CODE_ENTRYPOINT=sdk-ts`, only fills
+    //    gaps). Inheriting the lead's env means project-level path
+    //    blocks like `[defaults.env]` (WORK_DIR/ARTIFACTS_DIR/etc.)
+    //    reach subleads automatically; the lead doesn't have to re-pass
+    //    them in every spawn_sublead call.
     let lead_env = state
         .root
         .manifest
@@ -495,10 +516,17 @@ async fn spawn_sublead_session(
         .map(|l| l.env.clone())
         .unwrap_or_default();
     let sublead_env = compose_sublead_env(&lead_env, &operator_env);
+    let sublead_cwd = state
+        .root
+        .manifest
+        .lead
+        .as_ref()
+        .map(|l| l.directory.clone())
+        .unwrap_or_else(|| sub_layer.run_subdir.clone());
     let initial_cmd = SpawnCmd {
         program: sub_layer.claude_binary.clone(),
         args,
-        cwd: sub_layer.run_subdir.clone(),
+        cwd: sublead_cwd.clone(),
         env: sublead_env,
     };
 
@@ -646,10 +674,20 @@ async fn spawn_sublead_session(
                         .map(|l| l.env.clone())
                         .unwrap_or_default();
                     let resume_env = compose_sublead_env(&lead_env_resume, &operator_env_bg);
+                    // Same cwd rationale as the initial spawn: lead.directory
+                    // (not lead_cwd). See the long comment in
+                    // finalize_sublead_spawn.
+                    let resume_cwd = state_bg
+                        .root
+                        .manifest
+                        .lead
+                        .as_ref()
+                        .map(|l| l.directory.clone())
+                        .unwrap_or_else(|| sub_layer_bg.run_subdir.clone());
                     current_cmd = SpawnCmd {
                         program: sub_layer_bg.claude_binary.clone(),
                         args: resume_args,
-                        cwd: sub_layer_bg.run_subdir.clone(),
+                        cwd: resume_cwd,
                         env: resume_env,
                     };
 

--- a/crates/pitboss-cli/src/mcp/bridge.rs
+++ b/crates/pitboss-cli/src/mcp/bridge.rs
@@ -32,6 +32,8 @@ const MAX_C2S_LINE_BYTES: usize = 4 * 1024 * 1024;
 fn role_str(role: ActorRoleArg) -> &'static str {
     match role {
         ActorRoleArg::Lead => "lead",
+        ActorRoleArg::RootLead => "root_lead",
+        ActorRoleArg::Sublead => "sublead",
         ActorRoleArg::Worker => "worker",
     }
 }
@@ -189,6 +191,49 @@ mod tests {
     use super::*;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::{UnixListener, UnixStream};
+
+    #[test]
+    fn role_str_covers_every_actor_role_variant() {
+        // Regression: CLI previously had only Lead + Worker. Sub-lead mcp
+        // configs write `--actor-role sublead`; clap rejected the argv,
+        // mcp-bridge never started, and claude reported `pitboss: failed`.
+        // Silent depth-2 break since v0.6. These four strings are load-
+        // bearing: they must match the server-side ALLOWED_ROLES list.
+        assert_eq!(role_str(ActorRoleArg::Lead), "lead");
+        assert_eq!(role_str(ActorRoleArg::RootLead), "root_lead");
+        assert_eq!(role_str(ActorRoleArg::Sublead), "sublead");
+        assert_eq!(role_str(ActorRoleArg::Worker), "worker");
+        for role in [
+            ActorRoleArg::Lead,
+            ActorRoleArg::RootLead,
+            ActorRoleArg::Sublead,
+            ActorRoleArg::Worker,
+        ] {
+            assert!(
+                ALLOWED_ROLES.contains(&role_str(role)),
+                "role {:?} serializes to {:?} which is not in ALLOWED_ROLES \
+                 {ALLOWED_ROLES:?}",
+                role,
+                role_str(role)
+            );
+        }
+    }
+
+    #[test]
+    fn clap_accepts_sublead_and_root_lead_role_tokens() {
+        // Token-level check: the mcp-bridge subcommand must accept every
+        // string that pitboss itself writes into mcp-config files. Before
+        // this fix, `pitboss mcp-bridge --actor-role sublead ...` failed
+        // with `invalid value 'sublead' for '--actor-role'` before even
+        // attempting to connect the socket.
+        use clap::ValueEnum;
+        for token in ["lead", "root_lead", "sublead", "worker"] {
+            assert!(
+                ActorRoleArg::from_str(token, false).is_ok(),
+                "clap rejected actor-role token {token:?}"
+            );
+        }
+    }
 
     /// Sanity-check the unix-socket scaffolding the bridge relies on. We spin
     /// up a minimal echo server on a unix socket, connect to it directly, and

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -891,6 +891,11 @@ fn worker_spawn_args(
         "--output-format".into(),
         "stream-json".into(),
         "--verbose".into(),
+        // Permission authority is pitboss (see runner::lead_spawn_args doc
+        // for the full rationale). Without this flag, headless workers
+        // silently stall on bash-with-`$VAR`, write-outside-cwd, and
+        // every other claude-side gate that has no `-p`-mode answer.
+        "--dangerously-skip-permissions".into(),
     ];
     // Workers always get the shared-store MCP tools in their allowlist when
     // an mcp-config is supplied, alongside their user-declared tools. Without
@@ -2000,6 +2005,26 @@ mod tests {
             None,
             std::sync::Arc::new(crate::shared_store::SharedStore::new()),
         ))
+    }
+
+    #[test]
+    fn worker_spawn_args_passes_dangerously_skip_permissions() {
+        // Companion to the runner-side test: worker spawns are emitted from
+        // a different module and must independently pass the flag. Without
+        // it, headless workers stall on bash-with-`$VAR` and write-outside-
+        // cwd gates that have no `-p`-mode answer — the failure mode is
+        // silent (worker exits "successfully" having written nothing).
+        use std::path::PathBuf;
+        let argv = worker_spawn_args(
+            "p",
+            "claude-haiku-4-5",
+            &["Read".to_string()],
+            Some(&PathBuf::from("/tmp/cfg.json")),
+        );
+        assert!(
+            argv.iter().any(|a| a == "--dangerously-skip-permissions"),
+            "worker_spawn_args missing --dangerously-skip-permissions: {argv:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -1942,18 +1942,26 @@ pub async fn handle_wait_for_any(
         bail!("wait_for_any: task_ids is empty");
     }
 
-    // Fast path: any already Done?
-    {
-        let workers = state.workers.read().await;
-        for id in task_ids {
-            if let Some(WorkerState::Done(rec)) = workers.get(id) {
-                return Ok((id.clone(), rec.clone()));
-            }
-        }
-    }
-
+    // Subscribe FIRST so a completion that races the fast-path check is
+    // captured by the broadcast subscription. Same race fix pattern as
+    // wait_for_actor_internal (commit 70e2bd8). Without this, a worker
+    // that terminated between our existence check and our subscribe is
+    // lost and we block until timeout.
     let mut rx = state.done_tx.subscribe();
     let wait_duration = Duration::from_secs(timeout_secs.unwrap_or(3600));
+
+    // Fast path: any already Done? Scan ALL layers — sub-lead-spawned
+    // workers are registered in the sub-lead layer's workers map, not
+    // root's. Pre-fix, this only checked `state.workers.read()` (= root
+    // via Deref) and so stayed blocked indefinitely on sub-lead-owned
+    // workers. Same bug class as commit d134289 (which fixed wait_actor
+    // + list_workers + worker_status) but this handler had its own
+    // lookup code that was missed by that fix.
+    for id in task_ids {
+        if let Some(WorkerState::Done(rec)) = find_worker_across_layers(state, id).await {
+            return Ok((id.clone(), rec));
+        }
+    }
 
     loop {
         let result = tokio::time::timeout(wait_duration, rx.recv()).await;
@@ -1963,18 +1971,20 @@ pub async fn handle_wait_for_any(
             Ok(Ok(completed_id)) => {
                 // Primary path: our target completed.
                 if task_ids.iter().any(|id| id == &completed_id) {
-                    let workers = state.workers.read().await;
-                    if let Some(WorkerState::Done(rec)) = workers.get(&completed_id) {
-                        return Ok((completed_id, rec.clone()));
+                    if let Some(WorkerState::Done(rec)) =
+                        find_worker_across_layers(state, &completed_id).await
+                    {
+                        return Ok((completed_id, rec));
                     }
                 }
-                // Defensive re-scan: a prior broadcast we missed, or a write-ordering race,
-                // might mean one of our targets is actually Done now even though the recv'd
-                // id isn't in our set. Cheap to check; returns only if found.
-                let workers = state.workers.read().await;
+                // Defensive re-scan: a prior broadcast we missed, or a
+                // write-ordering race, might mean one of our targets is
+                // actually Done now even though the recv'd id isn't in
+                // our set. Cheap to check; returns only if found.
                 for id in task_ids {
-                    if let Some(WorkerState::Done(rec)) = workers.get(id) {
-                        return Ok((id.clone(), rec.clone()));
+                    if let Some(WorkerState::Done(rec)) = find_worker_across_layers(state, id).await
+                    {
+                        return Ok((id.clone(), rec));
                     }
                 }
             }

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -486,19 +486,38 @@ pub async fn handle_spawn_worker(
         .await
         .insert(task_id.clone(), worker_model.clone());
 
-    // Resolve the worker's directory: args override -> lead.directory fallback.
+    // Resolve the worker's directory and worktree-use, falling back through:
+    //   1. `args.directory` / per-args overrides — operator's spawn_worker call
+    //   2. target_layer's lead — set for root-lead callers, NOT for sub-leads
+    //      (derive_sublead_manifest clears `lead` on the sub-manifest)
+    //   3. ROOT lead — always present in hierarchical runs and pinned to the
+    //      operator's project directory
+    //   4. /tmp — last-ditch fallback (git worktree creation will fail loudly,
+    //      which is the right outcome for a malformed run)
+    //
+    // Pre-fix, sub-lead-spawned workers without an explicit `directory` arg
+    // landed at /tmp because step 2 returned None and we skipped to step 4
+    // immediately. Worker spawn then SpawnFailed with "not inside a git
+    // work-tree: /tmp", visible in summary.jsonl but not in the sublead's
+    // wait_for_worker reply (which sees the SpawnFailed task record but
+    // doesn't surface the cwd that caused it). Smoke-test artifact:
+    // sublead-1's only worker SpawnFailed; sublead-2's first worker
+    // SpawnFailed and its second only succeeded because haiku retried with
+    // an explicit directory after seeing the failure.
+    let root_lead = state.root.manifest.lead.as_ref();
     let worker_dir: std::path::PathBuf = args
         .directory
         .as_ref()
         .map(std::path::PathBuf::from)
-        .unwrap_or_else(|| {
+        .or_else(|| {
             target_layer
                 .manifest
                 .lead
                 .as_ref()
                 .map(|l| l.directory.clone())
-                .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
-        });
+        })
+        .or_else(|| root_lead.map(|l| l.directory.clone()))
+        .unwrap_or_else(|| std::path::PathBuf::from("/tmp"));
 
     // Resolve tools, timeout: per-args override -> lead defaults -> fallback.
     // (worker_model was resolved above for the budget guard.)
@@ -506,13 +525,22 @@ pub async fn handle_spawn_worker(
         .tools
         .clone()
         .or_else(|| lead.map(|l| l.tools.clone()))
+        .or_else(|| root_lead.map(|l| l.tools.clone()))
         .unwrap_or_default();
     let worker_timeout_secs = args
         .timeout_secs
         .or_else(|| lead.map(|l| l.timeout_secs))
+        .or_else(|| root_lead.map(|l| l.timeout_secs))
         .unwrap_or(3600);
     let worker_branch = args.branch.clone();
-    let worker_use_worktree = lead.is_none_or(|l| l.use_worktree);
+    // Mirror the directory cascade: target lead → root lead → default(true).
+    // Without the root-lead step, sub-lead workers always made a worktree
+    // (lead.is_none_or → true) regardless of root's `use_worktree` setting,
+    // surprising operators who set `use_worktree = false` at the root level.
+    let worker_use_worktree = lead
+        .map(|l| l.use_worktree)
+        .or_else(|| root_lead.map(|l| l.use_worktree))
+        .unwrap_or(true);
 
     // Retrieve the per-worker cancel token we inserted above.
     let worker_cancel_bg = target_layer

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -1119,57 +1119,80 @@ pub(crate) fn initial_estimate_for(model: &str) -> f64 {
 }
 
 pub async fn handle_list_workers(state: &Arc<DispatchState>) -> Vec<WorkerSummary> {
-    let workers = state.workers.read().await;
+    // Collect from every layer (root + each active sub-lead). Previously
+    // this read only `state.workers` (= root via Deref), so sub-leads
+    // calling `list_workers` got an empty list even when they had their
+    // own workers active — the workers were registered in the sub-lead
+    // layer's own `workers` map by `handle_spawn_worker`'s
+    // `target_layer.workers.write()`.
+    //
+    // Lead id filtering: excludes the root lead id. Sub-lead ids aren't
+    // registered as workers so they don't need filtering here.
+    let mut summaries: Vec<WorkerSummary> = Vec::new();
     let prompts = state.worker_prompts.read().await;
-    workers
-        .iter()
-        .filter(|(id, _)| *id != &state.lead_id)
-        .map(|(id, w)| {
-            let (state_str, started_at) = match w {
-                WorkerState::Pending => ("Pending".to_string(), None),
-                WorkerState::Running { started_at, .. } => {
-                    ("Running".to_string(), Some(started_at.to_rfc3339()))
-                }
-                WorkerState::Paused { paused_at, .. } => {
-                    ("Paused".to_string(), Some(paused_at.to_rfc3339()))
-                }
-                WorkerState::Frozen { started_at, .. } => {
-                    ("Frozen".to_string(), Some(started_at.to_rfc3339()))
-                }
-                WorkerState::Done(rec) => (
-                    match rec.status {
-                        pitboss_core::store::TaskStatus::Success => "Completed",
-                        pitboss_core::store::TaskStatus::Failed => "Failed",
-                        pitboss_core::store::TaskStatus::TimedOut => "TimedOut",
-                        pitboss_core::store::TaskStatus::Cancelled => "Cancelled",
-                        pitboss_core::store::TaskStatus::SpawnFailed => "SpawnFailed",
-                        pitboss_core::store::TaskStatus::ApprovalRejected => "ApprovalRejected",
-                        pitboss_core::store::TaskStatus::ApprovalTimedOut => "ApprovalTimedOut",
-                    }
-                    .to_string(),
-                    Some(rec.started_at.to_rfc3339()),
-                ),
-            };
-            let prompt_preview = prompts.get(id).cloned().unwrap_or_default();
-            WorkerSummary {
-                task_id: id.clone(),
-                state: state_str,
-                prompt_preview,
-                started_at,
+    let render = |id: &String, w: &WorkerState| -> WorkerSummary {
+        let (state_str, started_at) = match w {
+            WorkerState::Pending => ("Pending".to_string(), None),
+            WorkerState::Running { started_at, .. } => {
+                ("Running".to_string(), Some(started_at.to_rfc3339()))
             }
-        })
-        .collect()
+            WorkerState::Paused { paused_at, .. } => {
+                ("Paused".to_string(), Some(paused_at.to_rfc3339()))
+            }
+            WorkerState::Frozen { started_at, .. } => {
+                ("Frozen".to_string(), Some(started_at.to_rfc3339()))
+            }
+            WorkerState::Done(rec) => (
+                match rec.status {
+                    pitboss_core::store::TaskStatus::Success => "Completed",
+                    pitboss_core::store::TaskStatus::Failed => "Failed",
+                    pitboss_core::store::TaskStatus::TimedOut => "TimedOut",
+                    pitboss_core::store::TaskStatus::Cancelled => "Cancelled",
+                    pitboss_core::store::TaskStatus::SpawnFailed => "SpawnFailed",
+                    pitboss_core::store::TaskStatus::ApprovalRejected => "ApprovalRejected",
+                    pitboss_core::store::TaskStatus::ApprovalTimedOut => "ApprovalTimedOut",
+                }
+                .to_string(),
+                Some(rec.started_at.to_rfc3339()),
+            ),
+        };
+        WorkerSummary {
+            task_id: id.clone(),
+            state: state_str,
+            prompt_preview: prompts.get(id).cloned().unwrap_or_default(),
+            started_at,
+        }
+    };
+    for (id, w) in state.workers.read().await.iter() {
+        if id != &state.lead_id {
+            summaries.push(render(id, w));
+        }
+    }
+    let subleads = state.subleads.read().await;
+    for layer in subleads.values() {
+        for (id, w) in layer.workers.read().await.iter() {
+            // Sub-lead layers hold the sub-lead itself as a "worker" entry
+            // (the claude subprocess registered via workers.write() in
+            // finalize_sublead_spawn). Filter by layer.lead_id so the
+            // sub-lead doesn't show up as one of its own workers.
+            if id != &layer.lead_id {
+                summaries.push(render(id, w));
+            }
+        }
+    }
+    summaries
 }
 
 pub async fn handle_worker_status(
     state: &Arc<DispatchState>,
     task_id: &str,
 ) -> Result<WorkerStatus> {
-    let workers = state.workers.read().await;
-    let w = workers
-        .get(task_id)
+    // Scan all layers — same rationale as find_worker_across_layers:
+    // a sub-lead's own workers are registered in the sub-lead's layer.
+    let w = find_worker_across_layers(state, task_id)
+        .await
         .ok_or_else(|| anyhow::anyhow!("unknown task_id: {task_id}"))?;
-    let (state_str, started_at, partial_usage, last_text_preview) = match w {
+    let (state_str, started_at, partial_usage, last_text_preview) = match &w {
         WorkerState::Pending => (
             "Pending".to_string(),
             None,
@@ -1711,18 +1734,43 @@ pub async fn handle_propose_plan(
     }
 }
 
+/// Look up a worker by task_id across the root layer AND every active
+/// sub-lead layer. Returns the first matching `WorkerState`.
+///
+/// Workers spawned by a sub-lead are registered in that sub-lead's
+/// `LayerState.workers`, not in root's. Before this helper existed the
+/// v0.6 MCP handlers all read `state.workers` (= root via Deref), so a
+/// sub-lead's own worker looked "unknown" to every downstream tool
+/// (`wait_for_worker`, `wait_actor`, `worker_status`, `list_workers`).
+/// Surfaced via the depth-2 smoke test: sub-lead calls `spawn_worker`,
+/// gets a task_id, then `wait_actor` on that id immediately returns
+/// `unknown actor_id: worker-...`.
+async fn find_worker_across_layers(
+    state: &Arc<DispatchState>,
+    task_id: &str,
+) -> Option<WorkerState> {
+    if let Some(w) = state.workers.read().await.get(task_id).cloned() {
+        return Some(w);
+    }
+    let subleads = state.subleads.read().await;
+    for layer in subleads.values() {
+        if let Some(w) = layer.workers.read().await.get(task_id).cloned() {
+            return Some(w);
+        }
+    }
+    None
+}
+
 async fn wait_for_actor_internal(
     state: &Arc<DispatchState>,
     actor_id: &str,
     timeout_secs: Option<u64>,
 ) -> Result<ActorTerminalRecord> {
     // ── Fast path: already Done ────────────────────────────────────────────────
-    // 1. Worker already Done?
-    {
-        let workers = state.workers.read().await;
-        if let Some(WorkerState::Done(rec)) = workers.get(actor_id) {
-            return Ok(ActorTerminalRecord::Worker(rec.clone()));
-        }
+    // 1. Worker already Done? (scan all layers — the worker may be in a
+    //    sub-lead's layer, not root.)
+    if let Some(WorkerState::Done(rec)) = find_worker_across_layers(state, actor_id).await {
+        return Ok(ActorTerminalRecord::Worker(rec));
     }
     // 2. Sub-lead already terminated?
     {
@@ -1732,11 +1780,16 @@ async fn wait_for_actor_internal(
         }
     }
 
-    // 3. Is actor_id known at all (worker in any state OR active sub-lead)?
+    // 3. Is actor_id known at all (worker in any layer OR active sub-lead)?
     {
-        let workers = state.workers.read().await;
         let subleads = state.subleads.read().await;
-        if !workers.contains_key(actor_id) && !subleads.contains_key(actor_id) {
+        let is_sublead = subleads.contains_key(actor_id);
+        // Drop the subleads lock before scanning layers to avoid deadlock
+        // (find_worker_across_layers re-acquires it in read mode — RwLock
+        // permits multiple readers, but keep the surface tight).
+        drop(subleads);
+        let is_worker = find_worker_across_layers(state, actor_id).await.is_some();
+        if !is_worker && !is_sublead {
             bail!("unknown actor_id: {actor_id}");
         }
     }
@@ -1752,12 +1805,12 @@ async fn wait_for_actor_internal(
             Ok(Err(_)) => bail!("completion channel closed"),
             Ok(Ok(completed_id)) => {
                 if completed_id == actor_id {
-                    // Check workers first.
+                    // Check workers first (all layers — sub-lead-owned
+                    // workers aren't in root's workers map).
+                    if let Some(WorkerState::Done(rec)) =
+                        find_worker_across_layers(state, actor_id).await
                     {
-                        let workers = state.workers.read().await;
-                        if let Some(WorkerState::Done(rec)) = workers.get(actor_id) {
-                            return Ok(ActorTerminalRecord::Worker(rec.clone()));
-                        }
+                        return Ok(ActorTerminalRecord::Worker(rec));
                     }
                     // Then check sublead_results.
                     {
@@ -1768,12 +1821,12 @@ async fn wait_for_actor_internal(
                     }
                     bail!("internal: actor_id marked done but record not present");
                 }
-                // Defensive: our target may actually be Done now; re-check.
+                // Defensive: our target may actually be Done now; re-check
+                // across all layers.
+                if let Some(WorkerState::Done(rec)) =
+                    find_worker_across_layers(state, actor_id).await
                 {
-                    let workers = state.workers.read().await;
-                    if let Some(WorkerState::Done(rec)) = workers.get(actor_id) {
-                        return Ok(ActorTerminalRecord::Worker(rec.clone()));
-                    }
+                    return Ok(ActorTerminalRecord::Worker(rec));
                 }
                 {
                     let results = state.sublead_results.read().await;

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -669,11 +669,35 @@ async fn run_worker(
         }
     };
 
+    // Worker env: inherit from the parent layer's resolved lead env (which
+    // already merges `[defaults.env]` + `[lead.env]`), then apply pitboss
+    // defaults to fill gaps like `CLAUDE_CODE_ENTRYPOINT=sdk-ts`. Matches
+    // the precedence used at sublead spawn time.
+    //
+    // Previous behavior was `env: Default::default()` (empty env). A
+    // manifest setting `[defaults.env.WORK_DIR] = "/project/out"` would
+    // reach the lead and sublead subprocesses but NOT workers — a
+    // sublead's bash call to `echo ... >> "$WORK_DIR/file"` would get an
+    // empty `WORK_DIR` and drop output to `/file`. Same bug class as the
+    // sublead-env regression fixed earlier; this closes the worker hole.
+    //
+    // `SpawnWorkerArgs` has no `env` field today, so the operator-env
+    // layer is an empty HashMap. If we ever add one, pass it here.
+    let lead_env_for_worker = layer
+        .manifest
+        .lead
+        .as_ref()
+        .map(|l| l.env.clone())
+        .unwrap_or_default();
+    let worker_env = crate::dispatch::sublead::compose_sublead_env(
+        &lead_env_for_worker,
+        &std::collections::HashMap::new(),
+    );
     let cmd = SpawnCmd {
         program: layer.claude_binary.clone(),
         args: worker_spawn_args(&prompt, &model, &tools, mcp_config_arg.as_deref()),
         cwd: cwd.clone(),
-        env: Default::default(),
+        env: worker_env,
     };
 
     let outcome = {
@@ -975,11 +999,24 @@ pub async fn spawn_resume_worker(
     spawn_args_v.insert(0, "--resume".into());
     spawn_args_v.insert(1, session_id);
 
+    // Resume path mirrors the initial spawn: inherit the parent lead's
+    // resolved env so `[defaults.env]` and `[lead.env]` survive a
+    // pause/continue or reprompt cycle.
+    let lead_env_for_resume = state
+        .manifest
+        .lead
+        .as_ref()
+        .map(|l| l.env.clone())
+        .unwrap_or_default();
+    let resume_env = crate::dispatch::sublead::compose_sublead_env(
+        &lead_env_for_resume,
+        &std::collections::HashMap::new(),
+    );
     let cmd = pitboss_core::process::SpawnCmd {
         program: state.claude_binary.clone(),
         args: spawn_args_v,
         cwd,
-        env: Default::default(),
+        env: resume_env,
     };
     let task_dir = state.run_subdir.join("tasks").join(&task_id);
     let _ = tokio::fs::create_dir_all(&task_dir).await;

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -659,7 +659,13 @@ async fn run_worker(
                     .write()
                     .await
                     .insert(task_id.clone(), WorkerState::Done(rec));
-                let _ = layer.done_tx.send(task_id);
+                // Fan out to root so cross-layer wait_actor subscribers wake
+                // even on early-exit paths like SpawnFailed. Same rationale
+                // as the normal-exit fan-out below.
+                let _ = layer.done_tx.send(task_id.clone());
+                if !std::sync::Arc::ptr_eq(&layer, &state.root) {
+                    let _ = state.root.done_tx.send(task_id);
+                }
                 return;
             }
         }
@@ -860,7 +866,18 @@ async fn run_worker(
     if released_count > 0 {
         tracing::info!(worker_id = %task_id, count = released_count, "auto-released run-global leases on worker termination");
     }
-    let _ = layer.done_tx.send(task_id);
+    // Broadcast termination on the worker's own layer AND on root.
+    // wait_for_actor_internal (the engine for wait_actor / wait_for_worker)
+    // always subscribes via state.root.done_tx — regardless of which layer
+    // the caller is in — so a sublead-spawned worker that only fired its
+    // own layer's done_tx would be invisible to its parent sub-lead's
+    // wait_actor (which subscribes to root). Fan out to root so every
+    // wait_actor caller, anywhere in the tree, wakes on every worker
+    // completion. Cheap; broadcast.send is O(subscribers).
+    let _ = layer.done_tx.send(task_id.clone());
+    if !std::sync::Arc::ptr_eq(&layer, &state.root) {
+        let _ = state.root.done_tx.send(task_id);
+    }
 }
 
 /// Remove `task_id`'s spawn-time reservation from `reserved_usd` on the
@@ -1807,6 +1824,22 @@ async fn wait_for_actor_internal(
     actor_id: &str,
     timeout_secs: Option<u64>,
 ) -> Result<ActorTerminalRecord> {
+    // ── Subscribe FIRST so a completion that races the fast-path checks
+    //    is captured by the broadcast subscription. The original code
+    //    subscribed AFTER the fast-path + existence checks, which works
+    //    fine for root-lead callers (the worker can't complete in the
+    //    microseconds between the existence check and the subscribe in
+    //    practice) but exposed a real race once cross-layer worker
+    //    visibility (commit d134289) let sub-leads call wait_actor on
+    //    their own workers. Sub-lead callers' workers run very short
+    //    (smoke-test workers finished in 12s) and their wait_actor calls
+    //    are issued immediately after spawn_worker — giving the worker
+    //    time to complete before the sublead's wait subscribes. The
+    //    broadcast is missed and the wait blocks until either the
+    //    timeout fires or the sublead itself is killed by lead_timeout.
+    //    Subscribing first guarantees no completion is lost.
+    let mut rx = state.done_tx.subscribe();
+
     // ── Fast path: already Done ────────────────────────────────────────────────
     // 1. Worker already Done? (scan all layers — the worker may be in a
     //    sub-lead's layer, not root.)
@@ -1835,8 +1868,6 @@ async fn wait_for_actor_internal(
         }
     }
 
-    // Subscribe to done events and wait.
-    let mut rx = state.done_tx.subscribe();
     let wait_duration = Duration::from_secs(timeout_secs.unwrap_or(3600));
 
     loop {

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -711,11 +711,19 @@ async fn run_worker(
     //
     // `SpawnWorkerArgs` has no `env` field today, so the operator-env
     // layer is an empty HashMap. If we ever add one, pass it here.
+    //
+    // Same target_layer.lead = None pitfall as the worker_dir cascade
+    // above: sub-leads have `lead` cleared on their derived manifest, so
+    // a sub-lead-spawned worker would otherwise get an empty env even
+    // though the operator set `[defaults.env]` at the manifest level.
+    // Fall back through the root lead (always populated, carries the
+    // merged [defaults.env] + [lead.env]) before defaulting to empty.
     let lead_env_for_worker = layer
         .manifest
         .lead
         .as_ref()
         .map(|l| l.env.clone())
+        .or_else(|| state.root.manifest.lead.as_ref().map(|l| l.env.clone()))
         .unwrap_or_default();
     let worker_env = crate::dispatch::sublead::compose_sublead_env(
         &lead_env_for_worker,

--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -655,8 +655,21 @@ fn handle_prompt_reprompt(state: &mut AppState, code: KeyCode, modifiers: KeyMod
             state.mode = Mode::Normal;
             return Action::Continue;
         }
-        KeyCode::Enter if modifiers.contains(KeyModifiers::CONTROL) => {
-            // Ctrl+Enter: submit.
+        // Submit the reprompt. Multiple accepted chords because most
+        // terminal emulators (konsole, gnome-terminal, default VTE-based
+        // terminals, default xterm/alacritty/tilix without CSI-u /
+        // kitty-keyboard) DON'T distinguish Ctrl+Enter from Enter —
+        // crossterm only sees `Enter` with no CTRL modifier, and we'd
+        // silently swallow the submission. F2 is unambiguous across
+        // every terminal I know of; Alt+Enter is reliably distinct in
+        // most terminals because the Alt/Meta modifier survives even
+        // when Ctrl doesn't. Kept Ctrl+Enter for the terminals that
+        // DO route it (kitty with keyboard protocol, wezterm, iTerm2).
+        KeyCode::F(2) | KeyCode::Enter
+            if matches!(code, KeyCode::F(2))
+                || modifiers.contains(KeyModifiers::CONTROL)
+                || modifiers.contains(KeyModifiers::ALT) =>
+        {
             if !draft.is_empty() {
                 spawn_control_op(
                     state,
@@ -788,7 +801,15 @@ fn handle_approval_draft(
 ) {
     use crate::state::ApprovalSubMode;
     match code {
-        KeyCode::Enter if modifiers.contains(KeyModifiers::CONTROL) => {
+        // Submit. Same multi-chord fallback as the reprompt modal — see
+        // handle_prompt_reprompt for the full rationale. Ctrl+Enter is
+        // often swallowed by VTE-based terminals; F2 and Alt+Enter
+        // survive.
+        KeyCode::F(2) | KeyCode::Enter
+            if matches!(code, KeyCode::F(2))
+                || modifiers.contains(KeyModifiers::CONTROL)
+                || modifiers.contains(KeyModifiers::ALT) =>
+        {
             if editing {
                 send_approve(state, &ctx.request_id, true, None, Some(draft));
             } else {

--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -318,12 +318,18 @@ fn handle_normal(state: &mut AppState, code: KeyCode) -> Action {
             }
             KeyCode::Enter => {
                 if let Some(item) = state.approval_list.current().cloned() {
+                    // Preserve plan + kind so a dismissed-and-reopened
+                    // `propose_plan` approval still shows its structured
+                    // plan view and its "PRE-FLIGHT PLAN" badge. Before
+                    // the list learned to carry those, re-opens lost the
+                    // payload and the operator got a less-informative
+                    // modal than the first presentation.
                     state.mode = Mode::ApprovalModal {
-                        request_id: item.id.to_string(),
+                        request_id: item.id.clone(),
                         task_id: item.actor_path.clone(),
                         summary: item.summary.clone(),
-                        plan: None,
-                        kind: pitboss_cli::control::protocol::ApprovalKind::Action,
+                        plan: item.plan.clone(),
+                        kind: item.kind,
                         sub_mode: crate::state::ApprovalSubMode::Overview,
                     };
                 }
@@ -530,6 +536,37 @@ fn apply_control_event(state: &mut AppState, ev: pitboss_cli::control::protocol:
             plan,
             kind,
         } => {
+            // Push into the approval-list queue in addition to opening the
+            // modal. Without this, hitting Esc to dismiss the modal
+            // stranded the request: it stayed pending server-side but
+            // nothing in the TUI referenced it, so `'a'` opened an
+            // empty list pane and the operator had no retrieval path.
+            // De-dup by id so the same request never lands twice (can
+            // happen if a server restart replays events).
+            let actor_path = if task_id.is_empty() {
+                "root".to_string()
+            } else {
+                task_id.clone()
+            };
+            let category = match kind {
+                pitboss_cli::control::protocol::ApprovalKind::Plan => "plan",
+                pitboss_cli::control::protocol::ApprovalKind::Action => "action",
+            }
+            .to_string();
+            if !state.approval_list.items.iter().any(|i| i.id == request_id) {
+                state
+                    .approval_list
+                    .items
+                    .push_back(crate::state::ApprovalListItem {
+                        id: request_id.clone(),
+                        actor_path,
+                        category,
+                        summary: summary.clone(),
+                        plan: plan.clone(),
+                        kind,
+                        created_at: chrono::Utc::now(),
+                    });
+            }
             state.mode = Mode::ApprovalModal {
                 request_id,
                 task_id,
@@ -715,7 +752,23 @@ fn handle_approval_overview(state: &mut AppState, code: KeyCode, ctx: ApprovalCt
                 sub_mode: ApprovalSubMode::Editing { draft },
             };
         }
-        KeyCode::Esc => state.mode = Mode::Normal,
+        KeyCode::Esc => {
+            // Dismiss the modal without responding. The request stays
+            // pending server-side and is discoverable via the approval-
+            // list pane we just dropped the user into. Previously Esc
+            // transitioned to `Mode::Normal` with grid focus and the
+            // queue was invisible — the request looked lost.
+            state.mode = Mode::Normal;
+            state.pane_focus = PaneFocus::ApprovalList;
+            if let Some(pos) = state
+                .approval_list
+                .items
+                .iter()
+                .position(|i| i.id == ctx.request_id)
+            {
+                state.approval_list.selected_idx = pos;
+            }
+        }
         _ => {}
     }
 }
@@ -745,7 +798,20 @@ fn handle_approval_draft(
             return;
         }
         KeyCode::Esc => {
+            // Dismiss draft — request stays pending, visible in the
+            // approval list pane. Matches the Overview Esc behavior so
+            // the operator gets one consistent "escape" contract at
+            // every modal sub-mode.
             state.mode = Mode::Normal;
+            state.pane_focus = PaneFocus::ApprovalList;
+            if let Some(pos) = state
+                .approval_list
+                .items
+                .iter()
+                .position(|i| i.id == ctx.request_id)
+            {
+                state.approval_list.selected_idx = pos;
+            }
             return;
         }
         KeyCode::Char(c) => draft.push(c),
@@ -791,6 +857,25 @@ fn send_approve(
             reason,
         },
     );
+    // Drop from the approval-list queue optimistically — the server will
+    // ack the op before any subsequent ApprovalRequest with the same id
+    // could arrive, so a race that re-inserts a stale entry isn't
+    // reachable. Clamp `selected_idx` so an out-of-range index can't
+    // persist past the removal.
+    if let Some(pos) = state
+        .approval_list
+        .items
+        .iter()
+        .position(|i| i.id == request_id)
+    {
+        state.approval_list.items.remove(pos);
+    }
+    let len = state.approval_list.items.len();
+    if len == 0 {
+        state.approval_list.selected_idx = 0;
+    } else if state.approval_list.selected_idx >= len {
+        state.approval_list.selected_idx = len - 1;
+    }
 }
 
 // Fire-and-forget dispatch of a control op onto the runtime the
@@ -810,4 +895,82 @@ fn spawn_control_op(state: &AppState, op: pitboss_cli::control::protocol::Contro
     std::mem::drop(handle.spawn(async move {
         let _ = client.send_op(op).await;
     }));
+}
+
+#[cfg(test)]
+mod approval_queue_tests {
+    //! Regression coverage for the "Esc on approval modal strands the
+    //! request" papercut. Before these fixes, `ApprovalRequest` events
+    //! only opened the modal — they never populated the approval list
+    //! pane — so the moment the operator dismissed the modal the
+    //! request became unreachable from the TUI.
+
+    use super::*;
+    use pitboss_cli::control::protocol::{ApprovalKind, ControlEvent};
+
+    fn fresh_state() -> AppState {
+        AppState::new(PathBuf::from("/tmp/t"), "test-run".to_string())
+    }
+
+    fn mk_approval_event(request_id: &str, task_id: &str) -> ControlEvent {
+        ControlEvent::ApprovalRequest {
+            request_id: request_id.to_string(),
+            task_id: task_id.to_string(),
+            summary: "destructive rm -rf /".to_string(),
+            plan: None,
+            kind: ApprovalKind::Action,
+        }
+    }
+
+    #[test]
+    fn approval_request_populates_list_and_opens_modal() {
+        let mut state = fresh_state();
+        apply_control_event(&mut state, mk_approval_event("req-A", "root"));
+        assert_eq!(state.approval_list.items.len(), 1);
+        assert_eq!(state.approval_list.items[0].id, "req-A");
+        assert!(matches!(state.mode, Mode::ApprovalModal { .. }));
+    }
+
+    #[test]
+    fn empty_task_id_renders_as_root_actor_path() {
+        // Server emits `task_id: ""` for the root lead. An empty
+        // actor_path would render weirdly in the list line ("[]" prefix),
+        // so we substitute a stable label at event-receive time.
+        let mut state = fresh_state();
+        apply_control_event(&mut state, mk_approval_event("req-A", ""));
+        assert_eq!(state.approval_list.items[0].actor_path, "root");
+    }
+
+    #[test]
+    fn duplicate_request_id_does_not_double_enqueue() {
+        // Server restarts may replay events; the queue must stay a set
+        // keyed on request_id or a single approval shows twice.
+        let mut state = fresh_state();
+        apply_control_event(&mut state, mk_approval_event("req-A", "root"));
+        apply_control_event(&mut state, mk_approval_event("req-A", "root"));
+        assert_eq!(state.approval_list.items.len(), 1);
+    }
+
+    #[test]
+    fn send_approve_removes_matching_item_from_list() {
+        let mut state = fresh_state();
+        apply_control_event(&mut state, mk_approval_event("req-A", "root"));
+        apply_control_event(&mut state, mk_approval_event("req-B", "sublead-1"));
+        send_approve(&mut state, "req-A", true, None, None);
+        assert_eq!(state.approval_list.items.len(), 1);
+        assert_eq!(state.approval_list.items[0].id, "req-B");
+        // selected_idx must stay in bounds after a removal.
+        assert!(state.approval_list.selected_idx < state.approval_list.items.len());
+    }
+
+    #[test]
+    fn send_approve_clamps_selected_idx_when_last_item_removed() {
+        let mut state = fresh_state();
+        apply_control_event(&mut state, mk_approval_event("req-A", "root"));
+        apply_control_event(&mut state, mk_approval_event("req-B", "sublead-1"));
+        state.approval_list.selected_idx = 1;
+        send_approve(&mut state, "req-B", false, None, None);
+        assert_eq!(state.approval_list.items.len(), 1);
+        assert_eq!(state.approval_list.selected_idx, 0);
+    }
 }

--- a/crates/pitboss-tui/src/approval_list.rs
+++ b/crates/pitboss-tui/src/approval_list.rs
@@ -52,10 +52,12 @@ mod tests {
 
     fn mk_item(path: &str, summary: &str) -> ApprovalListItem {
         ApprovalListItem {
-            id: uuid::Uuid::now_v7(),
+            id: format!("req-{}", uuid::Uuid::now_v7()),
             actor_path: path.into(),
-            category: "tool_use".into(),
+            category: "action".into(),
             summary: summary.into(),
+            plan: None,
+            kind: pitboss_cli::control::protocol::ApprovalKind::Action,
             created_at: chrono::Utc::now(),
         }
     }
@@ -82,6 +84,6 @@ mod tests {
         let line = s.line_for(&mk_item("root→S1", "destructive op"));
         assert!(line.contains("root→S1"));
         assert!(line.contains("destructive op"));
-        assert!(line.contains("tool_use"));
+        assert!(line.contains("action"));
     }
 }

--- a/crates/pitboss-tui/src/state.rs
+++ b/crates/pitboss-tui/src/state.rs
@@ -88,15 +88,25 @@ pub enum PaneFocus {
 /// A single pending approval shown in the right-rail approval list pane.
 #[derive(Debug, Clone)]
 pub struct ApprovalListItem {
-    /// Opaque request id (forwarded to `ControlOp::Approve`).
-    pub id: uuid::Uuid,
+    /// Opaque request id (forwarded verbatim to `ControlOp::Approve`).
+    /// Server-generated format is `req-<uuidv7>`, so this is a string
+    /// rather than a parsed `Uuid` — no meaningful operation treats the
+    /// inner uuid as a uuid, only as a stable handle.
+    pub id: String,
     /// Human-readable path to the actor that raised the request
     /// (e.g. `"root"` or `"root→S1"`).
     pub actor_path: String,
-    /// Free-form category tag (e.g. `"tool_use"`, `"plan"`, …).
+    /// Free-form category tag (e.g. `"plan"`, `"action"`).
     pub category: String,
     /// One-line summary of the requested action.
     pub summary: String,
+    /// Optional typed plan payload carried by `propose_plan` requests.
+    /// None for `request_approval` calls. Preserved in the list so
+    /// re-opening a dismissed plan approval renders the structured
+    /// plan view (not just the summary).
+    pub plan: Option<pitboss_cli::control::protocol::ApprovalPlanWire>,
+    /// Discriminator for modal rendering (Plan vs Action badge).
+    pub kind: pitboss_cli::control::protocol::ApprovalKind,
     /// Wall-clock time when the request arrived.
     pub created_at: chrono::DateTime<chrono::Utc>,
 }

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -1526,7 +1526,7 @@ fn render_prompt_reprompt(frame: &mut Frame, area: Rect, task_id: &str, draft: &
     let modal = Rect::new(x, y, modal_w, modal_h);
     frame.render_widget(Clear, modal);
     let block = Block::default().borders(Borders::ALL).title(format!(
-        " Reprompt `{task_id}` — Ctrl+Enter to send, Esc cancel "
+        " Reprompt `{task_id}` — F2 / Alt+Enter / Ctrl+Enter to send, Esc cancel "
     ));
     let para = Paragraph::new(draft)
         .block(block)
@@ -1589,7 +1589,7 @@ fn render_approval_modal(
         ApprovalSubMode::Editing { draft } => {
             let block = Block::default()
                 .borders(Borders::ALL)
-                .title(" Edit summary — Ctrl+Enter to submit  Esc cancel ");
+                .title(" Edit summary — F2 / Alt+Enter / Ctrl+Enter to submit  Esc cancel ");
             let para = Paragraph::new(draft.clone())
                 .block(block)
                 .wrap(Wrap { trim: false })
@@ -1597,9 +1597,9 @@ fn render_approval_modal(
             frame.render_widget(para, modal);
         }
         ApprovalSubMode::Rejecting { draft } => {
-            let block = Block::default()
-                .borders(Borders::ALL)
-                .title(" Rejection reason (optional) — Ctrl+Enter to send  Esc cancel ");
+            let block = Block::default().borders(Borders::ALL).title(
+                " Rejection reason (optional) — F2 / Alt+Enter / Ctrl+Enter to send  Esc cancel ",
+            );
             let para = Paragraph::new(draft.clone())
                 .block(block)
                 .wrap(Wrap { trim: false })

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -1564,8 +1564,12 @@ fn render_approval_modal(
         ApprovalSubMode::Overview => {
             // When a typed plan is present, render structured fields as
             // a multi-section view. Plain summary otherwise.
+            // Esc is "dismiss" (request stays pending, retrievable from
+            // the approval list via `a`), NOT "cancel/reject". The old
+            // label misled operators into thinking Esc aborted the
+            // request; they'd then wonder why the run stayed blocked.
             let title = format!(
-                " [{badge}] Approval from `{task_id}` — y=approve  n=reject  e=edit  Esc=cancel "
+                " [{badge}] Approval from `{task_id}` — y=approve  n=reject  e=edit  Esc=dismiss (stays pending, press `a` to re-open) "
             );
             let block = Block::default().borders(Borders::ALL).title(title);
             let lines = plan.map_or_else(

--- a/crates/pitboss-tui/src/watcher.rs
+++ b/crates/pitboss-tui/src/watcher.rs
@@ -22,7 +22,21 @@ const TAIL_LINES: usize = 2000;
 /// within this window, without re-parsing multi-megabyte logs every poll.
 const TAIL_BYTES: u64 = 256 * 1024;
 /// A task is considered "running" if its log was modified within this many seconds.
-const RUNNING_FRESHNESS_SECS: u64 = 5;
+/// If the worker's stdout.log has been written to within this window,
+/// render as Running; otherwise Pending. Pure display heuristic since
+/// the TUI can't read pitboss's in-process WorkerState from outside the
+/// run. Bumped from 5s → 30s: Sonnet extended-thinking blocks and long
+/// Anthropic API calls routinely have 15–30s silent windows during
+/// normal work, which flipped healthy workers into Pending then back
+/// to Running each time they produced a chunk. 30s eliminates almost
+/// all legitimate-work flicker at the cost of a slightly longer lag
+/// before a genuinely-stalled worker shows as Pending.
+///
+/// Proper fix tracked in task #66: have pitboss emit a
+/// WorkerStateChanged event on the control-socket stream on every
+/// transition, and drive the TUI from that rather than log-mtime
+/// inference.
+const RUNNING_FRESHNESS_SECS: u64 = 30;
 
 // ---------------------------------------------------------------------------
 // resolved.json schema (only the fields we care about)

--- a/crates/pitboss-tui/src/watcher.rs
+++ b/crates/pitboss-tui/src/watcher.rs
@@ -22,18 +22,18 @@ const TAIL_LINES: usize = 2000;
 /// within this window, without re-parsing multi-megabyte logs every poll.
 const TAIL_BYTES: u64 = 256 * 1024;
 /// A task is considered "running" if its log was modified within this many seconds.
-/// If the worker's stdout.log has been written to within this window,
-/// render as Running; otherwise Pending. Pure display heuristic since
-/// the TUI can't read pitboss's in-process WorkerState from outside the
+/// If the worker's `stdout.log` has been written to within this window,
+/// render as `Running`; otherwise `Pending`. Pure display heuristic since
+/// the TUI can't read pitboss's in-process `WorkerState` from outside the
 /// run. Bumped from 5s → 30s: Sonnet extended-thinking blocks and long
 /// Anthropic API calls routinely have 15–30s silent windows during
-/// normal work, which flipped healthy workers into Pending then back
-/// to Running each time they produced a chunk. 30s eliminates almost
+/// normal work, which flipped healthy workers into `Pending` then back
+/// to `Running` each time they produced a chunk. 30s eliminates almost
 /// all legitimate-work flicker at the cost of a slightly longer lag
-/// before a genuinely-stalled worker shows as Pending.
+/// before a genuinely-stalled worker shows as `Pending`.
 ///
 /// Proper fix tracked in task #66: have pitboss emit a
-/// WorkerStateChanged event on the control-socket stream on every
+/// `WorkerStateChanged` event on the control-socket stream on every
 /// transition, and drive the TUI from that rather than log-mtime
 /// inference.
 const RUNNING_FRESHNESS_SECS: u64 = 30;


### PR DESCRIPTION
## Summary

Bundles 14 post-v0.7 commits that accumulated on my local branch
after PR #45 merged but were never shipped. Each is a distinct,
surgically-scoped fix; the bundle is large because the depth-2
smoke-test + v2.1 dispatch saga surfaced a lot of latent bugs in
rapid succession.

Split by area:

### Depth-2 orchestration correctness
- `cd85881` cli: accept `sublead`/`root_lead` as `--actor-role` values — sub-lead MCP bridge was silently broken since v0.6 (clap rejected the argv before the bridge could connect)
- `7be4b1d` sublead: cwd = `lead.directory` so claude's fs gate stops prompting
- `12b8944` worker: inherit env from parent layer's lead env
- `b7225ec` mcp: `wait_actor` / `list_workers` / `worker_status` scan all layers
- `7461a61` spawn: pass `--dangerously-skip-permissions` to every claude (pitboss is the sole permission authority; closes the bash-$VAR + fs-gate failure mode)
- `a79668c` spawn_worker: fall back through root lead before `/tmp`
- `7c63d9e` spawn_worker: worker env cascade through root lead too
- `a313b17` wait_actor: fan completion to root + subscribe before check
- `ff1c579` wait_for_any: scan all layers + subscribe before check (closes the final cross-layer gap)

### TUI fixes
- `1f87986` Esc on approval modal drops into queue, not into void — also populates `approval_list.items` for the first time (the pane shipped in v0.6 but was only ever populated in tests)
- `e560fb1` accept F2 + Alt+Enter as reprompt/approval submit chords — closes task #62, works around Ctrl+Enter being swallowed by VTE-based terminals
- `55c615b` control: `reprompt_worker` routes to sub-leads — routes via `sub_layer.reprompt_tx` so operators can reprompt a live sub-lead (previously returned `unknown task_id`)
- `beb2191` raise log-freshness threshold 5s → 30s (band-aid for task #66 — stops the Pending/Running flicker on normal Sonnet-with-extended-thinking cadence)

### Meta
- `d4fb3ed` .gitignore: NOTES-*.md at repo root (local scratch docs)

## Validation

- 494 lib tests pass (313 pitboss-cli + 106 pitboss-tui + 75 pitboss-core)
- `cargo clippy --workspace --lib -- -D warnings` clean
- `cargo fmt --all -- --check` clean
- Depth-2 smoke test passes zero-error end-to-end
- Multiple real multi-act dispatch runs completed successfully on this code

## Tasks closed on merge

- #62 TUI Ctrl+Enter submit-chord swallowed

## Tasks still open (code-level follow-ups)

- #58, #66, #68, #69 — TUI observability / rendering (next bundle)
- #60, #64, #67 — code hardening (cancel cascade, API-error bubble-up, `~/.claude/` isolation) — planned as next PR after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)