### PR TITLE
fix(tui): scroll-to-zoom into Detail + bottom-anchor focus log preview

### DIFF
--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -270,12 +270,18 @@ const DETAIL_VISIBLE_ROWS: usize = 40;
 fn handle_mouse(state: &mut AppState, mouse: crossterm::event::MouseEvent) -> Action {
     match (state.mode.clone(), mouse.kind) {
         // Wheel scroll inside Detail view — 5 rows/tick, matches J/K
-        // shift-scroll cadence.
+        // shift-scroll cadence. ScrollUp while already at the top of the
+        // log acts as "zoom out" — exits Detail back to the grid —
+        // symmetric with scroll-to-zoom-in from the grid (below).
+        (Mode::Detail { scroll, .. }, MouseEventKind::ScrollUp) => {
+            if scroll == 0 {
+                state.exit_detail();
+            } else {
+                state.detail_scroll_up(5);
+            }
+        }
         (Mode::Detail { .. }, MouseEventKind::ScrollDown) => {
             state.detail_scroll_down(5, DETAIL_VISIBLE_ROWS);
-        }
-        (Mode::Detail { .. }, MouseEventKind::ScrollUp) => {
-            state.detail_scroll_up(5);
         }
         // Right-click inside Detail view exits back to the grid —
         // symmetric with Esc, easier than reaching for the keyboard.
@@ -295,6 +301,16 @@ fn handle_mouse(state: &mut AppState, mouse: crossterm::event::MouseEvent) -> Ac
                     // path at the top of the event loop.
                     let _ = tile;
                 }
+                state.enter_detail();
+            }
+        }
+        // Wheel scroll over a tile in the grid: "zoom in" — focus the
+        // tile under the cursor and enter Detail. Either scroll direction
+        // performs the gesture. Scroll outside any tile is a no-op. The
+        // symmetric "zoom out" is the scroll-up-at-top branch above.
+        (Mode::Normal, MouseEventKind::ScrollDown | MouseEventKind::ScrollUp) => {
+            if let Some(idx) = state.tile_at(mouse.column, mouse.row) {
+                state.focus = idx;
                 state.enter_detail();
             }
         }

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -878,28 +878,53 @@ fn render_focus_log(frame: &mut Frame, area: Rect, state: &AppState) {
         .map(|t| status_label(&t.status))
         .unwrap_or_default();
 
+    // Full-frame block so wrapped content can't bleed outside the pane's
+    // rect when the terminal is tight or long log lines wrap unexpectedly.
+    // Prior `Borders::TOP` had no side/bottom to clip against.
     let block = Block::default()
-        .borders(Borders::TOP)
+        .borders(Borders::ALL)
         .title(format!(" Focus: {focused_id} ({status_str}) "))
         .border_style(theme::idle_border());
 
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    // Render last N lines of log that fit in the area height.
-    let height = inner.height as usize;
-    let log_slice = if state.focus_log.len() > height {
-        &state.focus_log[state.focus_log.len() - height..]
-    } else {
-        &state.focus_log
-    };
+    // Tail behavior: source-line slicing alone is incorrect when `wrap` is
+    // enabled — wrapped lines expand beyond `inner.height` and Paragraph
+    // shows the *head* of the slice. Cap source lines to a generous
+    // multiple of the visible height, then ask Paragraph for the
+    // width-aware wrapped line count and scroll to the bottom.
+    let source_cap = (inner.height as usize).saturating_mul(4).max(32);
+    let start = state.focus_log.len().saturating_sub(source_cap);
+    let log_slice = &state.focus_log[start..];
 
     let lines: Vec<Line> = log_slice
         .iter()
         .map(|l| Line::from(Span::styled(l.as_str(), crate::theme::log_line_style(l))))
         .collect();
 
-    let para = Paragraph::new(lines).wrap(Wrap { trim: false });
+    // Estimate wrapped row count per source line so we can scroll to the
+    // bottom. `Paragraph::line_count` is gated behind an unstable ratatui
+    // feature; a div-by-width approximation matches its behavior closely
+    // enough for bottom-anchor scroll. Uses char count (not grapheme
+    // width) — accurate for the ASCII + stream-json content pitboss tails.
+    let width = (inner.width as usize).max(1);
+    let total_rows: usize = lines
+        .iter()
+        .map(|l| {
+            let w = l.width();
+            if w == 0 {
+                1
+            } else {
+                w.div_ceil(width)
+            }
+        })
+        .sum();
+    let scroll =
+        u16::try_from(total_rows.saturating_sub(inner.height as usize)).unwrap_or(u16::MAX);
+    let para = Paragraph::new(lines)
+        .wrap(Wrap { trim: false })
+        .scroll((scroll, 0));
     frame.render_widget(para, inner);
 }
 


### PR DESCRIPTION
## Summary
Three adjacent TUI UX issues surfaced during manual testing today.

### 1. Scroll-wheel zoom-in / zoom-out (new behavior)
- Scroll wheel over a tile in the grid now focuses that tile and enters Detail — same effect as left-click, but hands-on-mouse. Either scroll direction triggers the gesture.
- Scroll-up in Detail when already pinned at the top of the log (scroll == 0) exits Detail back to the grid — overscroll gesture. Non-top ScrollUp still scrolls the log.
- Existing left-click (enter) + right-click (exit) + keyboard paths are unchanged.

### 2. Focus-log preview pane tails correctly
\`render_focus_log\` previously tailed source lines but then let \`Paragraph.wrap\` expand each into multiple visual rows — which could exceed the pane's inner height, making Paragraph show the *head* of the wrapped output while newest lines scrolled off the bottom.

Fix: cap source lines to \`inner.height * 4\`, compute approximate wrapped-row total (\`width.div_ceil(inner.width)\` per line), scroll to \`(total - height)\`.

ratatui 0.29's \`Paragraph::line_count\` is gated behind an unstable feature flag (\`unstable-rendered-line-info\`); the char-count÷width approximation matches its behavior closely enough for bottom anchoring on the ASCII + stream-json content pitboss tails.

### 3. Bleedover clipped by full frame
The preview block used \`Borders::TOP\` only — no side/bottom to clip. Switch to \`Borders::ALL\`; the block's inner rect now fully contains wrapped content.

## Test plan
- [x] \`cargo check -p pitboss-tui\` — clean
- [x] \`cargo clippy -p pitboss-tui --release --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p pitboss-tui --lib\` — 109/109 pass
- [ ] Manual: scroll over a tile → enters Detail. Scroll-up at top of log → exits. Scroll-up mid-log → scrolls log as before. Tail behavior: live log updates keep newest line visible instead of locking to top. Long wrapped lines don't bleed outside the frame.

## Scope notes
- The prior-behavior "scroll zoom" mentioned in the bug report never actually existed on main (no git history of it); this PR adds the behavior as a new feature aligned with operator expectations rather than restoring prior behavior.
- Log preview tailing was broken from the initial commit — pre-existing, not a recent regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)