### PR TITLE
fix(dispatch): bubble classified API failures to parent + gate spawns (#64)

### DIFF
--- a/crates/pitboss-cli/src/control/protocol.rs
+++ b/crates/pitboss-cli/src/control/protocol.rs
@@ -210,6 +210,20 @@ pub enum ControlEvent {
         /// root-layer KV keys).
         read_down: bool,
     },
+    /// A worker, sub-lead, or lead claude subprocess exited non-zero and
+    /// was classified with a structured `FailureReason`. Emitted from the
+    /// per-actor completion site (runner / sublead / hierarchical lead /
+    /// run_worker / continue_worker resume path) alongside the
+    /// `TaskRecord` persist. The TUI renders this in the tile footer so
+    /// operators see *why* something failed without opening logs; parent
+    /// leads consume it to back off on `RateLimit` or fail fast on
+    /// `AuthFailure`. Success exits never emit this event.
+    WorkerFailed {
+        task_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_task_id: Option<String>,
+        reason: pitboss_core::store::FailureReason,
+    },
     /// A sub-lead has terminated (success, cancel, timeout, or error).
     /// Emitted by `dispatch::sublead::reconcile_terminated_sublead` after
     /// the sub-tree LayerState is removed and budget is reconciled.
@@ -498,6 +512,34 @@ mod tests {
             },
         };
         assert_eq!(roundtrip_event(&rf), rf);
+    }
+
+    #[test]
+    fn worker_failed_roundtrips() {
+        use pitboss_core::store::FailureReason;
+        let ev = ControlEvent::WorkerFailed {
+            task_id: "w-1".into(),
+            parent_task_id: Some("lead".into()),
+            reason: FailureReason::RateLimit { resets_at: None },
+        };
+        let s = serde_json::to_string(&ev).unwrap();
+        assert!(s.contains("\"event\":\"worker_failed\""));
+        assert!(s.contains("\"kind\":\"rate_limit\""));
+        assert_eq!(roundtrip_event(&ev), ev);
+    }
+
+    #[test]
+    fn worker_failed_without_parent_elides_field() {
+        // Root-lead failures have no parent; ensure the field is omitted
+        // on the wire rather than serialized as `null`.
+        use pitboss_core::store::FailureReason;
+        let ev = ControlEvent::WorkerFailed {
+            task_id: "lead".into(),
+            parent_task_id: None,
+            reason: FailureReason::AuthFailure,
+        };
+        let s = serde_json::to_string(&ev).unwrap();
+        assert!(!s.contains("parent_task_id"));
     }
 
     #[test]

--- a/crates/pitboss-cli/src/diff.rs
+++ b/crates/pitboss-cli/src/diff.rs
@@ -536,6 +536,7 @@ mod tests {
             approvals_approved: 0,
             approvals_rejected: 0,
             model: None,
+            failure_reason: None,
         }
     }
 

--- a/crates/pitboss-cli/src/dispatch/failure_detection.rs
+++ b/crates/pitboss-cli/src/dispatch/failure_detection.rs
@@ -383,8 +383,8 @@ fn parse_12h_time(s: &str) -> Option<NaiveTime> {
         return None;
     }
     let hour24 = match (hour, is_pm) {
-        (12, false) => 0,        // 12am = 00:00
-        (12, true) => 12,        // 12pm = 12:00
+        (12, false) => 0, // 12am = 00:00
+        (12, true) => 12, // 12pm = 12:00
         (h, false) => h,
         (h, true) => h + 12,
     };
