### PR TITLE
fix: address bugs #104 #105 #106 #107

### DIFF
--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -269,35 +269,34 @@ async fn serve_connection(
     // but emits no event, and the lead blocks until TTL fallback fires.
     // The responder oneshot stays in the bridge; a subsequent approve/reject
     // op still delivers correctly.
-    {
+    // Collect live entries into a Vec while holding the lock (no async work),
+    // then drop the guard before calling ev_tx.send().await. Holding the lock
+    // across send() suspends while the channel is full, blocking every other
+    // lock waiter (expire_layer_approvals, the Approve op handler, concurrent
+    // Hello drain) for the full duration of the backpressure stall (#105).
+    let pending: Vec<ControlEvent> = {
         let bridge = state.root.approval_bridge.lock().await;
-        for (request_id, entry) in bridge.iter() {
-            // Drop entries whose responder oneshot has already been filled
-            // (e.g. TTL fallback fired between drain and this replay) — the
-            // canonical cleanup path for those is expire_layer_approvals;
-            // we just skip replaying to the TUI so it doesn't render a
-            // dangling approval card. is_closed is the best proxy we have
-            // without racing the responder's receiver. A concurrent TTL expiry
-            // between this check and the send below is accepted: the TUI will
-            // briefly render a card that vanishes when the expiry is processed
-            // (#109). Closing the window fully would require coordinating the
-            // replay and TTL paths via a version counter — not worth it.
-            if entry.responder.is_closed() {
-                continue;
-            }
-            let _ = ev_tx
-                .send(ControlEvent::ApprovalRequest {
-                    request_id: request_id.clone(),
-                    task_id: entry.task_id.clone(),
-                    summary: entry.summary.clone(),
-                    plan: entry
-                        .plan
-                        .clone()
-                        .map(crate::mcp::approval::approval_plan_to_wire),
-                    kind: entry.kind,
-                })
-                .await;
-        }
+        bridge
+            .iter()
+            .filter(|(_, entry)| !entry.responder.is_closed())
+            // is_closed is the best proxy without racing the receiver; a
+            // concurrent TTL expiry between this filter and the send below
+            // is accepted — the TUI briefly renders a card that vanishes
+            // when the expiry is processed (#109).
+            .map(|(request_id, entry)| ControlEvent::ApprovalRequest {
+                request_id: request_id.clone(),
+                task_id: entry.task_id.clone(),
+                summary: entry.summary.clone(),
+                plan: entry
+                    .plan
+                    .clone()
+                    .map(crate::mcp::approval::approval_plan_to_wire),
+                kind: entry.kind,
+            })
+            .collect()
+    }; // lock released here
+    for ev in pending {
+        let _ = ev_tx.send(ev).await;
     }
 
     // Concurrent outbound pump: forward events from the mpsc to the socket.

--- a/crates/pitboss-cli/src/diff.rs
+++ b/crates/pitboss-cli/src/diff.rs
@@ -91,8 +91,17 @@ pub fn load_summary(run_dir: &Path) -> Result<RunSummary> {
         if trimmed.is_empty() {
             continue;
         }
-        if let Ok(rec) = serde_json::from_str::<pitboss_core::store::TaskRecord>(trimmed) {
-            tasks.push(rec);
+        match serde_json::from_str::<pitboss_core::store::TaskRecord>(trimmed) {
+            Ok(rec) => tasks.push(rec),
+            Err(e) => {
+                // Warn rather than silently skip — corrupt/truncated lines
+                // cause silent undercounting of tasks_total, tasks_failed,
+                // token sums, and cost (#107). In-progress runs can have a
+                // genuinely partial trailing line (mid-write truncation), but
+                // that is indistinguishable here from format skew or disk
+                // corruption, so we always surface it.
+                tracing::warn!(error = %e, line = trimmed, "summary.jsonl: skipping unparseable line — diff output may be incomplete");
+            }
         }
     }
 

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -265,22 +265,27 @@ pub async fn spawn_sublead(
     {
         let amount = *budget_usd;
         if let Some(cap) = state.root.manifest.budget_usd {
-            // Snapshot both accumulators, then check before reserving.
-            // Mirroring the pattern in spawn_worker (mcp/tools.rs:329-356):
-            // read spent and reserved, check, then re-acquire reserved to add.
+            // Read spent first (snapshot acceptable — it only grows), then
+            // hold reserved_usd across the check-and-add so concurrent
+            // spawn_sublead calls can't both pass the guard simultaneously.
+            // Fixes the TOCTOU described in #106: two independent lock
+            // snapshots + an unlocked check allowed both callers to pass
+            // the guard before either wrote, enabling budget over-commit.
             let spent = *state.root.spent_usd.lock().await;
-            let reserved = *state.root.reserved_usd.lock().await;
-            if spent + reserved + amount > cap {
+            let mut reserved = state.root.reserved_usd.lock().await;
+            if spent + *reserved + amount > cap {
                 bail!(
                     "spawn_sublead: budget exceeded: ${:.2} spent + ${:.2} reserved + ${:.2} estimated > ${:.2} budget",
                     spent,
-                    reserved,
+                    *reserved,
                     amount,
                     cap
                 );
             }
+            *reserved += amount;
+        } else {
+            *state.root.reserved_usd.lock().await += amount;
         }
-        *state.root.reserved_usd.lock().await += amount;
         Some(amount)
     } else {
         None

--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -120,6 +120,17 @@ pub fn run(run_dir: PathBuf, run_id: String) -> anyhow::Result<()> {
                             snapshot_rx = new_rx;
                             focus_tx = new_tx;
                             reset_state_for_switch(&mut state, run_dir, run_id);
+                            // Drain in-flight events from the old run's socket
+                            // reader before connecting to the new run. The old
+                            // read_loop keeps running until its Unix socket
+                            // closes and still forwards through the shared
+                            // ctrl_events_tx. Without this drain, stale events
+                            // (including ApprovalRequest) can arrive after
+                            // reset_state_for_switch cleared the approval list,
+                            // pass the de-dup guard as "new", and open a modal
+                            // whose request_id the new dispatcher cannot ack
+                            // (#104).
+                            while ctrl_events_rx.try_recv().is_ok() {}
                             // Rebuild the control client against the new run's
                             // socket; without this, post-switch control ops
                             // (cancel/pause/approve/reprompt) keep targeting
@@ -162,6 +173,7 @@ pub fn run(run_dir: PathBuf, run_id: String) -> anyhow::Result<()> {
                             snapshot_rx = new_rx;
                             focus_tx = new_tx;
                             reset_state_for_switch(&mut state, run_dir, run_id);
+                            while ctrl_events_rx.try_recv().is_ok() {} // #104
                             connect_control(&mut state);
                             let _ = focus_tx.send(String::new());
                             dirty = true;


### PR DESCRIPTION
## Summary

Four bugs surfaced during the incremental docs pass, all fixed in a single commit.

- **#107** — `pitboss diff` silently undercounts when `summary.jsonl` has unparseable lines. `if let Ok(rec)` was swallowing corrupt/truncated lines without any signal; now emits `tracing::warn!` per skipped line so operators know the output may be incomplete.
- **#106** — `spawn_sublead` budget guard TOCTOU: two independent lock snapshots were checked without either held, allowing two concurrent callers to both pass the budget cap. Now reads `spent_usd` as a snapshot (acceptable; it only grows) and holds `reserved_usd` across the check-and-add.
- **#105** — `approval_bridge` Mutex held across `ev_tx.send().await` during bridge replay. A full channel suspends `send()`, blocking all other lock waiters (`expire_layer_approvals`, `Approve` op handler). Now collects live entries into a `Vec` while holding the lock, drops the guard, then sends without any lock held.
- **#104** — Stale `read_loop` events from the prior run's socket leak into the new run after `SwitchRun`. The old `read_loop` keeps forwarding through the shared `ctrl_events_tx` until the socket closes; stale `ApprovalRequest` events passed the de-dup guard and opened modals the new dispatcher couldn't ack. Now drains `ctrl_events_rx` at both `SwitchRun` sites before `connect_control`.

Also closing #98 and #99 as already fixed in prior commits.

## Test plan

- [ ] `cargo test --workspace` passes
- [ ] `pitboss diff` on a run with a truncated `summary.jsonl` line emits a warn log and reports correct counts for parseable lines
- [ ] Concurrent `spawn_sublead` calls near budget cap don't over-commit
- [ ] Switching runs in the TUI while an approval is pending on the old run does not open a modal on the new run

🤖 Generated with [Claude Code](https://claude.com/claude-code)