### PR TITLE
fix(tui): remove scroll-up-at-top exits-Detail gesture (#114 follow-up)

### DIFF
--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -270,15 +270,12 @@ const DETAIL_VISIBLE_ROWS: usize = 40;
 fn handle_mouse(state: &mut AppState, mouse: crossterm::event::MouseEvent) -> Action {
     match (state.mode.clone(), mouse.kind) {
         // Wheel scroll inside Detail view — 5 rows/tick, matches J/K
-        // shift-scroll cadence. ScrollUp while already at the top of the
-        // log acts as "zoom out" — exits Detail back to the grid —
-        // symmetric with scroll-to-zoom-in from the grid (below).
-        (Mode::Detail { scroll, .. }, MouseEventKind::ScrollUp) => {
-            if scroll == 0 {
-                state.exit_detail();
-            } else {
-                state.detail_scroll_up(5);
-            }
+        // shift-scroll cadence. Exit-by-overscroll was tried briefly
+        // in #114 but removed — too easy to accidentally exit while
+        // reading the top of a log. Right-click and Esc remain the
+        // explicit exit gestures.
+        (Mode::Detail { .. }, MouseEventKind::ScrollUp) => {
+            state.detail_scroll_up(5);
         }
         (Mode::Detail { .. }, MouseEventKind::ScrollDown) => {
             state.detail_scroll_down(5, DETAIL_VISIBLE_ROWS);


### PR DESCRIPTION
## Summary
The overscroll-exits-Detail gesture added in #114 turned out to be too easy to trigger by accident while reading the top of a log — operators kept accidentally exiting back to the grid mid-scan.

Reverts only that half. Scroll-to-zoom-IN from the grid (added in same PR) is preserved.

## Scroll-wheel surface (after this PR)
| Context | Wheel up | Wheel down |
|---|---|---|
| Grid (Mode::Normal) over a tile | enter Detail on that tile | enter Detail on that tile |
| Grid over empty space | no-op | no-op |
| Detail (Mode::Detail) | scroll log up 5 rows | scroll log down 5 rows |

Explicit exit from Detail stays right-click or Esc.

## Test plan
- [x] \`cargo check -p pitboss-tui\` — clean
- [x] \`cargo clippy -p pitboss-tui --release --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p pitboss-tui --lib\` — 109/109 pass
- [ ] Manual: scroll up while at top of log → log stays at top, Detail does not exit. Right-click + Esc still exit. Scroll-zoom-in still works from grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)