@@ -419,7 +419,9 @@ mod tests {
     fn rate_limit_with_reset_timestamp_parses() {
         let blob = "You've hit your limit · resets Apr 23, 3pm";
         match classify(blob) {
-            FailureReason::RateLimit { resets_at: Some(ts) } => {
+            FailureReason::RateLimit {
+                resets_at: Some(ts),
+            } => {
                 use chrono::{Datelike, Timelike};
                 assert_eq!(ts.month(), 4);
                 assert_eq!(ts.day(), 23);
@@ -434,7 +436,9 @@ mod tests {
     fn rate_limit_with_hour_minute_reset_parses() {
         let blob = "You've hit your limit · resets May 5, 9:45am";
         match classify(blob) {
-            FailureReason::RateLimit { resets_at: Some(ts) } => {
+            FailureReason::RateLimit {
+                resets_at: Some(ts),
+            } => {
                 use chrono::{Datelike, Timelike};
                 assert_eq!(ts.month(), 5);
                 assert_eq!(ts.day(), 5);
@@ -552,7 +556,8 @@ mod tests {
     #[tokio::test]
     async fn api_health_rate_limit_without_timestamp_uses_default_backoff() {
         let h = ApiHealth::new();
-        h.record(&FailureReason::RateLimit { resets_at: None }).await;
+        h.record(&FailureReason::RateLimit { resets_at: None })
+            .await;
         match h.check_can_spawn().await {
             Err(SpawnGateReason::RateLimited { retry_after }) => {
                 let remaining = (retry_after - Utc::now()).num_seconds();
@@ -611,7 +616,8 @@ mod tests {
         // Both gates active — auth is more actionable for the operator,
         // so its error should be reported first.
         let h = ApiHealth::new();
-        h.record(&FailureReason::RateLimit { resets_at: None }).await;
+        h.record(&FailureReason::RateLimit { resets_at: None })
+            .await;
         h.record(&FailureReason::AuthFailure).await;
         assert!(matches!(
             h.check_can_spawn().await,

--- a/crates/pitboss-cli/src/dispatch/failure_detection.rs
+++ b/crates/pitboss-cli/src/dispatch/failure_detection.rs
@@ -1,0 +1,405 @@
+//! Post-exit classification of claude-subprocess failures.
+//!
+//! When a claude worker/lead exits non-zero, we don't just want to know *that*
+//! it failed — callers (parent leads, the TUI, the spawn gater) need to know
+//! *why* so they can react appropriately: back off on rate-limit, retry on
+//! transient network, fail-fast on auth. Exit code alone is 1 for all of
+//! these; the distinguishing signal lives in the last few KB of stdout/stderr.
+//!
+//! This module reads the tail of those logs and maps known markers to
+//! [`FailureReason`] variants. The strategy is *conservative*:
+//!
+//! * Exit code 0 never produces a reason — a successful response that happens
+//!   to mention "rate limit" in prose is not a failure. Callers must gate on
+//!   a non-zero exit before invoking [`detect_failure_reason`].
+//! * Markers come from observed claude CLI output, not guesses. An unknown
+//!   non-zero exit becomes [`FailureReason::Unknown`] carrying a short log
+//!   excerpt rather than being misclassified.
+//! * Read only the tail (default 8 KiB) — rate-limit and error markers are
+//!   always at the end of a streamed session. Scanning full logs would hurt
+//!   at scale without changing the classification.
+
+use std::path::Path;
+
+use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
+use pitboss_core::store::FailureReason;
+
+/// How many bytes from the end of stdout+stderr to scan. Markers land at the
+/// tail of a session, and claude's final error block is typically <1 KiB —
+/// 8 KiB is generous without being wasteful.
+const TAIL_BYTES: u64 = 8 * 1024;
+
+/// Length cap on `message` excerpts embedded in `NetworkError`/`Unknown`
+/// variants. Keeps `TaskRecord`s compact in storage; full context is still
+/// in the log file for anyone who needs it.
+const EXCERPT_MAX_CHARS: usize = 240;
+
+/// Inspect a completed subprocess and classify the failure. Returns `None`
+/// only when the caller passed `exit_code == 0` — for any non-zero exit we
+/// return at least [`FailureReason::Unknown`] so downstream code can always
+/// distinguish "no failure" from "unclassified failure".
+///
+/// `stdout_path` and `stderr_path` may point at files that don't exist
+/// (e.g., the process died before flushing); missing files are treated as
+/// empty and do not cause an error.
+pub fn detect_failure_reason(
+    exit_code: Option<i32>,
+    stdout_path: Option<&Path>,
+    stderr_path: Option<&Path>,
+) -> Option<FailureReason> {
+    if exit_code == Some(0) {
+        return None;
+    }
+    let mut buf = String::new();
+    if let Some(p) = stdout_path {
+        buf.push_str(&read_tail(p, TAIL_BYTES));
+    }
+    if let Some(p) = stderr_path {
+        buf.push('\n');
+        buf.push_str(&read_tail(p, TAIL_BYTES));
+    }
+    Some(classify(&buf))
+}
+
+/// Public for unit tests — classify a pre-read log blob without touching the
+/// filesystem.
+pub fn classify(blob: &str) -> FailureReason {
+    if let Some(reason) = match_rate_limit(blob) {
+        return reason;
+    }
+    if let Some(reason) = match_auth(blob) {
+        return reason;
+    }
+    if let Some(reason) = match_context_exceeded(blob) {
+        return reason;
+    }
+    if let Some(reason) = match_invalid_argument(blob) {
+        return reason;
+    }
+    if let Some(reason) = match_network(blob) {
+        return reason;
+    }
+    FailureReason::Unknown {
+        message: excerpt(blob),
+    }
+}
+
+fn match_rate_limit(blob: &str) -> Option<FailureReason> {
+    // Claude CLI prints phrasings like:
+    //   "You've hit your limit · resets Apr 23, 3pm"
+    //   "rate_limit_exceeded"
+    //   "usage limit reached"
+    let hit = blob.contains("You've hit your limit")
+        || blob.contains("rate_limit_exceeded")
+        || blob.contains("rate limit exceeded")
+        || blob.contains("usage limit reached");
+    if !hit {
+        return None;
+    }
+    Some(FailureReason::RateLimit {
+        resets_at: parse_reset_timestamp(blob),
+    })
+}
+
+fn match_auth(blob: &str) -> Option<FailureReason> {
+    if blob.contains("invalid_api_key")
+        || blob.contains("authentication_error")
+        || blob.contains("401")
+            && (blob.contains("Unauthorized") || blob.contains("Authentication"))
+    {
+        Some(FailureReason::AuthFailure)
+    } else {
+        None
+    }
+}
+
+fn match_context_exceeded(blob: &str) -> Option<FailureReason> {
+    if blob.contains("context_length_exceeded") || blob.contains("prompt is too long") {
+        Some(FailureReason::ContextExceeded)
+    } else {
+        None
+    }
+}
+
+fn match_invalid_argument(blob: &str) -> Option<FailureReason> {
+    if blob.contains("invalid_request_error") {
+        Some(FailureReason::InvalidArgument {
+            message: excerpt(blob),
+        })
+    } else {
+        None
+    }
+}
+
+fn match_network(blob: &str) -> Option<FailureReason> {
+    let markers = [
+        "ENOTFOUND",
+        "ETIMEDOUT",
+        "ECONNRESET",
+        "ECONNREFUSED",
+        "EAI_AGAIN",
+        "getaddrinfo",
+        "socket hang up",
+        "network error",
+    ];
+    if markers.iter().any(|m| blob.contains(m)) {
+        Some(FailureReason::NetworkError {
+            message: excerpt(blob),
+        })
+    } else {
+        None
+    }
+}
+
+/// Read the last `max_bytes` of `path` as a lossy UTF-8 string. Missing files
+/// return empty. Errors (permission, I/O) are swallowed — the log tail is
+/// diagnostic-best-effort; we'd rather classify as Unknown than fail the whole
+/// record write.
+fn read_tail(path: &Path, max_bytes: u64) -> String {
+    use std::io::{Read, Seek, SeekFrom};
+    let Ok(mut f) = std::fs::File::open(path) else {
+        return String::new();
+    };
+    let len = f.metadata().map(|m| m.len()).unwrap_or(0);
+    let start = len.saturating_sub(max_bytes);
+    if f.seek(SeekFrom::Start(start)).is_err() {
+        return String::new();
+    }
+    let mut buf = Vec::with_capacity(max_bytes as usize);
+    let _ = f.read_to_end(&mut buf);
+    String::from_utf8_lossy(&buf).into_owned()
+}
+
+fn excerpt(blob: &str) -> String {
+    let trimmed = blob.trim();
+    if trimmed.chars().count() <= EXCERPT_MAX_CHARS {
+        return trimmed.to_string();
+    }
+    // Take the LAST EXCERPT_MAX_CHARS chars — errors sit at the tail.
+    let start = trimmed.chars().count().saturating_sub(EXCERPT_MAX_CHARS);
+    trimmed.chars().skip(start).collect()
+}
+
+/// Parse a claude-CLI reset timestamp like `"resets Apr 23, 3pm"` into a
+/// UTC `DateTime`. The CLI doesn't emit a year or timezone, so we assume
+/// the current UTC year and treat the timestamp as UTC — imprecise by up
+/// to a few hours but good enough to gate spawn decisions. Returns `None`
+/// when no timestamp is found or parsing fails — the `RateLimit` marker
+/// alone is still enough to classify, and Phase 3 can apply a default
+/// back-off when `resets_at` is missing.
+fn parse_reset_timestamp(blob: &str) -> Option<DateTime<Utc>> {
+    let idx = blob.find("resets ")?;
+    let rest = &blob[idx + "resets ".len()..];
+    let end = rest.find(['\n', '·', '|']).unwrap_or(rest.len().min(40));
+    let candidate = rest[..end].trim().trim_end_matches(['.', ',']);
+
+    // Splits we expect: "Apr 23, 3pm" → ["Apr", "23,", "3pm"].
+    let parts: Vec<&str> = candidate.split_whitespace().collect();
+    if parts.len() < 3 {
+        return None;
+    }
+    let month = month_from_abbrev(parts[0])?;
+    let day: u32 = parts[1].trim_end_matches(',').parse().ok()?;
+    let time = parse_12h_time(parts[2])?;
+    let now = Utc::now();
+    let year = {
+        use chrono::Datelike;
+        now.year()
+    };
+    let date = NaiveDate::from_ymd_opt(year, month, day)?;
+    let naive = NaiveDateTime::new(date, time);
+    Utc.from_utc_datetime(&naive).into()
+}
+
+fn month_from_abbrev(s: &str) -> Option<u32> {
+    match s.to_ascii_lowercase().as_str() {
+        "jan" => Some(1),
+        "feb" => Some(2),
+        "mar" => Some(3),
+        "apr" => Some(4),
+        "may" => Some(5),
+        "jun" => Some(6),
+        "jul" => Some(7),
+        "aug" => Some(8),
+        "sep" | "sept" => Some(9),
+        "oct" => Some(10),
+        "nov" => Some(11),
+        "dec" => Some(12),
+        _ => None,
+    }
+}
+
+/// Parse strings like `"3pm"`, `"3PM"`, `"3:45pm"`, `"12:00am"` into
+/// a `NaiveTime`. Returns `None` on any other shape.
+fn parse_12h_time(s: &str) -> Option<NaiveTime> {
+    let lower = s.to_ascii_lowercase();
+    let (body, is_pm) = if let Some(b) = lower.strip_suffix("pm") {
+        (b, true)
+    } else if let Some(b) = lower.strip_suffix("am") {
+        (b, false)
+    } else {
+        return None;
+    };
+    let (hour, minute) = if let Some((h, m)) = body.split_once(':') {
+        (h.parse::<u32>().ok()?, m.parse::<u32>().ok()?)
+    } else {
+        (body.parse::<u32>().ok()?, 0)
+    };
+    if !(1..=12).contains(&hour) || minute >= 60 {
+        return None;
+    }
+    let hour24 = match (hour, is_pm) {
+        (12, false) => 0,        // 12am = 00:00
+        (12, true) => 12,        // 12pm = 12:00
+        (h, false) => h,
+        (h, true) => h + 12,
+    };
+    NaiveTime::from_hms_opt(hour24, minute, 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn exit_zero_returns_none() {
+        assert!(detect_failure_reason(Some(0), None, None).is_none());
+    }
+
+    #[test]
+    fn non_zero_with_no_logs_is_unknown() {
+        let r = detect_failure_reason(Some(1), None, None).unwrap();
+        assert!(matches!(r, FailureReason::Unknown { .. }));
+    }
+
+    #[test]
+    fn rate_limit_hit_message_classifies_as_rate_limit() {
+        let blob = "...streaming output...\nYou've hit your limit · resets Apr 23, 3pm\n";
+        let r = classify(blob);
+        assert!(matches!(r, FailureReason::RateLimit { .. }));
+    }
+
+    #[test]
+    fn rate_limit_with_reset_timestamp_parses() {
+        let blob = "You've hit your limit · resets Apr 23, 3pm";
+        match classify(blob) {
+            FailureReason::RateLimit { resets_at: Some(ts) } => {
+                use chrono::{Datelike, Timelike};
+                assert_eq!(ts.month(), 4);
+                assert_eq!(ts.day(), 23);
+                assert_eq!(ts.hour(), 15);
+                assert_eq!(ts.minute(), 0);
+            }
+            other => panic!("expected RateLimit with timestamp, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rate_limit_with_hour_minute_reset_parses() {
+        let blob = "You've hit your limit · resets May 5, 9:45am";
+        match classify(blob) {
+            FailureReason::RateLimit { resets_at: Some(ts) } => {
+                use chrono::{Datelike, Timelike};
+                assert_eq!(ts.month(), 5);
+                assert_eq!(ts.day(), 5);
+                assert_eq!(ts.hour(), 9);
+                assert_eq!(ts.minute(), 45);
+            }
+            other => panic!("expected RateLimit with timestamp, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rate_limit_without_parseable_timestamp_still_classifies() {
+        // Even when we can't parse the reset time, the marker alone should
+        // produce a `RateLimit` — the kind is what callers gate on.
+        let blob = "rate_limit_exceeded (no timestamp here)";
+        match classify(blob) {
+            FailureReason::RateLimit { resets_at: None } => {}
+            other => panic!("expected RateLimit with no timestamp, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rate_limit_exceeded_api_error_classifies_as_rate_limit() {
+        let blob = r#"{"type":"error","error":{"type":"rate_limit_exceeded"}}"#;
+        let r = classify(blob);
+        assert!(matches!(r, FailureReason::RateLimit { resets_at: None }));
+    }
+
+    #[test]
+    fn network_marker_classifies_as_network_error() {
+        let blob = "Error: getaddrinfo ENOTFOUND api.anthropic.com";
+        let r = classify(blob);
+        match r {
+            FailureReason::NetworkError { message } => {
+                assert!(message.contains("ENOTFOUND"));
+            }
+            other => panic!("expected NetworkError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn invalid_api_key_classifies_as_auth() {
+        let blob = r#"{"error":{"type":"authentication_error","message":"invalid_api_key"}}"#;
+        assert!(matches!(classify(blob), FailureReason::AuthFailure));
+    }
+
+    #[test]
+    fn context_exceeded_classifies_correctly() {
+        let blob = r#"{"error":{"type":"invalid_request_error","message":"prompt is too long: 250000 tokens"}}"#;
+        // context_exceeded takes priority over invalid_argument.
+        assert!(matches!(classify(blob), FailureReason::ContextExceeded));
+    }
+
+    #[test]
+    fn invalid_request_without_context_marker_is_invalid_argument() {
+        let blob = r#"{"error":{"type":"invalid_request_error","message":"unknown tool"}}"#;
+        assert!(matches!(
+            classify(blob),
+            FailureReason::InvalidArgument { .. }
+        ));
+    }
+
+    #[test]
+    fn unclassified_non_zero_is_unknown_with_excerpt() {
+        let blob = "some unrelated stderr about disk IO";
+        match classify(blob) {
+            FailureReason::Unknown { message } => assert!(message.contains("disk IO")),
+            other => panic!("expected Unknown, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn excerpt_caps_length() {
+        let long = "x".repeat(1000);
+        match classify(&long) {
+            FailureReason::Unknown { message } => {
+                assert!(message.chars().count() <= EXCERPT_MAX_CHARS);
+            }
+            other => panic!("expected Unknown, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn read_tail_returns_last_bytes() {
+        let mut f = NamedTempFile::new().unwrap();
+        let payload = "A".repeat(10_000) + "MARKER";
+        f.write_all(payload.as_bytes()).unwrap();
+        let tail = read_tail(f.path(), 100);
+        assert!(tail.ends_with("MARKER"));
+        assert!(tail.len() <= 100);
+    }
+
+    #[test]
+    fn detect_reads_stdout_and_stderr() {
+        let mut out = NamedTempFile::new().unwrap();
+        out.write_all(b"normal output").unwrap();
+        let mut err = NamedTempFile::new().unwrap();
+        err.write_all(b"Error: ETIMEDOUT connecting\n").unwrap();
+        let r = detect_failure_reason(Some(1), Some(out.path()), Some(err.path())).unwrap();
+        assert!(matches!(r, FailureReason::NetworkError { .. }));
+    }
+}

--- a/crates/pitboss-cli/src/dispatch/failure_detection.rs
+++ b/crates/pitboss-cli/src/dispatch/failure_detection.rs
@@ -24,6 +24,10 @@ use std::path::Path;
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
 use pitboss_core::store::FailureReason;
 
+use crate::control::protocol::{ControlEvent, EventEnvelope};
+use crate::dispatch::actor::ActorPath;
+use crate::dispatch::layer::LayerState;
+
 /// How many bytes from the end of stdout+stderr to scan. Markers land at the
 /// tail of a session, and claude's final error block is typically <1 KiB —
 /// 8 KiB is generous without being wasteful.
@@ -59,6 +63,34 @@ pub fn detect_failure_reason(
         buf.push_str(&read_tail(p, TAIL_BYTES));
     }
     Some(classify(&buf))
+}
+
+/// Build a `WorkerFailed` control event envelope and broadcast it via the
+/// root layer's control writer. No-op if no TUI is connected. Call this
+/// alongside the `TaskRecord` persist in every worker/lead/sublead
+/// completion path so downstream consumers (TUI, parent lead) see
+/// classified failures without rescanning logs.
+///
+/// `actor_path_segments` builds the tree lineage — pass `[lead_id, task_id]`
+/// for a lead-owned worker, `[root, sublead_id, task_id]` for a sublead-
+/// owned worker, `[root]` alone for a root-lead failure. Empty paths are
+/// elided on the wire for v0.5 client compat.
+pub async fn broadcast_worker_failed(
+    root_layer: &LayerState,
+    task_id: String,
+    parent_task_id: Option<String>,
+    reason: FailureReason,
+    actor_path_segments: &[&str],
+) {
+    let envelope = EventEnvelope {
+        actor_path: ActorPath::new(actor_path_segments.iter().copied()),
+        event: ControlEvent::WorkerFailed {
+            task_id,
+            parent_task_id,
+            reason,
+        },
+    };
+    root_layer.broadcast_control_event(envelope).await;
 }
 
 /// Public for unit tests — classify a pre-read log blob without touching the
@@ -391,6 +423,148 @@ mod tests {
         let tail = read_tail(f.path(), 100);
         assert!(tail.ends_with("MARKER"));
         assert!(tail.len() <= 100);
+    }
+
+    #[tokio::test]
+    async fn broadcast_worker_failed_delivers_event() {
+        use crate::manifest::resolve::ResolvedManifest;
+        use crate::manifest::schema::WorktreeCleanup;
+        use crate::shared_store::SharedStore;
+        use pitboss_core::process::fake::{FakeScript, FakeSpawner};
+        use pitboss_core::session::CancelToken;
+        use pitboss_core::store::JsonFileStore;
+        use pitboss_core::worktree::{CleanupPolicy, WorktreeManager};
+        use std::path::PathBuf;
+        use std::sync::Arc;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let manifest = ResolvedManifest {
+            max_parallel: 4,
+            halt_on_failure: false,
+            run_dir: dir.path().to_path_buf(),
+            worktree_cleanup: WorktreeCleanup::OnSuccess,
+            emit_event_stream: false,
+            tasks: vec![],
+            lead: None,
+            max_workers: Some(4),
+            budget_usd: Some(5.0),
+            lead_timeout_secs: None,
+            approval_policy: None,
+            notifications: vec![],
+            dump_shared_store: false,
+            require_plan_approval: false,
+            approval_rules: vec![],
+        };
+        let store: Arc<dyn pitboss_core::store::SessionStore> =
+            Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
+        let spawner: Arc<dyn pitboss_core::process::ProcessSpawner> =
+            Arc::new(FakeSpawner::new(FakeScript::new()));
+        let layer = LayerState::new(
+            uuid::Uuid::now_v7(),
+            manifest,
+            store,
+            CancelToken::new(),
+            "lead".into(),
+            spawner,
+            PathBuf::from("claude"),
+            Arc::new(WorktreeManager::new()),
+            CleanupPolicy::Never,
+            dir.path().to_path_buf(),
+            crate::dispatch::state::ApprovalPolicy::Block,
+            None,
+            Arc::new(SharedStore::new()),
+            None,
+        );
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<ControlEvent>();
+        *layer.control_writer.lock().await = Some(tx);
+
+        broadcast_worker_failed(
+            &layer,
+            "w-1".into(),
+            Some("lead".into()),
+            FailureReason::RateLimit { resets_at: None },
+            &["root", "lead", "w-1"],
+        )
+        .await;
+
+        let ev = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv())
+            .await
+            .expect("event should arrive before timeout")
+            .expect("channel should deliver one event");
+        match ev {
+            ControlEvent::WorkerFailed {
+                task_id,
+                parent_task_id,
+                reason,
+            } => {
+                assert_eq!(task_id, "w-1");
+                assert_eq!(parent_task_id.as_deref(), Some("lead"));
+                assert!(matches!(reason, FailureReason::RateLimit { .. }));
+            }
+            other => panic!("expected WorkerFailed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn broadcast_without_control_writer_is_noop() {
+        // With no TUI attached, broadcast must not panic or block.
+        use crate::manifest::resolve::ResolvedManifest;
+        use crate::manifest::schema::WorktreeCleanup;
+        use crate::shared_store::SharedStore;
+        use pitboss_core::process::fake::{FakeScript, FakeSpawner};
+        use pitboss_core::session::CancelToken;
+        use pitboss_core::store::JsonFileStore;
+        use pitboss_core::worktree::{CleanupPolicy, WorktreeManager};
+        use std::path::PathBuf;
+        use std::sync::Arc;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let manifest = ResolvedManifest {
+            max_parallel: 4,
+            halt_on_failure: false,
+            run_dir: dir.path().to_path_buf(),
+            worktree_cleanup: WorktreeCleanup::OnSuccess,
+            emit_event_stream: false,
+            tasks: vec![],
+            lead: None,
+            max_workers: Some(4),
+            budget_usd: Some(5.0),
+            lead_timeout_secs: None,
+            approval_policy: None,
+            notifications: vec![],
+            dump_shared_store: false,
+            require_plan_approval: false,
+            approval_rules: vec![],
+        };
+        let store: Arc<dyn pitboss_core::store::SessionStore> =
+            Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
+        let spawner: Arc<dyn pitboss_core::process::ProcessSpawner> =
+            Arc::new(FakeSpawner::new(FakeScript::new()));
+        let layer = LayerState::new(
+            uuid::Uuid::now_v7(),
+            manifest,
+            store,
+            CancelToken::new(),
+            "lead".into(),
+            spawner,
+            PathBuf::from("claude"),
+            Arc::new(WorktreeManager::new()),
+            CleanupPolicy::Never,
+            dir.path().to_path_buf(),
+            crate::dispatch::state::ApprovalPolicy::Block,
+            None,
+            Arc::new(SharedStore::new()),
+            None,
+        );
+        // No control_writer installed.
+        broadcast_worker_failed(
+            &layer,
+            "w-1".into(),
+            None,
+            FailureReason::AuthFailure,
+            &["root", "w-1"],
+        )
+        .await;
     }
 
     #[test]

--- a/crates/pitboss-cli/src/dispatch/failure_detection.rs
+++ b/crates/pitboss-cli/src/dispatch/failure_detection.rs
@@ -23,10 +23,112 @@ use std::path::Path;
 
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
 use pitboss_core::store::FailureReason;
+use tokio::sync::RwLock;
 
 use crate::control::protocol::{ControlEvent, EventEnvelope};
 use crate::dispatch::actor::ActorPath;
 use crate::dispatch::layer::LayerState;
+
+/// Minimum back-off after a `RateLimit` failure when the CLI didn't emit a
+/// parseable `resets_at` timestamp. 5 minutes is long enough to cover most
+/// transient burst-limit windows; callers fall through to the timestamp when
+/// one was parsed.
+const RATE_LIMIT_DEFAULT_BACKOFF_SECS: i64 = 300;
+
+/// How long an `AuthFailure` is treated as fatal. Auth errors are almost
+/// never transient — a bad API key stays bad — so we set this high enough
+/// that the operator has time to notice and either kill the run or rotate
+/// credentials. 10 minutes.
+const AUTH_FAILURE_BACKOFF_SECS: i64 = 600;
+
+/// Rolling per-run view of the Anthropic API's recent behavior, derived from
+/// classified worker failures. Used by `handle_spawn_worker` /
+/// `handle_spawn_sublead` to reject new spawns while a known-bad condition
+/// persists (rate-limited, auth-broken) rather than burning budget on
+/// subprocesses that will immediately fail with the same error.
+///
+/// Only `RateLimit` and `AuthFailure` populate state here. `NetworkError` is
+/// intentionally *not* tracked — networks recover on their own and the
+/// spawn retry is cheap; flagging network blips as a gate would cause
+/// spurious refusals. `ContextExceeded`/`InvalidArgument`/`Unknown` are
+/// per-task payload problems, not API health.
+#[derive(Debug, Default)]
+pub struct ApiHealth {
+    rate_limit: RwLock<Option<RateLimitState>>,
+    auth_failure: RwLock<Option<DateTime<Utc>>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RateLimitState {
+    hit_at: DateTime<Utc>,
+    /// `None` when the CLI marker had no parseable timestamp — we fall back
+    /// to `RATE_LIMIT_DEFAULT_BACKOFF_SECS` from `hit_at`.
+    resets_at: Option<DateTime<Utc>>,
+}
+
+/// Why `ApiHealth::check_can_spawn` refused. Carries enough information for
+/// the spawn handler to return a helpful error to the lead (so its Claude
+/// session can plan around the outage rather than retrying immediately).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SpawnGateReason {
+    /// API is rate-limited. `retry_after` is best-effort: the parsed
+    /// `resets_at` from the CLI when available, else a default-backoff
+    /// projection from `hit_at`.
+    RateLimited { retry_after: DateTime<Utc> },
+    /// API auth failed recently. `clears_at` is a conservative 10-minute
+    /// projection so repeated spawns don't hammer the API while the
+    /// operator rotates credentials.
+    AuthFailed { clears_at: DateTime<Utc> },
+}
+
+impl ApiHealth {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Update health state from a classified failure. No-op for reasons that
+    /// don't affect spawn gating (`NetworkError`, `ContextExceeded`,
+    /// `InvalidArgument`, `Unknown`). Safe to call from any path that
+    /// received a `Some(FailureReason)`.
+    pub async fn record(&self, reason: &FailureReason) {
+        match reason {
+            FailureReason::RateLimit { resets_at } => {
+                *self.rate_limit.write().await = Some(RateLimitState {
+                    hit_at: Utc::now(),
+                    resets_at: *resets_at,
+                });
+            }
+            FailureReason::AuthFailure => {
+                *self.auth_failure.write().await = Some(Utc::now());
+            }
+            FailureReason::NetworkError { .. }
+            | FailureReason::ContextExceeded
+            | FailureReason::InvalidArgument { .. }
+            | FailureReason::Unknown { .. } => {}
+        }
+    }
+
+    /// Return `Err(SpawnGateReason)` when a new spawn should be refused,
+    /// `Ok(())` otherwise. Checks the most severe gate first (auth, then
+    /// rate-limit) so the returned reason is the most actionable.
+    pub async fn check_can_spawn(&self) -> Result<(), SpawnGateReason> {
+        if let Some(hit_at) = *self.auth_failure.read().await {
+            let clears_at = hit_at + chrono::Duration::seconds(AUTH_FAILURE_BACKOFF_SECS);
+            if Utc::now() < clears_at {
+                return Err(SpawnGateReason::AuthFailed { clears_at });
+            }
+        }
+        if let Some(state) = *self.rate_limit.read().await {
+            let retry_after = state.resets_at.unwrap_or_else(|| {
+                state.hit_at + chrono::Duration::seconds(RATE_LIMIT_DEFAULT_BACKOFF_SECS)
+            });
+            if Utc::now() < retry_after {
+                return Err(SpawnGateReason::RateLimited { retry_after });
+            }
+        }
+        Ok(())
+    }
+}
 
 /// How many bytes from the end of stdout+stderr to scan. Markers land at the
 /// tail of a session, and claude's final error block is typically <1 KiB —
@@ -423,6 +525,98 @@ mod tests {
         let tail = read_tail(f.path(), 100);
         assert!(tail.ends_with("MARKER"));
         assert!(tail.len() <= 100);
+    }
+
+    #[tokio::test]
+    async fn api_health_fresh_allows_spawn() {
+        let h = ApiHealth::new();
+        assert!(h.check_can_spawn().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn api_health_records_rate_limit_and_refuses_spawn() {
+        let h = ApiHealth::new();
+        let future = Utc::now() + chrono::Duration::minutes(10);
+        h.record(&FailureReason::RateLimit {
+            resets_at: Some(future),
+        })
+        .await;
+        match h.check_can_spawn().await {
+            Err(SpawnGateReason::RateLimited { retry_after }) => {
+                assert_eq!(retry_after, future);
+            }
+            other => panic!("expected RateLimited, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn api_health_rate_limit_without_timestamp_uses_default_backoff() {
+        let h = ApiHealth::new();
+        h.record(&FailureReason::RateLimit { resets_at: None }).await;
+        match h.check_can_spawn().await {
+            Err(SpawnGateReason::RateLimited { retry_after }) => {
+                let remaining = (retry_after - Utc::now()).num_seconds();
+                assert!(remaining > 0, "retry_after should be in the future");
+                assert!(
+                    remaining <= RATE_LIMIT_DEFAULT_BACKOFF_SECS,
+                    "retry_after should be within the default backoff window"
+                );
+            }
+            other => panic!("expected RateLimited, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn api_health_past_rate_limit_clears() {
+        let h = ApiHealth::new();
+        let past = Utc::now() - chrono::Duration::minutes(10);
+        h.record(&FailureReason::RateLimit {
+            resets_at: Some(past),
+        })
+        .await;
+        assert!(h.check_can_spawn().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn api_health_auth_failure_refuses_spawn() {
+        let h = ApiHealth::new();
+        h.record(&FailureReason::AuthFailure).await;
+        assert!(matches!(
+            h.check_can_spawn().await,
+            Err(SpawnGateReason::AuthFailed { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn api_health_ignores_non_gate_variants() {
+        let h = ApiHealth::new();
+        h.record(&FailureReason::NetworkError {
+            message: "ETIMEDOUT".into(),
+        })
+        .await;
+        h.record(&FailureReason::ContextExceeded).await;
+        h.record(&FailureReason::Unknown {
+            message: "boom".into(),
+        })
+        .await;
+        h.record(&FailureReason::InvalidArgument {
+            message: "bad".into(),
+        })
+        .await;
+        assert!(h.check_can_spawn().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn api_health_auth_takes_precedence_over_rate_limit() {
+        // Both gates active — auth is more actionable for the operator,
+        // so its error should be reported first.
+        let h = ApiHealth::new();
+        h.record(&FailureReason::RateLimit { resets_at: None }).await;
+        h.record(&FailureReason::AuthFailure).await;
+        assert!(matches!(
+            h.check_can_spawn().await,
+            Err(SpawnGateReason::AuthFailed { .. })
+        ));
     }
 
     #[tokio::test]

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -405,7 +405,11 @@ pub async fn run_hierarchical(
     store.append_record(run_id, &lead_record).await?;
     // Broadcast classified failure so the TUI and any attached client see
     // why the root lead died (rate-limit / network / auth / ...).
+    // Root-lead dying generally ends the run, but still record into
+    // api_health for completeness — any subleads spawned after this point
+    // (rare) will see the gate.
     if let Some(reason) = lead_record.failure_reason.clone() {
+        state.api_health.record(&reason).await;
         crate::dispatch::failure_detection::broadcast_worker_failed(
             &state.root,
             lead.id.clone(),

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -377,7 +377,7 @@ pub async fn run_hierarchical(
         } else {
             None
         },
-        log_path: lead_log_path,
+        log_path: lead_log_path.clone(),
         token_usage: total_token_usage,
         claude_session_id: final_outcome.claude_session_id,
         final_message_preview: final_outcome.final_message_preview,
@@ -388,6 +388,11 @@ pub async fn run_hierarchical(
         approvals_approved: lead_counters.approvals_approved,
         approvals_rejected: lead_counters.approvals_rejected,
         model: Some(lead.model.clone()),
+        failure_reason: crate::dispatch::failure_detection::detect_failure_reason(
+            final_outcome.exit_code,
+            Some(&lead_log_path),
+            Some(&lead_stderr_path),
+        ),
     };
 
     // Cleanup worktree per policy
@@ -459,6 +464,7 @@ pub async fn run_hierarchical(
                         approvals_approved: 0,
                         approvals_rejected: 0,
                         model: worker_models.get(id).cloned(),
+                        failure_reason: None,
                     }
                 }
             })

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -403,6 +403,18 @@ pub async fn run_hierarchical(
 
     // Persist lead record
     store.append_record(run_id, &lead_record).await?;
+    // Broadcast classified failure so the TUI and any attached client see
+    // why the root lead died (rate-limit / network / auth / ...).
+    if let Some(reason) = lead_record.failure_reason.clone() {
+        crate::dispatch::failure_detection::broadcast_worker_failed(
+            &state.root,
+            lead.id.clone(),
+            None,
+            reason,
+            &["root", lead.id.as_str()],
+        )
+        .await;
+    }
     state.workers.write().await.insert(
         lead.id.clone(),
         crate::dispatch::state::WorkerState::Done(lead_record.clone()),

--- a/crates/pitboss-cli/src/dispatch/mod.rs
+++ b/crates/pitboss-cli/src/dispatch/mod.rs
@@ -1,5 +1,6 @@
 pub mod actor;
 pub mod events;
+pub mod failure_detection;
 pub mod hierarchical;
 pub mod layer;
 pub mod probe;

--- a/crates/pitboss-cli/src/dispatch/resume.rs
+++ b/crates/pitboss-cli/src/dispatch/resume.rs
@@ -299,6 +299,7 @@ mod tests {
                 approvals_approved: 0,
                 approvals_rejected: 0,
                 model: None,
+                failure_reason: None,
             })
             .collect();
 
@@ -515,6 +516,7 @@ mod tests {
             approvals_approved: 0,
             approvals_rejected: 0,
             model: None,
+            failure_reason: None,
         };
         let summary = RunSummary {
             run_id: Uuid::now_v7(),
@@ -619,6 +621,7 @@ mod tests {
             approvals_approved: 0,
             approvals_rejected: 0,
             model: None,
+            failure_reason: None,
         };
         let summary = RunSummary {
             run_id: Uuid::now_v7(),

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -444,6 +444,7 @@ async fn execute_task(
                     approvals_approved: 0,
                     approvals_rejected: 0,
                     model: Some(task.model.clone()),
+                    failure_reason: None,
                 };
             }
         }
@@ -484,6 +485,11 @@ async fn execute_task(
     }
 
     let worktree_path = if task.use_worktree { Some(cwd) } else { None };
+    let failure_reason = crate::dispatch::failure_detection::detect_failure_reason(
+        outcome.exit_code,
+        Some(&log_path),
+        Some(&stderr_log_path),
+    );
     TaskRecord {
         task_id: task.id.clone(),
         status,
@@ -503,6 +509,7 @@ async fn execute_task(
         approvals_approved: 0,
         approvals_rejected: 0,
         model: Some(task.model.clone()),
+        failure_reason,
     }
 }
 

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -270,6 +270,13 @@ pub struct DispatchState {
     /// silent exits as `TaskStatus::ApprovalRejected`. See the
     /// `LastApprovalResponse` doc for the full lifecycle.
     pub last_approval_response: RwLock<HashMap<String, LastApprovalResponse>>,
+    /// Rolling view of Anthropic API health derived from classified worker
+    /// failures. Consulted by `handle_spawn_worker` /
+    /// `handle_spawn_sublead` to refuse new spawns while rate-limit or
+    /// auth conditions persist — otherwise a loop of failing workers
+    /// burns budget faster than the operator can intervene. Updated
+    /// alongside the `TaskRecord` persist in every completion path.
+    pub api_health: Arc<crate::dispatch::failure_detection::ApiHealth>,
 }
 
 /// CAUTION: This Deref always resolves to the root layer, which is correct
@@ -345,6 +352,7 @@ impl DispatchState {
             worker_layer_index: RwLock::new(HashMap::new()),
             run_leases: Arc::new(RunLeaseRegistry::new()),
             last_approval_response: RwLock::new(HashMap::new()),
+            api_health: Arc::new(crate::dispatch::failure_detection::ApiHealth::new()),
         }
     }
 

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -37,8 +37,16 @@ pub struct SubleadTerminalRecord {
 /// The return type of `wait_for_actor_internal`.
 /// Workers return a `TaskRecord`; sub-leads return a `SubleadTerminalRecord`.
 /// The MCP handler serializes whichever variant it gets.
+///
+/// The variant-size lint is allowed here: `TaskRecord` is ~300 B vs. ~80 B for
+/// `SubleadTerminalRecord`, but boxing `TaskRecord` would ripple through every
+/// `wait_actor` caller (plus pattern matches across TUI / dispatch / tests) to
+/// dereference through a `Box`. This type is constructed once per actor
+/// termination — a handful of times per run — so the extra inline bytes are
+/// immaterial compared to the churn that boxing would introduce.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "actor_type", rename_all = "snake_case")]
+#[allow(clippy::large_enum_variant)]
 pub enum ActorTerminalRecord {
     Worker(TaskRecord),
     Sublead(SubleadTerminalRecord),

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -731,7 +731,7 @@ async fn spawn_sublead_session(
                 .num_milliseconds()
                 .max(0),
             worktree_path: None,
-            log_path,
+            log_path: log_path.clone(),
             token_usage: total_token_usage,
             claude_session_id: final_outcome.claude_session_id,
             final_message_preview: final_outcome.final_message_preview,
@@ -742,6 +742,11 @@ async fn spawn_sublead_session(
             approvals_approved: 0,
             approvals_rejected: 0,
             model: Some(model_bg),
+            failure_reason: crate::dispatch::failure_detection::detect_failure_reason(
+                final_outcome.exit_code,
+                Some(&log_path),
+                Some(&stderr_path),
+            ),
         };
         if let Err(e) = sub_layer_bg
             .store

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -222,6 +222,29 @@ pub async fn spawn_sublead(
     state: &Arc<DispatchState>,
     req: SubleadSpawnRequest,
 ) -> Result<ActorId> {
+    // API health gate: refuse new sub-leads while a recent rate-limit or
+    // auth failure persists. Mirrors the check in `handle_spawn_worker`
+    // so the lead can't sidestep the gate by routing through a new
+    // sub-tree. See `dispatch::failure_detection` for the rules.
+    if let Err(gate) = state.api_health.check_can_spawn().await {
+        use crate::dispatch::failure_detection::SpawnGateReason;
+        match gate {
+            SpawnGateReason::RateLimited { retry_after } => {
+                bail!(
+                    "spawn_sublead: api rate-limited: refusing new sub-leads until {} (retry_after)",
+                    retry_after.to_rfc3339()
+                );
+            }
+            SpawnGateReason::AuthFailed { clears_at } => {
+                bail!(
+                    "spawn_sublead: api auth failed recently; refusing new sub-leads until {} \
+                     (clears_at). Rotate credentials or cancel the run",
+                    clears_at.to_rfc3339()
+                );
+            }
+        }
+    }
+
     // 1. Resolve envelope (apply defaults, check caps).
     let envelope = resolve_envelope(state, &req).await?;
 
@@ -760,8 +783,10 @@ async fn spawn_sublead_session(
             );
         }
         // Broadcast classified failure from the sub-lead so the root TUI
-        // sees why this branch of the tree died.
+        // sees why this branch of the tree died, and update api_health
+        // so further spawns across the tree see the gate.
         if let Some(reason) = rec.failure_reason.clone() {
+            state_bg.api_health.record(&reason).await;
             crate::dispatch::failure_detection::broadcast_worker_failed(
                 &state_bg.root,
                 sublead_id_bg.clone(),

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -759,6 +759,18 @@ async fn spawn_sublead_session(
                 "failed to persist sub-lead TaskRecord"
             );
         }
+        // Broadcast classified failure from the sub-lead so the root TUI
+        // sees why this branch of the tree died.
+        if let Some(reason) = rec.failure_reason.clone() {
+            crate::dispatch::failure_detection::broadcast_worker_failed(
+                &state_bg.root,
+                sublead_id_bg.clone(),
+                Some("root".into()),
+                reason,
+                &["root", sublead_id_bg.as_str()],
+            )
+            .await;
+        }
 
         // 10. Reconcile: release reservation, update root's spent_usd,
         //     populate sublead_results, and wake wait_actor subscribers.

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -624,6 +624,7 @@ async fn run_worker(
                     approvals_approved: 0,
                     approvals_rejected: 0,
                     model: Some(model.clone()),
+                    failure_reason: None,
                 };
                 let _ = layer.store.append_record(layer.run_id, &rec).await;
                 layer
@@ -707,7 +708,7 @@ async fn run_worker(
             .insert(task_id.clone(), pid_slot.clone());
         let outcome = SessionHandle::new(task_id.clone(), Arc::clone(&layer.spawner), cmd)
             .with_log_path(log_path.clone())
-            .with_stderr_log_path(stderr_path)
+            .with_stderr_log_path(stderr_path.clone())
             .with_session_id_tx(session_id_tx)
             .with_pid_slot(pid_slot)
             .run_to_completion(cancel, Duration::from_secs(timeout_secs))
@@ -755,6 +756,13 @@ async fn run_worker(
         .get(&task_id)
         .cloned()
         .unwrap_or_default();
+    // Classify non-zero exits by scanning the tail of stdout/stderr for known
+    // markers (rate-limit, network, auth, etc.). `None` on exit_code == 0.
+    let failure_reason = crate::dispatch::failure_detection::detect_failure_reason(
+        outcome.exit_code,
+        Some(&log_path),
+        Some(&stderr_path),
+    );
     let rec = TaskRecord {
         task_id: task_id.clone(),
         status,
@@ -774,6 +782,7 @@ async fn run_worker(
         approvals_approved: counters.approvals_approved,
         approvals_rejected: counters.approvals_rejected,
         model: Some(model.clone()),
+        failure_reason,
     };
 
     // Persist record.
@@ -1003,7 +1012,7 @@ pub async fn spawn_resume_worker(
             cmd,
         )
         .with_log_path(log_path.clone())
-        .with_stderr_log_path(stderr_path)
+        .with_stderr_log_path(stderr_path.clone())
         .with_pid_slot(resume_pid_slot)
         .run_to_completion(worker_cancel, std::time::Duration::from_secs(timeout_secs))
         .await;
@@ -1041,7 +1050,7 @@ pub async fn spawn_resume_worker(
             ended_at: outcome.ended_at,
             duration_ms: outcome.duration_ms(),
             worktree_path: None,
-            log_path,
+            log_path: log_path.clone(),
             token_usage: outcome.token_usage,
             claude_session_id: outcome.claude_session_id,
             final_message_preview: outcome.final_message_preview,
@@ -1052,6 +1061,11 @@ pub async fn spawn_resume_worker(
             approvals_approved: counters.approvals_approved,
             approvals_rejected: counters.approvals_rejected,
             model: Some(resume_model),
+            failure_reason: crate::dispatch::failure_detection::detect_failure_reason(
+                outcome.exit_code,
+                Some(&log_path),
+                Some(&stderr_path),
+            ),
         };
         let _ = state_bg.store.append_record(state_bg.run_id, &rec).await;
         state_bg
@@ -2132,6 +2146,7 @@ mod tests {
                 approvals_approved: 0,
                 approvals_rejected: 0,
                 model: None,
+                failure_reason: None,
             };
             let mut w = state_clone.workers.write().await;
             w.insert(task_id_clone.clone(), WorkerState::Done(rec));
@@ -2204,6 +2219,7 @@ mod tests {
                 approvals_approved: 0,
                 approvals_rejected: 0,
                 model: None,
+                failure_reason: None,
             };
             let mut w = state_clone.workers.write().await;
             w.insert("w-b".into(), WorkerState::Done(rec));
@@ -2795,6 +2811,7 @@ mod tests {
             approvals_approved: 0,
             approvals_rejected: 0,
             model: None,
+                failure_reason: None,
         };
         state
             .workers

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -775,7 +775,7 @@ async fn run_worker(
         token_usage: outcome.token_usage,
         claude_session_id: outcome.claude_session_id,
         final_message_preview: outcome.final_message_preview,
-        parent_task_id: Some(lead_id),
+        parent_task_id: Some(lead_id.clone()),
         pause_count: counters.pause_count,
         reprompt_count: counters.reprompt_count,
         approvals_requested: counters.approvals_requested,
@@ -787,6 +787,20 @@ async fn run_worker(
 
     // Persist record.
     let _ = layer.store.append_record(layer.run_id, &rec).await;
+
+    // Broadcast structured failure to any connected TUI so operators see
+    // *why* the worker failed without opening logs, and so a parent lead
+    // can react (back off on RateLimit, fail fast on AuthFailure).
+    if let Some(reason) = rec.failure_reason.clone() {
+        crate::dispatch::failure_detection::broadcast_worker_failed(
+            &state.root,
+            task_id.clone(),
+            Some(lead_id.clone()),
+            reason,
+            &["root", &lead_id, &task_id],
+        )
+        .await;
+    }
 
     // Release the spawn-time reservation before accumulating actual cost.
     release_reservation_for_layer(&layer, &task_id).await;
@@ -1054,7 +1068,7 @@ pub async fn spawn_resume_worker(
             token_usage: outcome.token_usage,
             claude_session_id: outcome.claude_session_id,
             final_message_preview: outcome.final_message_preview,
-            parent_task_id: Some(lead_id_bg),
+            parent_task_id: Some(lead_id_bg.clone()),
             pause_count: counters.pause_count,
             reprompt_count: counters.reprompt_count,
             approvals_requested: counters.approvals_requested,
@@ -1068,6 +1082,16 @@ pub async fn spawn_resume_worker(
             ),
         };
         let _ = state_bg.store.append_record(state_bg.run_id, &rec).await;
+        if let Some(reason) = rec.failure_reason.clone() {
+            crate::dispatch::failure_detection::broadcast_worker_failed(
+                &state_bg.root,
+                task_id_bg.clone(),
+                Some(lead_id_bg.clone()),
+                reason,
+                &["root", &lead_id_bg, &task_id_bg],
+            )
+            .await;
+        }
         state_bg
             .workers
             .write()

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -2912,7 +2912,7 @@ mod tests {
             approvals_approved: 0,
             approvals_rejected: 0,
             model: None,
-                failure_reason: None,
+            failure_reason: None,
         };
         state
             .workers

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -364,6 +364,28 @@ pub async fn handle_spawn_worker(
         bail!("run is draining: no new workers accepted");
     }
 
+    // Guard 1a: API health. If a recent worker classified as rate-limited
+    // or auth-failed, refuse new spawns until the condition clears. The
+    // lead's Claude session sees a structured error and can plan around
+    // the outage (wait for reset, report to operator) rather than firing
+    // another doomed subprocess. See `dispatch::failure_detection` for
+    // the gate rules.
+    if let Err(gate) = state.api_health.check_can_spawn().await {
+        use crate::dispatch::failure_detection::SpawnGateReason;
+        match gate {
+            SpawnGateReason::RateLimited { retry_after } => bail!(
+                "api rate-limited: refusing to spawn new workers until {} (retry_after); a \
+                 prior worker hit the limit",
+                retry_after.to_rfc3339()
+            ),
+            SpawnGateReason::AuthFailed { clears_at } => bail!(
+                "api auth failed on a recent worker; refusing to spawn new workers until {} \
+                 (clears_at). Rotate credentials or cancel the run",
+                clears_at.to_rfc3339()
+            ),
+        }
+    }
+
     // Guard 1b: plan approval. When the manifest opts in with
     // `[run].require_plan_approval = true`, the lead must call
     // `propose_plan` and get operator approval before any worker
@@ -791,7 +813,11 @@ async fn run_worker(
     // Broadcast structured failure to any connected TUI so operators see
     // *why* the worker failed without opening logs, and so a parent lead
     // can react (back off on RateLimit, fail fast on AuthFailure).
+    // Also record into `api_health` so the next spawn call short-circuits
+    // while the condition persists — one dead worker is enough; a loop
+    // of them burns budget faster than any operator can intervene.
     if let Some(reason) = rec.failure_reason.clone() {
+        state.api_health.record(&reason).await;
         crate::dispatch::failure_detection::broadcast_worker_failed(
             &state.root,
             task_id.clone(),
@@ -1083,6 +1109,7 @@ pub async fn spawn_resume_worker(
         };
         let _ = state_bg.store.append_record(state_bg.run_id, &rec).await;
         if let Some(reason) = rec.failure_reason.clone() {
+            state_bg.api_health.record(&reason).await;
             crate::dispatch::failure_detection::broadcast_worker_failed(
                 &state_bg.root,
                 task_id_bg.clone(),
@@ -2059,6 +2086,56 @@ mod tests {
         };
         let err = handle_spawn_worker(&state, args).await.unwrap_err();
         assert!(err.to_string().contains("budget exceeded"), "err: {err}");
+    }
+
+    #[tokio::test]
+    async fn spawn_worker_refuses_when_api_rate_limited() {
+        use pitboss_core::store::FailureReason;
+        let state = test_state().await;
+        // Simulate a just-finished worker that hit rate-limit with a
+        // reset 10 minutes in the future — any new spawn must refuse.
+        let future = chrono::Utc::now() + chrono::Duration::minutes(10);
+        state
+            .api_health
+            .record(&FailureReason::RateLimit {
+                resets_at: Some(future),
+            })
+            .await;
+        let args = SpawnWorkerArgs {
+            prompt: "p".into(),
+            directory: None,
+            branch: None,
+            tools: None,
+            timeout_secs: None,
+            model: None,
+            meta: None,
+        };
+        let err = handle_spawn_worker(&state, args).await.unwrap_err();
+        assert!(
+            err.to_string().contains("rate-limited"),
+            "err should mention rate-limited: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_worker_refuses_when_api_auth_failed() {
+        use pitboss_core::store::FailureReason;
+        let state = test_state().await;
+        state.api_health.record(&FailureReason::AuthFailure).await;
+        let args = SpawnWorkerArgs {
+            prompt: "p".into(),
+            directory: None,
+            branch: None,
+            tools: None,
+            timeout_secs: None,
+            model: None,
+            meta: None,
+        };
+        let err = handle_spawn_worker(&state, args).await.unwrap_err();
+        assert!(
+            err.to_string().contains("auth failed"),
+            "err should mention auth failed: {err}"
+        );
     }
 
     #[tokio::test]

--- a/crates/pitboss-cli/src/tui_table.rs
+++ b/crates/pitboss-cli/src/tui_table.rs
@@ -178,6 +178,7 @@ mod tests {
             approvals_approved: 0,
             approvals_rejected: 0,
             model: None,
+            failure_reason: None,
         }
     }
 

--- a/crates/pitboss-cli/tests/hierarchical_flows.rs
+++ b/crates/pitboss-cli/tests/hierarchical_flows.rs
@@ -278,6 +278,7 @@ async fn wait_actor_alias_resolves_worker_id() {
             approvals_approved: 0,
             approvals_rejected: 0,
             model: None,
+            failure_reason: None,
         };
         let mut w = state_clone.workers.write().await;
         w.insert(worker_id_clone.clone(), WorkerState::Done(rec));

--- a/crates/pitboss-cli/tests/sublead_flows.rs
+++ b/crates/pitboss-cli/tests/sublead_flows.rs
@@ -1239,6 +1239,7 @@ async fn wait_actor_still_handles_worker_back_compat() {
             approvals_approved: 0,
             approvals_rejected: 0,
             model: None,
+            failure_reason: None,
         };
         let mut w = state_clone.workers.write().await;
         w.insert(worker_id_clone.clone(), WorkerState::Done(rec));
@@ -1569,6 +1570,7 @@ async fn kill_with_reason_skips_delivery_when_lead_already_terminated() {
             approvals_approved: 0,
             approvals_rejected: 0,
             model: Some("claude-haiku-4-5".into()),
+            failure_reason: None,
         };
         sub.workers.write().await.insert(
             s1.clone(),

--- a/crates/pitboss-core/src/store/mod.rs
+++ b/crates/pitboss-core/src/store/mod.rs
@@ -3,7 +3,7 @@
 pub mod record;
 pub mod traits;
 
-pub use record::{RunMeta, RunSummary, TaskRecord, TaskStatus};
+pub use record::{FailureReason, RunMeta, RunSummary, TaskRecord, TaskStatus};
 pub use traits::SessionStore;
 
 pub mod json_file;
@@ -53,6 +53,7 @@ mod integration_tests {
             approvals_approved: 0,
             approvals_rejected: 0,
             model: None,
+            failure_reason: None,
         }
     }
 

--- a/crates/pitboss-core/src/store/record.rs
+++ b/crates/pitboss-core/src/store/record.rs
@@ -7,6 +7,31 @@ use uuid::Uuid;
 
 use crate::parser::TokenUsage;
 
+/// Structured classification of *why* a claude subprocess failed, derived by
+/// scanning its stdout/stderr after a non-zero exit. Populated on the
+/// `TaskRecord` so callers (TUI, parent lead, spawn gater) can react without
+/// re-parsing logs. Exit code 0 never produces a `FailureReason` — a successful
+/// response that happens to mention "rate limit" in body text is not a failure.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum FailureReason {
+    /// API rate/usage limit hit. `resets_at` is the parsed reset time when the
+    /// CLI emitted one (e.g., "resets Apr 23, 3pm"); `None` when the marker was
+    /// detected but no timestamp was parseable.
+    RateLimit { resets_at: Option<DateTime<Utc>> },
+    /// DNS/connection errors: ENOTFOUND, ETIMEDOUT, ECONNRESET, etc.
+    NetworkError { message: String },
+    /// 401 / `invalid_api_key` from the API.
+    AuthFailure,
+    /// Model refused the prompt due to context-length exceeded.
+    ContextExceeded,
+    /// 400 `invalid_request_error` surfaced by the CLI.
+    InvalidArgument { message: String },
+    /// Non-zero exit with no recognized marker. `message` is a short excerpt
+    /// from the tail of stderr/stdout for triage.
+    Unknown { message: String },
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TaskStatus {
     Success,
@@ -61,6 +86,10 @@ pub struct TaskRecord {
     /// scanning the log if they need this for an older run.
     #[serde(default)]
     pub model: Option<String>,
+    /// Structured failure classification for non-zero exits. `None` for
+    /// successful tasks, cancelled tasks, and pre-v0.7.1 records.
+    #[serde(default)]
+    pub failure_reason: Option<FailureReason>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -119,6 +148,7 @@ mod tests {
             approvals_approved: 0,
             approvals_rejected: 0,
             model: None,
+            failure_reason: None,
         };
         let json = serde_json::to_string(&rec).unwrap();
         let back: TaskRecord = serde_json::from_str(&json).unwrap();
@@ -147,6 +177,7 @@ mod tests {
             approvals_approved: 0,
             approvals_rejected: 0,
             model: None,
+            failure_reason: None,
         };
         let json = serde_json::to_string(&rec).unwrap();
         assert!(json.contains("parent_task_id"));
@@ -207,6 +238,7 @@ mod tests {
             approvals_approved: 0,
             approvals_rejected: 0,
             model: Some("claude-opus-4-7".into()),
+            failure_reason: None,
         };
         let json = serde_json::to_string(&rec).unwrap();
         assert!(json.contains("claude-opus-4-7"));
@@ -278,6 +310,7 @@ mod tests {
             approvals_approved: 2,
             approvals_rejected: 1,
             model: None,
+            failure_reason: None,
         };
         let s = serde_json::to_string(&rec).unwrap();
         let back: TaskRecord = serde_json::from_str(&s).unwrap();

--- a/crates/pitboss-core/src/store/sqlite.rs
+++ b/crates/pitboss-core/src/store/sqlite.rs
@@ -61,6 +61,7 @@ impl SqliteStore {
         migrate_parent_task_id(&conn)?;
         migrate_v04_event_counters(&conn)?;
         migrate_task_model(&conn)?;
+        migrate_failure_reason(&conn)?;
         Ok(Self {
             inner: Arc::new(Mutex::new(conn)),
         })
@@ -111,6 +112,31 @@ fn migrate_task_model(conn: &rusqlite::Connection) -> Result<(), StoreError> {
     if !has_model {
         conn.execute("ALTER TABLE task_records ADD COLUMN model TEXT NULL", [])
             .map_err(|e| StoreError::Incomplete(format!("migrate model alter: {e}")))?;
+    }
+    Ok(())
+}
+
+/// Idempotent migration: add the v0.7.1 `failure_reason` column to
+/// `task_records` if it's missing. Stores the `FailureReason` enum as JSON
+/// (TEXT NULL) so adding/removing variants doesn't require another schema
+/// migration. Populated by the post-exit failure-detection parser.
+fn migrate_failure_reason(conn: &rusqlite::Connection) -> Result<(), StoreError> {
+    let has_col = {
+        let mut stmt = conn
+            .prepare(
+                "SELECT 1 FROM pragma_table_info('task_records') \
+                 WHERE name = 'failure_reason'",
+            )
+            .map_err(|e| StoreError::Incomplete(format!("migrate failure_reason prepare: {e}")))?;
+        stmt.exists([])
+            .map_err(|e| StoreError::Incomplete(format!("migrate failure_reason exists: {e}")))?
+    };
+    if !has_col {
+        conn.execute(
+            "ALTER TABLE task_records ADD COLUMN failure_reason TEXT NULL",
+            [],
+        )
+        .map_err(|e| StoreError::Incomplete(format!("migrate failure_reason alter: {e}")))?;
     }
     Ok(())
 }
@@ -228,6 +254,7 @@ fn init_schema(conn: &rusqlite::Connection) -> Result<(), StoreError> {
             approvals_approved    INTEGER NOT NULL DEFAULT 0,
             approvals_rejected    INTEGER NOT NULL DEFAULT 0,
             model                 TEXT NULL,
+            failure_reason        TEXT NULL,
             PRIMARY KEY (run_id, task_id)
         );
         ",
@@ -331,6 +358,7 @@ struct TaskRow {
     approvals_approved: i64,
     approvals_rejected: i64,
     model: Option<String>,
+    failure_reason: Option<String>,
 }
 
 impl TaskRow {
@@ -357,6 +385,7 @@ impl TaskRow {
             approvals_approved: row.get("approvals_approved").unwrap_or(0),
             approvals_rejected: row.get("approvals_rejected").unwrap_or(0),
             model: row.get("model").unwrap_or(None),
+            failure_reason: row.get("failure_reason").unwrap_or(None),
         })
     }
 
@@ -389,6 +418,10 @@ impl TaskRow {
             approvals_approved: self.approvals_approved.try_into().unwrap_or(0),
             approvals_rejected: self.approvals_rejected.try_into().unwrap_or(0),
             model: self.model,
+            failure_reason: self
+                .failure_reason
+                .as_deref()
+                .and_then(|s| serde_json::from_str(s).ok()),
         })
     }
 }
@@ -426,7 +459,7 @@ fn fetch_task_records(
                   token_input, token_output, token_cache_read, token_cache_creation, \
                   claude_session_id, final_message_preview, parent_task_id, \
                   pause_count, reprompt_count, approvals_requested, \
-                  approvals_approved, approvals_rejected, model \
+                  approvals_approved, approvals_rejected, model, failure_reason \
              FROM task_records WHERE run_id = ?1 ORDER BY rowid",
         )
         .map_err(|e| StoreError::Incomplete(format!("task query prepare: {e}")))?;
@@ -544,9 +577,9 @@ impl SessionStore for SqliteStore {
                       token_input, token_output, token_cache_read, token_cache_creation, \
                       claude_session_id, final_message_preview, parent_task_id, \
                       pause_count, reprompt_count, approvals_requested, \
-                      approvals_approved, approvals_rejected, model) \
+                      approvals_approved, approvals_rejected, model, failure_reason) \
                      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, \
-                             ?17, ?18, ?19, ?20, ?21, ?22)",
+                             ?17, ?18, ?19, ?20, ?21, ?22, ?23)",
                     rusqlite::params![
                         run_id_str,
                         record.task_id,
@@ -573,6 +606,10 @@ impl SessionStore for SqliteStore {
                         i64::from(record.approvals_approved),
                         i64::from(record.approvals_rejected),
                         record.model.as_deref(),
+                        record
+                            .failure_reason
+                            .as_ref()
+                            .and_then(|fr| serde_json::to_string(fr).ok()),
                     ],
                 )
                 .map_err(|e| StoreError::Incomplete(format!("append_record insert: {e}")))?;
@@ -680,6 +717,7 @@ mod sqlite_tests {
             approvals_approved: 0,
             approvals_rejected: 0,
             model: None,
+            failure_reason: None,
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #64 — API errors on worker claude processes now surface to the parent layer with structured classification, broadcast to any attached TUI, and gate new spawns while the condition persists.

Three-phase deep implementation:

- **Phase 1 (4da2f57):** `FailureReason` enum + `TaskRecord.failure_reason`. Tail-scan classifier in new `dispatch::failure_detection` module recognises rate-limit, network, auth, context-exceeded, and invalid-argument markers; non-zero exits with no match become `Unknown` with a short excerpt. Wired into every completion path (`run_worker`, `continue_worker` resume, hierarchical root lead, flat `runner`, sublead). Persisted as JSON on a new SQLite column with idempotent migration.
- **Phase 2 (fa17c9e):** `ControlEvent::WorkerFailed { task_id, parent_task_id, reason }` broadcast via the root layer's control writer from each completion site. TUI and parent-lead consumers no longer have to rescan logs to know why something died.
- **Phase 3 (bb294bc):** `ApiHealth` on `DispatchState`; `handle_spawn_worker` and `spawn_sublead` now call `check_can_spawn()` and return structured `rate-limited` / `auth failed` errors carrying `retry_after`/`clears_at` timestamps so the lead's Claude can plan around the outage instead of looping failing subprocesses.

Before this change, a rate-limited or auth-broken worker just exited 1 and its siblings kept firing — one worker burned 87 min before the operator noticed. Now a single classified failure gates the whole layer.

## Test plan

- [x] `cargo test --workspace` passes (~600 tests including 24 new in `failure_detection`, 2 in protocol round-trip, 2 in spawn-handler gates)
- [x] `cargo clippy --workspace --all-targets` clean (only pre-existing `ActorTerminalRecord` size warning)
- [x] SQLite migration idempotent — tested via existing round-trip tests
- [x] JSON backwards-compat — serde default on `failure_reason` so v0.7 records still parse
- [x] Control event wire compat — `parent_task_id: None` elides the field; v0.5 clients that only understand old events keep parsing the rest of the stream
- [ ] Manual smoke: trigger a real rate-limit during a dispatch and confirm (a) TUI shows the structured reason in the tile footer, (b) subsequent `spawn_worker` calls bail with the `retry_after` error
- [ ] Manual smoke: sublead-owned worker hitting rate-limit gates spawns across the tree, not just within the sub-tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)