### PR TITLE
v0.8 post-release hardening — TUI #95, cascade plug #99, ultrareview nits

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,8 +3,8 @@
 Capture of deferred work. Items here are scoped but unscheduled — grab
 one when you're ready, or file issues to formalize priority.
 
-**Last refresh: v0.7.0 (2026-04-20).** Everything shipped through
-v0.7.0 has been removed from this file — check `CHANGELOG.md` for
+**Last refresh: v0.8.0 (2026-04-24).** Everything shipped through
+v0.8.0 has been removed from this file — check `CHANGELOG.md` for
 per-version history. If you're about to add an item, slot it into one
 of the tiered sections below (biggest effort first).
 
@@ -54,74 +54,47 @@ form explicitly retired.
 
 ---
 
-## Deferred from v0.7.0 (targeting v0.8+)
+## Deferred from v0.8.0 (targeting v0.9+)
 
-Items that were scoped or considered during v0.7 development but
+Items that were scoped or considered during v0.8 development but
 explicitly deferred. These are reasonably well-understood problems,
 not blue-sky ideas.
 
-### Queue-TTL fallback → response wiring
+### Path B stabilization (#92, #93, #94)
 
-`ApprovalTimedOut` terminal state was added in v0.7 but never fires —
-`expire_approvals` (in `runner.rs`) removes expired queue entries
-without sending a `{approved: false, from_ttl: true}` response back to
-the waiting actor. The actor instead sees a bridge-timeout error and
-lands in `Failed` rather than `ApprovalTimedOut`. **Status:** variant
-defined and classification path is ready; the wiring is a ~2-3 hour
-follow-up.
+v0.8 added the `permission_routing = "path_b"` manifest field but
+gates it with a validation error. Three tracked bugs block stabilization:
 
-### `pitboss status` subcommand
+- **#92:** `--permission-prompt-tool` flag isn't threaded to all
+  spawn-args call sites (root lead vs. sub-lead vs. worker).
+- **#93:** The `PermissionPromptResponse` wire format doesn't match
+  what claude's SDK expects.
+- **#94:** `CLAUDE_CODE_ENTRYPOINT=sdk-ts` must be evicted from the
+  environment when Path B is active (otherwise Path A takes over).
 
-Headless-mode inspection currently relies on `pitboss attach` +
-manual reads of `summary.jsonl` and `tasks/`. A dedicated `pitboss
-status <run-id>` would be a natural cap on the headless-agent flow.
-**Status:** deferred; needs a small spec on columns, flags, snapshot-
-vs-tail, JSON output.
+**Status:** work-in-progress on `feat/path-b-permission-routing`.
+Landing all three unblocks removal of the validate-time gate.
 
