### PR TITLE
feat: pitboss container-dispatch subcommand

### DIFF
--- a/crates/pitboss-cli/src/cli.rs
+++ b/crates/pitboss-cli/src/cli.rs
@@ -110,6 +110,21 @@ pub enum Command {
         #[arg(long, value_enum)]
         actor_role: ActorRoleArg,
     },
+    /// Run a dispatch inside a container, assembling the docker/podman invocation
+    /// from the manifest's `[container]` section. Replaces the current process
+    /// with the container run (exec-style). Requires `[container]` in the manifest.
+    ContainerDispatch {
+        manifest: PathBuf,
+        /// Override run_dir from the manifest / default.
+        #[arg(long)]
+        run_dir: Option<PathBuf>,
+        /// Print the container run command and exit without executing.
+        #[arg(long)]
+        dry_run: bool,
+        /// Override container runtime detection ("docker" or "podman").
+        #[arg(long)]
+        runtime: Option<String>,
+    },
     /// Print shell completion script for the given shell (bash, zsh, fish,
     /// elvish, powershell) to stdout.
     Completions {

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -967,6 +967,7 @@ mod tests {
             dump_shared_store: false,
             require_plan_approval: false,
             approval_rules: vec![],
+            container: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -1225,6 +1226,7 @@ mod tests {
             dump_shared_store: false,
             require_plan_approval: false,
             approval_rules: vec![],
+            container: None,
         };
         let sub_layer = std::sync::Arc::new(LayerState::new(
             run_id,

--- a/crates/pitboss-cli/src/dispatch/container.rs
+++ b/crates/pitboss-cli/src/dispatch/container.rs
@@ -136,10 +136,14 @@ fn build_run_args(
     }
 
     // ── Manifest ─────────────────────────────────────────────────────────────
+    // Strip the [container] section before mounting: the inner `pitboss dispatch`
+    // doesn't use it, and images built before this feature was added reject it
+    // as an unknown field under deny_unknown_fields.
+    let manifest_host = strip_container_section(manifest_abs)?;
     args.push("-v".into());
     args.push(format!(
         "{}:/run/pitboss.toml:ro,z",
-        manifest_abs.display()
+        manifest_host.display()
     ));
 
     // ── Working directory ─────────────────────────────────────────────────────
@@ -271,10 +275,48 @@ fn default_run_dir() -> PathBuf {
         .join(".local/share/pitboss/runs")
 }
 
+/// Read `manifest_abs`, remove the `[container]` key, and write the result to
+/// a temp file. Returns the temp file path, which is mounted read-only into the
+/// container in place of the original manifest.
+///
+/// Stripping is necessary because older container images (built before
+/// `container-dispatch` was introduced) reject `[container]` as an unknown
+/// field when parsing with `deny_unknown_fields`. The inner `pitboss dispatch`
+/// has no use for the section anyway — it is host-side metadata only.
+///
+/// The temp file is written to /tmp with the host PID in the name. Because
+/// this process is replaced by exec() there is no Drop-based cleanup; the
+/// file persists until /tmp is next cleared (acceptable for a small TOML file).
+fn strip_container_section(manifest_abs: &Path) -> Result<PathBuf> {
+    let text = std::fs::read_to_string(manifest_abs)
+        .with_context(|| format!("reading manifest {}", manifest_abs.display()))?;
+
+    let mut val: toml::Value = toml::from_str(&text)
+        .with_context(|| "parsing manifest to strip [container] section")?;
+
+    if let toml::Value::Table(ref mut table) = val {
+        table.remove("container");
+    }
+
+    let stripped = toml::to_string_pretty(&val)
+        .with_context(|| "re-serialising stripped manifest")?;
+
+    let tmp = std::env::temp_dir()
+        .join(format!("pitboss-manifest-{}.toml", std::process::id()));
+
+    std::fs::write(&tmp, stripped)
+        .with_context(|| format!("writing stripped manifest to {}", tmp.display()))?;
+
+    Ok(tmp)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::manifest::schema::{ContainerConfig, MountSpec};
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    static TEST_COUNTER: AtomicU32 = AtomicU32::new(0);
 
     fn make_config(mounts: Vec<MountSpec>) -> ContainerConfig {
         ContainerConfig {
@@ -286,10 +328,30 @@ mod tests {
         }
     }
 
+    /// Write a minimal valid TOML manifest to a temp file and return the path.
+    /// `build_run_args` now reads the manifest (to strip [container]), so tests
+    /// that previously passed a nonexistent path need a real file.
+    fn temp_manifest() -> PathBuf {
+        let n = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir()
+            .join(format!("pitboss-test-manifest-{}-{n}.toml", std::process::id()));
+        std::fs::write(
+            &path,
+            r#"
+[[task]]
+id = "t"
+directory = "/tmp"
+prompt = "hi"
+"#,
+        )
+        .expect("write test manifest");
+        path
+    }
+
     #[test]
     fn dry_run_includes_pitboss_dispatch() {
         let cfg = make_config(vec![]);
-        let manifest = PathBuf::from("/tmp/test.toml");
+        let manifest = temp_manifest();
         // Build args without calling exec.
         let args = build_run_args("podman", &cfg, &manifest, None).unwrap();
         let joined = args.join(" ");
@@ -304,7 +366,7 @@ mod tests {
     #[test]
     fn default_image_used_when_none_specified() {
         let cfg = make_config(vec![]);
-        let args = build_run_args("docker", &cfg, Path::new("/tmp/m.toml"), None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None).unwrap();
         let joined = args.join(" ");
         assert!(
             joined.contains(DEFAULT_IMAGE),
@@ -318,7 +380,7 @@ mod tests {
             image: Some("my-org/pitboss:latest".into()),
             ..ContainerConfig::default()
         };
-        let args = build_run_args("docker", &cfg, Path::new("/tmp/m.toml"), None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None).unwrap();
         let joined = args.join(" ");
         assert!(
             joined.contains("my-org/pitboss:latest"),
@@ -340,7 +402,7 @@ mod tests {
             }],
             ..ContainerConfig::default()
         };
-        let args = build_run_args("docker", &cfg, Path::new("/tmp/m.toml"), None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None).unwrap();
         let joined = args.join(" ");
         assert!(
             joined.contains("/home/alice/project:/project:rw,z"),
@@ -358,7 +420,7 @@ mod tests {
             }],
             ..ContainerConfig::default()
         };
-        let args = build_run_args("podman", &cfg, Path::new("/tmp/m.toml"), None).unwrap();
+        let args = build_run_args("podman", &cfg, &temp_manifest(), None).unwrap();
         let joined = args.join(" ");
         assert!(joined.contains("/ref:/ref:ro,z"), "readonly flag: {joined}");
     }
@@ -366,7 +428,7 @@ mod tests {
     #[test]
     fn auto_inject_claude_when_not_in_mounts() {
         let cfg = make_config(vec![]);
-        let args = build_run_args("docker", &cfg, Path::new("/tmp/m.toml"), None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None).unwrap();
         let joined = args.join(" ");
         assert!(
             joined.contains("/home/pitboss/.claude"),
@@ -384,7 +446,7 @@ mod tests {
             }],
             ..ContainerConfig::default()
         };
-        let args = build_run_args("docker", &cfg, Path::new("/tmp/m.toml"), None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None).unwrap();
         // Count -v args that mount to /home/pitboss/.claude — should be exactly 1
         // (the declared mount). The -w workdir may also reference the path but is
         // not a duplicate mount injection.
@@ -405,7 +467,7 @@ mod tests {
             }],
             ..ContainerConfig::default()
         };
-        let args = build_run_args("docker", &cfg, Path::new("/tmp/m.toml"), None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None).unwrap();
         // -w should be followed by /project
         let w_pos = args.iter().position(|a| a == "-w").expect("-w flag");
         assert_eq!(args[w_pos + 1], "/project", "workdir: {args:?}");
@@ -414,7 +476,7 @@ mod tests {
     #[test]
     fn workdir_falls_back_to_home_pitboss_when_no_mounts() {
         let cfg = make_config(vec![]);
-        let args = build_run_args("docker", &cfg, Path::new("/tmp/m.toml"), None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None).unwrap();
         let w_pos = args.iter().position(|a| a == "-w").expect("-w flag");
         assert_eq!(args[w_pos + 1], "/home/pitboss", "fallback workdir: {args:?}");
     }
@@ -430,7 +492,7 @@ mod tests {
             workdir: Some(PathBuf::from("/project/sub")),
             ..ContainerConfig::default()
         };
-        let args = build_run_args("docker", &cfg, Path::new("/tmp/m.toml"), None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None).unwrap();
         let w_pos = args.iter().position(|a| a == "-w").expect("-w flag");
         assert_eq!(args[w_pos + 1], "/project/sub", "explicit workdir: {args:?}");
     }
@@ -441,7 +503,7 @@ mod tests {
             extra_args: vec!["--network=host".into(), "--cap-drop=ALL".into()],
             ..ContainerConfig::default()
         };
-        let args = build_run_args("docker", &cfg, Path::new("/tmp/m.toml"), None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None).unwrap();
         let net_pos = args
             .iter()
             .position(|a| a == "--network=host")
@@ -476,7 +538,7 @@ mod tests {
         let custom = PathBuf::from("/tmp/my-runs");
         let cfg = make_config(vec![]);
         let args =
-            build_run_args("docker", &cfg, Path::new("/tmp/m.toml"), Some(custom.clone()))
+            build_run_args("docker", &cfg, &temp_manifest(), Some(custom.clone()))
                 .unwrap();
         let joined = args.join(" ");
         assert!(

--- a/crates/pitboss-cli/src/dispatch/container.rs
+++ b/crates/pitboss-cli/src/dispatch/container.rs
@@ -1,0 +1,487 @@
+//! `pitboss container-dispatch` — assemble and exec a docker/podman run command
+//! from the manifest's `[container]` section.
+//!
+//! The current process is replaced (exec-style on Unix) with the container
+//! invocation so signal propagation and TTY passthrough work naturally.
+//! On a dry run the assembled command is printed to stdout and the process
+//! exits 0.
+
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{bail, Context, Result};
+
+use crate::manifest::schema::ContainerConfig;
+
+const DEFAULT_IMAGE: &str = "ghcr.io/sds-mode/pitboss-with-claude:latest";
+const PITBOSS_CONTAINER_USER_UID: u32 = 1000;
+
+/// Entry point called from `main.rs` for `pitboss container-dispatch`.
+///
+/// Validates that the manifest has a `[container]` section, then builds and
+/// execs the container run command.
+pub fn run_container_dispatch(
+    manifest_path: &Path,
+    container: &ContainerConfig,
+    run_dir_override: Option<PathBuf>,
+    dry_run: bool,
+    runtime_override: Option<&str>,
+) -> Result<()> {
+    let runtime = detect_runtime(runtime_override, container.runtime.as_deref())?;
+    let manifest_abs = manifest_path
+        .canonicalize()
+        .with_context(|| format!("canonicalizing manifest path {}", manifest_path.display()))?;
+
+    let args = build_run_args(&runtime, container, &manifest_abs, run_dir_override)?;
+
+    if dry_run {
+        // Print the full command the operator would run so they can inspect it.
+        let cmd_str = std::iter::once(runtime.as_str())
+            .chain(args.iter().map(String::as_str))
+            .collect::<Vec<_>>()
+            .join(" ");
+        println!("{}", cmd_str);
+        return Ok(());
+    }
+
+    let err = Command::new(&runtime).args(&args).exec();
+    // exec() only returns on failure.
+    Err(err).with_context(|| format!("exec {runtime}: failed to launch container"))
+}
+
+/// Build the full argument list for `<runtime> run …`.
+fn build_run_args(
+    runtime: &str,
+    container: &ContainerConfig,
+    manifest_abs: &Path,
+    run_dir_override: Option<PathBuf>,
+) -> Result<Vec<String>> {
+    let mut args: Vec<String> = vec!["run".into(), "--rm".into()];
+
+    // TTY passthrough: only attach stdin/tty when the host stdout is a real
+    // terminal (interactive session, TUI support). In headless CI the flags
+    // are omitted so docker doesn't complain about a missing tty.
+    if atty::is(atty::Stream::Stdout) {
+        args.push("-it".into());
+    }
+
+    // ── UID alignment ────────────────────────────────────────────────────────
+    // Rootless podman: --userns=keep-id maps host UID → same container UID so
+    // mounted file ownership is transparent. Docker: no user namespace by
+    // default; if the host UID isn't 1000 (the container pitboss user) we
+    // pass -u host_uid:host_gid to align ownership.
+    let is_podman = runtime.ends_with("podman");
+    if is_podman && is_rootless_podman() {
+        args.push("--userns=keep-id".into());
+    } else if !is_podman {
+        let uid = unsafe { libc::getuid() };
+        if uid != PITBOSS_CONTAINER_USER_UID {
+            let gid = unsafe { libc::getgid() };
+            args.push("-u".into());
+            args.push(format!("{uid}:{gid}"));
+        }
+    }
+
+    // ── User-declared mounts ─────────────────────────────────────────────────
+    // Tracks container paths already covered so auto-inject logic can skip
+    // duplicates without error.
+    let mut covered_container_paths: Vec<PathBuf> = Vec::new();
+
+    for spec in &container.mounts {
+        let host = expand_tilde(&spec.host);
+        let container_path = &spec.container;
+        let options = if spec.readonly { "ro,z" } else { "rw,z" };
+        args.push("-v".into());
+        args.push(format!(
+            "{}:{}:{options}",
+            host.display(),
+            container_path.display()
+        ));
+        covered_container_paths.push(container_path.clone());
+    }
+
+    // ── Auto-inject ~/.claude ─────────────────────────────────────────────────
+    // Required for OAuth auth (Linux) unless the operator already declared
+    // a mount targeting /home/pitboss/.claude.
+    let claude_container = PathBuf::from("/home/pitboss/.claude");
+    if !covered_container_paths.contains(&claude_container) {
+        if let Some(home) = home_dir() {
+            let host_claude = home.join(".claude");
+            args.push("-v".into());
+            args.push(format!(
+                "{}:{}:rw,z",
+                host_claude.display(),
+                claude_container.display()
+            ));
+        }
+    }
+
+    // ── Auto-inject run_dir ───────────────────────────────────────────────────
+    // Artifacts produced inside the container should persist on the host.
+    // We mount the effective run_dir (override > default) to the same
+    // absolute path inside the container.
+    let effective_run_dir = run_dir_override.unwrap_or_else(default_run_dir);
+    // Ensure the directory exists on the host so Docker doesn't create it
+    // as root-owned when the mount target is absent.
+    std::fs::create_dir_all(&effective_run_dir).ok();
+    let run_dir_container = PathBuf::from("/home/pitboss/.local/share/pitboss/runs");
+    if !covered_container_paths.contains(&run_dir_container) {
+        args.push("-v".into());
+        args.push(format!(
+            "{}:{}:rw,z",
+            effective_run_dir.display(),
+            run_dir_container.display()
+        ));
+    }
+
+    // ── Manifest ─────────────────────────────────────────────────────────────
+    args.push("-v".into());
+    args.push(format!(
+        "{}:/run/pitboss.toml:ro,z",
+        manifest_abs.display()
+    ));
+
+    // ── Working directory ─────────────────────────────────────────────────────
+    let workdir = container
+        .workdir
+        .clone()
+        .or_else(|| container.mounts.first().map(|m| m.container.clone()))
+        .unwrap_or_else(|| PathBuf::from("/home/pitboss"));
+    args.push("-w".into());
+    args.push(workdir.display().to_string());
+
+    // ── Extra operator args ───────────────────────────────────────────────────
+    args.extend(container.extra_args.clone());
+
+    // ── Image + pitboss command ───────────────────────────────────────────────
+    let image = container
+        .image
+        .clone()
+        .unwrap_or_else(|| DEFAULT_IMAGE.to_string());
+    args.push(image);
+    args.push("pitboss".into());
+    args.push("dispatch".into());
+    args.push("/run/pitboss.toml".into());
+
+    Ok(args)
+}
+
+/// Detect the container runtime to use, in priority order:
+///   1. `runtime_override` (CLI `--runtime` flag)
+///   2. `container.runtime` from the manifest
+///   3. `PITBOSS_CONTAINER_RUNTIME` env var
+///   4. Auto-detect: prefer `podman`, fall back to `docker`
+fn detect_runtime(
+    runtime_override: Option<&str>,
+    manifest_runtime: Option<&str>,
+) -> Result<String> {
+    let preferred = runtime_override
+        .or(manifest_runtime)
+        .or_else(|| std::env::var("PITBOSS_CONTAINER_RUNTIME").ok().as_deref().map(|_| ""))
+        .unwrap_or("auto");
+
+    // Normalise the env var case separately (borrow-checker friendly).
+    let env_val = std::env::var("PITBOSS_CONTAINER_RUNTIME").unwrap_or_default();
+    let preferred = if preferred.is_empty() {
+        env_val.as_str()
+    } else {
+        preferred
+    };
+
+    match preferred {
+        "auto" | "" => {
+            // Prefer podman; fall back to docker.
+            if which("podman") {
+                return Ok("podman".into());
+            }
+            if which("docker") {
+                return Ok("docker".into());
+            }
+            bail!(
+                "no container runtime found on PATH (tried podman, docker). \
+                 Install one or set PITBOSS_CONTAINER_RUNTIME."
+            );
+        }
+        "podman" => {
+            if !which("podman") {
+                bail!("container runtime 'podman' not found on PATH");
+            }
+            Ok("podman".into())
+        }
+        "docker" => {
+            if !which("docker") {
+                bail!("container runtime 'docker' not found on PATH");
+            }
+            Ok("docker".into())
+        }
+        other => bail!(
+            "unknown container runtime '{}' — expected 'docker', 'podman', or 'auto'",
+            other
+        ),
+    }
+}
+
+/// Returns `true` if `podman info` reports the daemon is running rootless.
+/// On failure (not podman, podman not running, etc.) returns `false` — the
+/// safe default is to omit `--userns=keep-id` rather than fail hard.
+fn is_rootless_podman() -> bool {
+    Command::new("podman")
+        .args(["info", "--format", "{{.Host.Security.Rootless}}"])
+        .output()
+        .map(|out| {
+            String::from_utf8_lossy(&out.stdout)
+                .trim()
+                .eq_ignore_ascii_case("true")
+        })
+        .unwrap_or(false)
+}
+
+/// Returns `true` if `name` is present and executable on `$PATH`.
+fn which(name: &str) -> bool {
+    std::process::Command::new("sh")
+        .args(["-c", &format!("command -v {name}")])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Expand a leading `~` to the home directory.
+fn expand_tilde(path: &Path) -> PathBuf {
+    let s = path.to_string_lossy();
+    if let Some(rest) = s.strip_prefix("~/") {
+        if let Some(home) = home_dir() {
+            return home.join(rest);
+        }
+    } else if s == "~" {
+        if let Some(home) = home_dir() {
+            return home;
+        }
+    }
+    path.to_path_buf()
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(PathBuf::from)
+}
+
+fn default_run_dir() -> PathBuf {
+    home_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join(".local/share/pitboss/runs")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::schema::{ContainerConfig, MountSpec};
+
+    fn make_config(mounts: Vec<MountSpec>) -> ContainerConfig {
+        ContainerConfig {
+            image: None,
+            runtime: None,
+            extra_args: vec![],
+            mounts,
+            workdir: None,
+        }
+    }
+
+    #[test]
+    fn dry_run_includes_pitboss_dispatch() {
+        let cfg = make_config(vec![]);
+        let manifest = PathBuf::from("/tmp/test.toml");
+        // Build args without calling exec.
+        let args = build_run_args("podman", &cfg, &manifest, None).unwrap();
+        let joined = args.join(" ");
+        assert!(joined.contains("pitboss"), "should call pitboss: {joined}");
+        assert!(joined.contains("dispatch"), "should call dispatch: {joined}");
+        assert!(
+            joined.contains("/run/pitboss.toml"),
+            "manifest path: {joined}"
+        );
+    }
+
+    #[test]
+    fn default_image_used_when_none_specified() {
+        let cfg = make_config(vec![]);
+        let args = build_run_args("docker", &cfg, Path::new("/tmp/m.toml"), None).unwrap();
+        let joined = args.join(" ");
+        assert!(
+            joined.contains(DEFAULT_IMAGE),
+            "should use default image: {joined}"
+        );
+    }
+
+    #[test]
+    fn custom_image_overrides_default() {
+        let cfg = ContainerConfig {
+            image: Some("my-org/pitboss:latest".into()),
+            ..ContainerConfig::default()
+        };
+        let args = build_run_args("docker", &cfg, Path::new("/tmp/m.toml"), None).unwrap();
+        let joined = args.join(" ");
+        assert!(
+            joined.contains("my-org/pitboss:latest"),
+            "should use custom image: {joined}"
+        );
+        assert!(
+            !joined.contains(DEFAULT_IMAGE),
+            "should not contain default image: {joined}"
+        );
+    }
+
+    #[test]
+    fn user_mount_appears_before_image() {
+        let cfg = ContainerConfig {
+            mounts: vec![MountSpec {
+                host: PathBuf::from("/home/alice/project"),
+                container: PathBuf::from("/project"),
+                readonly: false,
+            }],
+            ..ContainerConfig::default()
+        };
+        let args = build_run_args("docker", &cfg, Path::new("/tmp/m.toml"), None).unwrap();
+        let joined = args.join(" ");
+        assert!(
+            joined.contains("/home/alice/project:/project:rw,z"),
+            "user mount: {joined}"
+        );
+    }
+
+    #[test]
+    fn readonly_mount_uses_ro_flag() {
+        let cfg = ContainerConfig {
+            mounts: vec![MountSpec {
+                host: PathBuf::from("/ref"),
+                container: PathBuf::from("/ref"),
+                readonly: true,
+            }],
+            ..ContainerConfig::default()
+        };
+        let args = build_run_args("podman", &cfg, Path::new("/tmp/m.toml"), None).unwrap();
+        let joined = args.join(" ");
+        assert!(joined.contains("/ref:/ref:ro,z"), "readonly flag: {joined}");
+    }
+
+    #[test]
+    fn auto_inject_claude_when_not_in_mounts() {
+        let cfg = make_config(vec![]);
+        let args = build_run_args("docker", &cfg, Path::new("/tmp/m.toml"), None).unwrap();
+        let joined = args.join(" ");
+        assert!(
+            joined.contains("/home/pitboss/.claude"),
+            "auto-inject claude: {joined}"
+        );
+    }
+
+    #[test]
+    fn skip_claude_auto_inject_when_already_declared() {
+        let cfg = ContainerConfig {
+            mounts: vec![MountSpec {
+                host: PathBuf::from("/my/claude"),
+                container: PathBuf::from("/home/pitboss/.claude"),
+                readonly: false,
+            }],
+            ..ContainerConfig::default()
+        };
+        let args = build_run_args("docker", &cfg, Path::new("/tmp/m.toml"), None).unwrap();
+        // Count -v args that mount to /home/pitboss/.claude — should be exactly 1
+        // (the declared mount). The -w workdir may also reference the path but is
+        // not a duplicate mount injection.
+        let mount_count = args
+            .windows(2)
+            .filter(|w| w[0] == "-v" && w[1].contains(":/home/pitboss/.claude:"))
+            .count();
+        assert_eq!(mount_count, 1, "claude mount should appear exactly once: {args:?}");
+    }
+
+    #[test]
+    fn workdir_defaults_to_first_mount_container_path() {
+        let cfg = ContainerConfig {
+            mounts: vec![MountSpec {
+                host: PathBuf::from("/project"),
+                container: PathBuf::from("/project"),
+                readonly: false,
+            }],
+            ..ContainerConfig::default()
+        };
+        let args = build_run_args("docker", &cfg, Path::new("/tmp/m.toml"), None).unwrap();
+        // -w should be followed by /project
+        let w_pos = args.iter().position(|a| a == "-w").expect("-w flag");
+        assert_eq!(args[w_pos + 1], "/project", "workdir: {args:?}");
+    }
+
+    #[test]
+    fn workdir_falls_back_to_home_pitboss_when_no_mounts() {
+        let cfg = make_config(vec![]);
+        let args = build_run_args("docker", &cfg, Path::new("/tmp/m.toml"), None).unwrap();
+        let w_pos = args.iter().position(|a| a == "-w").expect("-w flag");
+        assert_eq!(args[w_pos + 1], "/home/pitboss", "fallback workdir: {args:?}");
+    }
+
+    #[test]
+    fn explicit_workdir_overrides_mount_default() {
+        let cfg = ContainerConfig {
+            mounts: vec![MountSpec {
+                host: PathBuf::from("/project"),
+                container: PathBuf::from("/project"),
+                readonly: false,
+            }],
+            workdir: Some(PathBuf::from("/project/sub")),
+            ..ContainerConfig::default()
+        };
+        let args = build_run_args("docker", &cfg, Path::new("/tmp/m.toml"), None).unwrap();
+        let w_pos = args.iter().position(|a| a == "-w").expect("-w flag");
+        assert_eq!(args[w_pos + 1], "/project/sub", "explicit workdir: {args:?}");
+    }
+
+    #[test]
+    fn extra_args_appear_before_image() {
+        let cfg = ContainerConfig {
+            extra_args: vec!["--network=host".into(), "--cap-drop=ALL".into()],
+            ..ContainerConfig::default()
+        };
+        let args = build_run_args("docker", &cfg, Path::new("/tmp/m.toml"), None).unwrap();
+        let net_pos = args
+            .iter()
+            .position(|a| a == "--network=host")
+            .expect("--network");
+        let img_pos = args
+            .iter()
+            .position(|a| a == DEFAULT_IMAGE)
+            .expect("image");
+        assert!(net_pos < img_pos, "extra_args before image: {args:?}");
+    }
+
+    #[test]
+    fn detect_runtime_rejects_unknown() {
+        let err = detect_runtime(Some("containerd"), None);
+        assert!(err.is_err(), "should reject unknown runtime");
+    }
+
+    #[test]
+    fn detect_runtime_uses_override_before_manifest() {
+        // Both say different things; CLI override wins.
+        // We can't actually exec podman/docker in tests, so just confirm the
+        // returned value matches the override when the binary is present.
+        // If neither binary exists on the test host, skip gracefully.
+        if which("docker") {
+            let r = detect_runtime(Some("docker"), Some("podman")).unwrap();
+            assert_eq!(r, "docker");
+        }
+    }
+
+    #[test]
+    fn run_dir_mount_uses_override() {
+        let custom = PathBuf::from("/tmp/my-runs");
+        let cfg = make_config(vec![]);
+        let args =
+            build_run_args("docker", &cfg, Path::new("/tmp/m.toml"), Some(custom.clone()))
+                .unwrap();
+        let joined = args.join(" ");
+        assert!(
+            joined.contains("/tmp/my-runs"),
+            "run_dir override in mounts: {joined}"
+        );
+    }
+}

--- a/crates/pitboss-cli/src/dispatch/container.rs
+++ b/crates/pitboss-cli/src/dispatch/container.rs
@@ -182,7 +182,12 @@ fn detect_runtime(
 ) -> Result<String> {
     let preferred = runtime_override
         .or(manifest_runtime)
-        .or_else(|| std::env::var("PITBOSS_CONTAINER_RUNTIME").ok().as_deref().map(|_| ""))
+        .or_else(|| {
+            std::env::var("PITBOSS_CONTAINER_RUNTIME")
+                .ok()
+                .as_deref()
+                .map(|_| "")
+        })
         .unwrap_or("auto");
 
     // Normalise the env var case separately (borrow-checker friendly).
@@ -291,18 +296,17 @@ fn strip_container_section(manifest_abs: &Path) -> Result<PathBuf> {
     let text = std::fs::read_to_string(manifest_abs)
         .with_context(|| format!("reading manifest {}", manifest_abs.display()))?;
 
-    let mut val: toml::Value = toml::from_str(&text)
-        .with_context(|| "parsing manifest to strip [container] section")?;
+    let mut val: toml::Value =
+        toml::from_str(&text).with_context(|| "parsing manifest to strip [container] section")?;
 
     if let toml::Value::Table(ref mut table) = val {
         table.remove("container");
     }
 
-    let stripped = toml::to_string_pretty(&val)
-        .with_context(|| "re-serialising stripped manifest")?;
+    let stripped =
+        toml::to_string_pretty(&val).with_context(|| "re-serialising stripped manifest")?;
 
-    let tmp = std::env::temp_dir()
-        .join(format!("pitboss-manifest-{}.toml", std::process::id()));
+    let tmp = std::env::temp_dir().join(format!("pitboss-manifest-{}.toml", std::process::id()));
 
     std::fs::write(&tmp, stripped)
         .with_context(|| format!("writing stripped manifest to {}", tmp.display()))?;
@@ -333,8 +337,10 @@ mod tests {
     /// that previously passed a nonexistent path need a real file.
     fn temp_manifest() -> PathBuf {
         let n = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
-        let path = std::env::temp_dir()
-            .join(format!("pitboss-test-manifest-{}-{n}.toml", std::process::id()));
+        let path = std::env::temp_dir().join(format!(
+            "pitboss-test-manifest-{}-{n}.toml",
+            std::process::id()
+        ));
         std::fs::write(
             &path,
             r#"
@@ -356,7 +362,10 @@ prompt = "hi"
         let args = build_run_args("podman", &cfg, &manifest, None).unwrap();
         let joined = args.join(" ");
         assert!(joined.contains("pitboss"), "should call pitboss: {joined}");
-        assert!(joined.contains("dispatch"), "should call dispatch: {joined}");
+        assert!(
+            joined.contains("dispatch"),
+            "should call dispatch: {joined}"
+        );
         assert!(
             joined.contains("/run/pitboss.toml"),
             "manifest path: {joined}"
@@ -454,7 +463,10 @@ prompt = "hi"
             .windows(2)
             .filter(|w| w[0] == "-v" && w[1].contains(":/home/pitboss/.claude:"))
             .count();
-        assert_eq!(mount_count, 1, "claude mount should appear exactly once: {args:?}");
+        assert_eq!(
+            mount_count, 1,
+            "claude mount should appear exactly once: {args:?}"
+        );
     }
 
     #[test]
@@ -478,7 +490,11 @@ prompt = "hi"
         let cfg = make_config(vec![]);
         let args = build_run_args("docker", &cfg, &temp_manifest(), None).unwrap();
         let w_pos = args.iter().position(|a| a == "-w").expect("-w flag");
-        assert_eq!(args[w_pos + 1], "/home/pitboss", "fallback workdir: {args:?}");
+        assert_eq!(
+            args[w_pos + 1],
+            "/home/pitboss",
+            "fallback workdir: {args:?}"
+        );
     }
 
     #[test]
@@ -494,7 +510,11 @@ prompt = "hi"
         };
         let args = build_run_args("docker", &cfg, &temp_manifest(), None).unwrap();
         let w_pos = args.iter().position(|a| a == "-w").expect("-w flag");
-        assert_eq!(args[w_pos + 1], "/project/sub", "explicit workdir: {args:?}");
+        assert_eq!(
+            args[w_pos + 1],
+            "/project/sub",
+            "explicit workdir: {args:?}"
+        );
     }
 
     #[test]
@@ -508,10 +528,7 @@ prompt = "hi"
             .iter()
             .position(|a| a == "--network=host")
             .expect("--network");
-        let img_pos = args
-            .iter()
-            .position(|a| a == DEFAULT_IMAGE)
-            .expect("image");
+        let img_pos = args.iter().position(|a| a == DEFAULT_IMAGE).expect("image");
         assert!(net_pos < img_pos, "extra_args before image: {args:?}");
     }
 
@@ -537,9 +554,7 @@ prompt = "hi"
     fn run_dir_mount_uses_override() {
         let custom = PathBuf::from("/tmp/my-runs");
         let cfg = make_config(vec![]);
-        let args =
-            build_run_args("docker", &cfg, &temp_manifest(), Some(custom.clone()))
-                .unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), Some(custom.clone())).unwrap();
         let joined = args.join(" ");
         assert!(
             joined.contains("/tmp/my-runs"),

--- a/crates/pitboss-cli/src/dispatch/failure_detection.rs
+++ b/crates/pitboss-cli/src/dispatch/failure_detection.rs
@@ -671,6 +671,7 @@ mod tests {
             dump_shared_store: false,
             require_plan_approval: false,
             approval_rules: vec![],
+            container: None,
         };
         let store: Arc<dyn pitboss_core::store::SessionStore> =
             Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
@@ -757,6 +758,7 @@ mod tests {
             dump_shared_store: false,
             require_plan_approval: false,
             approval_rules: vec![],
+            container: None,
         };
         let store: Arc<dyn pitboss_core::store::SessionStore> =
             Arc::new(JsonFileStore::new(dir.path().to_path_buf()));

--- a/crates/pitboss-cli/src/dispatch/layer.rs
+++ b/crates/pitboss-cli/src/dispatch/layer.rs
@@ -414,6 +414,7 @@ mod tests {
             dump_shared_store: false,
             require_plan_approval: false,
             approval_rules: vec![],
+            container: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(FakeSpawner::new(FakeScript::new()));

--- a/crates/pitboss-cli/src/dispatch/mod.rs
+++ b/crates/pitboss-cli/src/dispatch/mod.rs
@@ -1,4 +1,5 @@
 pub mod actor;
+pub mod container;
 pub mod events;
 pub mod failure_detection;
 pub mod hierarchical;

--- a/crates/pitboss-cli/src/dispatch/resume.rs
+++ b/crates/pitboss-cli/src/dispatch/resume.rs
@@ -489,6 +489,7 @@ mod tests {
             dump_shared_store: false,
             require_plan_approval: false,
             approval_rules: vec![],
+            container: None,
         };
         std::fs::write(
             run_dir.join("resolved.json"),
@@ -591,6 +592,7 @@ mod tests {
             dump_shared_store: false,
             require_plan_approval: false,
             approval_rules: vec![],
+            container: None,
         };
         std::fs::write(
             run_dir.join("resolved.json"),

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -979,6 +979,7 @@ mod tests {
             dump_shared_store: false,
             require_plan_approval: false,
             approval_rules: vec![],
+            container: None,
         }
     }
 
@@ -1119,6 +1120,7 @@ mod tests {
             dump_shared_store: false,
             require_plan_approval: false,
             approval_rules: vec![],
+            container: None,
         };
 
         // Script: first call succeeds, second call fails. FakeSpawner is single-shot,
@@ -1207,6 +1209,7 @@ mod tests {
             dump_shared_store: false,
             require_plan_approval: false,
             approval_rules: vec![],
+            container: None,
         };
 
         let spawner = Arc::new(CyclingFake(
@@ -1308,6 +1311,7 @@ mod tests {
             dump_shared_store: false,
             require_plan_approval: false,
             approval_rules: vec![],
+            container: None,
         };
 
         let spawner = Arc::new(CyclingFake(

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -439,6 +439,7 @@ mod tests {
             dump_shared_store: false,
             require_plan_approval: false,
             approval_rules: vec![],
+            container: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/src/main.rs
+++ b/crates/pitboss-cli/src/main.rs
@@ -47,6 +47,14 @@ fn main() -> Result<()> {
         } => {
             run_mcp_bridge(&socket, &actor_id, actor_role);
         }
+        Command::ContainerDispatch {
+            manifest,
+            run_dir,
+            dry_run,
+            runtime,
+        } => {
+            run_container_dispatch(&manifest, run_dir, dry_run, runtime.as_deref());
+        }
         Command::Completions { shell } => {
             use clap::CommandFactory;
             let mut cmd = cli::Cli::command();
@@ -207,6 +215,40 @@ fn run_dispatch(
         }
     });
     std::process::exit(code);
+}
+
+fn run_container_dispatch(
+    manifest: &std::path::Path,
+    run_dir: Option<std::path::PathBuf>,
+    dry_run: bool,
+    runtime: Option<&str>,
+) -> ! {
+    let env_mp = parse_env_max_parallel();
+    let resolved = match manifest::load_manifest_skip_dir_check(manifest, env_mp) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("validation failed: {e:#}");
+            std::process::exit(2);
+        }
+    };
+    let container = match resolved.container {
+        Some(ref c) => c,
+        None => {
+            eprintln!(
+                "pitboss container-dispatch: manifest has no [container] section.\n\
+                 Add a [container] block with at least [[container.mount]] entries \
+                 to use container-dispatch."
+            );
+            std::process::exit(2);
+        }
+    };
+    match dispatch::container::run_container_dispatch(manifest, container, run_dir, dry_run, runtime) {
+        Ok(()) => std::process::exit(0),
+        Err(e) => {
+            eprintln!("container-dispatch: {e:#}");
+            std::process::exit(1);
+        }
+    }
 }
 
 fn parse_env_max_parallel() -> Option<u32> {

--- a/crates/pitboss-cli/src/main.rs
+++ b/crates/pitboss-cli/src/main.rs
@@ -242,7 +242,9 @@ fn run_container_dispatch(
             std::process::exit(2);
         }
     };
-    match dispatch::container::run_container_dispatch(manifest, container, run_dir, dry_run, runtime) {
+    match dispatch::container::run_container_dispatch(
+        manifest, container, run_dir, dry_run, runtime,
+    ) {
         Ok(()) => std::process::exit(0),
         Err(e) => {
             eprintln!("container-dispatch: {e:#}");

--- a/crates/pitboss-cli/src/manifest/load.rs
+++ b/crates/pitboss-cli/src/manifest/load.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 
 use super::resolve::{resolve, resolve_single_lead, ResolvedManifest};
 use super::schema::{Manifest, SingleLeadManifest};
-use super::validate::validate;
+use super::validate::{validate, validate_skip_dir_check};
 
 /// Load, parse, resolve, and validate a manifest from disk.
 ///
@@ -58,6 +58,44 @@ pub fn load_manifest(path: &Path, env_max_parallel: Option<u32>) -> Result<Resol
             // Add similar shape-only checks here as they get factored out of
             // validate() — the goal is parity between the two manifest forms
             // for everything that doesn't require real on-disk state.
+            super::validate::validate_sublead_defaults_adequate(&resolved)?;
+            Ok(resolved)
+        }
+    }
+}
+
+/// Like `load_manifest` but skips the directory-existence check.
+/// Used by `pitboss container-dispatch` where task/lead `directory` fields
+/// are container-side paths that don't exist on the host.
+pub fn load_manifest_skip_dir_check(
+    path: &Path,
+    env_max_parallel: Option<u32>,
+) -> Result<ResolvedManifest> {
+    let text = std::fs::read_to_string(path)
+        .with_context(|| format!("reading manifest at {}", path.display()))?;
+
+    match toml::from_str::<Manifest>(&text) {
+        Ok(mut manifest) => {
+            expand_paths(&mut manifest)?;
+            let resolved = resolve(manifest, env_max_parallel)?;
+            validate_skip_dir_check(&resolved)?;
+            Ok(resolved)
+        }
+        Err(primary_err) => {
+            let err_str = primary_err.to_string();
+            let is_lead_type_mismatch =
+                err_str.contains("expected a sequence") || err_str.contains("invalid type: map");
+            if !is_lead_type_mismatch {
+                return Err(primary_err)
+                    .with_context(|| format!("parsing manifest at {}", path.display()));
+            }
+            let single: SingleLeadManifest = toml::from_str(&text).with_context(|| {
+                format!(
+                    "parsing manifest at {} as single-lead format (primary error: {primary_err})",
+                    path.display()
+                )
+            })?;
+            let resolved = resolve_single_lead(single, env_max_parallel)?;
             super::validate::validate_sublead_defaults_adequate(&resolved)?;
             Ok(resolved)
         }

--- a/crates/pitboss-cli/src/manifest/mod.rs
+++ b/crates/pitboss-cli/src/manifest/mod.rs
@@ -4,6 +4,6 @@ pub mod schema;
 pub mod validate;
 
 #[allow(unused_imports)]
-pub use load::{load_manifest, load_manifest_from_str};
+pub use load::{load_manifest, load_manifest_from_str, load_manifest_skip_dir_check};
 #[allow(unused_imports)]
 pub use schema::{Defaults, Manifest, RunConfig, Task, Template};

--- a/crates/pitboss-cli/src/manifest/resolve.rs
+++ b/crates/pitboss-cli/src/manifest/resolve.rs
@@ -7,8 +7,8 @@ use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
 
 use super::schema::{
-    Defaults, Effort, Lead, LeadSpec, Manifest, RunConfig, SingleLeadManifest, SubleadDefaultsSpec,
-    Task, Template, WorktreeCleanup,
+    ContainerConfig, Defaults, Effort, Lead, LeadSpec, Manifest, RunConfig, SingleLeadManifest,
+    SubleadDefaultsSpec, Task, Template, WorktreeCleanup,
 };
 
 /// Fully resolved task ready for dispatch.
@@ -109,6 +109,9 @@ pub struct ResolvedManifest {
     // [[approval_policy]] manifest blocks. Empty vec means no policy.
     #[serde(default)]
     pub approval_rules: Vec<crate::mcp::policy::ApprovalRule>,
+    // NEW — optional [container] section for `pitboss container-dispatch`.
+    #[serde(default)]
+    pub container: Option<ContainerConfig>,
 }
 
 const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
@@ -177,6 +180,7 @@ pub fn resolve(manifest: Manifest, env_max_parallel: Option<u32>) -> Result<Reso
         dump_shared_store: manifest.run.dump_shared_store,
         require_plan_approval: manifest.run.require_plan_approval,
         approval_rules,
+        container: manifest.container,
     })
 }
 
@@ -322,6 +326,7 @@ pub fn resolve_single_lead(
         dump_shared_store: manifest.run.dump_shared_store,
         require_plan_approval: manifest.run.require_plan_approval,
         approval_rules,
+        container: manifest.container,
     })
 }
 

--- a/crates/pitboss-cli/src/manifest/schema.rs
+++ b/crates/pitboss-cli/src/manifest/schema.rs
@@ -5,6 +5,42 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+/// Optional `[container]` section for `pitboss container-dispatch`.
+/// When present, `pitboss container-dispatch` uses this config to build
+/// the `docker`/`podman run` invocation. `directory` fields in tasks/lead
+/// must be valid container-side paths (after mounts are applied).
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct ContainerConfig {
+    /// Container image. Default: `ghcr.io/sds-mode/pitboss-with-claude:latest`.
+    pub image: Option<String>,
+    /// Container runtime: `"docker"`, `"podman"`, or `"auto"` (default).
+    pub runtime: Option<String>,
+    /// Extra args inserted verbatim before the image name in the `run` call.
+    #[serde(default)]
+    pub extra_args: Vec<String>,
+    /// Host→container bind mounts (besides the auto-injected `~/.claude` and run_dir).
+    #[serde(default, rename = "mount")]
+    pub mounts: Vec<MountSpec>,
+    /// Working directory inside the container.
+    /// Defaults to the container path of the first `[[container.mount]]` entry,
+    /// or `/home/pitboss` if no mounts are declared.
+    pub workdir: Option<PathBuf>,
+}
+
+/// A single host→container bind mount entry.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MountSpec {
+    /// Absolute path on the host (tilde expansion is performed at dispatch time).
+    pub host: PathBuf,
+    /// Absolute path inside the container.
+    pub container: PathBuf,
+    /// Mount as read-only. Default: false.
+    #[serde(default)]
+    pub readonly: bool,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Manifest {
@@ -25,6 +61,9 @@ pub struct Manifest {
     /// Rules are evaluated in declaration order; first match wins.
     #[serde(default, rename = "approval_policy")]
     pub approval_policy_rules: Vec<ApprovalRuleSpec>,
+    /// Optional container config for `pitboss container-dispatch`.
+    #[serde(default)]
+    pub container: Option<ContainerConfig>,
 }
 
 /// TOML schema for a single `[[approval_policy]]` rule.
@@ -208,6 +247,9 @@ pub struct SingleLeadManifest {
     /// Approval policy rules (v0.6+).
     #[serde(default, rename = "approval_policy")]
     pub approval_policy_rules: Vec<ApprovalRuleSpec>,
+    /// Optional container config for `pitboss container-dispatch`.
+    #[serde(default)]
+    pub container: Option<ContainerConfig>,
 }
 
 /// v0.6 single-table `[lead]` schema. Used when the manifest author writes

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -25,7 +25,7 @@ fn validate_inner(resolved: &ResolvedManifest, skip_dir_check: bool) -> Result<(
         crate::notify::config::validate(cfg)?;
     }
     if resolved.lead.is_some() {
-        validate_lead(resolved)?;
+        validate_lead(resolved, skip_dir_check)?;
         validate_hierarchical_ranges(resolved)?;
         validate_sublead_defaults_adequate(resolved)?;
     } else {
@@ -61,7 +61,7 @@ fn validate_mode(r: &ResolvedManifest) -> Result<()> {
     Ok(())
 }
 
-fn validate_lead(r: &ResolvedManifest) -> Result<()> {
+fn validate_lead(r: &ResolvedManifest, skip_dir_check: bool) -> Result<()> {
     let lead = r.lead.as_ref().unwrap();
     if lead.id.is_empty() {
         bail!("lead id is required");
@@ -73,7 +73,7 @@ fn validate_lead(r: &ResolvedManifest) -> Result<()> {
     {
         bail!("lead id '{}' contains invalid characters", lead.id);
     }
-    if !lead.directory.is_dir() {
+    if !skip_dir_check && !lead.directory.is_dir() {
         bail!(
             "lead directory does not exist: {}",
             lead.directory.display()

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -9,6 +9,17 @@ use super::resolve::ResolvedManifest;
 
 /// Run all v0.1 validations. Call after [`crate::manifest::resolve::resolve`].
 pub fn validate(resolved: &ResolvedManifest) -> Result<()> {
+    validate_inner(resolved, false)
+}
+
+/// Like `validate` but skips the directory-existence check.
+/// Used by `container-dispatch` where task `directory` fields are
+/// container-side paths that don't exist on the host.
+pub fn validate_skip_dir_check(resolved: &ResolvedManifest) -> Result<()> {
+    validate_inner(resolved, true)
+}
+
+fn validate_inner(resolved: &ResolvedManifest, skip_dir_check: bool) -> Result<()> {
     validate_mode(resolved)?;
     for cfg in &resolved.notifications {
         crate::notify::config::validate(cfg)?;
@@ -20,7 +31,9 @@ pub fn validate(resolved: &ResolvedManifest) -> Result<()> {
     } else {
         // Flat-mode validations unchanged.
         validate_ids(resolved)?;
-        validate_directories(resolved)?;
+        if !skip_dir_check {
+            validate_directories(resolved)?;
+        }
         validate_branch_conflicts(resolved)?;
         validate_ranges(resolved)?;
     }
@@ -305,6 +318,7 @@ mod tests {
             dump_shared_store: false,
             require_plan_approval: false,
             approval_rules: vec![],
+            container: None,
         }
     }
 
@@ -329,6 +343,7 @@ mod tests {
             dump_shared_store: false,
             require_plan_approval: false,
             approval_rules: vec![],
+            container: None,
         };
         f(&mut m);
         m
@@ -409,6 +424,7 @@ mod tests {
             dump_shared_store: false,
             require_plan_approval: false,
             approval_rules: vec![],
+            container: None,
         };
         let err = validate(&r).unwrap_err().to_string();
         assert!(
@@ -436,6 +452,7 @@ mod tests {
             dump_shared_store: false,
             require_plan_approval: false,
             approval_rules: vec![],
+            container: None,
         };
         let err = validate(&r).unwrap_err().to_string();
         assert!(err.contains("max_workers"), "got: {err}");
@@ -460,6 +477,7 @@ mod tests {
             dump_shared_store: false,
             require_plan_approval: false,
             approval_rules: vec![],
+            container: None,
         };
         assert!(validate(&r).is_err());
     }
@@ -483,6 +501,7 @@ mod tests {
             dump_shared_store: false,
             require_plan_approval: false,
             approval_rules: vec![],
+            container: None,
         };
         assert!(validate(&r).is_err());
     }
@@ -513,6 +532,7 @@ mod tests {
             dump_shared_store: false,
             require_plan_approval: false,
             approval_rules: vec![],
+            container: None,
         };
         (d, r)
     }
@@ -631,6 +651,7 @@ mod tests {
             dump_shared_store: false,
             require_plan_approval: false,
             approval_rules: vec![],
+            container: None,
         };
         let err = validate(&r).unwrap_err().to_string();
         assert!(err.contains("empty manifest"), "got: {err}");

--- a/crates/pitboss-cli/src/mcp/approval.rs
+++ b/crates/pitboss-cli/src/mcp/approval.rs
@@ -317,6 +317,7 @@ mod tests {
             dump_shared_store: false,
             require_plan_approval: false,
             approval_rules: vec![],
+            container: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -1120,6 +1120,7 @@ mod tests {
             dump_shared_store: false,
             require_plan_approval: false,
             approval_rules: vec![],
+            container: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();
@@ -1185,6 +1186,7 @@ mod tests {
             dump_shared_store: false,
             require_plan_approval: false,
             approval_rules: vec![],
+            container: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -2202,6 +2202,7 @@ mod tests {
             dump_shared_store: false,
             require_plan_approval: false,
             approval_rules: vec![],
+            container: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();
@@ -2663,6 +2664,7 @@ mod tests {
             dump_shared_store: false,
             require_plan_approval: false,
             approval_rules: vec![],
+            container: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();
@@ -3276,6 +3278,7 @@ mod tests {
             dump_shared_store: false,
             require_plan_approval: false,
             approval_rules: vec![],
+            container: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let script = FakeScript::new().hold_until_signal();
@@ -3368,6 +3371,7 @@ mod tests {
             dump_shared_store: false,
             require_plan_approval,
             approval_rules: vec![],
+            container: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let script = FakeScript::new().hold_until_signal();

--- a/crates/pitboss-cli/tests/control_flows.rs
+++ b/crates/pitboss-cli/tests/control_flows.rs
@@ -50,6 +50,7 @@ async fn pause_op_writes_events_jsonl() {
         dump_shared_store: false,
         require_plan_approval: false,
         approval_rules: vec![],
+        container: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -252,6 +253,7 @@ async fn block_policy_queue_drains_on_tui_connect() {
         dump_shared_store: false,
         require_plan_approval: false,
         approval_rules: vec![],
+        container: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -361,6 +363,7 @@ async fn auto_approve_policy_responds_without_tui() {
         dump_shared_store: false,
         require_plan_approval: false,
         approval_rules: vec![],
+        container: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -417,6 +420,7 @@ async fn auto_reject_policy_responds_without_tui() {
         dump_shared_store: false,
         require_plan_approval: false,
         approval_rules: vec![],
+        container: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -481,6 +485,7 @@ async fn propose_plan_end_to_end_unblocks_spawn_gate() {
         dump_shared_store: false,
         require_plan_approval: true,
         approval_rules: vec![],
+        container: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());

--- a/crates/pitboss-cli/tests/dogfood_fake_flows.rs
+++ b/crates/pitboss-cli/tests/dogfood_fake_flows.rs
@@ -89,6 +89,7 @@ fn mk_state_with_subleads() -> (TempDir, Arc<DispatchState>) {
         dump_shared_store: false,
         require_plan_approval: false,
         approval_rules: vec![],
+        container: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();
@@ -1034,6 +1035,7 @@ async fn dogfood_envelope_cap_rejection() {
             dump_shared_store: false,
             require_plan_approval: false,
             approval_rules: vec![],
+            container: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/tests/e2e_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_flows.rs
@@ -74,6 +74,7 @@ fn mk_state(
         dump_shared_store: false,
         require_plan_approval: false,
         approval_rules: vec![],
+        container: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(run_dir.to_path_buf()));
     // Worker-side spawner: emits a complete stream-json run then exits 0.
@@ -371,6 +372,7 @@ async fn e2e_lead_cancels_worker_mid_flight() {
         dump_shared_store: false,
         require_plan_approval: false,
         approval_rules: vec![],
+        container: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let hold_script = FakeScript::new().hold_until_signal();
@@ -622,6 +624,7 @@ async fn e2e_lead_reprompts_running_worker() {
         dump_shared_store: false,
         require_plan_approval: false,
         approval_rules: vec![],
+        container: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     // Worker script emits init+result so session_id gets captured via the
@@ -808,6 +811,7 @@ async fn e2e_lead_propose_plan_gate_unblocks_spawn() {
         dump_shared_store: false,
         require_plan_approval: true,
         approval_rules: vec![],
+        container: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let worker_script = FakeScript::new()
@@ -1104,6 +1108,7 @@ async fn e2e_freeze_pause_and_continue_real_subprocess_worker() {
         dump_shared_store: false,
         require_plan_approval: false,
         approval_rules: vec![],
+        container: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(FakeClaudeWorkerSpawner {

--- a/crates/pitboss-cli/tests/e2e_sublead_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_sublead_flows.rs
@@ -74,6 +74,7 @@ fn mk_state(dir: &std::path::Path) -> (Uuid, Arc<DispatchState>) {
         dump_shared_store: false,
         require_plan_approval: false,
         approval_rules: vec![],
+        container: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.to_path_buf()));
     let worker_script = FakeScript::new()
@@ -140,6 +141,7 @@ fn mk_state_hold_workers(dir: &std::path::Path) -> (Uuid, Arc<DispatchState>) {
         dump_shared_store: false,
         require_plan_approval: false,
         approval_rules: vec![],
+        container: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.to_path_buf()));
     let hold_script = FakeScript::new().hold_until_signal();
@@ -777,6 +779,7 @@ async fn sublead_session_spawns_runs_and_reconciles() {
         dump_shared_store: false,
         require_plan_approval: false,
         approval_rules: vec![],
+        container: None,
     };
 
     let store: std::sync::Arc<dyn pitboss_core::store::SessionStore> = std::sync::Arc::new(

--- a/crates/pitboss-cli/tests/hierarchical_flows.rs
+++ b/crates/pitboss-cli/tests/hierarchical_flows.rs
@@ -57,6 +57,7 @@ fn mk_state() -> (TempDir, Arc<DispatchState>) {
         dump_shared_store: false,
         require_plan_approval: false,
         approval_rules: vec![],
+        container: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/tests/notify_flows.rs
+++ b/crates/pitboss-cli/tests/notify_flows.rs
@@ -252,6 +252,7 @@ async fn approval_pending_notification_fires_on_enqueue() {
         dump_shared_store: false,
         require_plan_approval: false,
         approval_rules: vec![],
+        container: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());

--- a/crates/pitboss-cli/tests/shared_store_flows.rs
+++ b/crates/pitboss-cli/tests/shared_store_flows.rs
@@ -459,6 +459,7 @@ async fn lease_released_when_mcp_connection_drops() {
         dump_shared_store: false,
         require_plan_approval: false,
         approval_rules: vec![],
+        container: None,
     };
     let store_trait: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().into()));
     let run_id = Uuid::now_v7();
@@ -595,6 +596,7 @@ async fn run_global_lease_released_when_mcp_connection_drops() {
         dump_shared_store: false,
         require_plan_approval: false,
         approval_rules: vec![],
+        container: None,
     };
     let store_trait: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().into()));
     let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/tests/sublead_flows.rs
+++ b/crates/pitboss-cli/tests/sublead_flows.rs
@@ -57,6 +57,7 @@ fn mk_state_with_subleads() -> (TempDir, Arc<DispatchState>) {
         dump_shared_store: false,
         require_plan_approval: false,
         approval_rules: vec![],
+        container: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();
@@ -120,6 +121,7 @@ fn mk_state_with_sublead_budget_cap(cap: f64) -> (TempDir, Arc<DispatchState>) {
         dump_shared_store: false,
         require_plan_approval: false,
         approval_rules: vec![],
+        container: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();

--- a/examples/container-dispatch-smoke.toml
+++ b/examples/container-dispatch-smoke.toml
@@ -1,0 +1,72 @@
+# Container-dispatch smoke test
+#
+# Exercises the `pitboss container-dispatch` feature (branch: claude/dynamic-container-pitboss-cEGMU).
+# Mounts the pitboss source tree read-only into the container and spawns
+# three workers (one per crate) to produce short summaries. Cheap and fast
+# (~2-3 min, ~$0.15).
+#
+# Dry-run (inspect generated podman/docker command — no container launched):
+#   pitboss container-dispatch examples/container-dispatch-smoke.toml --dry-run
+#
+# Live run:
+#   pitboss container-dispatch examples/container-dispatch-smoke.toml
+#
+# Attach TUI in a second terminal after the run starts:
+#   pitboss-tui
+#
+# Verify pass:
+#   grep "PASS" ~/.local/share/pitboss/runs/<latest-uuid>/tasks/container-smoke-lead/stdout.log
+
+# ── Container config ─────────────────────────────────────────────────────────
+[container]
+# runtime auto-detected (prefers podman on this system)
+workdir = "/project"
+
+[[container.mount]]
+host      = "/run/media/system/Dos/Projects/agentshire"
+container = "/project"
+readonly  = true
+
+# ── Run caps ─────────────────────────────────────────────────────────────────
+[run]
+max_workers       = 3
+budget_usd        = 0.50
+lead_timeout_secs = 180
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+[defaults]
+model        = "claude-haiku-4-5"
+use_worktree = false
+
+# ── Lead ──────────────────────────────────────────────────────────────────────
+[[lead]]
+id        = "container-smoke-lead"
+directory = "/project"
+prompt    = """
+You are running inside a pitboss container-dispatch smoke test.
+The pitboss source tree is mounted read-only at /project.
+
+Your task: spawn one worker per crate, collect their summaries, and report a pass/fail result.
+
+Step 1 — Spawn three workers using mcp__pitboss__spawn_worker.
+
+  Worker A:
+    prompt    = "Read the file /project/crates/pitboss-core/src/lib.rs and print a 2-sentence summary of pitboss-core's purpose and its main public modules. Begin your response with 'CORE:'"
+    directory = "/project/crates/pitboss-core/src"
+
+  Worker B:
+    prompt    = "Read the file /project/crates/pitboss-cli/src/lib.rs and print a 2-sentence summary of pitboss-cli's purpose and its main subsystems. Begin your response with 'CLI:'"
+    directory = "/project/crates/pitboss-cli/src"
+
+  Worker C:
+    prompt    = "Read the file /project/crates/pitboss-tui/src/lib.rs and print a 2-sentence summary of pitboss-tui's purpose and its main components. Begin your response with 'TUI:'"
+    directory = "/project/crates/pitboss-tui/src"
+
+Step 2 — Use mcp__pitboss__wait_actor for each of the three task_ids returned in step 1.
+
+Step 3 — Print the final_message_preview from each wait_actor result.
+
+Step 4 — Count how many workers returned status = "Success".
+  - If all 3 succeeded: print exactly "CONTAINER-DISPATCH SMOKE TEST: PASS — 3/3 workers completed inside container"
+  - Otherwise:          print exactly "CONTAINER-DISPATCH SMOKE TEST: FAIL — <N>/3 workers succeeded; details above"
+"""


### PR DESCRIPTION
## Summary

- Adds `pitboss container-dispatch <manifest.toml>` — assembles and exec()s a `docker`/`podman run` invocation from a `[container]` manifest section, replacing the host process so signal propagation and TTY passthrough work naturally
- Auto-injects `~/.claude` (OAuth auth) and the run artifact directory as bind mounts; operator declares project/reference mounts via `[[container.mount]]`
- Detects rootless podman (`--userns=keep-id`) vs Docker (UID flag) automatically; `--dry-run` prints the assembled command without launching
- Strips the `[container]` section from the manifest before mounting it, so existing container images (built before this feature) parse the inner `pitboss dispatch` cleanly
- Fixes `validate_skip_dir_check` not being threaded through to `validate_lead`, which blocked container-side directory paths (e.g. `/project`) from passing host validation
- Adds `examples/container-dispatch-smoke.toml` — 3-worker hierarchical smoke test mounting the pitboss source tree read-only; attach `pitboss-tui` in a second terminal to observe live

## New manifest schema

```toml
[container]
image   = "ghcr.io/sds-mode/pitboss-with-claude:latest"  # optional
runtime = "podman"   # optional; auto-detected (prefers podman)
workdir = "/project" # optional; defaults to first mount's container path

[[container.mount]]
host      = "~/projects/myproject"
container = "/project"
readonly  = false

[[container.mount]]
host      = "~/reference-docs"
container = "/ref"
readonly  = true
```

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --lib -p pitboss-cli` — 359/359
- [x] `--dry-run` generates correct podman command (mounts, UID, workdir, stripped manifest)
- [x] Live run with `examples/container-dispatch-smoke.toml` — container launched, 3 workers spawned, TUI attached and showed live tile updates, lead printed `CONTAINER-DISPATCH SMOKE TEST: PASS`
- [ ] Docker runtime path (only podman tested locally)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)