### PR TITLE
refactor(dispatch): remove DispatchState Deref; fix worktree test helper

### DIFF
--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -91,7 +91,7 @@ pub async fn start_control_server(
                             let run_kind = run_kind.clone();
                             let state_inner = state_outer.clone();
                             let workers_names: Vec<String> = {
-                                let guard = state_outer.workers.read().await;
+                                let guard = state_outer.root.workers.read().await;
                                 guard.keys().cloned().collect()
                             };
                             tracker_outer.spawn(async move {
@@ -190,7 +190,7 @@ async fn serve_connection(
     // Install this connection as the control_writer (displace any prior).
     let (ev_tx, mut ev_rx) = tokio::sync::mpsc::unbounded_channel::<ControlEvent>();
     {
-        let mut cw = state.control_writer.lock().await;
+        let mut cw = state.root.control_writer.lock().await;
         if let Some(old) = cw.take() {
             let _ = old.send(ControlEvent::Superseded);
         }
@@ -199,10 +199,11 @@ async fn serve_connection(
 
     // Drain any queued approvals now that a TUI is connected.
     {
-        let mut queue = state.approval_queue.lock().await;
+        let mut queue = state.root.approval_queue.lock().await;
         while let Some(q) = queue.pop_front() {
             // Transfer responder into the bridge map.
             state
+                .root
                 .approval_bridge
                 .lock()
                 .await
@@ -243,7 +244,7 @@ async fn serve_connection(
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
             interval.tick().await;
-            let snapshot = state_activity.shared_store.activity_snapshot().await;
+            let snapshot = state_activity.root.shared_store.activity_snapshot().await;
             let counters: Vec<crate::control::protocol::ActorActivityEntry> = snapshot
                 .into_iter()
                 .map(
@@ -280,7 +281,7 @@ async fn serve_connection(
 
     // Clear control_writer on disconnect.
     {
-        let mut cw = state.control_writer.lock().await;
+        let mut cw = state.root.control_writer.lock().await;
         *cw = None;
     }
     pump.abort();
@@ -294,13 +295,14 @@ async fn serve_connection(
 /// fail because of signal cleanup.
 async fn thaw_if_frozen(state: &Arc<crate::dispatch::state::DispatchState>, task_id: &str) {
     let is_frozen = matches!(
-        state.workers.read().await.get(task_id),
+        state.root.workers.read().await.get(task_id),
         Some(crate::dispatch::state::WorkerState::Frozen { .. })
     );
     if !is_frozen {
         return;
     }
     let pid = state
+        .root
         .worker_pids
         .read()
         .await
@@ -360,7 +362,7 @@ async fn dispatch_op(
             // deliverable — a stopped process can't drain signals until
             // it's running again. Harmless for non-frozen workers.
             thaw_if_frozen(state, &task_id).await;
-            let cancels = state.worker_cancels.read().await;
+            let cancels = state.root.worker_cancels.read().await;
             if let Some(tok) = cancels.get(&task_id) {
                 tok.terminate();
                 ControlEvent::OpAcked {
@@ -377,8 +379,8 @@ async fn dispatch_op(
         }
         ControlOp::CancelRun => {
             // Cascade cancel across the whole dispatch tree:
-            //   root lead   → state.cancel           (terminal)
-            //   root workers → state.worker_cancels  (per-worker tokens)
+            //   root lead   → state.root.cancel           (terminal)
+            //   root workers → state.root.worker_cancels  (per-worker tokens)
             //   sub-leads   → sub_layer.cancel       (bridged to the
             //                                          sub-lead's claude
             //                                          proc_cancel at
@@ -386,22 +388,22 @@ async fn dispatch_op(
             //   sub-lead-owned workers → sub_layer.worker_cancels
             //
             // First phase: DRAIN the root cancel. This flips
-            // `state.cancel.is_draining()` to true, which
+            // `state.root.cancel.is_draining()` to true, which
             // `spawn_sublead_session` checks synchronously at sublead.rs
             // :339 — any sublead spawn racing this handler sees the drain
             // and self-cancels before its claude subprocess starts. Must
             // precede the cascade iteration below, otherwise a sublead
             // that appears in state.subleads between our snapshot and
-            // state.cancel.terminate() would slip through.
-            state.cancel.drain();
+            // state.root.cancel.terminate() would slip through.
+            state.root.cancel.drain();
 
             // SIGCONT any frozen workers (root + every sublead) so they
             // respond to the subsequent terminate. Frozen via SIGSTOP
             // can't act on a cancel token until SIGCONT'd. Mirrors the
             // CancelWorker handler's behavior; now cascades to all layers.
             {
-                let pids = state.worker_pids.read().await;
-                let workers = state.workers.read().await;
+                let pids = state.root.worker_pids.read().await;
+                let workers = state.root.workers.read().await;
                 for (id, w) in workers.iter() {
                     if matches!(w, crate::dispatch::state::WorkerState::Frozen { .. }) {
                         let pid = pids
@@ -433,7 +435,7 @@ async fn dispatch_op(
 
             // Root-layer worker tokens.
             {
-                let cancels = state.worker_cancels.read().await;
+                let cancels = state.root.worker_cancels.read().await;
                 for tok in cancels.values() {
                     tok.terminate();
                 }
@@ -461,14 +463,14 @@ async fn dispatch_op(
             // Root cancel, last — the lead's SessionHandle observes this
             // via `await_terminate()` and sends SIGTERM → SIGKILL to the
             // root claude subprocess.
-            state.cancel.terminate();
+            state.root.cancel.terminate();
             ControlEvent::OpAcked {
                 op: "cancel_run".into(),
                 task_id: None,
             }
         }
         ControlOp::PauseWorker { task_id, mode } => {
-            let mut workers = state.workers.write().await;
+            let mut workers = state.root.workers.write().await;
             let Some(entry) = workers.get(&task_id).cloned() else {
                 return ControlEvent::OpFailed {
                     op: "pause_worker".into(),
@@ -483,7 +485,7 @@ async fn dispatch_op(
                 } => {
                     match mode {
                         crate::control::protocol::PauseMode::Cancel => {
-                            let cancels = state.worker_cancels.read().await;
+                            let cancels = state.root.worker_cancels.read().await;
                             if let Some(tok) = cancels.get(&task_id) {
                                 tok.terminate();
                             }
@@ -498,6 +500,7 @@ async fn dispatch_op(
                         }
                         crate::control::protocol::PauseMode::Freeze => {
                             let pid = state
+                                .root
                                 .worker_pids
                                 .read()
                                 .await
@@ -529,7 +532,7 @@ async fn dispatch_op(
                         }
                     }
                     let _ = crate::dispatch::events::append_event(
-                        &state.run_subdir,
+                        &state.root.run_subdir,
                         &task_id,
                         &crate::dispatch::events::TaskEvent::Pause {
                             at: chrono::Utc::now(),
@@ -538,6 +541,7 @@ async fn dispatch_op(
                     )
                     .await;
                     state
+                        .root
                         .worker_counters
                         .write()
                         .await
@@ -583,7 +587,7 @@ async fn dispatch_op(
             }
         }
         ControlOp::ContinueWorker { task_id, prompt } => {
-            let current = state.workers.read().await.get(&task_id).cloned();
+            let current = state.root.workers.read().await.get(&task_id).cloned();
             match current {
                 Some(crate::dispatch::state::WorkerState::Paused { session_id, .. }) => {
                     let prompt_text = prompt.unwrap_or_else(|| "continue".into());
@@ -599,7 +603,7 @@ async fn dispatch_op(
                     {
                         Ok(()) => {
                             let _ = crate::dispatch::events::append_event(
-                                &state.run_subdir,
+                                &state.root.run_subdir,
                                 &task_id,
                                 &crate::dispatch::events::TaskEvent::Continue {
                                     at: chrono::Utc::now(),
@@ -628,6 +632,7 @@ async fn dispatch_op(
                     // SIGCONT the frozen process. `prompt` is ignored —
                     // freeze-mode preserves state and has no resume point.
                     let pid = state
+                        .root
                         .worker_pids
                         .read()
                         .await
@@ -648,7 +653,7 @@ async fn dispatch_op(
                             error: format!("SIGCONT failed: {e}"),
                         };
                     }
-                    state.workers.write().await.insert(
+                    state.root.workers.write().await.insert(
                         task_id.clone(),
                         crate::dispatch::state::WorkerState::Running {
                             started_at,
@@ -685,16 +690,16 @@ async fn dispatch_op(
             // - Everything else → unknown task_id.
             //
             // Pre-fix, sub-lead reprompts returned "unknown task_id"
-            // because the handler only looked at `state.workers`
+            // because the handler only looked at `state.root.workers`
             // (= root layer via Deref). Sub-leads live in
-            // `state.subleads`, not `state.workers`, so the check
+            // `state.subleads`, not `state.root.workers`, so the check
             // always missed.
             {
                 let subleads = state.subleads.read().await;
                 if let Some(sub_layer) = subleads.get(&task_id).cloned() {
                     drop(subleads);
                     let _ = crate::dispatch::events::append_event(
-                        &state.run_subdir,
+                        &state.root.run_subdir,
                         &task_id,
                         &crate::dispatch::events::TaskEvent::Reprompt {
                             at: chrono::Utc::now(),
@@ -711,13 +716,13 @@ async fn dispatch_op(
                 }
             }
 
-            let current = state.workers.read().await.get(&task_id).cloned();
+            let current = state.root.workers.read().await.get(&task_id).cloned();
             let session_id = match current {
                 Some(crate::dispatch::state::WorkerState::Running {
                     session_id: Some(sid),
                     ..
                 }) => {
-                    let cancels = state.worker_cancels.read().await;
+                    let cancels = state.root.worker_cancels.read().await;
                     if let Some(tok) = cancels.get(&task_id) {
                         tok.terminate();
                     }
@@ -742,7 +747,7 @@ async fn dispatch_op(
                 }
             };
             let _ = crate::dispatch::events::append_event(
-                &state.run_subdir,
+                &state.root.run_subdir,
                 &task_id,
                 &crate::dispatch::events::TaskEvent::Reprompt {
                     at: chrono::Utc::now(),
@@ -756,6 +761,7 @@ async fn dispatch_op(
             {
                 Ok(()) => {
                     state
+                        .root
                         .worker_counters
                         .write()
                         .await
@@ -775,8 +781,8 @@ async fn dispatch_op(
             }
         }
         ControlOp::ListWorkers => {
-            let workers = state.workers.read().await;
-            let prompts = state.worker_prompts.read().await;
+            let workers = state.root.workers.read().await;
+            let prompts = state.root.worker_prompts.read().await;
             let entries = workers
                 .iter()
                 .map(|(id, w)| {
@@ -848,7 +854,7 @@ async fn dispatch_op(
             edited_summary,
             reason,
         } => {
-            let tx = state.approval_bridge.lock().await.remove(&request_id);
+            let tx = state.root.approval_bridge.lock().await.remove(&request_id);
             if let Some(tx) = tx {
                 let edited = edited_summary.is_some();
                 let _ = tx.send(crate::dispatch::state::ApprovalResponse {
@@ -862,8 +868,8 @@ async fn dispatch_op(
                 // ApprovalBridge::respond would. Matters when the approval
                 // was drained from the queue (no TUI at request time).
                 let _ = crate::dispatch::events::append_event(
-                    &state.run_subdir,
-                    &state.lead_id,
+                    &state.root.run_subdir,
+                    &state.root.lead_id,
                     &crate::dispatch::events::TaskEvent::ApprovalResponse {
                         at: chrono::Utc::now(),
                         request_id: request_id.clone(),
@@ -873,8 +879,8 @@ async fn dispatch_op(
                 )
                 .await;
                 {
-                    let mut guard = state.worker_counters.write().await;
-                    let entry = guard.entry(state.lead_id.clone()).or_default();
+                    let mut guard = state.root.worker_counters.write().await;
+                    let entry = guard.entry(state.root.lead_id.clone()).or_default();
                     if approved {
                         entry.approvals_approved += 1;
                     } else {
@@ -1040,6 +1046,7 @@ mod tests {
         // Pre-seed the bridge map with a request_id + oneshot sender.
         let (tx, rx) = tokio::sync::oneshot::channel();
         state
+            .root
             .approval_bridge
             .lock()
             .await
@@ -1097,11 +1104,13 @@ mod tests {
         let state = mk_state(dir.path(), run_id);
         let worker_token = CancelToken::new();
         state
+            .root
             .worker_cancels
             .write()
             .await
             .insert("w-1".into(), worker_token.clone());
         state
+            .root
             .workers
             .write()
             .await
@@ -1145,7 +1154,7 @@ mod tests {
     #[tokio::test]
     async fn cancel_run_op_cascades_to_sublead_layers() {
         // Regression coverage for task #60: CancelRun used to fire only
-        // root.cancel + state.worker_cancels. Sub-lead claude
+        // root.cancel + state.root.worker_cancels. Sub-lead claude
         // subprocesses, plus any workers the sub-lead had spawned,
         // stayed alive — their cancel tokens live on the sub-layer,
         // not on root. Observable pre-fix: operator hits cancel, root
@@ -1190,12 +1199,12 @@ mod tests {
         let sub_layer = std::sync::Arc::new(LayerState::new(
             run_id,
             sub_manifest,
-            state.store.clone(),
+            state.root.store.clone(),
             sub_cancel.clone(),
             "sublead-test".into(),
-            state.spawner.clone(),
+            state.root.spawner.clone(),
             std::path::PathBuf::from("/bin/true"),
-            state.wt_mgr.clone(),
+            state.root.wt_mgr.clone(),
             CleanupPolicy::Never,
             dir.path().join(run_id.to_string()),
             ApprovalPolicy::Block,
@@ -1250,10 +1259,13 @@ mod tests {
             ControlEvent::OpAcked { ref op, .. } if op == "cancel_run"
         ));
         assert!(
-            state.cancel.is_draining(),
+            state.root.cancel.is_draining(),
             "root cancel must be draining so racing sublead spawns self-cancel"
         );
-        assert!(state.cancel.is_terminated(), "root cancel terminates last");
+        assert!(
+            state.root.cancel.is_terminated(),
+            "root cancel terminates last"
+        );
         assert!(
             sub_cancel.is_terminated(),
             "sub-layer cancel must be terminated so the sub-lead's claude proc dies"
@@ -1271,8 +1283,8 @@ mod tests {
 
     #[tokio::test]
     async fn cancel_run_op_cascades_to_every_worker_token() {
-        // Regression: `CancelRun` used to only fire state.cancel (lead-only
-        // token). Workers have per-task tokens in state.worker_cancels;
+        // Regression: `CancelRun` used to only fire state.root.cancel (lead-only
+        // token). Workers have per-task tokens in state.root.worker_cancels;
         // without cascading, workers stayed alive after a kill-run and the
         // TUI showed the run as dead while `ps` showed live claude procs.
         let dir = TempDir::new().unwrap();
@@ -1282,11 +1294,13 @@ mod tests {
         let w1 = pitboss_core::session::CancelToken::new();
         let w2 = pitboss_core::session::CancelToken::new();
         state
+            .root
             .worker_cancels
             .write()
             .await
             .insert("w-1".into(), w1.clone());
         state
+            .root
             .worker_cancels
             .write()
             .await
@@ -1338,7 +1352,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let run_id = Uuid::now_v7();
         let state = mk_state(dir.path(), run_id);
-        let run_cancel = state.cancel.clone();
+        let run_cancel = state.root.cancel.clone();
 
         let sock = dir.path().join("cancel-run.sock");
         let handle = start_control_server(
@@ -1382,11 +1396,12 @@ mod tests {
 
         let worker_token = CancelToken::new();
         state
+            .root
             .worker_cancels
             .write()
             .await
             .insert("w-1".into(), worker_token.clone());
-        state.workers.write().await.insert(
+        state.root.workers.write().await.insert(
             "w-1".into(),
             crate::dispatch::state::WorkerState::Running {
                 started_at: chrono::Utc::now(),
@@ -1425,7 +1440,7 @@ mod tests {
             ControlEvent::OpAcked { ref op, .. } if op == "pause_worker"
         ));
         assert!(worker_token.is_terminated());
-        let workers = state.workers.read().await;
+        let workers = state.root.workers.read().await;
         match workers.get("w-1").unwrap() {
             crate::dispatch::state::WorkerState::Paused { session_id, .. } => {
                 assert_eq!(session_id, "sess-xyz");
@@ -1440,7 +1455,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let run_id = Uuid::now_v7();
         let state = mk_state(dir.path(), run_id);
-        state.workers.write().await.insert(
+        state.root.workers.write().await.insert(
             "w-1".into(),
             crate::dispatch::state::WorkerState::Paused {
                 session_id: "sess-xyz".into(),
@@ -1449,11 +1464,13 @@ mod tests {
             },
         );
         state
+            .root
             .worker_prompts
             .write()
             .await
             .insert("w-1".into(), "hi".into());
         state
+            .root
             .worker_models
             .write()
             .await
@@ -1489,7 +1506,7 @@ mod tests {
             reply,
             ControlEvent::OpAcked { ref op, .. } if op == "continue_worker"
         ));
-        let workers = state.workers.read().await;
+        let workers = state.root.workers.read().await;
         assert!(matches!(
             workers.get("w-1").unwrap(),
             crate::dispatch::state::WorkerState::Running { .. }
@@ -1504,11 +1521,12 @@ mod tests {
         let state = mk_state(dir.path(), run_id);
         let worker_token = CancelToken::new();
         state
+            .root
             .worker_cancels
             .write()
             .await
             .insert("w-1".into(), worker_token.clone());
-        state.workers.write().await.insert(
+        state.root.workers.write().await.insert(
             "w-1".into(),
             crate::dispatch::state::WorkerState::Running {
                 started_at: chrono::Utc::now(),
@@ -1516,11 +1534,13 @@ mod tests {
             },
         );
         state
+            .root
             .worker_prompts
             .write()
             .await
             .insert("w-1".into(), "hi".into());
         state
+            .root
             .worker_models
             .write()
             .await
@@ -1567,7 +1587,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let run_id = Uuid::now_v7();
         let state = mk_state(dir.path(), run_id);
-        state.workers.write().await.insert(
+        state.root.workers.write().await.insert(
             "w-1".into(),
             crate::dispatch::state::WorkerState::Running {
                 started_at: chrono::Utc::now(),
@@ -1575,6 +1595,7 @@ mod tests {
             },
         );
         state
+            .root
             .worker_prompts
             .write()
             .await

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -214,7 +214,7 @@ pub async fn run_hierarchical(
         env: lead_env,
     };
 
-    state.workers.write().await.insert(
+    state.root.workers.write().await.insert(
         lead.id.clone(),
         crate::dispatch::state::WorkerState::Running {
             started_at: Utc::now(),
@@ -262,7 +262,7 @@ pub async fn run_hierarchical(
 
         // Capture session_id from either the mid-run channel or the final result.
         if let Ok(sid) = session_id_rx.try_recv() {
-            state.workers.write().await.insert(
+            state.root.workers.write().await.insert(
                 lead.id.clone(),
                 crate::dispatch::state::WorkerState::Running {
                     started_at: overall_started_at,
@@ -302,7 +302,7 @@ pub async fn run_hierarchical(
                     env: resume_env,
                 };
                 // Reset the workers map entry to Running (session_id TBD).
-                state.workers.write().await.insert(
+                state.root.workers.write().await.insert(
                     lead.id.clone(),
                     crate::dispatch::state::WorkerState::Running {
                         started_at: overall_started_at,
@@ -329,10 +329,11 @@ pub async fn run_hierarchical(
 
     // Build lead TaskRecord using the accumulated data from all iterations.
     let lead_counters = state
+        .root
         .worker_counters
         .read()
         .await
-        .get(&state.lead_id)
+        .get(&state.root.lead_id)
         .cloned()
         .unwrap_or_default();
     // Merge the loop's own reprompt_count into the counter-based one.
@@ -419,11 +420,11 @@ pub async fn run_hierarchical(
         )
         .await;
     }
-    state.workers.write().await.insert(
+    state.root.workers.write().await.insert(
         lead.id.clone(),
         crate::dispatch::state::WorkerState::Done(lead_record.clone()),
     );
-    let _ = state.done_tx.send(lead.id.clone());
+    let _ = state.root.done_tx.send(lead.id.clone());
 
     // 4. Finalize.
     // Capture the ORIGINAL cancel state BEFORE we call terminate() below.
@@ -434,12 +435,12 @@ pub async fn run_hierarchical(
     // Any in-flight workers get cancelled. `cancel` is the RUN-level token
     // (observed only by the lead's SessionHandle), so terminating it alone
     // leaves workers orphaned — their sessions use per-task tokens in
-    // `state.worker_cancels`. Cascade to every live worker so their
+    // `state.root.worker_cancels`. Cascade to every live worker so their
     // SessionHandles SIGTERM the child claude processes too. Without this
     // cascade, `ps` showed live claude workers after the run "finished"
     // and the summary marked them Cancelled with no actual termination.
     {
-        let cancels = state.worker_cancels.read().await;
+        let cancels = state.root.worker_cancels.read().await;
         for tok in cancels.values() {
             tok.terminate();
         }
@@ -449,8 +450,8 @@ pub async fn run_hierarchical(
     tokio::time::sleep(pitboss_core::session::TERMINATE_GRACE).await;
 
     let worker_records: Vec<pitboss_core::store::TaskRecord> = {
-        let workers = state.workers.read().await;
-        let worker_models = state.worker_models.read().await;
+        let workers = state.root.workers.read().await;
+        let worker_models = state.root.worker_models.read().await;
         workers
             .iter()
             .filter(|(id, _)| *id != &lead.id) // don't double-count the lead
@@ -519,7 +520,7 @@ pub async fn run_hierarchical(
     // Optional post-mortem dump of shared-store contents.
     if resolved.dump_shared_store {
         let dump_path = run_subdir.join("shared-store.json");
-        if let Err(e) = state.shared_store.dump_to_path(&dump_path).await {
+        if let Err(e) = state.root.shared_store.dump_to_path(&dump_path).await {
             tracing::warn!(?e, "shared-store dump failed");
         }
     }

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -3,12 +3,21 @@
 //! populated as the root lead spawns sub-leads). The run-global
 //! `LeaseRegistry` lives here too — added in Phase 3.
 //!
-//! Backward-compatible constructor signature: depth-1 callers continue
-//! to use `DispatchState::new(...)` with the existing 13 arguments.
+//! ## Layer access is explicit
 //!
-//! `DispatchState` implements `Deref<Target = LayerState>` so every
-//! existing field access (e.g. `state.workers`, `state.cancel`) continues
-//! to work without callers knowing about the indirection.
+//! `DispatchState` does NOT implement `Deref<Target = LayerState>`. Every
+//! caller picks a layer explicitly:
+//!
+//! - Root-layer access: `state.root.<field>` (or `state.root_layer()` for
+//!   an `&Arc<LayerState>`).
+//! - Sub-tree access: look up the sub-lead in `state.subleads.read().await`.
+//! - Routed access (the canonical path for MCP tool handlers that dispatch
+//!   on `_meta.actor_role`): use `crate::mcp::server::resolve_layer_for_caller`,
+//!   which returns the correct layer for `Lead`/`Sublead`/`Worker` callers.
+//!
+//! The previous `Deref` impl silently aliased the root layer, which made it
+//! easy for new handlers to misroute sub-lead operations to root-layer state
+//! without any compile-time signal. See issue #56.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -226,8 +235,11 @@ pub struct QueuedApproval {
 /// Run-level wrapper. Holds the root `LayerState` plus (in Phase 2+) a map
 /// of sub-tree `LayerState`s keyed by sub-lead id.
 ///
-/// Implements `Deref<Target = LayerState>` so all existing callsites that
-/// access fields like `state.workers`, `state.cancel`, etc. compile unchanged.
+/// Layer access is explicit: callers reach the root layer via
+/// `state.root.<field>` (or `state.root_layer()`), and sub-tree layers via
+/// `state.subleads.read().await.get(sublead_id)`. Handlers that dispatch on
+/// `_meta.actor_role` should route through
+/// `crate::mcp::server::resolve_layer_for_caller`.
 ///
 /// ## Lock access rule (DO NOT VIOLATE)
 ///
@@ -282,19 +294,6 @@ pub struct DispatchState {
     /// burns budget faster than the operator can intervene. Updated
     /// alongside the `TaskRecord` persist in every completion path.
     pub api_health: Arc<crate::dispatch::failure_detection::ApiHealth>,
-}
-
-/// CAUTION: This Deref always resolves to the root layer, which is correct
-/// for depth-1 code. Phase 2+ code dispatching on `_meta.actor_role` MUST
-/// explicitly look up the correct layer: root-lead callers use `&state.root`,
-/// while sub-lead callers must call `state.subleads.read().await.get(sublead_id)`.
-/// See Phase 3.1's `resolve_layer_for_caller` helper for canonical resolution.
-impl std::ops::Deref for DispatchState {
-    type Target = LayerState;
-
-    fn deref(&self) -> &Self::Target {
-        &self.root
-    }
 }
 
 impl std::fmt::Debug for DispatchState {
@@ -472,21 +471,21 @@ mod tests {
     #[tokio::test]
     async fn active_worker_count_is_zero_on_new_state() {
         let st = mk_state(None, None);
-        assert_eq!(st.active_worker_count().await, 0);
+        assert_eq!(st.root.active_worker_count().await, 0);
     }
 
     #[tokio::test]
     async fn budget_remaining_reflects_spent() {
         let st = mk_state(Some(10.0), None);
-        assert_eq!(st.budget_remaining().await, Some(10.0));
-        *st.spent_usd.lock().await = 3.5;
-        assert_eq!(st.budget_remaining().await, Some(6.5));
+        assert_eq!(st.root.budget_remaining().await, Some(10.0));
+        *st.root.spent_usd.lock().await = 3.5;
+        assert_eq!(st.root.budget_remaining().await, Some(6.5));
     }
 
     #[tokio::test]
     async fn budget_remaining_is_none_when_uncapped() {
         let st = mk_state(None, None);
-        assert_eq!(st.budget_remaining().await, None);
+        assert_eq!(st.root.budget_remaining().await, None);
     }
 
     #[test]
@@ -511,19 +510,20 @@ mod tests {
     #[tokio::test]
     async fn state_initializes_new_v04_fields() {
         let st = mk_state(None, None);
-        assert!(st.approval_bridge.lock().await.is_empty());
-        assert!(st.approval_queue.lock().await.is_empty());
+        assert!(st.root.approval_bridge.lock().await.is_empty());
+        assert!(st.root.approval_queue.lock().await.is_empty());
         assert!(matches!(
-            st.approval_policy,
+            st.root.approval_policy,
             crate::dispatch::state::ApprovalPolicy::Block
         ));
-        assert!(st.control_writer.lock().await.is_none());
+        assert!(st.root.control_writer.lock().await.is_none());
     }
 
     #[tokio::test]
     async fn worker_counters_default_zero() {
         let st = mk_state(None, None);
         let c = st
+            .root
             .worker_counters
             .read()
             .await

--- a/crates/pitboss-cli/src/mcp/approval.rs
+++ b/crates/pitboss-cli/src/mcp/approval.rs
@@ -102,8 +102,8 @@ impl ApprovalBridge {
     ) -> Result<ApprovalResponse, ApprovalError> {
         let request_id = format!("req-{}", Uuid::now_v7());
         let _ = crate::dispatch::events::append_event(
-            &self.state.run_subdir,
-            &self.state.lead_id,
+            &self.state.root.run_subdir,
+            &self.state.root.lead_id,
             &crate::dispatch::events::TaskEvent::ApprovalRequest {
                 at: chrono::Utc::now(),
                 request_id: request_id.clone(),
@@ -112,9 +112,9 @@ impl ApprovalBridge {
         )
         .await;
 
-        if let Some(router) = self.state.notification_router.clone() {
+        if let Some(router) = self.state.root.notification_router.clone() {
             let envelope = crate::notify::NotificationEnvelope::new(
-                &self.state.run_id.to_string(),
+                &self.state.root.run_id.to_string(),
                 crate::notify::Severity::Warning,
                 crate::notify::PitbossEvent::ApprovalRequest {
                     request_id: request_id.clone(),
@@ -133,10 +133,11 @@ impl ApprovalBridge {
         // the "is it present?" check and the insert, so a TUI that
         // disconnected in that window would leave the responder orphaned
         // in `approval_bridge` — stuck until the bridge timeout.
-        let writer_guard = self.state.control_writer.lock().await;
+        let writer_guard = self.state.root.control_writer.lock().await;
 
         if let Some(w) = writer_guard.as_ref() {
             self.state
+                .root
                 .approval_bridge
                 .lock()
                 .await
@@ -154,7 +155,7 @@ impl ApprovalBridge {
         } else {
             drop(writer_guard);
             // No TUI attached: policy decides.
-            match self.state.approval_policy {
+            match self.state.root.approval_policy {
                 ApprovalPolicy::AutoApprove => {
                     let _ = tx.send(ApprovalResponse {
                         approved: true,
@@ -174,6 +175,7 @@ impl ApprovalBridge {
                 ApprovalPolicy::Block => {
                     // Queue; drain when a TUI connects (see control/server.rs).
                     self.state
+                        .root
                         .approval_queue
                         .lock()
                         .await
@@ -190,9 +192,9 @@ impl ApprovalBridge {
                         });
 
                     // Fire approval_pending notification
-                    if let Some(router) = self.state.notification_router.clone() {
+                    if let Some(router) = self.state.root.notification_router.clone() {
                         let envelope = crate::notify::NotificationEnvelope::new(
-                            &self.state.run_id.to_string(),
+                            &self.state.root.run_id.to_string(),
                             crate::notify::Severity::Warning,
                             crate::notify::PitbossEvent::ApprovalPending {
                                 request_id: request_id.clone(),
@@ -208,10 +210,11 @@ impl ApprovalBridge {
         }
 
         self.state
+            .root
             .worker_counters
             .write()
             .await
-            .entry(self.state.lead_id.clone())
+            .entry(self.state.root.lead_id.clone())
             .or_default()
             .approvals_requested += 1;
 
@@ -220,11 +223,17 @@ impl ApprovalBridge {
             Ok(Err(_)) => Err(ApprovalError::Cancelled),
             Err(_) => {
                 // Timeout: remove the pending entry so a late respond doesn't panic.
-                self.state.approval_bridge.lock().await.remove(&request_id);
+                self.state
+                    .root
+                    .approval_bridge
+                    .lock()
+                    .await
+                    .remove(&request_id);
                 // Also evict from the TUI-drain queue (Block policy, no TUI connected).
                 // Without this, a TUI that connects after the timeout fires sees a stale
                 // approval modal for a request that has already resolved.
                 self.state
+                    .root
                     .approval_queue
                     .lock()
                     .await
@@ -242,14 +251,15 @@ impl ApprovalBridge {
     ) -> Result<(), ApprovalError> {
         let tx = self
             .state
+            .root
             .approval_bridge
             .lock()
             .await
             .remove(request_id)
             .ok_or(ApprovalError::ControlDisconnected)?;
         let _ = crate::dispatch::events::append_event(
-            &self.state.run_subdir,
-            &self.state.lead_id,
+            &self.state.root.run_subdir,
+            &self.state.root.lead_id,
             &crate::dispatch::events::TaskEvent::ApprovalResponse {
                 at: chrono::Utc::now(),
                 request_id: request_id.to_string(),
@@ -261,8 +271,8 @@ impl ApprovalBridge {
         let approved = resp.approved;
         tx.send(resp).map_err(|_| ApprovalError::Cancelled)?;
         {
-            let mut guard = self.state.worker_counters.write().await;
-            let entry = guard.entry(self.state.lead_id.clone()).or_default();
+            let mut guard = self.state.root.worker_counters.write().await;
+            let entry = guard.entry(self.state.root.lead_id.clone()).or_default();
             if approved {
                 entry.approvals_approved += 1;
             } else {

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -943,7 +943,7 @@ impl McpServer {
                                 // returns without racing the moved handler.
                                 let h = handler.for_connection();
                                 let actor_slot = h.connection_actor_handle();
-                                let store_for_cleanup = h.state.shared_store.clone();
+                                let store_for_cleanup = h.state.root.shared_store.clone();
                                 let run_leases_for_cleanup = h.state.run_leases.clone();
                                 let cancel_inner = cancel_outer.clone();
                                 // Track the spawned session task so Drop can signal cancellation

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -360,7 +360,7 @@ pub async fn handle_spawn_worker(
     let target_layer = resolve_target_layer(state, &caller_id, caller_role).await?;
 
     // Guard 1: draining (root cancel gate — always check root even for sublead workers)
-    if state.cancel.is_draining() || state.cancel.is_terminated() {
+    if state.root.cancel.is_draining() || state.root.cancel.is_terminated() {
         bail!("run is draining: no new workers accepted");
     }
 
@@ -391,8 +391,9 @@ pub async fn handle_spawn_worker(
     // `propose_plan` and get operator approval before any worker
     // dispatches. The check happens here rather than earlier so draining
     // runs still short-circuit with their clearer error.
-    if state.manifest.require_plan_approval
+    if state.root.manifest.require_plan_approval
         && !state
+            .root
             .plan_approved
             .load(std::sync::atomic::Ordering::Acquire)
     {
@@ -448,10 +449,10 @@ pub async fn handle_spawn_worker(
             drop(reserved_guard);
             if let Some(router) = target_layer.notification_router.clone() {
                 let envelope = crate::notify::NotificationEnvelope::new(
-                    &state.run_id.to_string(),
+                    &state.root.run_id.to_string(),
                     crate::notify::Severity::Error,
                     crate::notify::PitbossEvent::BudgetExceeded {
-                        run_id: state.run_id.to_string(),
+                        run_id: state.root.run_id.to_string(),
                         spent_usd: spent,
                         budget_usd: budget,
                     },
@@ -1045,6 +1046,7 @@ pub async fn spawn_resume_worker(
 ) -> anyhow::Result<()> {
     use chrono::Utc;
     let model = state
+        .root
         .worker_models
         .read()
         .await
@@ -1052,18 +1054,21 @@ pub async fn spawn_resume_worker(
         .cloned()
         .unwrap_or_else(|| "claude-haiku-4-5".to_string());
     let tools: Vec<String> = state
+        .root
         .manifest
         .lead
         .as_ref()
         .map(|l| l.tools.clone())
         .unwrap_or_default();
     let timeout_secs = state
+        .root
         .manifest
         .lead
         .as_ref()
         .map(|l| l.timeout_secs)
         .unwrap_or(3600);
     let cwd = state
+        .root
         .manifest
         .lead
         .as_ref()
@@ -1071,11 +1076,12 @@ pub async fn spawn_resume_worker(
         .unwrap_or_else(|| std::path::PathBuf::from("/tmp"));
     let worker_cancel = pitboss_core::session::CancelToken::new();
     state
+        .root
         .worker_cancels
         .write()
         .await
         .insert(task_id.clone(), worker_cancel.clone());
-    state.workers.write().await.insert(
+    state.root.workers.write().await.insert(
         task_id.clone(),
         WorkerState::Running {
             started_at: Utc::now(),
@@ -1084,16 +1090,16 @@ pub async fn spawn_resume_worker(
     );
     let state_bg = Arc::clone(state);
     let task_id_bg = task_id.clone();
-    let lead_id_bg = state.lead_id.clone();
+    let lead_id_bg = state.root.lead_id.clone();
 
     // Generate (or reuse) worker-scoped mcp-config.json for the resumed
     // subprocess. write_worker_mcp_config is idempotent so calling it again
     // on an existing file is safe.
-    let worker_task_dir = state.run_subdir.join("tasks").join(&task_id);
+    let worker_task_dir = state.root.run_subdir.join("tasks").join(&task_id);
     tokio::fs::create_dir_all(&worker_task_dir).await.ok();
     let worker_mcp_config_path = worker_task_dir.join("mcp-config.json");
     let socket_path =
-        crate::mcp::server::socket_path_for_run(state.run_id, &state.manifest.run_dir);
+        crate::mcp::server::socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let mcp_config_arg = match crate::dispatch::hierarchical::write_worker_mcp_config(
         &worker_mcp_config_path,
         &socket_path,
@@ -1119,6 +1125,7 @@ pub async fn spawn_resume_worker(
     // resolved env so `[defaults.env]` and `[lead.env]` survive a
     // pause/continue or reprompt cycle.
     let lead_env_for_resume = state
+        .root
         .manifest
         .lead
         .as_ref()
@@ -1129,12 +1136,12 @@ pub async fn spawn_resume_worker(
         &std::collections::HashMap::new(),
     );
     let cmd = pitboss_core::process::SpawnCmd {
-        program: state.claude_binary.clone(),
+        program: state.root.claude_binary.clone(),
         args: spawn_args_v,
         cwd,
         env: resume_env,
     };
-    let task_dir = state.run_subdir.join("tasks").join(&task_id);
+    let task_dir = state.root.run_subdir.join("tasks").join(&task_id);
     let _ = tokio::fs::create_dir_all(&task_dir).await;
     let log_path = task_dir.join("stdout.log");
     let stderr_path = task_dir.join("stderr.log");
@@ -1143,6 +1150,7 @@ pub async fn spawn_resume_worker(
     // freeze-pause works across continue_worker boundaries.
     let resume_pid_slot = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
     state
+        .root
         .worker_pids
         .write()
         .await
@@ -1152,7 +1160,7 @@ pub async fn spawn_resume_worker(
         use pitboss_core::store::{TaskRecord, TaskStatus};
         let outcome = pitboss_core::session::SessionHandle::new(
             task_id_bg.clone(),
-            Arc::clone(&state_bg.spawner),
+            Arc::clone(&state_bg.root.spawner),
             cmd,
         )
         .with_log_path(log_path.clone())
@@ -1161,7 +1169,7 @@ pub async fn spawn_resume_worker(
         .run_to_completion(worker_cancel, std::time::Duration::from_secs(timeout_secs))
         .await;
         // Clean up the pid slot when the resumed subprocess exits.
-        state_bg.worker_pids.write().await.remove(&task_id_bg);
+        state_bg.root.worker_pids.write().await.remove(&task_id_bg);
         let mut status = match outcome.final_state {
             pitboss_core::session::SessionState::Completed => TaskStatus::Success,
             pitboss_core::session::SessionState::Failed { .. } => TaskStatus::Failed,
@@ -1180,6 +1188,7 @@ pub async fn spawn_resume_worker(
             }
         }
         let counters = state_bg
+            .root
             .worker_counters
             .read()
             .await
@@ -1211,7 +1220,11 @@ pub async fn spawn_resume_worker(
                 Some(&stderr_path),
             ),
         };
-        let _ = state_bg.store.append_record(state_bg.run_id, &rec).await;
+        let _ = state_bg
+            .root
+            .store
+            .append_record(state_bg.root.run_id, &rec)
+            .await;
         if let Some(reason) = rec.failure_reason.clone() {
             state_bg.api_health.record(&reason).await;
             crate::dispatch::failure_detection::broadcast_worker_failed(
@@ -1224,11 +1237,12 @@ pub async fn spawn_resume_worker(
             .await;
         }
         state_bg
+            .root
             .workers
             .write()
             .await
             .insert(task_id_bg.clone(), WorkerState::Done(rec));
-        let _ = state_bg.done_tx.send(task_id_bg);
+        let _ = state_bg.root.done_tx.send(task_id_bg);
     });
 
     Ok(())
@@ -1252,7 +1266,7 @@ pub(crate) fn initial_estimate_for(model: &str) -> f64 {
 
 pub async fn handle_list_workers(state: &Arc<DispatchState>) -> Vec<WorkerSummary> {
     // Collect from every layer (root + each active sub-lead). Previously
-    // this read only `state.workers` (= root via Deref), so sub-leads
+    // this read only `state.root.workers` (= root via Deref), so sub-leads
     // calling `list_workers` got an empty list even when they had their
     // own workers active — the workers were registered in the sub-lead
     // layer's own `workers` map by `handle_spawn_worker`'s
@@ -1261,7 +1275,7 @@ pub async fn handle_list_workers(state: &Arc<DispatchState>) -> Vec<WorkerSummar
     // Lead id filtering: excludes the root lead id. Sub-lead ids aren't
     // registered as workers so they don't need filtering here.
     let mut summaries: Vec<WorkerSummary> = Vec::new();
-    let prompts = state.worker_prompts.read().await;
+    let prompts = state.root.worker_prompts.read().await;
     let render = |id: &String, w: &WorkerState| -> WorkerSummary {
         let (state_str, started_at) = match w {
             WorkerState::Pending => ("Pending".to_string(), None),
@@ -1295,8 +1309,8 @@ pub async fn handle_list_workers(state: &Arc<DispatchState>) -> Vec<WorkerSummar
             started_at,
         }
     };
-    for (id, w) in state.workers.read().await.iter() {
-        if id != &state.lead_id {
+    for (id, w) in state.root.workers.read().await.iter() {
+        if id != &state.root.lead_id {
             summaries.push(render(id, w));
         }
     }
@@ -1373,6 +1387,7 @@ pub async fn handle_worker_status(
         ),
     };
     let prompt_preview = state
+        .root
         .worker_prompts
         .read()
         .await
@@ -1392,7 +1407,7 @@ pub async fn handle_cancel_worker(
     state: &Arc<DispatchState>,
     task_id: &str,
 ) -> Result<CancelResult> {
-    let cancels = state.worker_cancels.read().await;
+    let cancels = state.root.worker_cancels.read().await;
     let Some(token) = cancels.get(task_id) else {
         anyhow::bail!("unknown task_id: {task_id}");
     };
@@ -1405,7 +1420,7 @@ pub async fn handle_pause_worker(
     task_id: &str,
     mode: PauseMode,
 ) -> Result<CancelResult> {
-    let mut workers = state.workers.write().await;
+    let mut workers = state.root.workers.write().await;
     let Some(entry) = workers.get(task_id).cloned() else {
         anyhow::bail!("unknown task_id: {task_id}");
     };
@@ -1415,7 +1430,7 @@ pub async fn handle_pause_worker(
             session_id: Some(sid),
         } => match mode {
             PauseMode::Cancel => {
-                let cancels = state.worker_cancels.read().await;
+                let cancels = state.root.worker_cancels.read().await;
                 if let Some(tok) = cancels.get(task_id) {
                     tok.terminate();
                 }
@@ -1433,6 +1448,7 @@ pub async fn handle_pause_worker(
                 // Read the pid slot. If 0 (subprocess hasn't spawned
                 // yet), fail — freeze is meaningless without a pid.
                 let pid = state
+                    .root
                     .worker_pids
                     .read()
                     .await
@@ -1467,7 +1483,7 @@ pub async fn handle_continue_worker(
     state: &Arc<DispatchState>,
     args: ContinueWorkerArgs,
 ) -> Result<CancelResult> {
-    let current = state.workers.read().await.get(&args.task_id).cloned();
+    let current = state.root.workers.read().await.get(&args.task_id).cloned();
     match current {
         Some(WorkerState::Paused { session_id, .. }) => {
             let prompt = args.prompt.unwrap_or_else(|| "continue".into());
@@ -1485,6 +1501,7 @@ pub async fn handle_continue_worker(
             // a resume-only concept); clients that want to inject a
             // new prompt should thaw + reprompt as two steps.
             let pid = state
+                .root
                 .worker_pids
                 .read()
                 .await
@@ -1500,7 +1517,7 @@ pub async fn handle_continue_worker(
             crate::dispatch::signals::resume_stopped(pid)?;
             // Transition back to Running, preserving the ORIGINAL
             // started_at so wall-clock duration stays accurate.
-            state.workers.write().await.insert(
+            state.root.workers.write().await.insert(
                 args.task_id.clone(),
                 WorkerState::Running {
                     started_at,
@@ -1518,13 +1535,13 @@ pub async fn handle_reprompt_worker(
     state: &Arc<DispatchState>,
     args: RepromptWorkerArgs,
 ) -> Result<CancelResult> {
-    let current = state.workers.read().await.get(&args.task_id).cloned();
+    let current = state.root.workers.read().await.get(&args.task_id).cloned();
     let session_id = match current {
         Some(WorkerState::Running {
             session_id: Some(sid),
             ..
         }) => {
-            let cancels = state.worker_cancels.read().await;
+            let cancels = state.root.worker_cancels.read().await;
             if let Some(tok) = cancels.get(&args.task_id) {
                 tok.terminate();
             }
@@ -1548,7 +1565,7 @@ pub async fn handle_reprompt_worker(
     // Unconditionally record the reprompt attempt — audit trail even if
     // the subsequent spawn fails.
     let _ = crate::dispatch::events::append_event(
-        &state.run_subdir,
+        &state.root.run_subdir,
         &args.task_id,
         &crate::dispatch::events::TaskEvent::Reprompt {
             at: chrono::Utc::now(),
@@ -1563,6 +1580,7 @@ pub async fn handle_reprompt_worker(
     // Counter bump is conditional on spawn success so a failed spawn
     // doesn't falsely inflate the reprompt count.
     state
+        .root
         .worker_counters
         .write()
         .await
@@ -1662,7 +1680,7 @@ pub async fn handle_request_approval(
         created_at: chrono::Utc::now(),
         ttl_secs: args
             .timeout_secs
-            .or(state.manifest.lead_timeout_secs)
+            .or(state.root.manifest.lead_timeout_secs)
             .unwrap_or(3600),
         fallback: ApprovalFallback::AutoReject,
     };
@@ -1711,7 +1729,7 @@ pub async fn handle_request_approval(
 
     let timeout = Duration::from_secs(
         args.timeout_secs
-            .or(state.manifest.lead_timeout_secs)
+            .or(state.root.manifest.lead_timeout_secs)
             .unwrap_or(3600),
     );
     let caller_id_for_record = caller_id.clone();
@@ -1743,7 +1761,7 @@ pub async fn handle_request_approval(
 
 /// Handle `propose_plan`: the lead submits a full execution plan for
 /// pre-flight operator approval, distinct from `request_approval`'s
-/// in-flight per-action gating. Flips `state.plan_approved` to true on
+/// in-flight per-action gating. Flips `state.root.plan_approved` to true on
 /// approval; leaves it false on rejection (lead can revise and retry).
 ///
 /// Returns the same `ApprovalToolResponse` shape as `request_approval`
@@ -1775,7 +1793,7 @@ pub async fn handle_propose_plan(
         created_at: chrono::Utc::now(),
         ttl_secs: args
             .timeout_secs
-            .or(state.manifest.lead_timeout_secs)
+            .or(state.root.manifest.lead_timeout_secs)
             .unwrap_or(3600),
         fallback: ApprovalFallback::AutoReject,
     };
@@ -1791,6 +1809,7 @@ pub async fn handle_propose_plan(
                         "plan auto-approved by policy"
                     );
                     state
+                        .root
                         .plan_approved
                         .store(true, std::sync::atomic::Ordering::Release);
                     state
@@ -1827,7 +1846,7 @@ pub async fn handle_propose_plan(
 
     let timeout = Duration::from_secs(
         args.timeout_secs
-            .or(state.manifest.lead_timeout_secs)
+            .or(state.root.manifest.lead_timeout_secs)
             .unwrap_or(3600),
     );
     // Reuse the summary from the plan as the modal headline — a plan
@@ -1849,6 +1868,7 @@ pub async fn handle_propose_plan(
         Ok(resp) => {
             if resp.approved {
                 state
+                    .root
                     .plan_approved
                     .store(true, std::sync::atomic::Ordering::Release);
             }
@@ -1871,7 +1891,7 @@ pub async fn handle_propose_plan(
 ///
 /// Workers spawned by a sub-lead are registered in that sub-lead's
 /// `LayerState.workers`, not in root's. Before this helper existed the
-/// v0.6 MCP handlers all read `state.workers` (= root via Deref), so a
+/// v0.6 MCP handlers all read `state.root.workers` (= root via Deref), so a
 /// sub-lead's own worker looked "unknown" to every downstream tool
 /// (`wait_for_worker`, `wait_actor`, `worker_status`, `list_workers`).
 /// Surfaced via the depth-2 smoke test: sub-lead calls `spawn_worker`,
@@ -1881,7 +1901,7 @@ async fn find_worker_across_layers(
     state: &Arc<DispatchState>,
     task_id: &str,
 ) -> Option<WorkerState> {
-    if let Some(w) = state.workers.read().await.get(task_id).cloned() {
+    if let Some(w) = state.root.workers.read().await.get(task_id).cloned() {
         return Some(w);
     }
     let subleads = state.subleads.read().await;
@@ -1912,7 +1932,7 @@ async fn wait_for_actor_internal(
     //    broadcast is missed and the wait blocks until either the
     //    timeout fires or the sublead itself is killed by lead_timeout.
     //    Subscribing first guarantees no completion is lost.
-    let mut rx = state.done_tx.subscribe();
+    let mut rx = state.root.done_tx.subscribe();
 
     // ── Fast path: already Done ────────────────────────────────────────────────
     // 1. Worker already Done? (scan all layers — the worker may be in a
@@ -2021,12 +2041,12 @@ pub async fn handle_wait_for_any(
     // wait_for_actor_internal (commit 70e2bd8). Without this, a worker
     // that terminated between our existence check and our subscribe is
     // lost and we block until timeout.
-    let mut rx = state.done_tx.subscribe();
+    let mut rx = state.root.done_tx.subscribe();
     let wait_duration = Duration::from_secs(timeout_secs.unwrap_or(3600));
 
     // Fast path: any already Done? Scan ALL layers — sub-lead-spawned
     // workers are registered in the sub-lead layer's workers map, not
-    // root's. Pre-fix, this only checked `state.workers.read()` (= root
+    // root's. Pre-fix, this only checked `state.root.workers.read()` (= root
     // via Deref) and so stayed blocked indefinitely on sub-lead-owned
     // workers. Same bug class as commit d134289 (which fixed wait_actor
     // + list_workers + worker_status) but this handler had its own
@@ -2214,7 +2234,7 @@ mod tests {
     async fn list_workers_shows_pending_and_running() {
         let state = test_state().await;
         {
-            let mut w = state.workers.write().await;
+            let mut w = state.root.workers.write().await;
             w.insert("w-1".into(), WorkerState::Pending);
             w.insert(
                 "w-2".into(),
@@ -2251,7 +2271,7 @@ mod tests {
         // The background task may have already transitioned the worker to
         // Running or Done by the time we read, so we just assert the key
         // exists and is in a valid state (Pending / Running / Done).
-        let workers = state.workers.read().await;
+        let workers = state.root.workers.read().await;
         assert_eq!(workers.len(), 1);
         let entry = workers.get(&result.task_id).unwrap();
         assert!(matches!(
@@ -2260,7 +2280,7 @@ mod tests {
         ));
 
         // Verify prompt_preview was recorded.
-        let prompts = state.worker_prompts.read().await;
+        let prompts = state.root.worker_prompts.read().await;
         assert_eq!(
             prompts.get(&result.task_id).unwrap(),
             "investigate issue #1"
@@ -2300,7 +2320,7 @@ mod tests {
     #[tokio::test]
     async fn spawn_worker_refuses_when_budget_exceeded() {
         let state = test_state().await; // budget_usd = 5.0
-        *state.spent_usd.lock().await = 5.0; // at cap
+        *state.root.spent_usd.lock().await = 5.0; // at cap
         let args = SpawnWorkerArgs {
             prompt: "p".into(),
             directory: None,
@@ -2367,7 +2387,7 @@ mod tests {
     #[tokio::test]
     async fn spawn_worker_refuses_when_draining() {
         let state = test_state().await;
-        state.cancel.drain();
+        state.root.cancel.drain();
         let args = SpawnWorkerArgs {
             prompt: "p".into(),
             directory: None,
@@ -2432,7 +2452,7 @@ mod tests {
         assert!(result.ok);
 
         // Note: in real wiring, CancelToken signals the SessionHandle to terminate
-        // and the subsequent Done(...) entry in state.workers carries status=Cancelled.
+        // and the subsequent Done(...) entry in state.root.workers carries status=Cancelled.
         // For v0.3 Task 14 (unit-level), we just verify the cancel call succeeded
         // and didn't panic. Full flow is tested in integration tests (Phase 6).
     }
@@ -2445,7 +2465,7 @@ mod tests {
         let state = test_state().await;
         let task_id = "worker-test-1".to_string();
         {
-            let mut w = state.workers.write().await;
+            let mut w = state.root.workers.write().await;
             w.insert(task_id.clone(), WorkerState::Pending);
         }
 
@@ -2475,9 +2495,9 @@ mod tests {
                 model: None,
                 failure_reason: None,
             };
-            let mut w = state_clone.workers.write().await;
+            let mut w = state_clone.root.workers.write().await;
             w.insert(task_id_clone.clone(), WorkerState::Done(rec));
-            let _ = state_clone.done_tx.send(task_id_clone);
+            let _ = state_clone.root.done_tx.send(task_id_clone);
         });
 
         let outcome = handle_wait_for_worker(&state, &task_id, Some(5))
@@ -2491,7 +2511,7 @@ mod tests {
         let state = test_state().await;
         let task_id = "worker-stuck".to_string();
         {
-            let mut w = state.workers.write().await;
+            let mut w = state.root.workers.write().await;
             w.insert(task_id.clone(), WorkerState::Pending);
         }
         let err = handle_wait_for_worker(&state, &task_id, Some(0))
@@ -2517,7 +2537,7 @@ mod tests {
         let state = test_state().await;
         let ids = vec!["w-a".to_string(), "w-b".to_string(), "w-c".to_string()];
         {
-            let mut w = state.workers.write().await;
+            let mut w = state.root.workers.write().await;
             for id in &ids {
                 w.insert(id.clone(), WorkerState::Pending);
             }
@@ -2548,9 +2568,9 @@ mod tests {
                 model: None,
                 failure_reason: None,
             };
-            let mut w = state_clone.workers.write().await;
+            let mut w = state_clone.root.workers.write().await;
             w.insert("w-b".into(), WorkerState::Done(rec));
-            let _ = state_clone.done_tx.send("w-b".into());
+            let _ = state_clone.root.done_tx.send("w-b".into());
         });
 
         let (winner_id, _rec) = handle_wait_for_any(&state, &ids, Some(5)).await.unwrap();
@@ -2659,7 +2679,7 @@ mod tests {
         };
 
         // Subscribe to done events BEFORE spawning.
-        let mut rx = state.done_tx.subscribe();
+        let mut rx = state.root.done_tx.subscribe();
         let spawn = handle_spawn_worker(&state, args).await.unwrap();
 
         // Wait for the broadcast.
@@ -2670,7 +2690,7 @@ mod tests {
         assert_eq!(id, spawn.task_id, "broadcast id matches spawn id");
 
         // Verify Done state + Success + parent_task_id.
-        let workers = state.workers.read().await;
+        let workers = state.root.workers.read().await;
         let entry = workers.get(&spawn.task_id).expect("worker recorded");
         match entry {
             WorkerState::Done(rec) => {
@@ -2689,7 +2709,7 @@ mod tests {
 
         // Verify cost accumulation. claude-haiku-4-5: input $0.80/1M, output $4.00/1M.
         // 1000 input = $0.0008; 2000 output = $0.008; total = $0.0088.
-        let spent = *state.spent_usd.lock().await;
+        let spent = *state.root.spent_usd.lock().await;
         assert!(
             (spent - 0.0088).abs() < 1e-6,
             "expected spent_usd ≈ 0.0088, got {spent}"
@@ -2697,6 +2717,7 @@ mod tests {
 
         // Verify prompt_preview is present.
         let preview = state
+            .root
             .worker_prompts
             .read()
             .await
@@ -2742,7 +2763,7 @@ mod tests {
         );
 
         // Sanity: the reservation should now reflect the two passing spawns.
-        let reserved_now = *state.reserved_usd.lock().await;
+        let reserved_now = *state.root.reserved_usd.lock().await;
         assert!(
             (reserved_now - 0.20).abs() < 1e-9,
             "expected reserved ≈ 0.20, got {reserved_now}"
@@ -2758,7 +2779,7 @@ mod tests {
 
         // Subscribe to done events BEFORE spawning — the completion path is
         // fast (FakeScript exits immediately after emitting the result line).
-        let mut rx = state.done_tx.subscribe();
+        let mut rx = state.root.done_tx.subscribe();
 
         let spawn = handle_spawn_worker(
             &state,
@@ -2788,12 +2809,12 @@ mod tests {
             .expect("broadcast channel open");
         assert_eq!(completed_id, spawn.task_id);
 
-        let reserved_after = *state.reserved_usd.lock().await;
+        let reserved_after = *state.root.reserved_usd.lock().await;
         assert!(
             reserved_after.abs() < 1e-9,
             "reservation should be released after completion, got {reserved_after}"
         );
-        let reservations = state.worker_reservations.read().await;
+        let reservations = state.root.worker_reservations.read().await;
         assert!(
             !reservations.contains_key(&spawn.task_id),
             "reservation entry should be removed on completion"
@@ -2818,7 +2839,7 @@ mod tests {
         use std::time::Duration;
 
         let state = completing_test_state().await;
-        let mut rx = state.done_tx.subscribe();
+        let mut rx = state.root.done_tx.subscribe();
         let args = SpawnWorkerArgs {
             prompt: "analyze".into(),
             directory: None,
@@ -2836,7 +2857,7 @@ mod tests {
 
         // Post-completion, the worker is in Done state. The session_id is
         // preserved on TaskRecord via SessionOutcome. Assert it.
-        let workers = state.workers.read().await;
+        let workers = state.root.workers.read().await;
         match workers.get(&spawn.task_id).unwrap() {
             WorkerState::Done(rec) => {
                 assert_eq!(rec.claude_session_id.as_deref(), Some("sess_ok"));
@@ -2909,11 +2930,12 @@ mod tests {
         let state = test_state().await;
         let worker_token = pitboss_core::session::CancelToken::new();
         state
+            .root
             .worker_cancels
             .write()
             .await
             .insert("w-1".into(), worker_token.clone());
-        state.workers.write().await.insert(
+        state.root.workers.write().await.insert(
             "w-1".into(),
             WorkerState::Running {
                 started_at: chrono::Utc::now(),
@@ -2925,7 +2947,7 @@ mod tests {
             .unwrap();
         assert!(res.ok);
         assert!(worker_token.is_terminated());
-        let workers = state.workers.read().await;
+        let workers = state.root.workers.read().await;
         assert!(matches!(
             workers.get("w-1").unwrap(),
             WorkerState::Paused { .. }
@@ -2950,16 +2972,18 @@ mod tests {
         // Register the pid + Running state.
         let slot = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(pid));
         state
+            .root
             .worker_pids
             .write()
             .await
             .insert("w-freeze".into(), slot);
         state
+            .root
             .worker_cancels
             .write()
             .await
             .insert("w-freeze".into(), pitboss_core::session::CancelToken::new());
-        state.workers.write().await.insert(
+        state.root.workers.write().await.insert(
             "w-freeze".into(),
             WorkerState::Running {
                 started_at: chrono::Utc::now(),
@@ -2973,7 +2997,7 @@ mod tests {
             .unwrap();
         assert!(res.ok);
         assert!(matches!(
-            state.workers.read().await.get("w-freeze").unwrap(),
+            state.root.workers.read().await.get("w-freeze").unwrap(),
             WorkerState::Frozen { .. }
         ));
 
@@ -3001,7 +3025,7 @@ mod tests {
         .unwrap();
         assert!(cres.ok);
         assert!(matches!(
-            state.workers.read().await.get("w-freeze").unwrap(),
+            state.root.workers.read().await.get("w-freeze").unwrap(),
             WorkerState::Running { .. }
         ));
 
@@ -3014,7 +3038,7 @@ mod tests {
     #[tokio::test]
     async fn handle_continue_worker_resumes_paused() {
         let state = test_state().await;
-        state.workers.write().await.insert(
+        state.root.workers.write().await.insert(
             "w-1".into(),
             WorkerState::Paused {
                 session_id: "sess".into(),
@@ -3023,11 +3047,13 @@ mod tests {
             },
         );
         state
+            .root
             .worker_prompts
             .write()
             .await
             .insert("w-1".into(), "hi".into());
         state
+            .root
             .worker_models
             .write()
             .await
@@ -3042,7 +3068,7 @@ mod tests {
         .await
         .unwrap();
         assert!(res.ok);
-        let workers = state.workers.read().await;
+        let workers = state.root.workers.read().await;
         assert!(matches!(
             workers.get("w-1").unwrap(),
             WorkerState::Running { .. }
@@ -3054,11 +3080,12 @@ mod tests {
         let state = test_state().await;
         let worker_token = pitboss_core::session::CancelToken::new();
         state
+            .root
             .worker_cancels
             .write()
             .await
             .insert("w-1".into(), worker_token.clone());
-        state.workers.write().await.insert(
+        state.root.workers.write().await.insert(
             "w-1".into(),
             WorkerState::Running {
                 started_at: chrono::Utc::now(),
@@ -3066,11 +3093,13 @@ mod tests {
             },
         );
         state
+            .root
             .worker_prompts
             .write()
             .await
             .insert("w-1".into(), "original".into());
         state
+            .root
             .worker_models
             .write()
             .await
@@ -3089,6 +3118,7 @@ mod tests {
         assert!(res.ok);
         // Counter bumps on success.
         let counters = state
+            .root
             .worker_counters
             .read()
             .await
@@ -3098,6 +3128,7 @@ mod tests {
         assert_eq!(counters.reprompt_count, 1);
         // events.jsonl records the reprompt.
         let events_path = state
+            .root
             .run_subdir
             .join("tasks")
             .join("w-1")
@@ -3108,7 +3139,7 @@ mod tests {
             "events.jsonl missing reprompt: {events}"
         );
         // Worker transitioned back to Running via spawn_resume_worker.
-        let workers = state.workers.read().await;
+        let workers = state.root.workers.read().await;
         assert!(matches!(
             workers.get("w-1").unwrap(),
             WorkerState::Running { .. }
@@ -3141,6 +3172,7 @@ mod tests {
             failure_reason: None,
         };
         state
+            .root
             .workers
             .write()
             .await
@@ -3389,6 +3421,7 @@ mod tests {
     async fn propose_plan_auto_approve_flips_flag() {
         let state = mk_plan_state(crate::dispatch::state::ApprovalPolicy::AutoApprove, true).await;
         assert!(!state
+            .root
             .plan_approved
             .load(std::sync::atomic::Ordering::Acquire));
 
@@ -3410,6 +3443,7 @@ mod tests {
         .unwrap();
         assert!(resp.approved);
         assert!(state
+            .root
             .plan_approved
             .load(std::sync::atomic::Ordering::Acquire));
     }
@@ -3433,6 +3467,7 @@ mod tests {
         assert!(!resp.approved);
         assert!(
             !state
+                .root
                 .plan_approved
                 .load(std::sync::atomic::Ordering::Acquire),
             "rejected plan must not flip plan_approved — lead should be able to retry"

--- a/crates/pitboss-cli/tests/control_flows.rs
+++ b/crates/pitboss-cli/tests/control_flows.rs
@@ -71,11 +71,12 @@ async fn pause_op_writes_events_jsonl() {
     ));
     let worker_token = CancelToken::new();
     state
+        .root
         .worker_cancels
         .write()
         .await
         .insert("w-1".into(), worker_token);
-    state.workers.write().await.insert(
+    state.root.workers.write().await.insert(
         "w-1".into(),
         WorkerState::Running {
             started_at: chrono::Utc::now(),
@@ -289,7 +290,7 @@ async fn block_policy_queue_drains_on_tui_connect() {
 
     // Give the request a moment to queue.
     tokio::time::sleep(Duration::from_millis(50)).await;
-    assert_eq!(state.approval_queue.lock().await.len(), 1);
+    assert_eq!(state.root.approval_queue.lock().await.len(), 1);
 
     // Connect a TUI. The server drains the queue on connect.
     let sock = dir.path().join("block-drain.sock");
@@ -599,6 +600,7 @@ async fn propose_plan_end_to_end_unblocks_spawn_gate() {
         .unwrap();
     assert!(resp.approved);
     assert!(state
+        .root
         .plan_approved
         .load(std::sync::atomic::Ordering::Acquire));
 

--- a/crates/pitboss-cli/tests/dogfood_fake_flows.rs
+++ b/crates/pitboss-cli/tests/dogfood_fake_flows.rs
@@ -289,7 +289,7 @@ async fn dogfood_isolation_strict_tree() {
     use serde_json::json;
 
     let (_dir, state) = mk_state_with_subleads();
-    let socket = socket_path_for_run(state.run_id, &state.root.manifest.run_dir);
+    let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
@@ -509,7 +509,7 @@ async fn dogfood_kill_cascade_drain() {
     // depth-first drain reaches every worker within the grace window.
 
     let (_dir, state) = mk_state_with_subleads();
-    let socket = socket_path_for_run(state.run_id, &state.root.manifest.run_dir);
+    let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
@@ -650,7 +650,7 @@ async fn dogfood_run_lease_contention() {
     // acquires. Demonstrates the run_lease_* API for cross-tree coordination.
 
     let (_dir, state) = mk_state_with_subleads();
-    let socket = socket_path_for_run(state.run_id, &state.root.manifest.run_dir);
+    let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
@@ -789,7 +789,7 @@ async fn dogfood_policy_auto_filter() {
     // - Only S2's tool-use and S1's plan blocked in queue (2 entries)
 
     let (_dir, state) = mk_state_with_subleads();
-    let socket = socket_path_for_run(state.run_id, &state.root.manifest.run_dir);
+    let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
@@ -1059,7 +1059,7 @@ async fn dogfood_envelope_cap_rejection() {
         (dir, state)
     };
 
-    let socket = socket_path_for_run(state.run_id, &state.root.manifest.run_dir);
+    let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();

--- a/crates/pitboss-cli/tests/e2e_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_flows.rs
@@ -210,7 +210,7 @@ async fn e2e_lead_spawns_worker_via_real_subprocess() {
     let (run_id, state) = mk_state(dir.path(), ApprovalPolicy::Block);
 
     // Start the MCP server so fake-claude's mcp_call can land somewhere.
-    let sock = socket_path_for_run(run_id, &state.manifest.run_dir);
+    let sock = socket_path_for_run(run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(sock.clone(), state.clone()).await.unwrap();
 
     // Write the script. spawn_worker returns {task_id: "worker-..."},
@@ -227,7 +227,7 @@ async fn e2e_lead_spawns_worker_via_real_subprocess() {
     tokio::fs::write(&script, script_body).await.unwrap();
 
     // Run fake-claude as the lead. A real TokioSpawner subprocess, not the
-    // FakeSpawner in state.spawner (which backs the workers it spawns).
+    // FakeSpawner in state.root.spawner (which backs the workers it spawns).
     let outcome = run_fake_claude_lead(
         dir.path(),
         &script,
@@ -249,7 +249,7 @@ async fn e2e_lead_spawns_worker_via_real_subprocess() {
     ));
 
     // Worker state should be Done with a captured session_id.
-    let workers = state.workers.read().await;
+    let workers = state.root.workers.read().await;
     assert_eq!(
         workers.len(),
         1,
@@ -266,7 +266,7 @@ async fn e2e_lead_spawns_worker_via_real_subprocess() {
     }
 
     // Explicit cleanup: cancel the run token so any stray tasks exit.
-    state.cancel.terminate();
+    state.root.cancel.terminate();
 }
 
 #[tokio::test]
@@ -276,7 +276,7 @@ async fn e2e_lead_spawns_three_workers_and_waits_for_any() {
     let dir = TempDir::new().unwrap();
     let (run_id, state) = mk_state(dir.path(), ApprovalPolicy::Block);
 
-    let sock = socket_path_for_run(run_id, &state.manifest.run_dir);
+    let sock = socket_path_for_run(run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(sock.clone(), state.clone()).await.unwrap();
 
     // Three spawn_workers then one wait_for_any. Workers complete quickly
@@ -308,7 +308,7 @@ async fn e2e_lead_spawns_three_workers_and_waits_for_any() {
 
     // All 3 workers should be registered (at least 1 Done; the rest can be
     // Done or Running depending on timing).
-    let workers = state.workers.read().await;
+    let workers = state.root.workers.read().await;
     assert_eq!(
         workers.len(),
         3,
@@ -325,7 +325,7 @@ async fn e2e_lead_spawns_three_workers_and_waits_for_any() {
         "expected at least one Done worker after wait_for_any, got {done_count}"
     );
 
-    state.cancel.terminate();
+    state.root.cancel.terminate();
 }
 
 #[tokio::test]
@@ -393,7 +393,7 @@ async fn e2e_lead_cancels_worker_mid_flight() {
         std::sync::Arc::new(pitboss_cli::shared_store::SharedStore::new()),
     ));
 
-    let sock = socket_path_for_run(run_id, &state.manifest.run_dir);
+    let sock = socket_path_for_run(run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(sock.clone(), state.clone()).await.unwrap();
 
     // spawn_worker (worker hangs), sleep for slot fill, cancel_worker, list.
@@ -424,7 +424,7 @@ async fn e2e_lead_cancels_worker_mid_flight() {
     tokio::time::sleep(Duration::from_millis(1000)).await;
 
     // Worker should now be Cancelled.
-    let workers = state.workers.read().await;
+    let workers = state.root.workers.read().await;
     let (_, w) = workers.iter().next().expect("at least one worker");
     match w {
         pitboss_cli::dispatch::state::WorkerState::Done(rec) => {
@@ -438,7 +438,7 @@ async fn e2e_lead_cancels_worker_mid_flight() {
         other => panic!("expected Done(Cancelled), got {other:?}"),
     }
 
-    state.cancel.terminate();
+    state.root.cancel.terminate();
 }
 
 #[tokio::test]
@@ -449,16 +449,18 @@ async fn e2e_lead_request_approval_round_trip() {
     let (run_id, state) = mk_state(dir.path(), ApprovalPolicy::Block);
 
     // Ensure the run subdir exists so events.jsonl writes don't fail.
-    tokio::fs::create_dir_all(&state.run_subdir).await.unwrap();
+    tokio::fs::create_dir_all(&state.root.run_subdir)
+        .await
+        .unwrap();
 
     // Start BOTH the MCP server (for the lead) and the Control server
     // (for FakeControlClient).
-    let mcp_sock = socket_path_for_run(run_id, &state.manifest.run_dir);
+    let mcp_sock = socket_path_for_run(run_id, &state.root.manifest.run_dir);
     let _mcp_server = McpServer::start(mcp_sock.clone(), state.clone())
         .await
         .unwrap();
 
-    let ctrl_sock = pitboss_cli::control::control_socket_path(run_id, &state.manifest.run_dir);
+    let ctrl_sock = pitboss_cli::control::control_socket_path(run_id, &state.root.manifest.run_dir);
     let _ctrl_server = pitboss_cli::control::server::start_control_server(
         ctrl_sock.clone(),
         "0.4.1".into(),
@@ -479,7 +481,7 @@ async fn e2e_lead_request_approval_round_trip() {
         // Poll up to 2s for the approval_queue to fill.
         let poll_deadline = tokio::time::Instant::now() + Duration::from_secs(2);
         loop {
-            if !state_for_fcc.approval_queue.lock().await.is_empty() {
+            if !state_for_fcc.root.approval_queue.lock().await.is_empty() {
                 break;
             }
             if tokio::time::Instant::now() >= poll_deadline {
@@ -542,6 +544,7 @@ async fn e2e_lead_request_approval_round_trip() {
 
     // Check events.jsonl for both approval_request and approval_response.
     let events_path = state
+        .root
         .run_subdir
         .join("tasks")
         .join("lead")
@@ -562,6 +565,7 @@ async fn e2e_lead_request_approval_round_trip() {
 
     // Counters should record one request + one approval.
     let counters = state
+        .root
         .worker_counters
         .read()
         .await
@@ -572,7 +576,7 @@ async fn e2e_lead_request_approval_round_trip() {
     assert_eq!(counters.approvals_approved, 1);
     assert_eq!(counters.approvals_rejected, 0);
 
-    state.cancel.terminate();
+    state.root.cancel.terminate();
 }
 
 #[tokio::test]
@@ -648,7 +652,7 @@ async fn e2e_lead_reprompts_running_worker() {
         std::sync::Arc::new(pitboss_cli::shared_store::SharedStore::new()),
     ));
 
-    let sock = socket_path_for_run(run_id, &state.manifest.run_dir);
+    let sock = socket_path_for_run(run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(sock.clone(), state.clone()).await.unwrap();
 
     // Spawn a worker, sleep for init+result to land (session_id captured),
@@ -676,7 +680,7 @@ async fn e2e_lead_reprompts_running_worker() {
 
     // Extract the worker's task_id for subsequent assertions.
     let task_id = {
-        let workers = state.workers.read().await;
+        let workers = state.root.workers.read().await;
         workers.keys().next().cloned().expect("at least one worker")
     };
 
@@ -690,6 +694,7 @@ async fn e2e_lead_reprompts_running_worker() {
 
     // Counter bumped.
     let counters = state
+        .root
         .worker_counters
         .read()
         .await
@@ -698,7 +703,7 @@ async fn e2e_lead_reprompts_running_worker() {
         .unwrap_or_default();
     assert_eq!(counters.reprompt_count, 1);
 
-    state.cancel.terminate();
+    state.root.cancel.terminate();
 }
 
 #[tokio::test]
@@ -831,11 +836,11 @@ async fn e2e_lead_propose_plan_gate_unblocks_spawn() {
         std::sync::Arc::new(pitboss_cli::shared_store::SharedStore::new()),
     ));
 
-    let mcp_sock = socket_path_for_run(run_id, &state.manifest.run_dir);
+    let mcp_sock = socket_path_for_run(run_id, &state.root.manifest.run_dir);
     let _mcp_server = McpServer::start(mcp_sock.clone(), state.clone())
         .await
         .unwrap();
-    let ctrl_sock = pitboss_cli::control::control_socket_path(run_id, &state.manifest.run_dir);
+    let ctrl_sock = pitboss_cli::control::control_socket_path(run_id, &state.root.manifest.run_dir);
     let _ctrl_server = pitboss_cli::control::server::start_control_server(
         ctrl_sock.clone(),
         "0.4.5".into(),
@@ -852,7 +857,7 @@ async fn e2e_lead_propose_plan_gate_unblocks_spawn() {
     let fcc_task = tokio::spawn(async move {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
         loop {
-            if !state_for_fcc.approval_queue.lock().await.is_empty() {
+            if !state_for_fcc.root.approval_queue.lock().await.is_empty() {
                 break;
             }
             if tokio::time::Instant::now() >= deadline {
@@ -920,9 +925,10 @@ async fn e2e_lead_propose_plan_gate_unblocks_spawn() {
 
     // plan_approved latched true, one worker spawned successfully.
     assert!(state
+        .root
         .plan_approved
         .load(std::sync::atomic::Ordering::Acquire));
-    let workers = state.workers.read().await;
+    let workers = state.root.workers.read().await;
     assert_eq!(
         workers.len(),
         1,
@@ -930,7 +936,7 @@ async fn e2e_lead_propose_plan_gate_unblocks_spawn() {
         workers.len()
     );
 
-    state.cancel.terminate();
+    state.root.cancel.terminate();
 }
 
 /// Full-stack bridge test: fake-claude lead spawns `pitboss mcp-bridge`
@@ -948,7 +954,7 @@ async fn e2e_lead_through_mcp_bridge_injects_meta() {
     let dir = TempDir::new().unwrap();
     let (run_id, state) = mk_state(dir.path(), ApprovalPolicy::Block);
 
-    let sock = socket_path_for_run(run_id, &state.manifest.run_dir);
+    let sock = socket_path_for_run(run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(sock.clone(), state.clone()).await.unwrap();
 
     // Lead script: init, kv_set on /shared/bridge_probe, result.
@@ -991,6 +997,7 @@ async fn e2e_lead_through_mcp_bridge_injects_meta() {
     // the call (missing required _meta) or write with a different
     // actor_id — both caught here.
     let entry = state
+        .root
         .shared_store
         .get("/shared/bridge_probe")
         .await
@@ -1002,7 +1009,7 @@ async fn e2e_lead_through_mcp_bridge_injects_meta() {
         entry.written_by
     );
 
-    state.cancel.terminate();
+    state.root.cancel.terminate();
 }
 
 /// Test-only ProcessSpawner that rewrites each spawn to run fake-claude
@@ -1125,7 +1132,7 @@ async fn e2e_freeze_pause_and_continue_real_subprocess_worker() {
         std::sync::Arc::new(pitboss_cli::shared_store::SharedStore::new()),
     ));
 
-    let mcp_sock = socket_path_for_run(run_id, &state.manifest.run_dir);
+    let mcp_sock = socket_path_for_run(run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(mcp_sock.clone(), state.clone())
         .await
         .unwrap();
@@ -1171,6 +1178,6 @@ async fn e2e_freeze_pause_and_continue_real_subprocess_worker() {
     // We do wait a tick for the worker background task to settle so
     // the test's Drop teardown doesn't race a live subprocess.
     tokio::time::sleep(Duration::from_millis(200)).await;
-    state.cancel.terminate();
+    state.root.cancel.terminate();
     tokio::time::sleep(Duration::from_millis(200)).await;
 }

--- a/crates/pitboss-cli/tests/e2e_sublead_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_sublead_flows.rs
@@ -376,7 +376,7 @@ async fn root_kill_cascades_to_sublead_workers() {
 ///
 /// Using `mk_state_hold_workers` (hold-until-signal FakeScript) keeps both
 /// sub-lead subprocesses alive for the duration of the test so no reconcile
-/// fires until `state.cancel.terminate()` cascades the shutdown.
+/// fires until `state.root.cancel.terminate()` cascades the shutdown.
 #[tokio::test]
 async fn run_global_lease_serializes_two_subleads() {
     use serde_json::json;
@@ -473,7 +473,7 @@ async fn run_global_lease_serializes_two_subleads() {
         acq3.err()
     );
 
-    state.cancel.terminate();
+    state.root.cancel.terminate();
 }
 
 // ── Test 4: Reject-with-reason reaches sub-lead session ──────────────────────
@@ -494,7 +494,9 @@ async fn reject_with_reason_reaches_sublead_session() {
     let (run_id, state) = mk_state(dir.path());
 
     // create run subdir so events.jsonl writes don't fail
-    tokio::fs::create_dir_all(&state.run_subdir).await.unwrap();
+    tokio::fs::create_dir_all(&state.root.run_subdir)
+        .await
+        .unwrap();
 
     let mcp_sock = socket_path_for_run(run_id, &state.root.manifest.run_dir);
     let _mcp_server = McpServer::start(mcp_sock.clone(), state.clone())
@@ -603,7 +605,7 @@ async fn reject_with_reason_reaches_sublead_session() {
     );
 
     // Rejection counter is keyed by the root layer's lead_id ("root"), since
-    // ApprovalBridge::new receives the root DispatchState and uses state.lead_id.
+    // ApprovalBridge::new receives the root DispatchState and uses state.root.lead_id.
     let counters = state
         .root
         .worker_counters
@@ -617,7 +619,7 @@ async fn reject_with_reason_reaches_sublead_session() {
         "rejections counter on root lead should be 1 after sub-lead rejection"
     );
 
-    state.cancel.terminate();
+    state.root.cancel.terminate();
 }
 
 // ── Test 5: Budget envelope returns to root pool ──────────────────────────────
@@ -913,5 +915,5 @@ async fn sublead_session_spawns_runs_and_reconciles() {
         "root.reserved_usd should be 0 after reconcile"
     );
 
-    state.cancel.terminate();
+    state.root.cancel.terminate();
 }

--- a/crates/pitboss-cli/tests/hierarchical_flows.rs
+++ b/crates/pitboss-cli/tests/hierarchical_flows.rs
@@ -22,7 +22,7 @@ use uuid::Uuid;
 fn mk_state() -> (TempDir, Arc<DispatchState>) {
     let dir = TempDir::new().unwrap();
     // Lead with use_worktree=false so background worker spawns don't require
-    // an actual git repo at state.manifest.lead.directory.
+    // an actual git repo at state.root.manifest.lead.directory.
     let lead = ResolvedLead {
         id: "lead".into(),
         directory: PathBuf::from("/tmp"),
@@ -87,7 +87,7 @@ fn mk_state() -> (TempDir, Arc<DispatchState>) {
 #[tokio::test]
 async fn mcp_spawn_and_list_round_trip() {
     let (_dir, state) = mk_state();
-    let socket = socket_path_for_run(state.run_id, &state.manifest.run_dir);
+    let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
@@ -118,7 +118,7 @@ async fn mcp_spawn_and_list_round_trip() {
 #[tokio::test]
 async fn mcp_spawn_over_max_workers_returns_error() {
     let (_dir, state) = mk_state(); // max_workers = 4
-    let socket = socket_path_for_run(state.run_id, &state.manifest.run_dir);
+    let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
@@ -161,8 +161,8 @@ async fn mcp_spawn_over_max_workers_returns_error() {
 #[tokio::test]
 async fn mcp_spawn_over_budget_returns_error() {
     let (_dir, state) = mk_state(); // budget_usd = 5.0
-    *state.spent_usd.lock().await = 5.0;
-    let socket = socket_path_for_run(state.run_id, &state.manifest.run_dir);
+    *state.root.spent_usd.lock().await = 5.0;
+    let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
@@ -194,8 +194,8 @@ async fn mcp_spawn_over_budget_returns_error() {
 #[tokio::test]
 async fn mcp_spawn_while_draining_returns_error() {
     let (_dir, state) = mk_state();
-    state.cancel.drain();
-    let socket = socket_path_for_run(state.run_id, &state.manifest.run_dir);
+    state.root.cancel.drain();
+    let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
@@ -237,7 +237,7 @@ async fn wait_actor_alias_resolves_worker_id() {
     use std::time::Duration;
 
     let (_dir, state) = mk_state();
-    let socket = socket_path_for_run(state.run_id, &state.manifest.run_dir);
+    let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
@@ -280,9 +280,9 @@ async fn wait_actor_alias_resolves_worker_id() {
             model: None,
             failure_reason: None,
         };
-        let mut w = state_clone.workers.write().await;
+        let mut w = state_clone.root.workers.write().await;
         w.insert(worker_id_clone.clone(), WorkerState::Done(rec));
-        let _ = state_clone.done_tx.send(worker_id_clone);
+        let _ = state_clone.root.done_tx.send(worker_id_clone);
     });
 
     // wait_actor should accept a worker id (back-compat path) and

--- a/crates/pitboss-cli/tests/shared_store_flows.rs
+++ b/crates/pitboss-cli/tests/shared_store_flows.rs
@@ -479,7 +479,7 @@ async fn lease_released_when_mcp_connection_drops() {
         Arc::new(SharedStore::new()),
     ));
 
-    let socket = socket_path_for_run(state.run_id, &state.manifest.run_dir);
+    let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
@@ -615,7 +615,7 @@ async fn run_global_lease_released_when_mcp_connection_drops() {
         Arc::new(SharedStore::new()),
     ));
 
-    let socket = socket_path_for_run(state.run_id, &state.manifest.run_dir);
+    let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();

--- a/crates/pitboss-cli/tests/sublead_flows.rs
+++ b/crates/pitboss-cli/tests/sublead_flows.rs
@@ -156,7 +156,7 @@ async fn sublead_kv_writes_isolated_from_root() {
     use serde_json::json;
 
     let (_dir, state) = mk_state_with_subleads();
-    let socket = socket_path_for_run(state.run_id, &state.root.manifest.run_dir);
+    let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
@@ -227,7 +227,7 @@ async fn sublead_workers_cannot_read_sibling_peer_slots() {
     use serde_json::json;
 
     let (_dir, state) = mk_state_with_subleads();
-    let socket = socket_path_for_run(state.run_id, &state.root.manifest.run_dir);
+    let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
@@ -271,7 +271,7 @@ async fn sublead_workers_cannot_wait_on_sibling_peer_slots() {
     use serde_json::json;
 
     let (_dir, state) = mk_state_with_subleads();
-    let socket = socket_path_for_run(state.run_id, &state.root.manifest.run_dir);
+    let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
@@ -304,7 +304,7 @@ async fn sublead_workers_cannot_wait_on_sibling_peer_slots() {
 #[tokio::test]
 async fn spawn_sublead_tool_is_exposed_to_root() {
     let (_dir, state) = mk_state_with_subleads();
-    let socket = socket_path_for_run(state.run_id, &state.root.manifest.run_dir);
+    let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
@@ -322,7 +322,7 @@ async fn spawn_sublead_creates_isolated_layer() {
     use serde_json::json;
 
     let (_dir, state) = mk_state_with_subleads();
-    let socket = socket_path_for_run(state.run_id, &state.root.manifest.run_dir);
+    let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
@@ -378,7 +378,7 @@ async fn root_cancel_cascades_to_sublead_workers() {
     use serde_json::json;
 
     let (_dir, state) = mk_state_with_subleads();
-    let socket = socket_path_for_run(state.run_id, &state.root.manifest.run_dir);
+    let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
@@ -440,7 +440,7 @@ async fn sublead_cannot_call_spawn_sublead() {
     use serde_json::json;
 
     let (_dir, state) = mk_state_with_subleads();
-    let socket = socket_path_for_run(state.run_id, &state.root.manifest.run_dir);
+    let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
@@ -529,7 +529,7 @@ async fn run_lease_blocks_cross_subtree_acquisition() {
     use serde_json::json;
 
     let (_dir, state) = mk_state_with_subleads();
-    let socket = socket_path_for_run(state.run_id, &state.root.manifest.run_dir);
+    let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
@@ -725,7 +725,7 @@ async fn policy_auto_approves_sublead_actor() {
     use serde_json::json;
 
     let (_dir, state) = mk_state_with_subleads();
-    let socket = socket_path_for_run(state.run_id, &state.root.manifest.run_dir);
+    let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
@@ -918,7 +918,7 @@ async fn kill_worker_with_reason_reprompts_parent_sublead() {
     use serde_json::json;
 
     let (_dir, state) = mk_state_with_subleads();
-    let socket = socket_path_for_run(state.run_id, &state.root.manifest.run_dir);
+    let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
@@ -1053,7 +1053,7 @@ async fn spawn_sublead_rejected_when_over_max_sublead_budget() {
     // Build state with max_sublead_budget_usd = 3.0 baked into the manifest.
     let (_dir, state) = mk_state_with_sublead_budget_cap(3.0);
 
-    let socket = socket_path_for_run(state.run_id, &state.root.manifest.run_dir);
+    let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
@@ -1211,7 +1211,7 @@ async fn wait_actor_still_handles_worker_back_compat() {
     // Register a worker in Pending state.
     let worker_id = "worker-bc-test".to_string();
     {
-        let mut w = state.workers.write().await;
+        let mut w = state.root.workers.write().await;
         w.insert(worker_id.clone(), WorkerState::Pending);
     }
 
@@ -1241,9 +1241,9 @@ async fn wait_actor_still_handles_worker_back_compat() {
             model: None,
             failure_reason: None,
         };
-        let mut w = state_clone.workers.write().await;
+        let mut w = state_clone.root.workers.write().await;
         w.insert(worker_id_clone.clone(), WorkerState::Done(rec));
-        let _ = state_clone.done_tx.send(worker_id_clone);
+        let _ = state_clone.root.done_tx.send(worker_id_clone);
     });
 
     // wait_actor should return the Worker variant for a regular worker.
@@ -1270,7 +1270,7 @@ async fn sublead_spawn_worker_registers_in_sub_tree_layer() {
     use serde_json::json;
 
     let (_dir, state) = mk_state_with_subleads();
-    let socket = socket_path_for_run(state.run_id, &state.root.manifest.run_dir);
+    let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
@@ -1342,7 +1342,7 @@ async fn worker_cannot_spawn_worker() {
     use serde_json::json;
 
     let (_dir, state) = mk_state_with_subleads();
-    let socket = socket_path_for_run(state.run_id, &state.root.manifest.run_dir);
+    let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
@@ -1421,7 +1421,7 @@ async fn kill_with_reason_delivers_synthetic_reprompt_to_running_lead() {
     use serde_json::json;
 
     let (_dir, state) = mk_state_with_subleads();
-    let socket = socket_path_for_run(state.run_id, &state.root.manifest.run_dir);
+    let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
@@ -1509,7 +1509,7 @@ async fn kill_with_reason_skips_delivery_when_lead_already_terminated() {
     use serde_json::json;
 
     let (_dir, state) = mk_state_with_subleads();
-    let socket = socket_path_for_run(state.run_id, &state.root.manifest.run_dir);
+    let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
@@ -1695,7 +1695,7 @@ async fn kill_with_reason_delivers_to_root_lead() {
     use serde_json::json;
 
     let (_dir, state) = mk_state_with_subleads();
-    let socket = socket_path_for_run(state.run_id, &state.root.manifest.run_dir);
+    let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();

--- a/crates/pitboss-core/src/worktree/mod.rs
+++ b/crates/pitboss-core/src/worktree/mod.rs
@@ -12,8 +12,14 @@ mod tests {
     use tempfile::TempDir;
 
     fn init_repo(root: &std::path::Path) {
+        // Pin the initial branch name to `master` so these tests don't depend
+        // on the runner's `init.defaultBranch` git config. libgit2's worktree
+        // creation resolves HEAD → `refs/heads/master` when the manager is
+        // invoked without an explicit branch; runners that default HEAD to
+        // `main` (GitHub Actions post-Oct 2020) previously failed all 8
+        // tests here with "reference 'refs/heads/master' not found".
         Command::new("git")
-            .args(["init", "-q"])
+            .args(["init", "-q", "--initial-branch=master"])
             .current_dir(root)
             .status()
             .unwrap();
@@ -24,6 +30,14 @@ mod tests {
             .unwrap();
         Command::new("git")
             .args(["config", "user.name", "t"])
+            .current_dir(root)
+            .status()
+            .unwrap();
+        // Disable commit signing so the init commit succeeds regardless of
+        // the developer's global git config (CI runners don't sign; some
+        // local setups do and fail without a signing key available).
+        Command::new("git")
+            .args(["config", "commit.gpgsign", "false"])
             .current_dir(root)
             .status()
             .unwrap();


### PR DESCRIPTION
## Summary

Two independent fixes:

### 1. Close issue #56 — remove `Deref` from `DispatchState`

`DispatchState` implemented `Deref<Target = LayerState>` that silently aliased the root layer. Any handler that forgot to call `resolve_layer_for_caller` before a KV, lease, or worker op fell through to the root layer with no compile-time signal — the root cause of #51 (approval TTL watcher missing sublead layer) and a class of sub-tree lease leaks.

Per the architecture options I wrote up on #56, this is option 3: drop the Deref and migrate every call site to the explicit `state.root.<field>` form. Sub-tree access is unchanged (`state.subleads.read().await` / `resolve_layer_for_caller`).

270+ mechanical substitutions across 13 files. All sites previously resolved to root via Deref; nothing changes at runtime. What changes is that adding a new handler that writes `state.<field>` now fails to compile — forcing the author to pick a layer. Module + struct doc on `DispatchState` rewritten to document the new contract.

### 2. Fix the post-merge CI failure on `main`

The push-to-`main` run for c96b974 (PR #74 squash-merge) failed 8 `worktree::tests` in pitboss-core with `reference 'refs/heads/master' not found`. The test helper `init_repo` (`crates/pitboss-core/src/worktree/mod.rs:14`) ran `git init -q` without a branch name, so the repo's HEAD depended on the runner's `init.defaultBranch`. libgit2 looks for `refs/heads/master` when the worktree manager is invoked without an explicit branch — on runners with `init.defaultBranch=main`, that ref doesn't exist.

Pin `--initial-branch=master` in the helper. Also set `commit.gpgsign false` in the test repo so the init commit succeeds on dev machines whose global config enables signing (previously surfaced as a signing-server 400 that masked the branch-name issue locally).

Both PR #71 and PR #74 had flagged this as a pre-existing failure that CI wasn't hitting; it started biting once `init.defaultBranch=main` propagated to the GHA runner image.

## Test plan

- [x] `bash scripts/ci-local.sh` — fmt, clippy with `-D warnings` + `--all-features`, full test suite with `--features pitboss-core/test-support` — all green.
- [x] Targeted: `cargo test -p pitboss-core worktree::tests` — 8/8 pass (previously 0/8).
- [x] Targeted: full workspace `cargo build --tests` with `--all-features` — 0 errors after Deref removal; every missed call site would surface as `no field X on type DispatchState` and none remain.

https://claude.ai/code/session_01Dc5J61yB7QiKYV8LrJsQoA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dc5J61yB7QiKYV8LrJsQoA)_