-### Path B — route claude's permission gate through pitboss
-
-Alternative to the v0.7 Path A default (`CLAUDE_CODE_ENTRYPOINT=sdk-ts`
-bypasses claude's own gate). Path B would route claude's per-tool
-permission requests through a new `permission_prompt` MCP tool,
-surfacing them in pitboss's approval queue + TUI. **Status:** spec
-pinned at `docs/superpowers/specs/2026-04-20-path-b-permission-prompt-routing-pin.md`;
-revisit when a concrete trigger appears.
-
-### Per-sub-tree runners (Phase 4 ownership cleanup)
+### Phase 4 per-sub-tree runners (#100)
 
 The watcher cascades cancel tokens directly across sub-tree boundaries
 rather than going through a per-sub-tree runner that owns its workers'
-cancellation. Current implementation works correctly but the ownership
-inversion is a known footgun. Also: `terminate()` does not cascade to
-sub-tree workers (only `drain()` does); gates Phase 4 work.
-**Status:** deferred; tracked in codebase via `TODO(Phase 4)` in
-`signals.rs:222` and CAUTION doc block on `DispatchState`'s `Deref` impl.
+cancellation. Watchers are fire-once, so workers registered after the
+cascade fires can be orphaned. Also: `terminate()` does not cascade to
+sub-tree workers (only `drain()` does).
 
-### TUI runtime policy mutation
+**Status:** tracked in #100 with a detailed architecture memo. Tactical
+mitigation (post-register cascade check at worker-registration time)
+lands separately as #99.
 
-`[[approval_policy]]` rules are manifest-only — the TUI can display
-and act on policy but cannot edit rules while a run is live. Useful
-for operators who want to tighten or relax auto-approve rules mid-run
-without restarting. **Status:** deferred; manifest-only is safe and
-sufficient for current use cases.
+### TUI approval replay on run-switch (#95)
 
-### Sub-lead resume support
+When the TUI is launched without a run-id and the operator picks a run
+from the selector, pending approval_requested events already in the
+queue are not re-displayed. Launching with a run-id prefix works.
 
-`pitboss resume <run-id>` only resumes the root lead. Sub-leads that
-were live when the run was interrupted are not individually resumed;
-the root lead must re-spawn them. Full sub-lead resume would require
-persisting sub-lead `sublead_id` → `session_id` mappings and threading
-`--resume` through `spawn_sublead_session`. **Status:** deferred; the
-current fallback (root lead re-spawns) is workable for the typical
-interruption+retry case.
-
-### Hierarchical mode requires a git repo even with `use_worktree = false`
-
-Lead setup runs a git-repo check regardless of the `use_worktree`
-setting. Flat mode has no equivalent check — the hierarchical side is
-inconsistent. **Status:** deferred; documented in AGENTS.md "Headless
-mode" section as a known quirk. Fix is a 1-line code change or a more
-prominent book note.
+**Status:** diagnosed as stale `approval_list` state not being cleared
+in the `SwitchRun` handler.
 
 ### Slack notification sink escaping
 
@@ -130,6 +103,16 @@ but the Slack sink wasn't audited for the same class of injection.
 If Slack sink formats untrusted fields into `mrkdwn` blocks, same
 treatment applies. **Status:** deferred; audit + fix in one small PR
 when prioritized.
+
+### Low-severity nits from v0.8 ultrareview
+
+- **#96:** `pitboss status` table overflows the task-ID column for
+  sub-lead IDs (hard-coded `{:<30}` pad, no truncation).
+- **#97:** Duration formatter has no hour rollover — 2h run shows as
+  `"120m00s"`. Four duplicated copies (`status.rs`, `tui_table.rs`,
+  `diff.rs`, `tui.rs`) — centralize into one helper.
+- **#98:** Sync `std::fs` write inside a `tokio::spawn` async task in
+  `sublead.rs` — switch to `tokio::fs` or `spawn_blocking`.
 
 ---
 

--- a/crates/pitboss-cli/src/diff.rs
+++ b/crates/pitboss-cli/src/diff.rs
@@ -332,15 +332,14 @@ pub fn build_report(
 // ---------------------------------------------------------------------------
 
 fn fmt_ms(ms: i64) -> String {
-    #[allow(clippy::cast_sign_loss)]
-    let secs = (ms.max(0) / 1_000) as u64;
-    let m = secs / 60;
-    let s = secs % 60;
-    if m > 0 {
-        format!("{m}m{s:02}s")
-    } else {
-        format!("{s}s")
+    // Diff display treats a zero duration as "0s", not "—", because a run
+    // pair that both completed in <1ms is still meaningful data. Clamp
+    // negatives to 0 and bump through the shared formatter; its "—" case
+    // won't fire because we hand it a non-negative number.
+    if ms <= 0 {
+        return "0s".to_string();
     }
+    pitboss_core::fmt::format_duration_ms(ms)
 }
 
 fn fmt_delta_ms(delta: i64) -> String {

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -881,13 +881,22 @@ async fn spawn_sublead_session(
             let subleads_jsonl = sub_layer_bg.run_subdir.join("subleads.jsonl");
             if let Ok(mut line) = serde_json::to_string(&entry) {
                 line.push('\n');
-                // Best-effort: failure to persist is not fatal.
-                if let Err(e) = std::fs::OpenOptions::new()
-                    .create(true)
-                    .append(true)
-                    .open(&subleads_jsonl)
-                    .and_then(|mut f| std::io::Write::write_all(&mut f, line.as_bytes()))
-                {
+                // Best-effort: failure to persist is not fatal. Use tokio::fs
+                // instead of std::fs here because this closure runs on the
+                // tokio runtime; a sync open+write would block a runtime
+                // worker thread (#98).
+                let res: std::io::Result<()> = async {
+                    use tokio::io::AsyncWriteExt;
+                    let mut f = tokio::fs::OpenOptions::new()
+                        .create(true)
+                        .append(true)
+                        .open(&subleads_jsonl)
+                        .await?;
+                    f.write_all(line.as_bytes()).await?;
+                    Ok(())
+                }
+                .await;
+                if let Err(e) = res {
                     tracing::warn!(
                         sublead_id = %sublead_id_bg,
                         error = %e,

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -503,6 +503,23 @@ pub async fn handle_spawn_worker(
         .await
         .insert(task_id.clone(), worker_cancel);
 
+    // Plug the post-register cascade gap (#99): `install_sublead_cancel_watcher`
+    // is fire-once — it snapshots `worker_cancels`, propagates, then exits. A
+    // worker registered after the watcher has already fired never receives the
+    // signal. Check the target layer's cancel state now and propagate eagerly
+    // before the background task starts. `is_terminated` is checked first
+    // since terminate subsumes drain.
+    {
+        let cancels = target_layer.worker_cancels.read().await;
+        if let Some(w) = cancels.get(&task_id) {
+            if target_layer.cancel.is_terminated() {
+                w.terminate();
+            } else if target_layer.cancel.is_draining() {
+                w.drain();
+            }
+        }
+    }
+
     // Record the prompt preview before spawning the background task.
     let prompt_preview: String = args.prompt.chars().take(80).collect();
     target_layer
@@ -1109,6 +1126,15 @@ pub async fn spawn_resume_worker(
         .map(|l| l.directory.clone())
         .unwrap_or_else(|| std::path::PathBuf::from("/tmp"));
     let worker_cancel = pitboss_core::session::CancelToken::new();
+    // Same post-register cascade plug as `handle_spawn_worker` (#99): if the
+    // root layer's cancel has already fired, the fire-once watcher won't
+    // re-issue to this token — propagate synchronously before we register a
+    // Running worker against it.
+    if state.root.cancel.is_terminated() {
+        worker_cancel.terminate();
+    } else if state.root.cancel.is_draining() {
+        worker_cancel.drain();
+    }
     state
         .root
         .worker_cancels

--- a/crates/pitboss-cli/src/status.rs
+++ b/crates/pitboss-cli/src/status.rs
@@ -60,25 +60,35 @@ pub fn run(run_id_prefix: &str, json: bool, run_dir_override: Option<PathBuf>) -
         .map(|n| n.to_string_lossy().into_owned())
         .unwrap_or_else(|| run_dir.display().to_string());
     writeln!(stdout, "Run: {run_name}")?;
+
+    // Size the TASK_ID column to fit the widest id (with a floor of 30 and
+    // ceiling of 60) instead of a hard-coded 30-pad that silently overflows
+    // into the STATUS column when sub-lead ids are long (#96).
+    const TASK_ID_MIN: usize = 30;
+    const TASK_ID_MAX: usize = 60;
+    let observed_max = records.iter().map(|r| r.task_id.chars().count()).max().unwrap_or(0);
+    let task_id_width = observed_max.clamp(TASK_ID_MIN, TASK_ID_MAX);
+    let sep_width = task_id_width + 1 + 16 + 1 + 10 + 1 + 24 + 1 + 6;
+
     writeln!(
         stdout,
-        "{:<30} {:<16} {:>10} {:<24} {:>6}",
-        "TASK_ID", "STATUS", "DURATION", "STARTED", "EXIT"
+        "{:<task_id_width$} {:<16} {:>10} {:<24} {:>6}",
+        "TASK_ID", "STATUS", "DURATION", "STARTED", "EXIT",
     )?;
-    writeln!(stdout, "{}", "-".repeat(90))?;
+    writeln!(stdout, "{}", "-".repeat(sep_width))?;
 
     for rec in &records {
         let status = status_label(&rec.status);
-        let duration = format_duration(rec.duration_ms);
+        let duration = pitboss_core::fmt::format_duration_ms(rec.duration_ms);
         let started = rec.started_at.format("%Y-%m-%d %H:%M:%S").to_string();
         let exit = rec
             .exit_code
             .map(|c| c.to_string())
             .unwrap_or_else(|| "—".to_string());
+        let task_id = pitboss_core::fmt::truncate_ellipsis(&rec.task_id, task_id_width);
         writeln!(
             stdout,
-            "{:<30} {:<16} {:>10} {:<24} {:>6}",
-            &rec.task_id, status, duration, started, exit
+            "{task_id:<task_id_width$} {status:<16} {duration:>10} {started:<24} {exit:>6}",
         )?;
     }
 
@@ -90,7 +100,7 @@ pub fn run(run_id_prefix: &str, json: bool, run_dir_override: Option<PathBuf>) -
             .iter()
             .filter(|r| !matches!(r.status, TaskStatus::Success))
             .count();
-        writeln!(stdout, "{}", "-".repeat(90))?;
+        writeln!(stdout, "{}", "-".repeat(sep_width))?;
         writeln!(stdout, "Total: {total}  Failed: {failed}")?;
     }
 
@@ -107,14 +117,6 @@ fn status_label(s: &TaskStatus) -> &'static str {
         TaskStatus::ApprovalRejected => "⊘ ApprovalRej",
         TaskStatus::ApprovalTimedOut => "⏱ ApprovalTO",
     }
-}
-
-fn format_duration(ms: i64) -> String {
-    if ms <= 0 {
-        return "—".to_string();
-    }
-    let secs = ms / 1000;
-    format!("{}m{:02}s", secs / 60, secs % 60)
 }
 
 fn default_runs_dir() -> PathBuf {

--- a/crates/pitboss-cli/src/status.rs
+++ b/crates/pitboss-cli/src/status.rs
@@ -66,7 +66,11 @@ pub fn run(run_id_prefix: &str, json: bool, run_dir_override: Option<PathBuf>) -
     // into the STATUS column when sub-lead ids are long (#96).
     const TASK_ID_MIN: usize = 30;
     const TASK_ID_MAX: usize = 60;
-    let observed_max = records.iter().map(|r| r.task_id.chars().count()).max().unwrap_or(0);
+    let observed_max = records
+        .iter()
+        .map(|r| r.task_id.chars().count())
+        .max()
+        .unwrap_or(0);
     let task_id_width = observed_max.clamp(TASK_ID_MIN, TASK_ID_MAX);
     let sep_width = task_id_width + 1 + 16 + 1 + 10 + 1 + 24 + 1 + 6;
 

--- a/crates/pitboss-cli/src/tui_table.rs
+++ b/crates/pitboss-cli/src/tui_table.rs
@@ -124,12 +124,7 @@ impl ProgressTable {
             Status::Done(TaskStatus::ApprovalRejected) => "⊘ ApprovalRej".to_string(),
             Status::Done(TaskStatus::ApprovalTimedOut) => "⏱ ApprovalTO".to_string(),
         };
-        let time = if r.duration_ms == 0 {
-            "—".to_string()
-        } else {
-            let secs = r.duration_ms / 1000;
-            format!("{}m{:02}s", secs / 60, secs % 60)
-        };
+        let time = pitboss_core::fmt::format_duration_ms(r.duration_ms);
         let tokens = if r.tokens_in == 0 && r.tokens_out == 0 {
             "—".to_string()
         } else {

--- a/crates/pitboss-core/src/fmt.rs
+++ b/crates/pitboss-core/src/fmt.rs
@@ -1,8 +1,8 @@
 //! Small display-format helpers shared across pitboss binaries.
 //!
 //! Centralized so we have one canonical answer to "how does pitboss render
-//! a duration?" — four duplicated copies across status.rs, tui_table.rs,
-//! diff.rs, and tui.rs drifted apart over the v0.7/v0.8 cycle (#97).
+//! a duration?" — four duplicated copies across `status.rs`, `tui_table.rs`,
+//! `diff.rs`, and `tui.rs` drifted apart over the v0.7/v0.8 cycle (#97).
 
 /// Format a millisecond duration as a human-readable string.
 ///

--- a/crates/pitboss-core/src/fmt.rs
+++ b/crates/pitboss-core/src/fmt.rs
@@ -1,0 +1,109 @@
+//! Small display-format helpers shared across pitboss binaries.
+//!
+//! Centralized so we have one canonical answer to "how does pitboss render
+//! a duration?" — four duplicated copies across status.rs, tui_table.rs,
+//! diff.rs, and tui.rs drifted apart over the v0.7/v0.8 cycle (#97).
+
+/// Format a millisecond duration as a human-readable string.
+///
+/// - `ms <= 0` renders as `"—"` (em-dash) to mean "unknown / not started".
+/// - Sub-minute durations render as `"Ns"` (e.g. `"42s"`).
+/// - Sub-hour durations render as `"NmSSs"` (e.g. `"12m03s"`).
+/// - Hour+ durations render as `"HhMMmSSs"` (e.g. `"2h07m03s"`) — without
+///   this rollover the display kept ballooning minutes past 60 (#97).
+#[must_use]
+pub fn format_duration_ms(ms: i64) -> String {
+    if ms <= 0 {
+        return "—".to_string();
+    }
+    #[allow(clippy::cast_sign_loss)]
+    let secs = (ms / 1000) as u64;
+    let h = secs / 3600;
+    let m = (secs % 3600) / 60;
+    let s = secs % 60;
+    if h > 0 {
+        format!("{h}h{m:02}m{s:02}s")
+    } else if m > 0 {
+        format!("{m}m{s:02}s")
+    } else {
+        format!("{s}s")
+    }
+}
+
+/// Truncate `s` to at most `max` display columns, appending `…` (single char)
+/// when truncation occurs. Widths are measured in `char`s, which is correct
+/// for the ASCII task-IDs and sublead arrows pitboss emits; a full grapheme-
+/// width implementation would pull in unicode-width for no current benefit.
+///
+/// Used by `pitboss status` and the TUI table header to keep long sub-lead
+/// IDs from pushing subsequent columns out of alignment (#96).
+#[must_use]
+pub fn truncate_ellipsis(s: &str, max: usize) -> String {
+    if max == 0 {
+        return String::new();
+    }
+    let len = s.chars().count();
+    if len <= max {
+        return s.to_string();
+    }
+    let keep = max.saturating_sub(1);
+    let mut out: String = s.chars().take(keep).collect();
+    out.push('…');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn duration_nonpositive_renders_as_dash() {
+        assert_eq!(format_duration_ms(0), "—");
+        assert_eq!(format_duration_ms(-5), "—");
+    }
+
+    #[test]
+    fn duration_sub_minute_drops_minute_component() {
+        assert_eq!(format_duration_ms(1), "0s");
+        assert_eq!(format_duration_ms(42_000), "42s");
+        assert_eq!(format_duration_ms(59_999), "59s");
+    }
+
+    #[test]
+    fn duration_sub_hour_shows_minutes_and_zero_padded_seconds() {
+        assert_eq!(format_duration_ms(60_000), "1m00s");
+        assert_eq!(format_duration_ms(180_000), "3m00s");
+        // Just under the 1h rollover boundary.
+        assert_eq!(format_duration_ms(3_599_000), "59m59s");
+    }
+
+    #[test]
+    fn duration_rolls_over_at_one_hour() {
+        assert_eq!(format_duration_ms(3_600_000), "1h00m00s");
+        assert_eq!(format_duration_ms(7_623_000), "2h07m03s");
+        // 100-hour run formats without overflowing the h-slot.
+        assert_eq!(format_duration_ms(360_000_000), "100h00m00s");
+    }
+
+    #[test]
+    fn truncate_shorter_than_max_returns_unchanged() {
+        assert_eq!(truncate_ellipsis("abc", 5), "abc");
+        assert_eq!(truncate_ellipsis("abcde", 5), "abcde");
+    }
+
+    #[test]
+    fn truncate_longer_than_max_appends_ellipsis() {
+        assert_eq!(truncate_ellipsis("abcdef", 5), "abcd…");
+        assert_eq!(truncate_ellipsis("root→S1→w3", 6), "root→…");
+    }
+
+    #[test]
+    fn truncate_max_zero_returns_empty() {
+        assert_eq!(truncate_ellipsis("abc", 0), "");
+    }
+
+    #[test]
+    fn truncate_max_one_is_just_ellipsis() {
+        assert_eq!(truncate_ellipsis("abc", 1), "…");
+    }
+}

--- a/crates/pitboss-core/src/lib.rs
+++ b/crates/pitboss-core/src/lib.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::module_name_repetitions, clippy::missing_errors_doc)]
 
 pub mod error;
+pub mod fmt;
 pub mod parser;
 pub mod prices;
 pub mod process;

--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -119,12 +119,7 @@ pub fn run(run_dir: PathBuf, run_id: String) -> anyhow::Result<()> {
                             let (new_rx, new_tx) = spawn_watcher(run_dir.clone());
                             snapshot_rx = new_rx;
                             focus_tx = new_tx;
-                            state.run_dir = run_dir;
-                            state.run_id = run_id;
-                            state.tasks = vec![];
-                            state.focus = 0;
-                            state.run_list.clear();
-                            state.mode = Mode::Normal;
+                            reset_state_for_switch(&mut state, run_dir, run_id);
                             // Rebuild the control client against the new run's
                             // socket; without this, post-switch control ops
                             // (cancel/pause/approve/reprompt) keep targeting
@@ -160,16 +155,13 @@ pub fn run(run_dir: PathBuf, run_id: String) -> anyhow::Result<()> {
                             // Same transition as the keyboard-driven
                             // SwitchRun path above — restart the watcher,
                             // rebuild the control client, and reset
-                            // run-local state.
+                            // run-local state via the shared helper so mouse
+                            // and key paths can't drift on per-run cleanup
+                            // (e.g. missing approval_list clear — #95).
                             let (new_rx, new_tx) = spawn_watcher(run_dir.clone());
                             snapshot_rx = new_rx;
                             focus_tx = new_tx;
-                            state.run_dir = run_dir;
-                            state.run_id = run_id;
-                            state.tasks = vec![];
-                            state.focus = 0;
-                            state.run_list.clear();
-                            state.mode = Mode::Normal;
+                            reset_state_for_switch(&mut state, run_dir, run_id);
                             connect_control(&mut state);
                             let _ = focus_tx.send(String::new());
                             dirty = true;
@@ -232,6 +224,35 @@ enum Action {
     Continue,
     Quit,
     SwitchRun { run_dir: PathBuf, run_id: String },
+}
+
+/// Reset all per-run state when the operator switches runs from the picker.
+/// Leaves non-run state (runtime handle, control_client slot which the caller
+/// rebuilds) untouched. Kept as a free function so the SwitchRun path can be
+/// unit-tested without running the full event loop.
+fn reset_state_for_switch(state: &mut AppState, run_dir: PathBuf, run_id: String) {
+    state.run_dir = run_dir;
+    state.run_id = run_id;
+    state.tasks = vec![];
+    state.focus = 0;
+    state.run_list.clear();
+    state.mode = Mode::Normal;
+    // Pending approvals from the prior run's dispatcher reference request_ids
+    // that no longer exist on the new run's bridge. Leaving them in the list
+    // makes the approval-list pane lie about state; the new server will
+    // re-emit its own pending approvals on Hello and those must land cleanly.
+    state.approval_list.items.clear();
+    state.approval_list.selected_idx = 0;
+    state.policy_rules.clear();
+    state.subtrees.clear();
+    state.expanded.clear();
+    state.focused_subtree_idx = 0;
+    state.pane_focus = crate::state::PaneFocus::Grid;
+    state.store_activity.clear();
+    state.cached_git_diff.clear();
+    state.failed_count = 0;
+    state.run_started_at = None;
+    state.focus_log.clear();
 }
 
 /// The visible height used for snap-in scroll calculations.
@@ -1103,5 +1124,59 @@ mod approval_queue_tests {
         send_approve(&mut state, "req-B", false, None, None);
         assert_eq!(state.approval_list.items.len(), 1);
         assert_eq!(state.approval_list.selected_idx, 0);
+    }
+
+    #[test]
+    fn switch_run_clears_stale_approval_list_and_policy_rules() {
+        // Issue #95: when the operator navigates from the run selector to a
+        // different run, per-run state (approval queue, policy rules, subtree
+        // cache) must be cleared so the new run's Hello + queue-drain lands
+        // against a fresh slate. Leaving stale entries behind means the
+        // approval list pane shows requests that no longer have valid
+        // responders on the new run's bridge.
+        let mut state = fresh_state();
+        apply_control_event(&mut state, mk_approval_event("old-req-A", "root"));
+        apply_control_event(&mut state, mk_approval_event("old-req-B", "sublead-1"));
+        state.policy_rules.push(pitboss_cli::mcp::policy::ApprovalRule {
+            r#match: pitboss_cli::mcp::policy::ApprovalMatch::default(),
+            action: pitboss_cli::mcp::policy::ApprovalAction::Block,
+        });
+        assert_eq!(state.approval_list.items.len(), 2);
+        assert_eq!(state.policy_rules.len(), 1);
+
+        reset_state_for_switch(
+            &mut state,
+            PathBuf::from("/tmp/new-run"),
+            "new-run-id".to_string(),
+        );
+
+        assert_eq!(state.approval_list.items.len(), 0);
+        assert_eq!(state.approval_list.selected_idx, 0);
+        assert_eq!(state.policy_rules.len(), 0);
+        assert!(matches!(state.mode, Mode::Normal));
+        assert_eq!(state.run_id, "new-run-id");
+        assert_eq!(state.run_dir, PathBuf::from("/tmp/new-run"));
+    }
+
+    #[test]
+    fn switch_run_lets_new_approval_request_open_modal_cleanly() {
+        // The reset is a precondition for the modal path: after it runs, a
+        // fresh ApprovalRequest from the new run's dispatcher must be able
+        // to populate the list AND open the modal with no stale siblings.
+        let mut state = fresh_state();
+        apply_control_event(&mut state, mk_approval_event("old-req", "root"));
+        assert!(matches!(state.mode, Mode::ApprovalModal { .. }));
+
+        reset_state_for_switch(
+            &mut state,
+            PathBuf::from("/tmp/new-run"),
+            "new-run-id".to_string(),
+        );
+        assert!(matches!(state.mode, Mode::Normal));
+
+        apply_control_event(&mut state, mk_approval_event("new-req", "root"));
+        assert_eq!(state.approval_list.items.len(), 1);
+        assert_eq!(state.approval_list.items[0].id, "new-req");
+        assert!(matches!(state.mode, Mode::ApprovalModal { .. }));
     }
 }

--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -227,8 +227,8 @@ enum Action {
 }
 
 /// Reset all per-run state when the operator switches runs from the picker.
-/// Leaves non-run state (runtime handle, control_client slot which the caller
-/// rebuilds) untouched. Kept as a free function so the SwitchRun path can be
+/// Leaves non-run state (runtime handle, `control_client` slot which the caller
+/// rebuilds) untouched. Kept as a free function so the `SwitchRun` path can be
 /// unit-tested without running the full event loop.
 fn reset_state_for_switch(state: &mut AppState, run_dir: PathBuf, run_id: String) {
     state.run_dir = run_dir;

--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -1137,10 +1137,12 @@ mod approval_queue_tests {
         let mut state = fresh_state();
         apply_control_event(&mut state, mk_approval_event("old-req-A", "root"));
         apply_control_event(&mut state, mk_approval_event("old-req-B", "sublead-1"));
-        state.policy_rules.push(pitboss_cli::mcp::policy::ApprovalRule {
-            r#match: pitboss_cli::mcp::policy::ApprovalMatch::default(),
-            action: pitboss_cli::mcp::policy::ApprovalAction::Block,
-        });
+        state
+            .policy_rules
+            .push(pitboss_cli::mcp::policy::ApprovalRule {
+                r#match: pitboss_cli::mcp::policy::ApprovalMatch::default(),
+                action: pitboss_cli::mcp::policy::ApprovalAction::Block,
+            });
         assert_eq!(state.approval_list.items.len(), 2);
         assert_eq!(state.policy_rules.len(), 1);
 

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -75,17 +75,15 @@ fn fmt_tokens(n: u64) -> String {
     }
 }
 
-/// Format milliseconds as `"8m24s"` (or `"0s"` for zero).
+/// Format milliseconds as `"8m24s"` / `"2h07m03s"` (or `"0s"` for zero).
+/// Thin wrapper around `pitboss_core::fmt::format_duration_ms` that swaps the
+/// "not started" em-dash for `"0s"` — the TUI title bar and tile detail pane
+/// want a concrete zero, not an unknown-marker.
 fn fmt_ms(ms: i64) -> String {
-    #[allow(clippy::cast_sign_loss)]
-    let secs = (ms.max(0) / 1_000) as u64;
-    let m = secs / 60;
-    let s = secs % 60;
-    if m > 0 {
-        format!("{m}m{s:02}s")
-    } else {
-        format!("{s}s")
+    if ms <= 0 {
+        return "0s".to_string();
     }
+    pitboss_core::fmt::format_duration_ms(ms)
 }
 
 // Number of tile columns in the grid.
@@ -317,11 +315,7 @@ fn render_title(frame: &mut Frame, area: Rect, state: &AppState) {
         // Show wall-clock elapsed time if we know when the run started.
         if let Some(started) = state.run_started_at {
             let elapsed = chrono::Utc::now() - started;
-            #[allow(clippy::cast_sign_loss)]
-            let secs = elapsed.num_seconds().max(0) as u64;
-            let m = secs / 60;
-            let s = secs % 60;
-            format!(" — live {m}m{s:02}s")
+            format!(" — live {}", fmt_ms(elapsed.num_milliseconds()))
         } else {
             " — in progress".to_string()
         }


### PR DESCRIPTION
## Summary
- Refreshes ROADMAP for v0.8.0 (moves shipped items out, files stale git-repo entry, adds deferred list for v0.9+).
- Fixes TUI #95: operator navigating from the run selector to a different run no longer leaks per-run state (`approval_list`, `policy_rules`, subtree cache, focus log, …) from the prior run. Extracted `reset_state_for_switch()` so both keyboard- and mouse-driven SwitchRun paths use the same sweep — they had already drifted apart.
- Plugs the post-register cascade gap #99: workers registered after `install_sublead_cancel_watcher`'s fire-once task has exited now receive the drain/terminate signal via an eager check at `handle_spawn_worker` + `spawn_resume_worker`. Safe to double-cascade — `watch::Sender::send` is idempotent.
- Bundles three v0.8 ultrareview nits:
  - **#97** — centralize duration formatter in `pitboss_core::fmt::format_duration_ms` with `H:MM:SS` rollover; replaces four drifted copies (status.rs, tui_table.rs, diff.rs, tui.rs).
  - **#96** — auto-size the `pitboss status` TASK_ID column (observed max, clamped 30..=60) with ellipsis truncation for long sub-lead IDs; separator scales with column totals.
  - **#98** — swap sync `std::fs` for `tokio::fs` + `AsyncWriteExt` in the best-effort `subleads.jsonl` append so the runtime worker thread doesn't block.
- Files Phase 4 per-sub-tree runners as tracking issue #100 (architectural refactor, deferred out of this PR).

## Test plan
- [x] `cargo build --workspace` — clean
- [x] `cargo build --release --workspace` — clean
- [x] `cargo clippy --workspace --release --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --lib` — 565 tests pass (373 cli + 83 core + 109 tui)
- [x] `cargo test -p pitboss-cli --test sublead_flows --test control_flows` — 39/39 pass (incl. `root_cancel_cascades_to_sublead_workers`)
- [x] New unit coverage:
  - `switch_run_clears_stale_approval_list_and_policy_rules`
  - `switch_run_lets_new_approval_request_open_modal_cleanly`
  - 8 tests on `pitboss_core::fmt::{format_duration_ms, truncate_ellipsis}`
- [x] Manual smoke: `./target/release/pitboss status <run-id>` against a real run renders with corrected column widths and the new duration formatter (`10m53s`, `52s`, `2m23s` — no overflow, no stale `{:<30}` padding).
- [x] Manual smoke: `./target/release/pitboss validate` accepts a hierarchical manifest with `use_worktree=false` on a non-git dir (confirms the stale ROADMAP "git-repo check" item).
- [x] Manual smoke for #95 requires reproducing the original scenario (TUI opened without a run-id, then navigating via picker to a run with a pending approval). Unit coverage exercises the reset helper both paths use.

## Issues addressed
- Fixes #95, #99
- Files #96–#100 (three follow-on nits, one Phase 4 tracking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)