### PR TITLE
fix: resolve 5 high-severity bugs in approval/session/TUI paths

### DIFF
--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -849,40 +849,69 @@ pub fn install_approval_ttl_watcher(state: Arc<crate::dispatch::state::DispatchS
 }
 
 async fn expire_approvals(state: &Arc<crate::dispatch::state::DispatchState>) {
+    // Root layer first.
+    expire_layer_approvals(state, &state.root).await;
+
+    // Then every sub-lead layer. Acquiring the outer `subleads` read lock
+    // first and each inner `approval_queue` lock in a fresh per-iteration
+    // scope matches the project-wide lock ordering rule (see DispatchState
+    // docs) and avoids holding both kinds of locks across await points.
+    let subleads = state.subleads.read().await;
+    for sub_layer in subleads.values() {
+        expire_layer_approvals(state, sub_layer).await;
+    }
+}
+
+async fn expire_layer_approvals(
+    state: &Arc<crate::dispatch::state::DispatchState>,
+    layer: &Arc<crate::dispatch::layer::LayerState>,
+) {
+    use crate::dispatch::state::ApprovalResponse;
     use crate::mcp::approval::ApprovalFallback;
 
     let now = chrono::Utc::now();
-    let mut queue = state.root.approval_queue.lock().await;
-    let to_resolve: Vec<_> = queue
-        .iter()
-        .enumerate()
-        .filter_map(|(idx, a)| {
-            // Only process if TTL is set (None means never expires)
-            if let Some(ttl_secs) = a.ttl_secs {
-                let age = (now - a.created_at).num_seconds() as u64;
-                // Check if expired and not a Block fallback
-                if age > ttl_secs {
-                    let fallback = a.fallback.unwrap_or(ApprovalFallback::Block);
-                    if !matches!(fallback, ApprovalFallback::Block) {
-                        return Some((idx, a.request_id.clone(), fallback));
-                    }
-                }
-            }
-            None
-        })
-        .collect();
+    let mut queue = layer.approval_queue.lock().await;
 
-    // Remove expired in reverse so indices stay valid
-    for (idx, request_id, fallback) in to_resolve.into_iter().rev() {
-        queue.remove(idx);
+    let mut i = 0;
+    let mut expired = Vec::new();
+    while i < queue.len() {
+        let expired_now = match queue[i].ttl_secs {
+            Some(ttl_secs) => {
+                let age = (now - queue[i].created_at).num_seconds() as u64;
+                let fallback = queue[i].fallback.unwrap_or(ApprovalFallback::Block);
+                age > ttl_secs && !matches!(fallback, ApprovalFallback::Block)
+            }
+            None => false,
+        };
+        if expired_now {
+            expired.push(queue.remove(i).expect("index in range"));
+        } else {
+            i += 1;
+        }
+    }
+    drop(queue);
+
+    for entry in expired {
+        let fallback = entry.fallback.unwrap_or(ApprovalFallback::Block);
+        let approved = matches!(fallback, ApprovalFallback::AutoApprove);
         tracing::info!(
-            request_id = %request_id,
+            request_id = %entry.request_id,
+            task_id = %entry.task_id,
             fallback = ?fallback,
+            approved,
             "approval TTL expired, applying fallback"
         );
-        // Note: The response_tx was already consumed when the approval was enqueued.
-        // The actual response handling would be implemented when integrating with
-        // the request_approval flow to capture and send back responses.
+        let response = ApprovalResponse {
+            approved,
+            comment: Some("TTL expired".to_string()),
+            edited_summary: None,
+            reason: Some(format!("TTL expired: fallback={fallback:?}")),
+        };
+        state
+            .record_last_approval_response(&entry.task_id, approved)
+            .await;
+        // Best-effort: responder may have been dropped if the caller gave up.
+        let _ = entry.responder.send(response);
     }
 }
 

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -136,13 +136,10 @@ pub struct LastApprovalResponse {
 /// Returned by `DispatchState::approval_driven_termination`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ApprovalTerminationKind {
-    /// Last approval returned `{approved: false}` from an operator action
-    /// or a `[[approval_policy]]` `auto_reject` rule.
+    /// Last approval returned `{approved: false}` from an operator action,
+    /// a `[[approval_policy]]` `auto_reject` rule, or a TTL fallback of
+    /// `auto_reject`.
     Rejected,
-    // Future: TimedOut variant when queue-TTL fallback is wired through to
-    // an actual {approved: false} response (today's expire_approvals removes
-    // the entry without responding, so the actor sees a bridge timeout
-    // rather than a clean rejection — that's a separate fix).
 }
 
 #[derive(Default, Clone, Debug)]

--- a/crates/pitboss-core/src/process/fake.rs
+++ b/crates/pitboss-core/src/process/fake.rs
@@ -81,6 +81,10 @@ struct FakeChild {
     stdout: Option<Pin<Box<DuplexStream>>>,
     stderr: Option<Pin<Box<DuplexStream>>>,
     exit_rx: Option<oneshot::Receiver<i32>>,
+    /// Populated if `try_wait` observed a ready exit code before `wait`
+    /// was called, so `wait` still returns the correct status instead of
+    /// the -1 fallback.
+    cached_exit_code: Option<i32>,
     kill_tx: Option<oneshot::Sender<()>>,
     pid: u32,
 }
@@ -93,7 +97,31 @@ impl ChildProcess for FakeChild {
     fn take_stderr(&mut self) -> Option<Pin<Box<dyn AsyncRead + Send + Unpin>>> {
         self.stderr.take().map(|s| s as _)
     }
+    fn try_wait(&mut self) -> std::io::Result<Option<ExitStatus>> {
+        if let Some(code) = self.cached_exit_code {
+            return Ok(Some(exit_status_from_code(code)));
+        }
+        if let Some(rx) = self.exit_rx.as_mut() {
+            match rx.try_recv() {
+                Ok(code) => {
+                    self.cached_exit_code = Some(code);
+                    self.exit_rx = None;
+                    Ok(Some(exit_status_from_code(code)))
+                }
+                Err(oneshot::error::TryRecvError::Empty) => Ok(None),
+                Err(oneshot::error::TryRecvError::Closed) => {
+                    self.exit_rx = None;
+                    Ok(Some(exit_status_from_code(-1)))
+                }
+            }
+        } else {
+            Ok(None)
+        }
+    }
     async fn wait(&mut self) -> std::io::Result<ExitStatus> {
+        if let Some(code) = self.cached_exit_code.take() {
+            return Ok(exit_status_from_code(code));
+        }
         let code = if let Some(rx) = self.exit_rx.take() {
             rx.await.unwrap_or(-1)
         } else {
@@ -166,6 +194,7 @@ impl ProcessSpawner for FakeSpawner {
             stdout: Some(Box::pin(stdout_r)),
             stderr: Some(Box::pin(stderr_r)),
             exit_rx: Some(exit_rx),
+            cached_exit_code: None,
             kill_tx: Some(kill_tx),
             pid: 1,
         }))

--- a/crates/pitboss-core/src/process/spawner.rs
+++ b/crates/pitboss-core/src/process/spawner.rs
@@ -24,6 +24,9 @@ pub trait ChildProcess: Send {
     fn take_stdout(&mut self) -> Option<Pin<Box<dyn AsyncRead + Send + Unpin>>>;
     /// Take stderr (consuming — may only be called once).
     fn take_stderr(&mut self) -> Option<Pin<Box<dyn AsyncRead + Send + Unpin>>>;
+    /// Non-blocking check: return `Ok(Some(status))` if the child has
+    /// already exited, `Ok(None)` if it's still running.
+    fn try_wait(&mut self) -> std::io::Result<Option<ExitStatus>>;
     /// Wait for the child to exit. Must be called exactly once.
     async fn wait(&mut self) -> std::io::Result<ExitStatus>;
     /// Send SIGTERM (best effort).

--- a/crates/pitboss-core/src/process/tokio_impl.rs
+++ b/crates/pitboss-core/src/process/tokio_impl.rs
@@ -33,6 +33,10 @@ impl ChildProcess for TokioChild {
         self.inner.stderr.take().map(|s| Box::pin(s) as _)
     }
 
+    fn try_wait(&mut self) -> std::io::Result<Option<ExitStatus>> {
+        self.inner.try_wait()
+    }
+
     async fn wait(&mut self) -> std::io::Result<ExitStatus> {
         self.inner.wait().await
     }

--- a/crates/pitboss-core/src/session/handle.rs
+++ b/crates/pitboss-core/src/session/handle.rs
@@ -78,6 +78,7 @@ impl SessionHandle {
     /// stdout.
     #[allow(clippy::too_many_lines)]
     pub async fn run_to_completion(self, cancel: CancelToken, timeout: Duration) -> SessionOutcome {
+        const STREAM_DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
         let _ = self.task_id; // kept for future logging
         let started_at = Utc::now();
 
@@ -153,15 +154,28 @@ impl SessionHandle {
             None
         };
 
-        let terminate_fut = cancel.await_terminate();
-        tokio::pin!(terminate_fut);
+        // Shortcut: if the child already exited before we reached this
+        // point (e.g. very fast subprocess, or a CancelToken that was
+        // pre-terminated before the session even entered the select), take
+        // that exit directly. Without this check the select below —
+        // especially with `biased` — can classify a cleanly-finished child
+        // as `Terminated`, discarding the exit code, token usage and
+        // claude_session_id.
+        let end_reason = if let Ok(Some(status)) = child.try_wait() {
+            EndReason::Exited(Some(status))
+        } else {
+            let terminate_fut = cancel.await_terminate();
+            tokio::pin!(terminate_fut);
 
-        // Primary race: child exit, terminate signal, or overall timeout.
-        let end_reason = tokio::select! {
-            biased;
-            () = &mut terminate_fut => EndReason::Terminated,
-            () = tokio::time::sleep(timeout) => EndReason::TimedOut,
-            status = child.wait() => EndReason::Exited(status.ok()),
+            // Primary race: child exit, terminate signal, or overall timeout.
+            // No `biased` — if both the child's exit and terminate are ready in
+            // the same poll, fair selection avoids systematically preferring
+            // cancellation over a clean completion.
+            tokio::select! {
+                () = &mut terminate_fut => EndReason::Terminated,
+                () = tokio::time::sleep(timeout) => EndReason::TimedOut,
+                status = child.wait() => EndReason::Exited(status.ok()),
+            }
         };
 
         // If we need to stop the child, send SIGTERM and wait up to TERMINATE_GRACE.
@@ -185,10 +199,25 @@ impl SessionHandle {
             }
         };
 
-        // Let stream_task + stderr_task wrap up briefly (they see EOF when child's pipes close).
-        let _ = tokio::time::timeout(Duration::from_secs(1), stream_task).await;
+        // Let the stream + stderr drain tasks finish. Stdout/stderr EOF is
+        // guaranteed once the child is reaped, so we can wait generously
+        // — a premature timeout here would throw away the final
+        // Event::Result (which carries token usage, cost, and the claude
+        // session id) and misclassify the task as `Failed { "no result
+        // event" }`. A multi-second ceiling is kept as a safety net so a
+        // hung log writer can't wedge the dispatcher indefinitely.
+        if tokio::time::timeout(STREAM_DRAIN_TIMEOUT, stream_task)
+            .await
+            .is_err()
+        {
+            tracing::warn!(
+                "stream drain exceeded {}s after child exit; final Event::Result \
+                 may be lost",
+                STREAM_DRAIN_TIMEOUT.as_secs()
+            );
+        }
         if let Some(t) = stderr_task {
-            let _ = tokio::time::timeout(Duration::from_secs(1), t).await;
+            let _ = tokio::time::timeout(STREAM_DRAIN_TIMEOUT, t).await;
         }
 
         let exit_code = exit_status

--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -194,7 +194,15 @@ pub fn run(run_dir: PathBuf, run_id: String) -> anyhow::Result<()> {
         }
 
         // --- Snapshot from watcher (non-blocking) ---
-        if let Ok(snapshot) = snapshot_rx.try_recv() {
+        // Drain: if multiple snapshots queued up while the main loop was
+        // busy (e.g. a slow render tick), keep the most recent and drop the
+        // stale ones. This also prevents the 4-capacity channel from
+        // staying full and tripping the watcher's backpressure path.
+        let mut latest_snapshot: Option<AppSnapshot> = None;
+        while let Ok(snapshot) = snapshot_rx.try_recv() {
+            latest_snapshot = Some(snapshot);
+        }
+        if let Some(snapshot) = latest_snapshot {
             state.apply_snapshot(snapshot);
             // If we're in snap-in mode and at the bottom, keep the view
             // scrolled to the last line as new log lines arrive.

--- a/crates/pitboss-tui/src/watcher.rs
+++ b/crates/pitboss-tui/src/watcher.rs
@@ -88,9 +88,12 @@ pub fn watch(
             }
 
             let snapshot = build_snapshot(&run_dir, focused_id.as_deref());
-            // If the receiver is gone (app quit), exit thread.
-            if snapshot_tx.try_send(snapshot).is_err() {
-                break;
+            // Full channel means the UI is temporarily behind (e.g. a blocking
+            // render tick). Drop this snapshot — the next tick will publish
+            // a fresh one. Only a disconnected receiver ends the watcher.
+            match snapshot_tx.try_send(snapshot) {
+                Ok(()) | Err(mpsc::TrySendError::Full(_)) => {}
+                Err(mpsc::TrySendError::Disconnected(_)) => break,
             }
 
             // Wait up to POLL_INTERVAL_MS for the next tick, OR wake early


### PR DESCRIPTION
## Summary

Fixes the five open `severity:high` issues (#50, #51, #52, #53, #54).

### Approval subsystem (#50, #51)
`dispatch/runner.rs`
- Extracted `expire_layer_approvals` and call it for the root layer **plus every sub-lead layer** — depth-2 sublead approvals now honor their TTL + fallback policy (#51).
- TTL expiry now actually sends an `ApprovalResponse` on the queued `oneshot::Sender` (`AutoApprove` → `approved=true`, `AutoReject` → `false`) and records it via `record_last_approval_response`, so the requesting Claude agent unblocks immediately instead of hanging until the MCP bridge timeout (#50).
- Removed the now-obsolete "Future: TimedOut" TODO on `ApprovalTerminationKind` — the code it was waiting on now exists.

### TUI watcher (#52)
`pitboss-tui/src/watcher.rs`, `app.rs`
- `TrySendError::Full` now means "UI is temporarily behind, drop this snapshot and try again next tick"; only `Disconnected` ends the watcher thread. Previously both were conflated and a single >1 s UI stall killed live updates until restart.
- The app loop drains all queued snapshots and applies only the latest, reducing the chance of filling the 4-capacity channel in the first place.

### SessionHandle (#53, #54)
`pitboss-core/src/session/handle.rs`, plus `process/` trait + impls
- Added `try_wait` to `ChildProcess` (TokioChild delegates to `tokio::process::Child::try_wait`; FakeChild peeks the oneshot and caches the code so a follow-up `wait()` still returns the correct status).
- `run_to_completion` checks `try_wait` first — a child that already exited skips the select and is classified as `Exited`, not `Terminated` (#53). Removed `biased;` so a live race between child exit and terminate is fair.
- Stream-drain timeout after child exit raised from 1 s → 30 s with a `tracing::warn!` if it ever fires. Stdout EOF is guaranteed once the child is reaped, so the tight bound was systematically discarding the final `Event::Result` (token usage, cost, `claude_session_id`) on slow pipes and misclassifying clean tasks as `Failed { "no result event" }` (#54).

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --lib -p pitboss-cli` — 343/343
- [x] `cargo test --lib -p pitboss-tui` — 106/106
- [x] `cargo test --lib -p pitboss-core` — `session::` 16/16, `process::` 5/5 (8 pre-existing `worktree::tests` failures are unrelated — local `git init` defaults to `main` but tests expect `master`; verified they also fail on the base branch)
- [x] Manual: exercise `request_approval` with `ttl_secs` in a headless run and confirm the caller unblocks with `approved=false` at TTL — **PASS** (completed in ~28s vs 120s lead_timeout_secs; see `examples/pr71-manual-tests/01-approval-ttl-root.toml`)
- [x] Manual: hierarchical run with a sublead that requests approval, confirm sublead TTL fires — **PASS** (sublead unblocked at TTL; also surfaced issue #72 — stale modal on late TUI connect, fixed in PR #73)
- [x] Manual: run TUI against a repo with a slow `git diff` and confirm tile updates continue after the stall — **PASS** (all 6 tiles updated to terminal state without freezing; see `examples/pr71-manual-tests/03-tui-stall.toml`)
- [x] Manual: run a very short-lived worker and confirm it's recorded as `Success` with a `claude_session_id`, not `Cancelled` / `Failed { "no result event" }` — **PASS** (all 5 tasks: `status=Success`, non-null `claude_session_id`; see `examples/pr71-manual-tests/04-short-lived-worker.toml`)

https://claude.ai/code/session_01Dc5J61yB7QiKYV8LrJsQoA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dc5J61yB7QiKYV8LrJsQoA)_