### PR TITLE
fix: resolve 13 medium-severity bugs in dispatch/TUI/storage/notify paths

### DIFF
--- a/crates/pitboss-cli/src/attach.rs
+++ b/crates/pitboss-cli/src/attach.rs
@@ -25,7 +25,7 @@ use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
 
-use pitboss_core::parser::{parse_line, Event};
+use pitboss_core::parser::{parse_line_all, Event};
 
 /// Poll cadence for new bytes. 200 ms feels responsive without burning
 /// CPU when a worker is idle between turns.
@@ -72,6 +72,18 @@ async fn run_async(run_id_prefix: &str, task_id: &str, raw: bool, lines: usize) 
         bail!("task id '{task_id}' resolves outside the run directory; refusing to follow",);
     }
     let log_path = task_dir_canon.join("stdout.log");
+    // stdout.log may itself be a symlink (e.g. if the task dir was pre-
+    // planted with one). The earlier starts_with() check covered the task
+    // dir but not the file, so re-canonicalize and repeat the containment
+    // assertion before opening it. Missing file is fine — follow_log
+    // handles absent logs; we only guard once it exists.
+    if log_path.exists() {
+        let log_canon = std::fs::canonicalize(&log_path)
+            .with_context(|| format!("canonicalize {}", log_path.display()))?;
+        if !log_canon.starts_with(&tasks_root_canon) {
+            bail!("stdout.log for task '{task_id}' resolves outside the run directory; refusing to follow");
+        }
+    }
 
     let mut stderr = std::io::stderr();
     writeln!(
@@ -120,6 +132,9 @@ fn default_runs_dir() -> PathBuf {
 /// directory. Mirrors the resolver in `main.rs` (used by `resume`)
 /// except the error messages are tailored for `attach`.
 fn resolve_run_dir(base: &Path, prefix: &str) -> Result<PathBuf> {
+    if prefix.is_empty() {
+        bail!("run id prefix must not be empty");
+    }
     let entries = std::fs::read_dir(base)
         .with_context(|| format!("cannot read runs directory {}", base.display()))?;
 
@@ -214,8 +229,8 @@ async fn follow_log(
                 // In raw mode we preserve the exact JSON line (newline
                 // appended below). No parse needed for the tail slice.
                 rendered.push(String::from_utf8_lossy(raw_line).into_owned());
-            } else if let Some(s) = format_event_capped(raw_line) {
-                rendered.push(s);
+            } else {
+                rendered.extend(format_event_capped(raw_line));
             }
         }
         let start = rendered.len().saturating_sub(history);
@@ -271,8 +286,10 @@ async fn follow_log(
                     if raw {
                         stdout.write_all(line)?;
                         stdout.write_all(b"\n")?;
-                    } else if let Some(s) = format_event_capped(line) {
-                        writeln!(stdout, "{s}")?;
+                    } else {
+                        for s in format_event_capped(line) {
+                            writeln!(stdout, "{s}")?;
+                        }
                     }
                     // Terminal event — claude wrote its final `result`.
                     // Emit, then exit so pipelines move on.
@@ -294,15 +311,32 @@ async fn follow_log(
 }
 
 fn is_result_event(line: &[u8]) -> bool {
-    matches!(parse_line(line), Ok(Event::Result { .. }))
+    parse_line_all(line)
+        .ok()
+        .is_some_and(|evs| evs.iter().any(|e| matches!(e, Event::Result { .. })))
 }
 
 /// Same shape + caps as the TUI watcher's `format_event` — parse one
-/// stream-json line and return a display string, or `None` to skip.
-/// Duplicated here rather than cross-crate imported so `attach` works
-/// without pulling pitboss-tui into pitboss-cli.
-fn format_event_capped(bytes: &[u8]) -> Option<String> {
-    match parse_line(bytes).ok()? {
+/// stream-json line and return the display string(s). Returns a Vec
+/// because an assistant message with multiple content blocks (e.g.
+/// `[text, tool_use, text]`) renders one line per block. Duplicated here
+/// rather than cross-crate imported so `attach` works without pulling
+/// pitboss-tui into pitboss-cli.
+fn format_event_capped(bytes: &[u8]) -> Vec<String> {
+    let Ok(events) = parse_line_all(bytes) else {
+        return Vec::new();
+    };
+    let mut out = Vec::with_capacity(events.len());
+    for event in events {
+        if let Some(s) = format_single_event_capped(event) {
+            out.push(s);
+        }
+    }
+    out
+}
+
+fn format_single_event_capped(event: Event) -> Option<String> {
+    match event {
         Event::AssistantText { text } => {
             let first = text.lines().find(|l| !l.trim().is_empty()).unwrap_or(&text);
             Some(format!("> {}", cap_with_marker(first, CAP_ASSISTANT_TEXT)))
@@ -389,17 +423,29 @@ mod tests {
     fn format_event_assistant_text_gets_arrow_prefix() {
         let line =
             br#"{"type":"assistant","message":{"content":[{"type":"text","text":"hi there"}]}}"#;
-        let out = format_event_capped(line).unwrap();
-        assert!(out.starts_with("> "));
-        assert!(out.contains("hi there"));
+        let out = format_event_capped(line);
+        assert_eq!(out.len(), 1);
+        assert!(out[0].starts_with("> "));
+        assert!(out[0].contains("hi there"));
     }
 
     #[test]
     fn format_event_result_shows_usage() {
         let line = br#"{"type":"result","session_id":"s","usage":{"input_tokens":10,"output_tokens":5,"cache_read_input_tokens":3,"cache_creation_input_tokens":2}}"#;
-        let out = format_event_capped(line).unwrap();
-        assert!(out.contains("in=10"));
-        assert!(out.contains("out=5"));
+        let out = format_event_capped(line);
+        assert_eq!(out.len(), 1);
+        assert!(out[0].contains("in=10"));
+        assert!(out[0].contains("out=5"));
+    }
+
+    #[test]
+    fn format_event_capped_renders_all_blocks_of_multi_block_assistant() {
+        let line = br#"{"type":"assistant","message":{"content":[{"type":"text","text":"first"},{"type":"tool_use","name":"Read","input":{"file_path":"x"}},{"type":"text","text":"second"}]}}"#;
+        let out = format_event_capped(line);
+        assert_eq!(out.len(), 3, "expected 3 rendered lines, got {out:?}");
+        assert!(out[0].starts_with("> ") && out[0].contains("first"));
+        assert!(out[1].starts_with("* ") && out[1].contains("Read"));
+        assert!(out[2].starts_with("> ") && out[2].contains("second"));
     }
 
     #[test]

--- a/crates/pitboss-cli/src/dispatch/signals.rs
+++ b/crates/pitboss-cli/src/dispatch/signals.rs
@@ -194,14 +194,15 @@ async fn cancel_actor_in_tree(state: &Arc<DispatchState>, target: &str) -> Resul
 /// Two-phase drain semantics are preserved at each layer: the existing
 /// per-layer logic respects its grace window before forceful termination.
 pub fn install_cascade_cancel_watcher(state: Arc<DispatchState>) {
-    let root_cancel = state.root.cancel.clone();
+    let root_cancel_drain = state.root.cancel.clone();
+    let state_drain = state.clone();
     tokio::spawn(async move {
         // Wait for the root layer to drain.
-        root_cancel.await_drain().await;
+        root_cancel_drain.await_drain().await;
         // Cascade to every registered sub-tree.
-        let subleads = state.subleads.read().await;
+        let subleads = state_drain.subleads.read().await;
         for (sublead_id, sub_layer) in subleads.iter() {
-            tracing::info!(sublead_id = %sublead_id, "cascading cancel to sub-tree");
+            tracing::info!(sublead_id = %sublead_id, "cascading drain to sub-tree");
             // Trip the sub-tree's own cancel token so its runner stops
             // spawning new work.
             sub_layer.cancel.drain();
@@ -214,17 +215,34 @@ pub fn install_cascade_cancel_watcher(state: Arc<DispatchState>) {
                 tracing::debug!(
                     sublead_id = %sublead_id,
                     worker_id = %worker_id,
-                    "cascading cancel to sub-tree worker"
+                    "cascading drain to sub-tree worker"
                 );
                 tok.drain();
             }
         }
-        // TODO(Phase 4): Currently only drain cascades; terminate does not.
-        // When Phase 4+ wires real sub-tree workers, sub-tree workers will
-        // receive drain but no terminate cascade — they'd hang waiting for
-        // terminate that never comes. Either add a parallel terminate cascade
-        // OR move worker cancellation into per-sub-tree runners that observe
-        // both their cancel and the run-level escalation.
+    });
+
+    // Parallel watcher for the escalation (second Ctrl-C) path. Without
+    // this, a double Ctrl-C force-terminates root-layer workers but leaves
+    // sub-tree workers only drained — they'd only die when the sublead
+    // itself exits, leaving stray `claude` processes behind.
+    let root_cancel_term = state.root.cancel.clone();
+    tokio::spawn(async move {
+        root_cancel_term.await_terminate().await;
+        let subleads = state.subleads.read().await;
+        for (sublead_id, sub_layer) in subleads.iter() {
+            tracing::info!(sublead_id = %sublead_id, "cascading terminate to sub-tree");
+            sub_layer.cancel.terminate();
+            let worker_cancels = sub_layer.worker_cancels.read().await;
+            for (worker_id, tok) in worker_cancels.iter() {
+                tracing::debug!(
+                    sublead_id = %sublead_id,
+                    worker_id = %worker_id,
+                    "cascading terminate to sub-tree worker"
+                );
+                tok.terminate();
+            }
+        }
     });
 }
 

--- a/crates/pitboss-cli/src/main.rs
+++ b/crates/pitboss-cli/src/main.rs
@@ -274,6 +274,9 @@ fn resolve_run_dir(
     base_runs_dir: &std::path::Path,
     run_id_prefix: &str,
 ) -> Result<std::path::PathBuf> {
+    if run_id_prefix.is_empty() {
+        anyhow::bail!("run id prefix must not be empty");
+    }
     let entries = match std::fs::read_dir(base_runs_dir) {
         Ok(e) => e,
         Err(e) => {

--- a/crates/pitboss-cli/src/manifest/resolve.rs
+++ b/crates/pitboss-cli/src/manifest/resolve.rs
@@ -411,16 +411,24 @@ fn substitute(template: &str, vars: &HashMap<String, String>) -> Result<String> 
             }
             '{' => {
                 let mut name = String::new();
+                let mut closed = false;
                 for nc in iter.by_ref() {
                     if nc == '}' {
-                        let value = vars
-                            .get(&name)
-                            .ok_or_else(|| anyhow!("undeclared var '{}' in template", name))?;
-                        out.push_str(value);
+                        closed = true;
                         break;
                     }
                     name.push(nc);
                 }
+                if !closed {
+                    bail!(
+                        "unclosed '{{' in template string; expected '}}' after '{}'",
+                        name
+                    );
+                }
+                let value = vars
+                    .get(&name)
+                    .ok_or_else(|| anyhow!("undeclared var '{}' in template", name))?;
+                out.push_str(value);
             }
             other => out.push(other),
         }

--- a/crates/pitboss-cli/src/manifest/schema.rs
+++ b/crates/pitboss-cli/src/manifest/schema.rs
@@ -217,6 +217,7 @@ pub struct SingleLeadManifest {
 /// Defaults to a "no-op" state so existing manifests without this block
 /// continue to work identically.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct LeadSpec {
     pub prompt: Option<String>,
     pub model: Option<String>,
@@ -257,6 +258,7 @@ pub struct LeadSpec {
 /// v0.6: optional `[lead.sublead_defaults]` block that supplies fallback values
 /// for `spawn_sublead` when the caller omits them.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct SubleadDefaultsSpec {
     pub budget_usd: Option<f64>,
     pub max_workers: Option<u32>,

--- a/crates/pitboss-cli/src/manifest/schema.rs
+++ b/crates/pitboss-cli/src/manifest/schema.rs
@@ -253,6 +253,25 @@ pub struct LeadSpec {
     /// v0.6: optional defaults applied when `spawn_sublead` omits a param.
     #[serde(default)]
     pub sublead_defaults: Option<SubleadDefaultsSpec>,
+
+    // ── Tolerated-but-unused fields ────────────────────────────────────
+    //
+    // These belong on `[run]`, not `[lead]`, and have been silently
+    // dropped when placed on `[lead]` in manifests since the field was
+    // introduced. `deny_unknown_fields` (#67) would reject them as
+    // typos; listing them explicitly here preserves the historical
+    // accept-and-ignore behavior for existing manifests (e.g. the
+    // dogfood smoke-test set and sublead_flows tests) without
+    // compromising the typo guard for unrelated fields.
+    //
+    // Behavior: these values are parsed then discarded. The authoritative
+    // copies live on `[run]` and are what the dispatcher actually reads.
+    #[serde(default, rename = "budget_usd")]
+    pub _legacy_budget_usd: Option<f64>,
+    #[serde(default, rename = "max_workers")]
+    pub _legacy_max_workers: Option<u32>,
+    #[serde(default, rename = "lead_timeout_secs")]
+    pub _legacy_lead_timeout_secs: Option<u64>,
 }
 
 /// v0.6: optional `[lead.sublead_defaults]` block that supplies fallback values

--- a/crates/pitboss-cli/src/mcp/approval.rs
+++ b/crates/pitboss-cli/src/mcp/approval.rs
@@ -128,28 +128,31 @@ impl ApprovalBridge {
 
         let (tx, rx) = oneshot::channel::<ApprovalResponse>();
 
-        // Does a TUI have the control writer?
-        let writer_present = self.state.control_writer.lock().await.is_some();
+        // Hold the control_writer lock across the `bridge.insert` and the
+        // `w.send(ev)`. A previous version released the writer lock between
+        // the "is it present?" check and the insert, so a TUI that
+        // disconnected in that window would leave the responder orphaned
+        // in `approval_bridge` — stuck until the bridge timeout.
+        let writer_guard = self.state.control_writer.lock().await;
 
-        if writer_present {
+        if let Some(w) = writer_guard.as_ref() {
             self.state
                 .approval_bridge
                 .lock()
                 .await
                 .insert(request_id.clone(), tx);
-            // Push the event to the TUI.
-            if let Some(w) = self.state.control_writer.lock().await.as_ref() {
-                let ev = crate::control::protocol::ControlEvent::ApprovalRequest {
-                    request_id: request_id.clone(),
-                    task_id,
-                    summary,
-                    plan: plan.map(approval_plan_to_wire),
-                    kind,
-                };
-                // Best-effort send.
-                let _ = w.send(ev);
-            }
+            let ev = crate::control::protocol::ControlEvent::ApprovalRequest {
+                request_id: request_id.clone(),
+                task_id,
+                summary,
+                plan: plan.map(approval_plan_to_wire),
+                kind,
+            };
+            // Best-effort send.
+            let _ = w.send(ev);
+            drop(writer_guard);
         } else {
+            drop(writer_guard);
             // No TUI attached: policy decides.
             match self.state.approval_policy {
                 ApprovalPolicy::AutoApprove => {

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -122,12 +122,25 @@ pub fn socket_path_for_run(run_id: Uuid, run_dir: &Path) -> PathBuf {
     if let Some(xdg) = std::env::var_os("XDG_RUNTIME_DIR") {
         let p = PathBuf::from(xdg).join("pitboss");
         if std::fs::create_dir_all(&p).is_ok() {
+            // XDG_RUNTIME_DIR itself is 0o700, but our subdirectory inherits
+            // the process umask; lock it down so other local users cannot
+            // observe the socket file's metadata.
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o700));
+            }
             return p.join(format!("{}.sock", run_id));
         }
     }
     // Fallback: alongside the run artifacts.
     let p = run_dir.join(run_id.to_string());
     let _ = std::fs::create_dir_all(&p);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o700));
+    }
     p.join("mcp.sock")
 }
 
@@ -897,6 +910,15 @@ impl McpServer {
             let _ = std::fs::remove_file(&socket_path);
         }
         let listener = tokio::net::UnixListener::bind(&socket_path)?;
+        // Explicit hardening — inherited umask (e.g. 0022) would leave the
+        // socket world-readable, letting any local user connect and inject
+        // `actor_role: root_lead` in _meta to call spawn_worker / kv_set.
+        // 0o600 restricts to the running user.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o600))?;
+        }
         let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();
         let handler = PitbossHandler::new(state);
 

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -431,13 +431,21 @@ pub async fn handle_spawn_worker(
     // semantics; for now treat None budget_usd on the target layer as
     // uncapped (no reservation placed, same as root-layer uncapped behavior).
     if let Some(budget) = target_layer.manifest.budget_usd {
-        let spent = *target_layer.spent_usd.lock().await;
-        let reserved = *target_layer.reserved_usd.lock().await;
         // Estimate this worker's cost using its intended model, as the median
         // of prior workers priced at their actual models (or a model-specific
         // fallback if no worker has completed yet).
         let estimate = estimate_new_worker_cost_for_layer(&target_layer, &worker_model).await;
+
+        // Hold `reserved_usd` across the whole compute/compare/add step so
+        // two concurrent spawn_workers can't both pass the budget check
+        // before either increments the reservation. Spent_usd is captured
+        // inside the same critical section to keep the arithmetic on a
+        // single consistent snapshot.
+        let mut reserved_guard = target_layer.reserved_usd.lock().await;
+        let spent = *target_layer.spent_usd.lock().await;
+        let reserved = *reserved_guard;
         if spent + reserved + estimate > budget {
+            drop(reserved_guard);
             if let Some(router) = target_layer.notification_router.clone() {
                 let envelope = crate::notify::NotificationEnvelope::new(
                     &state.run_id.to_string(),
@@ -457,7 +465,8 @@ pub async fn handle_spawn_worker(
             );
         }
         // Reserve against the target layer.
-        *target_layer.reserved_usd.lock().await += estimate;
+        *reserved_guard += estimate;
+        drop(reserved_guard);
         target_layer
             .worker_reservations
             .write()

--- a/crates/pitboss-cli/src/notify/mod.rs
+++ b/crates/pitboss-cli/src/notify/mod.rs
@@ -204,7 +204,10 @@ impl NotificationRouter {
 }
 
 /// Try emitting 3 times with exponential backoff: 100ms, 300ms, 900ms.
-/// Returns Ok on first success; Err on final failure.
+/// Returns Ok on first success; Err on final failure. Non-retryable 4xx
+/// client errors (except 429) short-circuit without further attempts —
+/// they will fail identically every time and the delay just postpones the
+/// inevitable failure notification.
 async fn emit_with_retry(
     sink: &Arc<dyn NotificationSink>,
     env: &NotificationEnvelope,
@@ -213,6 +216,14 @@ async fn emit_with_retry(
     for (attempt, &delay_ms) in backoffs.iter().enumerate() {
         match sink.emit(env).await {
             Ok(()) => return Ok(()),
+            Err(e) if is_fatal(&e) => {
+                tracing::warn!(
+                    attempt = attempt + 1,
+                    error = %e,
+                    "notification emit failed fatally, not retrying"
+                );
+                return Err(e);
+            }
             Err(e) if attempt < 2 => {
                 tracing::warn!(
                     attempt = attempt + 1,
@@ -231,8 +242,18 @@ async fn emit_with_retry(
 }
 
 /// Heuristic for determining if an error is fatal (should not retry).
-/// v0.4.1: always false — retry everything.
-fn is_fatal(_err: &anyhow::Error) -> bool {
+/// A 4xx response (except 429 Too Many Requests) means the request is
+/// malformed or unauthenticated — retrying doesn't help. Everything else
+/// (network errors, 5xx, unknown) remains retryable.
+fn is_fatal(err: &anyhow::Error) -> bool {
+    for cause in err.chain() {
+        if let Some(reqwest_err) = cause.downcast_ref::<reqwest::Error>() {
+            if let Some(status) = reqwest_err.status() {
+                return status.is_client_error()
+                    && status != reqwest::StatusCode::TOO_MANY_REQUESTS;
+            }
+        }
+    }
     false
 }
 

--- a/crates/pitboss-cli/src/shared_store/leases.rs
+++ b/crates/pitboss-cli/src/shared_store/leases.rs
@@ -48,14 +48,17 @@ impl LeaseRegistry {
         }
     }
 
+    /// Attempt to acquire `name`. Returns the new lease on success plus the
+    /// names of any leases evicted by TTL during this call — callers lift
+    /// those onto the lease notifier so waiters wake promptly.
     pub async fn acquire(
         &self,
         name: &str,
         ttl: Duration,
         caller: &CallerIdentity,
-    ) -> Result<Lease, StoreError> {
+    ) -> Result<(Lease, Vec<String>), StoreError> {
         let mut map = self.inner.lock().await;
-        Self::prune_expired(&mut map);
+        let evicted = Self::prune_expired(&mut map);
         if map.contains_key(name) {
             return Err(StoreError::Conflict);
         }
@@ -70,12 +73,18 @@ impl LeaseRegistry {
         };
         let deadline = Instant::now() + ttl;
         map.insert(name.to_string(), (lease.clone(), deadline));
-        Ok(lease)
+        Ok((lease, evicted))
     }
 
-    pub async fn release(&self, lease_id: &str, caller: &CallerIdentity) -> Result<(), StoreError> {
+    /// Release a lease by id. Returns the names of any leases evicted by
+    /// TTL during this call so the caller can wake waiters.
+    pub async fn release(
+        &self,
+        lease_id: &str,
+        caller: &CallerIdentity,
+    ) -> Result<Vec<String>, StoreError> {
         let mut map = self.inner.lock().await;
-        Self::prune_expired(&mut map);
+        let evicted = Self::prune_expired(&mut map);
         let found = map
             .iter()
             .find(|(_, (l, _))| l.lease_id == lease_id)
@@ -89,21 +98,24 @@ impl LeaseRegistry {
             return Err(StoreError::Forbidden("only the holder can release".into()));
         }
         map.remove(&name);
-        Ok(())
+        Ok(evicted)
     }
 
-    pub async fn list(&self) -> Vec<Lease> {
+    /// List active leases. Returns (list, evicted-by-ttl-names).
+    pub async fn list(&self) -> (Vec<Lease>, Vec<String>) {
         let mut map = self.inner.lock().await;
-        Self::prune_expired(&mut map);
-        map.values().map(|(l, _)| l.clone()).collect()
+        let evicted = Self::prune_expired(&mut map);
+        (map.values().map(|(l, _)| l.clone()).collect(), evicted)
     }
 
-    /// Release every lease currently held by the given actor. Returns the
-    /// lease names that were released. Called when an actor's MCP
-    /// connection drops.
-    pub async fn release_all_for_actor(&self, actor_id: &str) -> Vec<String> {
+    /// Release every lease currently held by the given actor. Returns
+    /// `(released, evicted_by_ttl)`.
+    pub async fn release_all_for_actor(
+        &self,
+        actor_id: &str,
+    ) -> (Vec<String>, Vec<String>) {
         let mut map = self.inner.lock().await;
-        Self::prune_expired(&mut map);
+        let evicted = Self::prune_expired(&mut map);
         let to_remove: Vec<String> = map
             .iter()
             .filter(|(_, (l, _))| l.holder == actor_id)
@@ -112,12 +124,20 @@ impl LeaseRegistry {
         for name in &to_remove {
             map.remove(name);
         }
-        to_remove
+        (to_remove, evicted)
     }
 
-    fn prune_expired(map: &mut HashMap<String, (Lease, Instant)>) {
+    fn prune_expired(map: &mut HashMap<String, (Lease, Instant)>) -> Vec<String> {
         let now = Instant::now();
-        map.retain(|_, (_, deadline)| *deadline > now);
+        let expired: Vec<String> = map
+            .iter()
+            .filter(|(_, (_, deadline))| *deadline <= now)
+            .map(|(name, _)| name.clone())
+            .collect();
+        for name in &expired {
+            map.remove(name);
+        }
+        expired
     }
 }
 
@@ -142,12 +162,13 @@ mod tests {
     #[tokio::test]
     async fn acquire_succeeds_when_free() {
         let reg = LeaseRegistry::new();
-        let lease = reg
+        let (lease, evicted) = reg
             .acquire("foo", Duration::from_secs(30), &caller("w1"))
             .await
             .unwrap();
         assert_eq!(lease.name, "foo");
         assert_eq!(lease.holder, "w1");
+        assert!(evicted.is_empty());
     }
 
     #[tokio::test]
@@ -166,7 +187,7 @@ mod tests {
     #[tokio::test]
     async fn release_succeeds_by_holder() {
         let reg = LeaseRegistry::new();
-        let lease = reg
+        let (lease, _) = reg
             .acquire("foo", Duration::from_secs(30), &caller("w1"))
             .await
             .unwrap();
@@ -179,7 +200,7 @@ mod tests {
     #[tokio::test]
     async fn release_rejected_for_non_holder() {
         let reg = LeaseRegistry::new();
-        let lease = reg
+        let (lease, _) = reg
             .acquire("foo", Duration::from_secs(30), &caller("w1"))
             .await
             .unwrap();
@@ -197,8 +218,10 @@ mod tests {
             .await
             .unwrap();
         tokio::time::sleep(Duration::from_millis(60)).await;
-        reg.acquire("foo", Duration::from_secs(30), &caller("w2"))
+        let (_, evicted) = reg
+            .acquire("foo", Duration::from_secs(30), &caller("w2"))
             .await
             .unwrap();
+        assert_eq!(evicted, vec!["foo".to_string()]);
     }
 }

--- a/crates/pitboss-cli/src/shared_store/leases.rs
+++ b/crates/pitboss-cli/src/shared_store/leases.rs
@@ -110,10 +110,7 @@ impl LeaseRegistry {
 
     /// Release every lease currently held by the given actor. Returns
     /// `(released, evicted_by_ttl)`.
-    pub async fn release_all_for_actor(
-        &self,
-        actor_id: &str,
-    ) -> (Vec<String>, Vec<String>) {
+    pub async fn release_all_for_actor(&self, actor_id: &str) -> (Vec<String>, Vec<String>) {
         let mut map = self.inner.lock().await;
         let evicted = Self::prune_expired(&mut map);
         let to_remove: Vec<String> = map

--- a/crates/pitboss-cli/src/shared_store/mod.rs
+++ b/crates/pitboss-cli/src/shared_store/mod.rs
@@ -440,7 +440,19 @@ impl SharedStore {
                     match res {
                         Err(_elapsed) => return Err(StoreError::Timeout),
                         Ok(Err(broadcast::error::RecvError::Closed)) => return Err(StoreError::Shutdown),
-                        Ok(Err(broadcast::error::RecvError::Lagged(_))) => continue,
+                        Ok(Err(broadcast::error::RecvError::Lagged(_))) => {
+                            // A burst of unrelated writes evicted entries from
+                            // the 256-slot channel. The write that satisfies
+                            // min may have been one of them — re-read the
+                            // store before waiting again, or we'd block until
+                            // timeout even when the condition is already met.
+                            if let Some(entry) = self.entries.read().await.get(&key) {
+                                if entry.version >= min {
+                                    return Ok(entry.clone());
+                                }
+                            }
+                            continue;
+                        }
                         Ok(Ok(evt)) => {
                             if evt.path == key && evt.version >= min {
                                 if let Some(entry) = self.entries.read().await.get(&key) {
@@ -472,7 +484,8 @@ impl SharedStore {
     ) -> Result<AcquireResult, StoreError> {
         // Non-blocking attempt first.
         match self.leases.acquire(name, ttl, caller).await {
-            Ok(lease) => {
+            Ok((lease, evicted)) => {
+                self.notify_lease_evictions(&evicted);
                 return Ok(AcquireResult {
                     acquired: true,
                     lease_id: Some(lease.lease_id),
@@ -519,7 +532,8 @@ impl SharedStore {
                         Ok(_) => {
                             // Something was released — retry.
                             match self.leases.acquire(name, ttl, caller).await {
-                                Ok(lease) => {
+                                Ok((lease, evicted)) => {
+                                    self.notify_lease_evictions(&evicted);
                                     return Ok(AcquireResult {
                                         acquired: true,
                                         lease_id: Some(lease.lease_id),
@@ -536,12 +550,19 @@ impl SharedStore {
         }
     }
 
+    fn notify_lease_evictions(&self, names: &[String]) {
+        for name in names {
+            let _ = self.lease_notifier.send(name.clone());
+        }
+    }
+
     pub async fn lease_release(
         &self,
         lease_id: &str,
         caller: &CallerIdentity,
     ) -> Result<(), StoreError> {
-        self.leases.release(lease_id, caller).await?;
+        let evicted = self.leases.release(lease_id, caller).await?;
+        self.notify_lease_evictions(&evicted);
         let _ = self.lease_notifier.send(lease_id.to_string());
         Ok(())
     }
@@ -550,7 +571,8 @@ impl SharedStore {
     /// actor's MCP connection drops (lease-on-connection semantics). Wakes
     /// any waiters subscribed via `lease_acquire(wait_secs > 0)`.
     pub async fn release_all_for_actor(&self, actor_id: &str) {
-        let released = self.leases.release_all_for_actor(actor_id).await;
+        let (released, evicted) = self.leases.release_all_for_actor(actor_id).await;
+        self.notify_lease_evictions(&evicted);
         for name in released {
             let _ = self.lease_notifier.send(name);
         }
@@ -591,7 +613,8 @@ impl SharedStore {
             })
             .collect();
         drop(entries);
-        let leases = self.leases.list().await;
+        let (leases, evicted) = self.leases.list().await;
+        self.notify_lease_evictions(&evicted);
         let dump = Dump {
             finalized_at: Utc::now(),
             entries: dump_entries,

--- a/crates/pitboss-core/src/parser/mod.rs
+++ b/crates/pitboss-core/src/parser/mod.rs
@@ -6,7 +6,25 @@ pub use events::{Event, TokenUsage};
 
 use crate::error::ParseError;
 
+/// Parse a single stream-json line and return the first recognized event.
+/// For assistant messages with multiple content blocks, only the first
+/// block is returned — prefer [`parse_line_all`] when the downstream needs
+/// every block (e.g. mid-message `tool_use` after a text block).
+///
+/// Kept for source compatibility with existing callers and tests; new
+/// code should use [`parse_line_all`].
 pub fn parse_line(bytes: &[u8]) -> Result<Event, ParseError> {
+    let mut events = parse_line_all(bytes)?;
+    // `parse_line_all` guarantees at least one element on Ok.
+    Ok(events.remove(0))
+}
+
+/// Parse a single stream-json line and return every event emitted by the
+/// line. For non-assistant lines this is always a single-element vec;
+/// assistant messages expand to one event per `text` / `tool_use` block so
+/// downstream consumers don't drop the tail of a `[text, tool_use, text]`
+/// layout.
+pub fn parse_line_all(bytes: &[u8]) -> Result<Vec<Event>, ParseError> {
     let raw = std::str::from_utf8(bytes)
         .map_err(|_| {
             ParseError::malformed("non-utf8 line", String::from_utf8_lossy(bytes).into_owned())
@@ -28,31 +46,32 @@ pub fn parse_line(bytes: &[u8]) -> Result<Event, ParseError> {
                 .get("subtype")
                 .and_then(|v| v.as_str())
                 .map(str::to_string);
-            Ok(Event::System { subtype })
+            Ok(vec![Event::System { subtype }])
         }
         Some("assistant") => parse_assistant(&value, raw),
-        Some("user") => parse_user(&value, raw),
-        Some("result") => parse_result(&value, raw),
-        Some("rate_limit_event") => Ok(parse_rate_limit(&value)),
-        _ => Ok(Event::Unknown {
+        Some("user") => parse_user(&value, raw).map(|e| vec![e]),
+        Some("result") => parse_result(&value, raw).map(|e| vec![e]),
+        Some("rate_limit_event") => Ok(vec![parse_rate_limit(&value)]),
+        _ => Ok(vec![Event::Unknown {
             raw: raw.to_string(),
-        }),
+        }]),
     }
 }
 
-fn parse_assistant(value: &serde_json::Value, raw: &str) -> Result<Event, ParseError> {
+fn parse_assistant(value: &serde_json::Value, raw: &str) -> Result<Vec<Event>, ParseError> {
     let content = value
         .get("message")
         .and_then(|m| m.get("content"))
         .and_then(|c| c.as_array())
         .ok_or_else(|| ParseError::malformed("assistant missing message.content", raw))?;
 
+    let mut events = Vec::new();
     for block in content {
         let btype = block.get("type").and_then(|v| v.as_str()).unwrap_or("");
         match btype {
             "text" => {
                 if let Some(text) = block.get("text").and_then(|v| v.as_str()) {
-                    return Ok(Event::AssistantText {
+                    events.push(Event::AssistantText {
                         text: text.to_string(),
                     });
                 }
@@ -67,7 +86,7 @@ fn parse_assistant(value: &serde_json::Value, raw: &str) -> Result<Event, ParseE
                     .get("input")
                     .map(ToString::to_string)
                     .unwrap_or_default();
-                return Ok(Event::AssistantToolUse {
+                events.push(Event::AssistantToolUse {
                     tool_name,
                     input_summary,
                 });
@@ -76,10 +95,13 @@ fn parse_assistant(value: &serde_json::Value, raw: &str) -> Result<Event, ParseE
         }
     }
 
-    Err(ParseError::malformed(
-        "assistant content had no text or tool_use block",
-        raw,
-    ))
+    if events.is_empty() {
+        return Err(ParseError::malformed(
+            "assistant content had no text or tool_use block",
+            raw,
+        ));
+    }
+    Ok(events)
 }
 
 fn parse_user(value: &serde_json::Value, raw: &str) -> Result<Event, ParseError> {

--- a/crates/pitboss-core/src/session/handle.rs
+++ b/crates/pitboss-core/src/session/handle.rs
@@ -8,7 +8,7 @@ use tokio::fs::OpenOptions;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::Mutex;
 
-use crate::parser::{parse_line, Event, TokenUsage};
+use crate::parser::{parse_line_all, Event, TokenUsage};
 use crate::process::{ProcessSpawner, SpawnCmd};
 
 use super::{CancelToken, SessionOutcome, SessionState};
@@ -284,37 +284,42 @@ async fn stream_loop(
                     let _ = w.write_all(line.as_bytes()).await;
                     let _ = w.write_all(b"\n").await;
                 }
-                match parse_line(line.as_bytes()) {
-                    Ok(Event::AssistantText { text }) => {
-                        let mut a = accum.lock().await;
-                        // Prefer the longest nontrivial assistant text as the preview.
-                        // Rationale: claude often appends a short confirmation
-                        // ("Done.", "OK") after the real output; taking the last text
-                        // buries the real content. A length-keyed winner avoids that.
-                        let trimmed_len = text.trim().len();
-                        let current_len = a
-                            .last_text
-                            .as_deref()
-                            .map_or(0, |t| t.trim_end_matches('…').trim().len());
-                        if trimmed_len >= current_len {
-                            a.last_text = Some(truncate_preview(&text));
+                let Ok(events) = parse_line_all(line.as_bytes()) else {
+                    continue;
+                };
+                for ev in events {
+                    match ev {
+                        Event::AssistantText { text } => {
+                            let mut a = accum.lock().await;
+                            // Prefer the longest nontrivial assistant text as the preview.
+                            // Rationale: claude often appends a short confirmation
+                            // ("Done.", "OK") after the real output; taking the last text
+                            // buries the real content. A length-keyed winner avoids that.
+                            let trimmed_len = text.trim().len();
+                            let current_len = a
+                                .last_text
+                                .as_deref()
+                                .map_or(0, |t| t.trim_end_matches('…').trim().len());
+                            if trimmed_len >= current_len {
+                                a.last_text = Some(truncate_preview(&text));
+                            }
                         }
-                    }
-                    Ok(Event::Result {
-                        session_id: sid,
-                        usage: u,
-                        ..
-                    }) => {
-                        let mut a = accum.lock().await;
-                        if let Some(tx) = &session_id_tx {
-                            // Best-effort: if receiver is closed or full, drop the send.
-                            let _ = tx.try_send(sid.clone());
+                        Event::Result {
+                            session_id: sid,
+                            usage: u,
+                            ..
+                        } => {
+                            let mut a = accum.lock().await;
+                            if let Some(tx) = &session_id_tx {
+                                // Best-effort: if receiver is closed or full, drop the send.
+                                let _ = tx.try_send(sid.clone());
+                            }
+                            a.session_id = Some(sid);
+                            a.usage.add(&u);
+                            a.saw_result = true;
                         }
-                        a.session_id = Some(sid);
-                        a.usage.add(&u);
-                        a.saw_result = true;
+                        _ => {}
                     }
-                    Ok(_) | Err(_) => {}
                 }
             }
             Ok(None) | Err(_) => return,

--- a/crates/pitboss-core/src/store/sqlite.rs
+++ b/crates/pitboss-core/src/store/sqlite.rs
@@ -51,6 +51,14 @@ impl SqliteStore {
     pub fn new(path: PathBuf) -> Result<Self, StoreError> {
         let conn = rusqlite::Connection::open(path)
             .map_err(|e| StoreError::Incomplete(format!("sqlite open: {e}")))?;
+        // Enable WAL so concurrent readers (e.g. `pitboss diff` opening the
+        // same DB file while the dispatcher is writing) don't hit SQLITE_BUSY
+        // from the default rollback journal. Pair with a generous busy_timeout
+        // so the rare contended write retries rather than bailing.
+        conn.pragma_update(None, "journal_mode", "WAL")
+            .map_err(|e| StoreError::Incomplete(format!("pragma journal_mode: {e}")))?;
+        conn.pragma_update(None, "busy_timeout", 5000)
+            .map_err(|e| StoreError::Incomplete(format!("pragma busy_timeout: {e}")))?;
         // Migration order matters: rename the legacy `shire_version` column
         // BEFORE init_schema runs its CREATE TABLE IF NOT EXISTS, otherwise
         // the pragma check below would still see the old column name for an
@@ -538,7 +546,7 @@ impl SessionStore for SqliteStore {
         let started_at = meta.started_at.to_rfc3339();
 
         tokio::task::spawn_blocking(move || {
-            let guard = conn.lock().unwrap();
+            let guard = conn.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
             guard
                 .execute(
                     "INSERT OR REPLACE INTO runs \
@@ -567,7 +575,7 @@ impl SessionStore for SqliteStore {
         let run_id_str = run_id.to_string();
 
         tokio::task::spawn_blocking(move || {
-            let guard = conn.lock().unwrap();
+            let guard = conn.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
             guard
                 .execute(
                     "INSERT OR REPLACE INTO task_records \
@@ -633,7 +641,7 @@ impl SessionStore for SqliteStore {
         let was_interrupted = i64::from(summary.was_interrupted);
 
         tokio::task::spawn_blocking(move || {
-            let guard = conn.lock().unwrap();
+            let guard = conn.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
             let rows = guard
                 .execute(
                     "UPDATE runs \
@@ -664,7 +672,7 @@ impl SessionStore for SqliteStore {
         let conn = Arc::clone(&self.inner);
 
         tokio::task::spawn_blocking(move || {
-            let guard = conn.lock().unwrap();
+            let guard = conn.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
             load_run_blocking(&guard, run_id)
         })
         .await

--- a/crates/pitboss-core/src/store/sqlite.rs
+++ b/crates/pitboss-core/src/store/sqlite.rs
@@ -546,7 +546,9 @@ impl SessionStore for SqliteStore {
         let started_at = meta.started_at.to_rfc3339();
 
         tokio::task::spawn_blocking(move || {
-            let guard = conn.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            let guard = conn
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             guard
                 .execute(
                     "INSERT OR REPLACE INTO runs \
@@ -641,7 +643,9 @@ impl SessionStore for SqliteStore {
         let was_interrupted = i64::from(summary.was_interrupted);
 
         tokio::task::spawn_blocking(move || {
-            let guard = conn.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            let guard = conn
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             let rows = guard
                 .execute(
                     "UPDATE runs \
@@ -672,7 +676,9 @@ impl SessionStore for SqliteStore {
         let conn = Arc::clone(&self.inner);
 
         tokio::task::spawn_blocking(move || {
-            let guard = conn.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            let guard = conn
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             load_run_blocking(&guard, run_id)
         })
         .await

--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -42,48 +42,44 @@ pub fn run(run_dir: PathBuf, run_id: String) -> anyhow::Result<()> {
     let (ctrl_events_tx, ctrl_events_rx) =
         std::sync::mpsc::channel::<pitboss_cli::control::protocol::ControlEvent>();
 
-    // Resolve the control socket path from the run dir. Best-effort: if the
-    // uuid parse or socket open fails, the TUI continues in observe-only mode.
-    let control_client = match uuid::Uuid::parse_str(&state.run_id) {
-        Ok(uuid) => {
-            let socket_path = pitboss_cli::control::control_socket_path(uuid, &state.run_dir);
-            let (bridge_tx, mut bridge_rx) =
-                tokio::sync::mpsc::channel::<pitboss_cli::control::protocol::ControlEvent>(64);
-            // Forward async → sync so the render loop can pull without tokio.
-            let forward_tx = ctrl_events_tx.clone();
-            runtime.spawn(async move {
-                while let Some(ev) = bridge_rx.recv().await {
-                    if forward_tx.send(ev).is_err() {
-                        break;
+    // Connect to the run's control socket. Extracted into a closure so the
+    // same path can be used on both initial startup and when the user
+    // switches runs — without a fresh client, control ops after SwitchRun
+    // would still target the old run's socket.
+    let connect_control = |state: &mut AppState| {
+        let client = match uuid::Uuid::parse_str(&state.run_id) {
+            Ok(uuid) => {
+                let socket_path = pitboss_cli::control::control_socket_path(uuid, &state.run_dir);
+                let (bridge_tx, mut bridge_rx) =
+                    tokio::sync::mpsc::channel::<pitboss_cli::control::protocol::ControlEvent>(64);
+                let forward_tx = ctrl_events_tx.clone();
+                runtime.spawn(async move {
+                    while let Some(ev) = bridge_rx.recv().await {
+                        if forward_tx.send(ev).is_err() {
+                            break;
+                        }
                     }
-                }
-            });
-            let client = runtime
-                .block_on(crate::control::ControlClient::connect(
-                    socket_path,
-                    bridge_tx,
-                ))
-                .ok();
-            client.map(Arc::new)
-        }
-        Err(_) => None,
+                });
+                runtime
+                    .block_on(crate::control::ControlClient::connect(
+                        socket_path,
+                        bridge_tx,
+                    ))
+                    .ok()
+                    .map(Arc::new)
+            }
+            Err(_) => None,
+        };
+        state.control_connected = client.as_ref().is_some_and(|c| c.is_connected());
+        state.control_client = client;
+        state.runtime_handle = Some(runtime.handle().clone());
     };
-    state.control_connected = control_client.as_ref().is_some_and(|c| c.is_connected());
-    state.control_client = control_client;
-    // Stash a handle to THE runtime the ControlClient was built under.
-    // `send_op` callers must spawn on this handle — spinning up a fresh
-    // runtime per call (as the removed `futures_block_on` helper did)
-    // left the socket writer registered with a dead reactor and every
-    // kill/pause/reprompt op hung without error.
-    state.runtime_handle = Some(runtime.handle().clone());
-    // `runtime` owns the background reader + forward tasks and must be kept
-    // alive for the full event loop. It falls out of scope at the end of
-    // `run()`; the tasks are dropped cleanly then.
-    let _runtime = runtime;
-    // Our local handle to `ctrl_events_tx` is unused past this point — the
-    // forward task owns the only clone that matters. Dropping makes the
-    // receiver observe a closed channel once the forwarder exits.
-    drop(ctrl_events_tx);
+
+    connect_control(&mut state);
+    // `ctrl_events_tx` and `runtime` are both held by `connect_control`
+    // (the closure clones the sender and spawns tasks on the runtime). They
+    // have to stay alive for the full event loop so a SwitchRun can rebuild
+    // the control client. Both fall out of scope at the end of `run()`.
 
     // Mutable channel endpoints so we can swap them when switching runs.
     let (mut snapshot_rx, mut focus_tx) = spawn_watcher(run_dir);
@@ -129,6 +125,11 @@ pub fn run(run_dir: PathBuf, run_id: String) -> anyhow::Result<()> {
                             state.focus = 0;
                             state.run_list.clear();
                             state.mode = Mode::Normal;
+                            // Rebuild the control client against the new run's
+                            // socket; without this, post-switch control ops
+                            // (cancel/pause/approve/reprompt) keep targeting
+                            // the previous run.
+                            connect_control(&mut state);
                             let _ = focus_tx.send(String::new());
                             dirty = true;
                             continue;
@@ -157,8 +158,9 @@ pub fn run(run_dir: PathBuf, run_id: String) -> anyhow::Result<()> {
                         Action::Quit => break,
                         Action::SwitchRun { run_dir, run_id } => {
                             // Same transition as the keyboard-driven
-                            // SwitchRun path above — restart the watcher
-                            // and reset run-local state.
+                            // SwitchRun path above — restart the watcher,
+                            // rebuild the control client, and reset
+                            // run-local state.
                             let (new_rx, new_tx) = spawn_watcher(run_dir.clone());
                             snapshot_rx = new_rx;
                             focus_tx = new_tx;
@@ -168,6 +170,7 @@ pub fn run(run_dir: PathBuf, run_id: String) -> anyhow::Result<()> {
                             state.focus = 0;
                             state.run_list.clear();
                             state.mode = Mode::Normal;
+                            connect_control(&mut state);
                             let _ = focus_tx.send(String::new());
                             dirty = true;
                             continue;

--- a/crates/pitboss-tui/src/state.rs
+++ b/crates/pitboss-tui/src/state.rs
@@ -650,19 +650,37 @@ impl AppState {
 /// Compute `git diff --stat HEAD` in the given directory. Walks up to
 /// find the enclosing git worktree (so passing in `<run-dir>/tasks/<id>/`
 /// works — git discovers the worktree via the parent hierarchy). Returns
-/// `None` if the shell-out fails or the directory isn't inside a worktree.
+/// `None` if the shell-out fails, the directory isn't inside a worktree,
+/// or the command exceeds the wall-clock timeout.
 ///
-/// Blocks the caller for ~20-50 ms. Only called once on detail-view entry;
-/// cached in `AppState.cached_git_diff` thereafter.
+/// Blocks the caller until git returns or `GIT_DIFF_TIMEOUT` elapses.
+/// Callers that run this on the event loop should wrap it in a background
+/// thread (see `AppState` for the polling pattern) — without that, a
+/// slow or contended `.git` freezes input handling.
+///
+/// `--no-optional-locks` avoids taking the index lock, so a concurrent
+/// `git commit` / `gc` can't contend with the TUI's read.
 pub(crate) fn compute_git_diff_summary(worktree: &std::path::Path) -> Option<GitDiffSummary> {
-    let output = std::process::Command::new("git")
-        .arg("-C")
-        .arg(worktree)
-        .arg("diff")
-        .arg("--shortstat")
-        .arg("HEAD")
-        .output()
-        .ok()?;
+    const GIT_DIFF_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    let worktree = worktree.to_path_buf();
+    std::thread::spawn(move || {
+        let output = std::process::Command::new("git")
+            .arg("--no-optional-locks")
+            .arg("-C")
+            .arg(&worktree)
+            .arg("diff")
+            .arg("--shortstat")
+            .arg("HEAD")
+            .output();
+        let _ = tx.send(output);
+    });
+
+    let Ok(Ok(output)) = rx.recv_timeout(GIT_DIFF_TIMEOUT) else {
+        return None;
+    };
+
     if !output.status.success() {
         return None;
     }

--- a/crates/pitboss-tui/src/watcher.rs
+++ b/crates/pitboss-tui/src/watcher.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::time::Duration;
 
-use pitboss_core::parser::{parse_line, Event};
+use pitboss_core::parser::{parse_line_all, Event};
 use pitboss_core::store::{TaskRecord, TaskStatus};
 use serde::Deserialize;
 
@@ -539,9 +539,7 @@ fn tail_log(path: &Path, n: usize) -> Vec<String> {
         if trimmed.is_empty() {
             continue;
         }
-        if let Some(display) = format_event(trimmed.as_bytes()) {
-            rendered.push(display);
-        }
+        rendered.extend(format_event(trimmed.as_bytes()));
     }
     if rendered.len() <= n {
         rendered
@@ -559,9 +557,25 @@ const CAP_ASSISTANT_TEXT: usize = 2000;
 const CAP_TOOL_INPUT: usize = 1000;
 const CAP_TOOL_RESULT: usize = 3000;
 
-/// Parse one stream-json line and return a display string, or `None` to skip.
-fn format_event(bytes: &[u8]) -> Option<String> {
-    let event = parse_line(bytes).ok()?;
+/// Parse one stream-json line and return the display string(s).
+///
+/// Returns a Vec because an assistant message can carry multiple content
+/// blocks (e.g. `[text, tool_use, text]`) — each renders to its own line
+/// so the operator sees every step of a multi-block turn.
+fn format_event(bytes: &[u8]) -> Vec<String> {
+    let Ok(events) = parse_line_all(bytes) else {
+        return Vec::new();
+    };
+    let mut out = Vec::with_capacity(events.len());
+    for event in events {
+        if let Some(s) = format_single_event(event) {
+            out.push(s);
+        }
+    }
+    out
+}
+
+fn format_single_event(event: Event) -> Option<String> {
     match event {
         Event::AssistantText { text } => {
             let first_line = text.lines().find(|l| !l.trim().is_empty()).unwrap_or(&text);
@@ -681,63 +695,68 @@ mod tests {
     fn format_event_assistant_text() {
         let line =
             br#"{"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]}}"#;
-        let out = format_event(line).unwrap();
-        assert!(out.starts_with("> "));
-        assert!(out.contains("hello"));
+        let out = format_event(line);
+        assert_eq!(out.len(), 1);
+        assert!(out[0].starts_with("> "));
+        assert!(out[0].contains("hello"));
     }
 
     #[test]
     fn format_event_tool_use() {
         let line = br#"{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Write","input":{"file_path":"x"}}]}}"#;
-        let out = format_event(line).unwrap();
-        assert!(out.starts_with("* "));
-        assert!(out.contains("Write"));
+        let out = format_event(line);
+        assert_eq!(out.len(), 1);
+        assert!(out[0].starts_with("* "));
+        assert!(out[0].contains("Write"));
     }
 
     #[test]
     fn format_event_tool_result() {
         let line =
             br#"{"type":"user","message":{"content":[{"type":"tool_result","content":"ok"}]}}"#;
-        let out = format_event(line).unwrap();
-        assert!(out.starts_with("< "));
-        assert!(out.contains("ok"));
+        let out = format_event(line);
+        assert_eq!(out.len(), 1);
+        assert!(out[0].starts_with("< "));
+        assert!(out[0].contains("ok"));
     }
 
     #[test]
     fn format_event_result() {
         let line = br#"{"type":"result","session_id":"sess_abcdef12","usage":{"input_tokens":1,"output_tokens":2}}"#;
-        let out = format_event(line).unwrap();
-        assert!(out.starts_with("v "));
-        assert!(out.contains("sess_abc"));
-        assert!(out.contains("in=1"));
-        assert!(out.contains("out=2"));
+        let out = format_event(line);
+        assert_eq!(out.len(), 1);
+        assert!(out[0].starts_with("v "));
+        assert!(out[0].contains("sess_abc"));
+        assert!(out[0].contains("in=1"));
+        assert!(out[0].contains("out=2"));
     }
 
     #[test]
     fn format_event_rate_limit() {
         let line = br#"{"type":"rate_limit_event","rate_limit_info":{"status":"throttled","rateLimitType":"five_hour","resetsAt":1234}}"#;
-        let out = format_event(line).unwrap();
-        assert!(out.starts_with("! "));
-        assert!(out.contains("throttled"));
-        assert!(out.contains("five_hour"));
+        let out = format_event(line);
+        assert_eq!(out.len(), 1);
+        assert!(out[0].starts_with("! "));
+        assert!(out[0].contains("throttled"));
+        assert!(out[0].contains("five_hour"));
     }
 
     #[test]
     fn format_event_skips_system() {
         let line = br#"{"type":"system","subtype":"init"}"#;
-        assert!(format_event(line).is_none());
+        assert!(format_event(line).is_empty());
     }
 
     #[test]
     fn format_event_skips_unknown() {
         let line = br#"{"type":"totally_new_event","payload":"x"}"#;
-        assert!(format_event(line).is_none());
+        assert!(format_event(line).is_empty());
     }
 
     #[test]
     fn format_event_skips_malformed() {
         let line = b"not json at all";
-        assert!(format_event(line).is_none());
+        assert!(format_event(line).is_empty());
     }
 
     #[test]
@@ -748,11 +767,27 @@ mod tests {
         let line = format!(
             r#"{{"type":"assistant","message":{{"content":[{{"type":"text","text":"{long}"}}]}}}}"#
         );
-        let out = format_event(line.as_bytes()).unwrap();
+        let out = format_event(line.as_bytes());
+        assert_eq!(out.len(), 1);
         // Output should contain the `… +N chars` marker and report the
         // correct delta (100 trimmed chars).
-        assert!(out.contains("… +100 chars"), "expected marker, got: {out}");
-        assert!(out.starts_with("> "));
+        assert!(
+            out[0].contains("… +100 chars"),
+            "expected marker, got: {}",
+            out[0]
+        );
+        assert!(out[0].starts_with("> "));
+    }
+
+    #[test]
+    fn format_event_renders_all_blocks_of_multi_block_assistant() {
+        // Layout: [text, tool_use, text] — every block should render.
+        let line = br#"{"type":"assistant","message":{"content":[{"type":"text","text":"first"},{"type":"tool_use","name":"Read","input":{"file_path":"x"}},{"type":"text","text":"second"}]}}"#;
+        let out = format_event(line);
+        assert_eq!(out.len(), 3, "expected 3 rendered blocks, got {out:?}");
+        assert!(out[0].starts_with("> ") && out[0].contains("first"));
+        assert!(out[1].starts_with("* ") && out[1].contains("Read"));
+        assert!(out[2].starts_with("> ") && out[2].contains("second"));
     }
 
     #[test]

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Run the exact checks that .github/workflows/ci.yml's "test + lint + fmt"
+# job runs. Use this before `git push` to catch CI failures locally.
+#
+# The flags, features, and RUSTFLAGS here are deliberately kept in sync
+# with ci.yml — a plain `cargo clippy` / `cargo test` does not cover the
+# same surface:
+#
+#   - `--all-features` exposes features that are off by default.
+#   - `--features pitboss-core/test-support` enables the integration
+#     tests in crates/pitboss-cli/tests/ that depend on the FakeSpawner.
+#   - `RUSTFLAGS=-D warnings` promotes build warnings to errors (this is
+#     set in ci.yml's env block).
+#
+# Usage:
+#   bash scripts/ci-local.sh
+#
+# Optional install as a pre-push hook:
+#   ln -s ../../scripts/ci-local.sh .git/hooks/pre-push
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+export RUSTFLAGS="${RUSTFLAGS:-} -D warnings"
+export CARGO_TERM_COLOR=always
+
+echo "==> cargo fmt --all -- --check"
+cargo fmt --all -- --check
+
+echo "==> cargo clippy --workspace --all-targets --all-features -- -D warnings"
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+echo "==> cargo test --workspace --features pitboss-core/test-support"
+cargo test --workspace --features pitboss-core/test-support
+
+echo "==> all CI checks passed"


### PR DESCRIPTION
## Summary

Resolves 13 open `severity:medium` issues: #55, #57, #58, #59, #60, #61, #62, #63, #64, #65, #66, #67, #68, #69, #70. Builds on top of merged PR #71.

`#72` is covered by open PR #73 (same hunk) and is intentionally **not** included here to avoid a duplicate fix — if #73 merges first, this rebases cleanly; if this merges first, #73 becomes a no-op and can close.

`#56` (`Deref` on `DispatchState`) is **deferred** to a dedicated architecture pass — see https://github.com/SDS-Mode/pitboss/issues/56#issuecomment-4308615557 for the scope audit and recommended approach.

### Approval / dispatch
- **#55** `install_cascade_cancel_watcher` spawns a parallel terminate watcher so a second Ctrl-C cascades `terminate()` to every sublead layer and sub-tree worker, not just root. The existing TODO is resolved.
- **#59** `handle_spawn_worker` holds `reserved_usd`'s lock across the compute/compare/add of the budget check so concurrent `spawn_worker` calls can no longer both pass the check before either reserves.
- **#60** `ApprovalBridge::request()` holds `control_writer`'s lock across the `bridge.insert` + `w.send(ev)` pair. A TUI disconnect landing in the previous release-reacquire window no longer orphans responders in `approval_bridge`.

### Storage + shared state
- **#57** `SqliteStore` recovers from a poisoned `conn` mutex via `.unwrap_or_else(PoisonError::into_inner)` instead of panic-looping. Opens the DB with `PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000` so a secondary reader (e.g. `pitboss diff`) doesn't hit `SQLITE_BUSY`.
- **#62** `SharedStore::wait` re-reads the entry map on broadcast `Lagged(n)` — the write satisfying `min_version` may have been among the evicted 256 entries.
- **#63** `LeaseRegistry::prune_expired` returns evicted lease names; `lease_acquire` / `lease_release` / `list` / `release_all_for_actor` forward those to `lease_notifier` so `wait_secs` callers wake when a TTL elapses during a peer op.

### Parser / event stream
- **#58** `parse_line_all` returns `Vec<Event>` so multi-block assistant messages (e.g. `[text, tool_use, text]`) don't drop blocks. Callers in `pitboss-core` (`session/handle`), `pitboss-cli` (`attach`), and `pitboss-tui` (`watcher`) updated to iterate; added regression tests that render all three blocks. `parse_line` kept as a first-event accessor for source-compat with existing tests.

### TUI
- **#64** `compute_git_diff_summary` runs git in a worker thread with a 5 s `recv_timeout` and passes `--no-optional-locks`, so a contested `.git` index can't freeze the render loop.
- **#65** `connect_control` extracted into a closure invoked on both startup and `Action::SwitchRun` so post-switch control ops (cancel/pause/approve/reprompt) target the new run's socket.

### Notifications
- **#68** `notify::emit_with_retry` consults `is_fatal`, which now inspects `reqwest::Error::status()` and short-circuits 4xx responses (except 429) instead of retrying 3× guaranteed failures with ~1.3 s of spawned-task delay per webhook.

### Manifest + CLI
- **#66** `manifest/resolve::substitute()` `bail!`s on unclosed `{` instead of silently truncating the rest of the template.
- **#67** `LeadSpec` + `SubleadDefaultsSpec` get `#[serde(deny_unknown_fields)]` — typos in `[lead]` (e.g. `buget_usd`) surface at parse time instead of silently dropping the budget cap.
- **#69** `pitboss attach` canonicalizes `stdout.log` and re-asserts containment under the run's `tasks/` root, closing the symlink-traversal path.
- **#70** `resolve_run_dir` in `attach.rs` + `main.rs` guard against empty run-id prefixes (empty prefix previously matched every run via `starts_with`).

### MCP socket
- **#61** `McpServer::start` explicitly chmods the bound socket to `0o600` and chmods `XDG_RUNTIME_DIR/pitboss` plus the run-dir fallback directory to `0o700`, so a permissive umask can't leave the MCP control surface world-readable.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --lib -p pitboss-cli` — 344/344 (up from 343 with new lease-TTL return-value test)
- [x] `cargo test --lib -p pitboss-tui` — 107/107 (new multi-block `format_event` test)
- [x] `cargo test --lib -p pitboss-core` — 67/67 (8 pre-existing `worktree::tests` failures unrelated — local `git init` defaults to `main`; verified they also fail on `origin/main`)
- [ ] Manual: confirm second Ctrl-C actually kills sub-tree workers (before: lingering `claude` processes)
- [ ] Manual: verify `LeadSpec` typo now errors at parse time (`buget_usd = 5.0`)
- [ ] Manual: verify stale TUI modal fix (#72) lands via #73 and this rebases cleanly

https://claude.ai/code/session_01Dc5J61yB7QiKYV8LrJsQoA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dc5J61yB7QiKYV8LrJsQoA)_