### PR TITLE
fix(approval): evict stale queue entry when request_approval TTL fires (#72)

### DIFF
--- a/crates/pitboss-cli/src/mcp/approval.rs
+++ b/crates/pitboss-cli/src/mcp/approval.rs
@@ -218,6 +218,14 @@ impl ApprovalBridge {
             Err(_) => {
                 // Timeout: remove the pending entry so a late respond doesn't panic.
                 self.state.approval_bridge.lock().await.remove(&request_id);
+                // Also evict from the TUI-drain queue (Block policy, no TUI connected).
+                // Without this, a TUI that connects after the timeout fires sees a stale
+                // approval modal for a request that has already resolved.
+                self.state
+                    .approval_queue
+                    .lock()
+                    .await
+                    .retain(|q| q.request_id != request_id);
                 Err(ApprovalError::Timeout)
             }
         }


### PR DESCRIPTION
## Summary

- On `tokio::time::timeout` expiry in `ApprovalBridge::request()`, also evict the entry from `state.approval_queue` (the TUI-drain queue) in addition to `state.approval_bridge`.
- Without this, a TUI connecting after TTL expiry drains the stale entry and renders an approval modal for a request that has already resolved.
- Closes #72.

## Root cause

Two queues, one cleanup:

| Queue | Used when |
|-------|-----------|
| `state.approval_bridge` | TUI connected at call time — entry moved here for live response |
| `state.approval_queue` | No TUI at call time, `policy=block` — entry queued here for drain on connect |

The timeout handler only removed from `approval_bridge`. In the Block path the entry is in `approval_queue` — the `remove` was a no-op, leaving the entry to be replayed to any TUI that connects later.

## Test plan

- [x] `cargo clippy -p pitboss-cli --lib -- -D warnings` — clean
- [x] Confirmed bug reproduced on PR #71 build: run approval TTL test with no TUI, then launch TUI after completion → stale modal appears (pre-fix)
- [x] Confirmed modal no longer appears after fix

🤖 Generated with [Claude Code](https://claude.ai/claude-code)