### PR TITLE
fix(tui): Completed page UX fixes + log pane text leakage

### DIFF
--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -317,32 +317,10 @@ fn handle_mouse(state: &mut AppState, mouse: crossterm::event::MouseEvent) -> Ac
         (Mode::Completed { .. }, MouseEventKind::Down(MouseButton::Right)) => {
             state.mode = Mode::Normal;
         }
-        // Left-click on a completed table row: open Detail for that task.
+        // Left-click on the Completed page: check tab bar first (no-op if
+        // already on Completed), then fall through to row → Detail.
         (Mode::Completed { .. }, MouseEventKind::Down(MouseButton::Left)) => {
-            let task_id = state.completed_hit_rects.lock().ok().and_then(|rects| {
-                rects.iter().find_map(|&(task_idx, r)| {
-                    if mouse.column >= r.x
-                        && mouse.column < r.x + r.width
-                        && mouse.row >= r.y
-                        && mouse.row < r.y + r.height
-                    {
-                        Some(state.tasks[task_idx].id.clone())
-                    } else {
-                        None
-                    }
-                })
-            });
-            if let Some(task_id) = task_id {
-                state.enter_detail_for(task_id);
-            }
-        }
-        // Left-click on the "Completed" tab in the tab bar: navigate to the
-        // Completed page. Works from both Normal and Completed modes (clicking
-        // the Active tab from Completed returns to Normal via the Completed
-        // right-click / Esc path; clicking Completed from Completed is a no-op
-        // because we're already there).
-        (Mode::Normal | Mode::Completed { .. }, MouseEventKind::Down(MouseButton::Left))
-            if state
+            let on_tab = state
                 .completed_tab_rect
                 .lock()
                 .ok()
@@ -352,9 +330,41 @@ fn handle_mouse(state: &mut AppState, mouse: crossterm::event::MouseEvent) -> Ac
                         && mouse.column < r.x + r.width
                         && mouse.row >= r.y
                         && mouse.row < r.y + r.height
-                }) =>
-        {
-            if !matches!(state.mode, Mode::Completed { .. }) {
+                });
+            if !on_tab {
+                let task_id = state.completed_hit_rects.lock().ok().and_then(|rects| {
+                    rects.iter().find_map(|&(task_idx, r)| {
+                        if mouse.column >= r.x
+                            && mouse.column < r.x + r.width
+                            && mouse.row >= r.y
+                            && mouse.row < r.y + r.height
+                        {
+                            Some(state.tasks[task_idx].id.clone())
+                        } else {
+                            None
+                        }
+                    })
+                });
+                if let Some(task_id) = task_id {
+                    state.enter_detail_for(task_id);
+                }
+            }
+        }
+        // Left-click on a tile in the grid (or the Completed tab when in
+        // Normal mode): check tab bar first, then fall through to tile → Detail.
+        (Mode::Normal, MouseEventKind::Down(MouseButton::Left)) => {
+            let on_tab = state
+                .completed_tab_rect
+                .lock()
+                .ok()
+                .and_then(|g| *g)
+                .is_some_and(|r| {
+                    mouse.column >= r.x
+                        && mouse.column < r.x + r.width
+                        && mouse.row >= r.y
+                        && mouse.row < r.y + r.height
+                });
+            if on_tab {
                 let completed = state.completed_tile_indices();
                 if !completed.is_empty() {
                     let first_id = state.tasks[completed[0]].id.clone();
@@ -365,13 +375,7 @@ fn handle_mouse(state: &mut AppState, mouse: crossterm::event::MouseEvent) -> Ac
                         filter_status: None,
                     };
                 }
-            }
-        }
-        // Left-click on a tile in the grid: focus + enter Detail
-        // (equivalent to hjkl + Enter). Clicks on the already-focused
-        // tile also enter Detail.
-        (Mode::Normal, MouseEventKind::Down(MouseButton::Left)) => {
-            if let Some(idx) = state.tile_at(mouse.column, mouse.row) {
+            } else if let Some(idx) = state.tile_at(mouse.column, mouse.row) {
                 state.focus = idx;
                 if let Some(tile) = state.focused_tile() {
                     // The focus_tx is owned by run(); we can't touch it

--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -274,10 +274,13 @@ fn reset_state_for_switch(state: &mut AppState, run_dir: PathBuf, run_id: String
     // from showing on the status bar during the one render tick between this
     // reset and the new connection being established (#113).
     state.control_connected = false;
-    // Clear completed-page hit cache so stale rects from the old run don't
-    // produce phantom clicks on the new run's layout.
+    // Clear hit caches so stale rects from the old run don't produce
+    // phantom clicks on the new run's layout.
     if let Ok(mut rects) = state.completed_hit_rects.lock() {
         rects.clear();
+    }
+    if let Ok(mut rect) = state.completed_tab_rect.lock() {
+        *rect = None;
     }
 }
 
@@ -310,6 +313,10 @@ fn handle_mouse(state: &mut AppState, mouse: crossterm::event::MouseEvent) -> Ac
         (Mode::Detail { .. }, MouseEventKind::Down(MouseButton::Right)) => {
             state.exit_detail();
         }
+        // Right-click on the Completed page exits back to Active (same as Esc).
+        (Mode::Completed { .. }, MouseEventKind::Down(MouseButton::Right)) => {
+            state.mode = Mode::Normal;
+        }
         // Left-click on a completed table row: open Detail for that task.
         (Mode::Completed { .. }, MouseEventKind::Down(MouseButton::Left)) => {
             let task_id = state.completed_hit_rects.lock().ok().and_then(|rects| {
@@ -327,6 +334,39 @@ fn handle_mouse(state: &mut AppState, mouse: crossterm::event::MouseEvent) -> Ac
             });
             if let Some(task_id) = task_id {
                 state.enter_detail_for(task_id);
+            }
+        }
+        // Left-click on the "Completed" tab in the tab bar: navigate to the
+        // Completed page. Works from both Normal and Completed modes (clicking
+        // the Active tab from Completed returns to Normal via the Completed
+        // right-click / Esc path; clicking Completed from Completed is a no-op
+        // because we're already there).
+        (
+            Mode::Normal | Mode::Completed { .. },
+            MouseEventKind::Down(MouseButton::Left),
+        ) if state
+            .completed_tab_rect
+            .lock()
+            .ok()
+            .and_then(|g| *g)
+            .is_some_and(|r| {
+                mouse.column >= r.x
+                    && mouse.column < r.x + r.width
+                    && mouse.row >= r.y
+                    && mouse.row < r.y + r.height
+            }) =>
+        {
+            if !matches!(state.mode, Mode::Completed { .. }) {
+                let completed = state.completed_tile_indices();
+                if !completed.is_empty() {
+                    let first_id = state.tasks[completed[0]].id.clone();
+                    state.mode = crate::state::Mode::Completed {
+                        selected_task_id: first_id,
+                        scroll_offset: 0,
+                        sort_key: crate::state::SortKey::EndedAtDesc,
+                        filter_status: None,
+                    };
+                }
             }
         }
         // Left-click on a tile in the grid: focus + enter Detail

--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -341,20 +341,18 @@ fn handle_mouse(state: &mut AppState, mouse: crossterm::event::MouseEvent) -> Ac
         // the Active tab from Completed returns to Normal via the Completed
         // right-click / Esc path; clicking Completed from Completed is a no-op
         // because we're already there).
-        (
-            Mode::Normal | Mode::Completed { .. },
-            MouseEventKind::Down(MouseButton::Left),
-        ) if state
-            .completed_tab_rect
-            .lock()
-            .ok()
-            .and_then(|g| *g)
-            .is_some_and(|r| {
-                mouse.column >= r.x
-                    && mouse.column < r.x + r.width
-                    && mouse.row >= r.y
-                    && mouse.row < r.y + r.height
-            }) =>
+        (Mode::Normal | Mode::Completed { .. }, MouseEventKind::Down(MouseButton::Left))
+            if state
+                .completed_tab_rect
+                .lock()
+                .ok()
+                .and_then(|g| *g)
+                .is_some_and(|r| {
+                    mouse.column >= r.x
+                        && mouse.column < r.x + r.width
+                        && mouse.row >= r.y
+                        && mouse.row < r.y + r.height
+                }) =>
         {
             if !matches!(state.mode, Mode::Completed { .. }) {
                 let completed = state.completed_tile_indices();

--- a/crates/pitboss-tui/src/state.rs
+++ b/crates/pitboss-tui/src/state.rs
@@ -8,7 +8,10 @@ use pitboss_core::store::TaskStatus;
 
 /// Seconds after a terminal state before a tile is promoted to the Completed
 /// page. Configurable per-run via `AppState.completed_after_secs`.
-pub const COMPLETED_COOLDOWN_DEFAULT_SECS: i64 = 5;
+/// 120s (2 min): long enough for the operator to read the tile's outcome
+/// before it moves, without leaving a finished dispatch's tiles cluttering
+/// the Active grid indefinitely.
+pub const COMPLETED_COOLDOWN_DEFAULT_SECS: i64 = 120;
 
 /// Sort order for the Completed page table.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -277,6 +280,10 @@ pub struct AppState {
     /// original `tasks[]` index. Populated by `render_completed_page` each
     /// frame; used by the mouse click handler in `app.rs`.
     pub completed_hit_rects: std::sync::Mutex<Vec<(usize, ratatui::layout::Rect)>>,
+    /// Bounding rect of the "Completed" tab in the tab bar. Populated by
+    /// `render_tab_bar` each frame; used by the mouse click handler so
+    /// clicking the Completed tab navigates to the Completed page.
+    pub completed_tab_rect: std::sync::Mutex<Option<ratatui::layout::Rect>>,
     /// Sub-tree views keyed by `sublead_id`. Empty in depth-1 runs.
     pub subtrees: HashMap<String, SubtreeView>,
     /// Collapse state for each sub-tree container. `true` = expanded (default
@@ -344,6 +351,7 @@ impl AppState {
             tile_hit_rects: std::sync::Mutex::new(Vec::new()),
             picker_hit_rects: std::sync::Mutex::new(Vec::new()),
             completed_hit_rects: std::sync::Mutex::new(Vec::new()),
+            completed_tab_rect: std::sync::Mutex::new(None),
             subtrees: HashMap::new(),
             expanded: HashMap::new(),
             focused_subtree_idx: 0,
@@ -512,6 +520,15 @@ impl AppState {
     pub fn enter_detail_for(&mut self, task_id: String) {
         if matches!(self.mode, Mode::Detail { .. }) {
             return;
+        }
+        // Update `self.focus` to the viewed tile so that the watcher's
+        // focus-notification path (which calls `focused_tile()` after each
+        // key event) sends the correct task id and tails the right log.
+        // Without this, Detail opened from the Completed page always tailed
+        // the Active-grid focused tile's log, making every Completed row open
+        // the same log content.
+        if let Some(pos) = self.tasks.iter().position(|t| t.id == task_id) {
+            self.focus = pos;
         }
         // worktree_path is populated for in-flight tiles via the
         // `worktree.path` sidecar (written by the dispatcher at spawn
@@ -1589,7 +1606,7 @@ mod tests {
     #[test]
     fn is_promoted_true_after_threshold() {
         let state = make_state();
-        let tile = make_done_tile("t", 6); // ended 6s ago > 5s threshold
+        let tile = make_done_tile("t", 130); // ended 130s ago > 120s threshold
         assert!(state.is_promoted(&tile));
     }
 
@@ -1618,7 +1635,7 @@ mod tests {
     fn active_and_completed_indices_partition_tasks() {
         let mut state = make_state();
         state.tasks = vec![
-            make_done_tile("old", 30), // promoted
+            make_done_tile("old", 130), // promoted (130s > 120s threshold)
             TileState {
                 // running, not promoted
                 id: "live".into(),

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -307,6 +307,27 @@ fn render_tab_bar(
     let active_label = format!("Active ({running} running · {pending} pending)");
     let completed_label = format!("Completed ({completed_count})");
 
+    // Compute the Completed tab's bounding rect so the mouse handler can
+    // detect clicks on it. Ratatui's Tabs renders each tab as:
+    //   " " (left pad) + label + " " (right pad) + "│" (divider)
+    // The Active tab therefore occupies `active_label.chars().count() + 3`
+    // terminal columns (pad + label + pad + divider). The Completed tab
+    // starts immediately after.
+    let active_tab_cols = active_label.chars().count() as u16 + 3;
+    let completed_tab_cols = completed_label.chars().count() as u16 + 2; // no trailing divider
+    let completed_tab_x = area.x.saturating_add(active_tab_cols);
+    if completed_tab_x < area.x + area.width {
+        let rect = ratatui::layout::Rect::new(
+            completed_tab_x,
+            area.y,
+            completed_tab_cols.min(area.width.saturating_sub(active_tab_cols)),
+            1,
+        );
+        if let Ok(mut guard) = state.completed_tab_rect.lock() {
+            *guard = Some(rect);
+        }
+    }
+
     let selected_idx = usize::from(on_completed_page);
     let tabs = Tabs::new(vec![active_label, completed_label])
         .select(selected_idx)
@@ -1277,9 +1298,31 @@ fn render_focus_log(frame: &mut Frame, area: Rect, state: &AppState) {
     let start = state.focus_log.len().saturating_sub(source_cap);
     let log_slice = &state.focus_log[start..];
 
+    // Truncate each source line to 4× the pane width before building spans.
+    // Very long lines (JSON blobs, base64, table rows) with no whitespace
+    // break points defeat ratatui's word-wrap and overflow the pane boundary
+    // into adjacent columns. The focus pane is a live monitor — displaying
+    // at most 4 screenfuls of horizontal content per source line is enough
+    // for any triage purpose. Truncation happens at char boundaries to avoid
+    // splitting multi-byte sequences.
+    let max_line_chars = (inner.width as usize).saturating_mul(4).max(160);
     let lines: Vec<Line> = log_slice
         .iter()
-        .map(|l| Line::from(Span::styled(l.as_str(), crate::theme::log_line_style(l))))
+        .map(|l| {
+            let display: &str = if l.chars().count() > max_line_chars {
+                // Safety: char_indices gives byte offsets; we advance by
+                // char count, so the slice is always on a char boundary.
+                let byte_end = l
+                    .char_indices()
+                    .nth(max_line_chars)
+                    .map(|(b, _)| b)
+                    .unwrap_or(l.len());
+                &l[..byte_end]
+            } else {
+                l.as_str()
+            };
+            Line::from(Span::styled(display, crate::theme::log_line_style(l)))
+        })
         .collect();
 
     // Estimate wrapped row count per source line so we can scroll to the
@@ -1313,6 +1356,10 @@ fn render_focus_log(frame: &mut Frame, area: Rect, state: &AppState) {
 
 fn render_approval_list_pane(frame: &mut Frame, area: Rect, state: &AppState) {
     use crate::state::PaneFocus;
+
+    // Explicit clear before rendering so no stale cells from a previous frame
+    // (e.g., leftover log content if the pane was shorter last tick) remain.
+    frame.render_widget(Clear, area);
 
     let focused = state.pane_focus == PaneFocus::ApprovalList;
     let border_style = if focused {
@@ -2263,6 +2310,7 @@ mod tests {
             tile_hit_rects: std::sync::Mutex::new(Vec::new()),
             picker_hit_rects: std::sync::Mutex::new(Vec::new()),
             completed_hit_rects: std::sync::Mutex::new(Vec::new()),
+            completed_tab_rect: std::sync::Mutex::new(None),
             subtrees: std::collections::HashMap::new(),
             expanded: std::collections::HashMap::new(),
             focused_subtree_idx: 0,

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -313,8 +313,12 @@ fn render_tab_bar(
     // The Active tab therefore occupies `active_label.chars().count() + 3`
     // terminal columns (pad + label + pad + divider). The Completed tab
     // starts immediately after.
-    let active_tab_cols = active_label.chars().count() as u16 + 3;
-    let completed_tab_cols = completed_label.chars().count() as u16 + 2; // no trailing divider
+    let active_tab_cols = u16::try_from(active_label.chars().count())
+        .unwrap_or(u16::MAX)
+        .saturating_add(3);
+    let completed_tab_cols = u16::try_from(completed_label.chars().count())
+        .unwrap_or(u16::MAX)
+        .saturating_add(2);
     let completed_tab_x = area.x.saturating_add(active_tab_cols);
     if completed_tab_x < area.x + area.width {
         let rect = ratatui::layout::Rect::new(
@@ -1315,8 +1319,7 @@ fn render_focus_log(frame: &mut Frame, area: Rect, state: &AppState) {
                 let byte_end = l
                     .char_indices()
                     .nth(max_line_chars)
-                    .map(|(b, _)| b)
-                    .unwrap_or(l.len());
+                    .map_or(l.len(), |(b, _)| b);
                 &l[..byte_end]
             } else {
                 l.as_str()


### PR DESCRIPTION
## Summary

- **Detail view from Completed page always showed the same log** — `enter_detail_for` now updates `state.focus` to the viewed tile so the watcher's focus-notification path tails the correct log. Previously `state.focus` still pointed to the Active grid tile.
- **Click "Completed" tab** to navigate to the Completed page (same as `C`). Tab rect computed from label widths at render time, stored for mouse hit-testing.
- **Right-click on Completed page** exits back to Active (same as `Esc`).
- **Promotion threshold 5s → 120s** — tiles were vanishing from the Active grid before the operator could read their status during live dispatches.
- **Log pane text leakage** — JSON blobs and long markdown lines with no whitespace have no word-wrap break points; ratatui overflowed them past the pane boundary into the approval column. Fix: truncate source lines to 4× the inner pane width + explicit `Clear` before the approval pane renders.

## Test plan

- [ ] Open Completed page, navigate rows with j/k, press Enter on different rows — each opens the correct log
- [ ] Click the "Completed" tab label in the tab bar — navigates to Completed page
- [ ] Right-click anywhere on the Completed page — returns to Active view
- [ ] Run a dispatch with fast-completing workers — tiles stay on Active grid for ~2 minutes before promoting
- [ ] Lead with long JSON tool-call output — no text bleeds into the right approval column
- [ ] `cargo test --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)