### PR TITLE
feat: external MCP injection + validate promptless lead + AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,11 +171,18 @@ Inherited by every `[[task]]` and `[[lead]]` unless overridden.
 | `branch` | no | Branch name for the worktree. Defaults to a generated name. |
 | `model`, `effort`, `tools`, `timeout_secs`, `use_worktree`, `env` | no | Per-task overrides of `[defaults]`. |
 
-### `[[lead]]` (hierarchical mode, exactly one, mutually exclusive with `[[task]]`)
+### `[[lead]]` / `[lead]` (hierarchical mode, exactly one, mutually exclusive with `[[task]]`)
 
-Same fields as `[[task]]`. `id` is used as the tile label in the TUI.
-Mutually exclusive with `[[task]]` — a manifest is either flat or
-hierarchical.
+Both `[[lead]]` (array-table) and `[lead]` (single-table) are accepted.
+Use `[lead]` for depth-2 manifests that also declare `[lead.sublead_defaults]` —
+it is cleaner than the array-table form for single-lead hierarchical manifests.
+`id` is used as the tile label in the TUI. Mutually exclusive with `[[task]]`.
+
+> **Important:** `prompt =` must appear **before** any subtable declaration
+> (e.g. `[lead.sublead_defaults]`) in the TOML source. A `prompt =` key that
+> appears after a subtable header is parsed into that subtable's scope and
+> silently dropped; `pitboss validate` will catch this and report
+> `"prompt is required but is empty"`.
 
 Additional `[lead]` fields for depth-2 sub-leads (v0.6+):
 
@@ -217,6 +224,34 @@ The `[container]` section enables `pitboss container-dispatch`, which assembles 
 | `readonly` | no | Default `false`. |
 
 Two mounts are always auto-injected: `~/.claude → /home/pitboss/.claude` (OAuth) and the run artifact directory; the manifest itself is injected at `/run/pitboss.toml` read-only.
+
+### `[[mcp_server]]` (v0.9+)
+
+Declare external MCP servers to inject into **every actor's** `--mcp-config` (lead, sub-leads, and workers). This is the native alternative to the KV-bridge workaround for giving all actors access to tools like context7.
+
+```toml
+[[mcp_server]]
+id      = "context7"
+command = "npx"
+args    = ["-y", "@upstash/context7-mcp"]
+
+[[mcp_server]]
+id      = "my-tool"
+command = "/usr/local/bin/my-mcp-server"
+args    = ["--port", "3000"]
+env     = { MY_TOKEN = "abc" }
+```
+
+| Key | Required? | Notes |
+|---|---|---|
+| `id` | yes | Key name in the generated `mcpServers` JSON. Must be unique within the manifest. |
+| `command` | yes | Executable to launch (e.g. `"npx"`, `"uvx"`, absolute path). |
+| `args` | no | Arguments passed to the command. Default `[]`. |
+| `env` | no | Environment variables injected into the server process. Default `{}`. |
+
+All declared servers are injected into all actors (scope = all). Per-actor scoping is deferred — see roadmap.
+
+**Tools from injected servers are available immediately** — no additional `--allowedTools` configuration is needed; claude's MCP client discovers the tools from the server at startup.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`[[mcp_server]]` — external MCP server injection** — declare external MCP
+  servers in the manifest and they are injected into every actor's
+  `--mcp-config` (lead, sub-leads, and workers) at dispatch time. Eliminates
+  the KV-bridge workaround required to give workers access to tools like
+  context7.
+
+  ```toml
+  [[mcp_server]]
+  id      = "context7"
+  command = "npx"
+  args    = ["-y", "@upstash/context7-mcp"]
+  ```
+
+  All actors receive the server (scope = all). Per-actor scoping deferred.
+
+- **`pitboss validate` detects promptless lead** — a `[lead]` block whose
+  `prompt =` key appears after a subtable declaration (e.g.
+  `[lead.sublead_defaults]`) is silently reassigned by TOML, resolving to `""`
+  at dispatch. The lead then spawns with no `-p` argument and exits in ~700ms.
+  `validate` now rejects empty or whitespace-only prompts with an explanatory
+  error that names the TOML ordering root cause.
+
 - **TUI Completed page** — tiles that have been in a terminal state for 120
   seconds (configurable via `AppState::completed_after_secs`) are automatically
   promoted off the Active grid to a dedicated Completed page. At 100+ workers

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -157,16 +157,9 @@ item.
   first-attempt parse failures and lets the agent focus on prompt
   content. Defaults to `simple`; agents reach for `full` only when
   a task genuinely requires a seam worker or nested sub-leads.
-- **`pitboss validate` — detect promptless lead.** A `[lead]` /
-  `[[lead]]` block whose `prompt` key sits *after* a subtable
-  declaration (e.g. `[lead.sublead_defaults]`) parses as
-  syntactically valid TOML but assigns `prompt` outside the lead's
-  scope. The lead spawns, gets no `-p` argument, and exits with
-  code 1 in ~700ms. `pitboss validate` reports `OK` because the
-  schema is satisfied — only `prompt` is silently empty. Fix:
-  validate should fail when a resolved lead/sub-lead config has a
-  missing or empty `prompt`, since a promptless actor cannot run.
-  Cheap, single-day change.
+- ~~**`pitboss validate` — detect promptless lead.**~~ **Closed** — shipped in
+  PR #122. `validate` now rejects empty or whitespace-only lead prompts with an
+  error pointing at the TOML subtable-ordering root cause.
 - **AGENTS.md `[[lead]]` vs `[lead]` consistency.** The manifest
   schema section uses `[[lead]]` while the depth-2 example uses
   `[lead]`. The depth-2 fields (`allow_subleads`, `max_subleads`,
@@ -305,55 +298,24 @@ operators can observe the eat-rate live.
 **Status:** scoped, not started. Sibling to typed worker profiles
 above; both are operator-declared bounds the dispatcher enforces.
 
-### External MCP server injection in manifests
+### External MCP server injection — per-actor scoping (v2)
 
-Pitboss generates per-actor `--mcp-config` files containing only the
-pitboss bridge server. Claude Code's `--mcp-config` flag is not
-additive with project-level `.mcp.json` auto-discovery, so any
-project-local MCP server placed in the working directory is
-silently absent inside lead, sub-lead, and worker actors. The
-manifest schema has no field to declare additional MCP servers
-either.
+~~v1 (`scope = "all"`) shipped in v0.9~~ — `[[mcp_server]]` declarations are
+now injected into every actor's `--mcp-config` at dispatch time.
 
-Confirmed via live test on 2026-04-24 (run 019dc06a): context7
-MCP tools (`resolve-library-id`, `query-docs`) were absent at every
-actor level despite a valid `.mcp.json` in the working directory.
-Workers are additionally sandbox-locked to the run directory, so a
-helper script wrapping the MCP call is not reachable either.
-
-Add a manifest field that declares MCP servers to merge into the
-generated `--mcp-config`:
-
-```toml
-[[mcp_server]]
-id      = "context7"
-command = "npx"
-args    = ["-y", "@upstash/context7-mcp"]
-# optional: scope = "lead" | "sublead" | "worker" | "all"
-```
-
-v1 ships `scope = "all"` (run-wide injection, all actors receive the
-server). This covers the dominant use case — "give every actor context7
-docs access" — in one manifest line.
-
-**Deferred scope decisions (v2):**
+Remaining work:
 
 - **Per-actor scoping** (`scope = "lead" | "sublead" | "worker"`).
-  More secure but more verbose; worth adding once operators encounter
-  cases where they want to restrict a server to only part of the tree.
-  Natural landing point is alongside typed worker profiles, where a
-  `worker_type` profile could declare which MCP servers its workers see.
-- **Allowlist interaction with typed profiles.** A `worker_type`
-  profile should be able to declare which MCP servers its workers
-  see — keeps the safety belt even when a server is in scope run-wide.
+  More secure but more verbose; useful once operators need to restrict a server
+  to only part of the tree (e.g. context7 for the lead only, not workers).
+  Natural landing point is alongside typed worker profiles — a `worker_type`
+  profile could declare which MCP servers workers of that type see.
+- **Allowlist interaction with typed profiles.** When typed profiles ship,
+  `[[mcp_server]]` entries should be gateable per type so the safety belt
+  holds even when a server is declared run-wide.
 
-Today's workaround: the lead pre-fetches docs via a bash helper running
-outside the worker sandbox, writes results to `/ref/context7/<lib>`
-in KV, and workers read from KV. Functional but operator-heavy.
-Native injection makes context7-style augmentation a one-line
-manifest declaration.
-
-**Status:** v1 (scope=all) in progress. Per-actor scoping deferred.
+**Status:** v1 shipped (PR #122). Per-actor scoping deferred pending typed
+worker profiles.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -128,6 +128,8 @@ item.
   who knows the layout, but a built-in `prune` makes the lifecycle
   legible. Defaults to dry-run; `--apply` for the destructive path;
   `--older-than 24h` for time-windowed sweeps.
+  **Status:** fully scoped; reserved for its own PR (separate from
+  manifest-quality work) due to new-subcommand test surface.
 - **TUI run-list staleness detection.** The run-list status column
   derives "running" from "summary.json missing + control socket
   liveness probe doesn't fail." A stale unix socket file can stick
@@ -330,27 +332,28 @@ args    = ["-y", "@upstash/context7-mcp"]
 # optional: scope = "lead" | "sublead" | "worker" | "all"
 ```
 
-Open scope decisions:
+v1 ships `scope = "all"` (run-wide injection, all actors receive the
+server). This covers the dominant use case — "give every actor context7
+docs access" — in one manifest line.
 
-- **Run-wide vs per-actor.** Initial cut: run-wide with optional
-  per-actor override (`scope = "lead"` to limit context7 to the
-  lead, for example). Per-actor is more secure but more verbose;
-  run-wide is the right default for the common "give all actors
-  context7 docs access" case.
+**Deferred scope decisions (v2):**
+
+- **Per-actor scoping** (`scope = "lead" | "sublead" | "worker"`).
+  More secure but more verbose; worth adding once operators encounter
+  cases where they want to restrict a server to only part of the tree.
+  Natural landing point is alongside typed worker profiles, where a
+  `worker_type` profile could declare which MCP servers its workers see.
 - **Allowlist interaction with typed profiles.** A `worker_type`
   profile should be able to declare which MCP servers its workers
-  see — keeps the safety belt even when context7 is in scope
-  run-wide.
+  see — keeps the safety belt even when a server is in scope run-wide.
 
-Today's workaround is documented in `Pitboss.md` (Larry notes,
-2026-04-24): the lead pre-fetches docs via a bash helper running
+Today's workaround: the lead pre-fetches docs via a bash helper running
 outside the worker sandbox, writes results to `/ref/context7/<lib>`
 in KV, and workers read from KV. Functional but operator-heavy.
 Native injection makes context7-style augmentation a one-line
 manifest declaration.
 
-**Status:** scoped, not started. Pairs with typed worker profiles
-above for the per-type allowlist piece.
+**Status:** v1 (scope=all) in progress. Per-actor scoping deferred.
 
 ---
 

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -1039,6 +1039,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -1413,6 +1414,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
         let sub_layer = std::sync::Arc::new(LayerState::new(
             run_id,

--- a/crates/pitboss-cli/src/dispatch/failure_detection.rs
+++ b/crates/pitboss-cli/src/dispatch/failure_detection.rs
@@ -686,6 +686,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
         let store: Arc<dyn pitboss_core::store::SessionStore> =
             Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
@@ -773,6 +774,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
         let store: Arc<dyn pitboss_core::store::SessionStore> =
             Arc::new(JsonFileStore::new(dir.path().to_path_buf()));

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -181,7 +181,14 @@ pub async fn run_hierarchical(
 
     // 2. Build the --mcp-config file for the lead.
     let mcp_config_path = run_subdir.join("lead-mcp-config.json");
-    write_mcp_config(&mcp_config_path, &socket, &lead.id, "lead").await?;
+    write_mcp_config(
+        &mcp_config_path,
+        &socket,
+        &lead.id,
+        "lead",
+        &resolved.mcp_servers,
+    )
+    .await?;
 
     // 3. Prepare lead worktree + spawn.
     let mut lead_worktree_handle: Option<pitboss_core::worktree::Worktree> = None;
@@ -580,30 +587,62 @@ pub async fn run_hierarchical(
 /// This avoids relying on a non-standard `transport: { type: "unix", ... }`
 /// field that claude's MCP client may not honor. The generated config uses
 /// only the documented `command` + `args` (stdio transport) shape.
+/// Build the `mcpServers` JSON object with the pitboss bridge entry plus any
+/// operator-declared `[[mcp_server]]` entries from the manifest.
+fn build_mcp_servers_json(
+    pitboss_exe: &std::path::Path,
+    socket: &std::path::Path,
+    actor_id: &str,
+    actor_role: &str,
+    extra_servers: &[crate::manifest::schema::McpServerSpec],
+) -> serde_json::Map<String, serde_json::Value> {
+    let mut servers = serde_json::Map::new();
+    servers.insert(
+        "pitboss".into(),
+        serde_json::json!({
+            "command": pitboss_exe.to_string_lossy(),
+            "args": [
+                "mcp-bridge",
+                "--actor-id", actor_id,
+                "--actor-role", actor_role,
+                socket.to_string_lossy(),
+            ],
+        }),
+    );
+    for s in extra_servers {
+        let mut entry = serde_json::Map::new();
+        entry.insert("command".into(), s.command.clone().into());
+        entry.insert(
+            "args".into(),
+            serde_json::Value::Array(
+                s.args
+                    .iter()
+                    .map(|a| serde_json::Value::String(a.clone()))
+                    .collect(),
+            ),
+        );
+        if !s.env.is_empty() {
+            entry.insert("env".into(), serde_json::json!(s.env));
+        }
+        servers.insert(s.id.clone(), serde_json::Value::Object(entry));
+    }
+    servers
+}
+
 async fn write_mcp_config(
     path: &std::path::Path,
     socket: &std::path::Path,
     actor_id: &str,
     actor_role: &str, // "lead" or "worker"
+    extra_servers: &[crate::manifest::schema::McpServerSpec],
 ) -> Result<()> {
     // Find the pitboss binary path (the one running us now) so the lead can
     // re-exec the same build for the bridge subcommand.
     let pitboss_exe =
         std::env::current_exe().context("resolve current exe for mcp-bridge subcommand")?;
-
-    let cfg = serde_json::json!({
-        "mcpServers": {
-            "pitboss": {
-                "command": pitboss_exe.to_string_lossy(),
-                "args": [
-                    "mcp-bridge",
-                    "--actor-id", actor_id,
-                    "--actor-role", actor_role,
-                    socket.to_string_lossy(),
-                ],
-            }
-        }
-    });
+    let mcp_servers =
+        build_mcp_servers_json(&pitboss_exe, socket, actor_id, actor_role, extra_servers);
+    let cfg = serde_json::json!({ "mcpServers": mcp_servers });
     let bytes = serde_json::to_vec_pretty(&cfg)?;
     tokio::fs::write(path, bytes).await?;
     Ok(())
@@ -617,22 +656,14 @@ pub async fn write_worker_mcp_config(
     path: &std::path::Path,
     socket: &std::path::Path,
     worker_id: &str,
+    extra_servers: &[crate::manifest::schema::McpServerSpec],
 ) -> Result<()> {
     let pitboss_exe =
         std::env::current_exe().context("resolve current exe for mcp-bridge subcommand")?;
-
+    let mcp_servers =
+        build_mcp_servers_json(&pitboss_exe, socket, worker_id, "worker", extra_servers);
     let cfg = serde_json::json!({
-        "mcpServers": {
-            "pitboss": {
-                "command": pitboss_exe.to_string_lossy(),
-                "args": [
-                    "mcp-bridge",
-                    "--actor-id", worker_id,
-                    "--actor-role", "worker",
-                    socket.to_string_lossy(),
-                ],
-            }
-        },
+        "mcpServers": mcp_servers,
         "allowedTools": [
             "mcp__pitboss__kv_get",
             "mcp__pitboss__kv_set",
@@ -656,24 +687,16 @@ pub async fn build_sublead_mcp_config(
     sublead_id: &str,
     socket: &std::path::Path,
     run_subdir: &std::path::Path,
+    extra_servers: &[crate::manifest::schema::McpServerSpec],
 ) -> Result<PathBuf> {
     use crate::dispatch::runner::SUBLEAD_MCP_TOOLS;
 
     let pitboss_exe =
         std::env::current_exe().context("resolve current exe for mcp-bridge subcommand")?;
-
+    let mcp_servers =
+        build_mcp_servers_json(&pitboss_exe, socket, sublead_id, "sublead", extra_servers);
     let cfg = serde_json::json!({
-        "mcpServers": {
-            "pitboss": {
-                "command": pitboss_exe.to_string_lossy(),
-                "args": [
-                    "mcp-bridge",
-                    "--actor-id", sublead_id,
-                    "--actor-role", "sublead",
-                    socket.to_string_lossy(),
-                ],
-            }
-        },
+        "mcpServers": mcp_servers,
         "allowedTools": SUBLEAD_MCP_TOOLS.iter().collect::<Vec<_>>()
     });
     let bytes = serde_json::to_vec_pretty(&cfg)?;

--- a/crates/pitboss-cli/src/dispatch/layer.rs
+++ b/crates/pitboss-cli/src/dispatch/layer.rs
@@ -422,6 +422,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(FakeSpawner::new(FakeScript::new()));

--- a/crates/pitboss-cli/src/dispatch/resume.rs
+++ b/crates/pitboss-cli/src/dispatch/resume.rs
@@ -539,6 +539,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
         std::fs::write(
             run_dir.join("resolved.json"),
@@ -644,6 +645,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
         std::fs::write(
             run_dir.join("resolved.json"),
@@ -752,6 +754,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
         std::fs::write(
             run_dir.join("resolved.json"),

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -1073,6 +1073,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         }
     }
 
@@ -1214,6 +1215,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
 
         // Script: first call succeeds, second call fails. FakeSpawner is single-shot,
@@ -1303,6 +1305,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
 
         let spawner = Arc::new(CyclingFake(
@@ -1405,6 +1408,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
 
         let spawner = Arc::new(CyclingFake(

--- a/crates/pitboss-cli/src/dispatch/signals.rs
+++ b/crates/pitboss-cli/src/dispatch/signals.rs
@@ -324,6 +324,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -408,6 +409,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -495,6 +495,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -494,10 +494,14 @@ async fn spawn_sublead_session(
     let socket_path = socket_path_for_run(sub_layer.run_id, &sub_layer.manifest.run_dir);
 
     // 2. Build per-sub-lead mcp-config.json.
-    let mcp_config_path =
-        build_sublead_mcp_config(&sublead_id, &socket_path, &state.root.run_subdir)
-            .await
-            .context("build sublead mcp-config")?;
+    let mcp_config_path = build_sublead_mcp_config(
+        &sublead_id,
+        &socket_path,
+        &state.root.run_subdir,
+        &state.root.manifest.mcp_servers,
+    )
+    .await
+    .context("build sublead mcp-config")?;
 
     // 3. Build the CLI args: sublead toolset (or operator override),
     //    model, prompt, and optional --resume when continuing a prior session.

--- a/crates/pitboss-cli/src/manifest/resolve.rs
+++ b/crates/pitboss-cli/src/manifest/resolve.rs
@@ -119,6 +119,9 @@ pub struct ResolvedManifest {
     // NEW — optional [container] section for `pitboss container-dispatch`.
     #[serde(default)]
     pub container: Option<ContainerConfig>,
+    // NEW in v0.9 — external MCP servers injected into all actor mcp-configs.
+    #[serde(default)]
+    pub mcp_servers: Vec<crate::manifest::schema::McpServerSpec>,
 }
 
 const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
@@ -188,6 +191,7 @@ pub fn resolve(manifest: Manifest, env_max_parallel: Option<u32>) -> Result<Reso
         require_plan_approval: manifest.run.require_plan_approval,
         approval_rules,
         container: manifest.container,
+        mcp_servers: manifest.mcp_servers,
     })
 }
 
@@ -336,6 +340,7 @@ pub fn resolve_single_lead(
         require_plan_approval: manifest.run.require_plan_approval,
         approval_rules,
         container: manifest.container,
+        mcp_servers: manifest.mcp_servers,
     })
 }
 

--- a/crates/pitboss-cli/src/manifest/schema.rs
+++ b/crates/pitboss-cli/src/manifest/schema.rs
@@ -60,6 +60,34 @@ pub struct MountSpec {
     pub readonly: bool,
 }
 
+/// An external MCP server to inject into every actor's `--mcp-config`.
+/// Declared as `[[mcp_server]]` in the manifest. All actors (lead, sub-lead,
+/// and workers) receive the server so they can call its tools directly.
+///
+/// Per-actor scope granularity is deferred — see roadmap.
+///
+/// Example:
+/// ```toml
+/// [[mcp_server]]
+/// id      = "context7"
+/// command = "npx"
+/// args    = ["-y", "@upstash/context7-mcp"]
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct McpServerSpec {
+    /// Key name for this server in the generated `mcpServers` JSON object.
+    pub id: String,
+    /// Executable to launch (e.g. `"npx"`, `"uvx"`, absolute path).
+    pub command: String,
+    /// Arguments passed to the command.
+    #[serde(default)]
+    pub args: Vec<String>,
+    /// Environment variables injected into the MCP server process.
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Manifest {
@@ -83,6 +111,9 @@ pub struct Manifest {
     /// Optional container config for `pitboss container-dispatch`.
     #[serde(default)]
     pub container: Option<ContainerConfig>,
+    /// External MCP servers injected into all actor configs (v0.9+).
+    #[serde(default, rename = "mcp_server")]
+    pub mcp_servers: Vec<McpServerSpec>,
 }
 
 /// TOML schema for a single `[[approval_policy]]` rule.
@@ -269,6 +300,9 @@ pub struct SingleLeadManifest {
     /// Optional container config for `pitboss container-dispatch`.
     #[serde(default)]
     pub container: Option<ContainerConfig>,
+    /// External MCP servers injected into all actor configs (v0.9+).
+    #[serde(default, rename = "mcp_server")]
+    pub mcp_servers: Vec<McpServerSpec>,
 }
 
 /// v0.6 single-table `[lead]` schema. Used when the manifest author writes

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -80,6 +80,18 @@ fn validate_lead(r: &ResolvedManifest, skip_dir_check: bool) -> Result<()> {
         );
     }
 
+    // A lead with an empty prompt starts, receives no `-p` argument, and exits
+    // with code 1 in ~700ms. Common cause: the `prompt =` key appears after a
+    // subtable declaration (`[lead.sublead_defaults]`) in the TOML source,
+    // which moves it out of the `[lead]` scope — TOML silently assigns it to
+    // the subtable or drops it, and serde falls back to `unwrap_or_default()`.
+    if lead.prompt.trim().is_empty() {
+        bail!(
+            "lead '{}': prompt is required but is empty. If using [lead.sublead_defaults], \
+             ensure `prompt =` appears before any subtable declaration in the TOML source.",
+            lead.id
+        );
+    }
     if lead.id.is_empty() {
         bail!("lead id is required");
     }
@@ -336,6 +348,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         }
     }
 
@@ -361,6 +374,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
         f(&mut m);
         m
@@ -442,6 +456,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
         let err = validate(&r).unwrap_err().to_string();
         assert!(
@@ -470,6 +485,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
         let err = validate(&r).unwrap_err().to_string();
         assert!(err.contains("max_workers"), "got: {err}");
@@ -495,6 +511,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
         assert!(validate(&r).is_err());
     }
@@ -519,6 +536,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
         assert!(validate(&r).is_err());
     }
@@ -550,6 +568,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
         (d, r)
     }
@@ -669,6 +688,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
         let err = validate(&r).unwrap_err().to_string();
         assert!(err.contains("empty manifest"), "got: {err}");
@@ -695,6 +715,64 @@ mod tests {
             max_workers_across_tree: None,
             sublead_defaults: None,
         }
+    }
+
+    #[test]
+    fn rejects_lead_with_empty_prompt() {
+        let d = with_tmp_repo(true);
+        let mut lead = rl("l", d.path().to_path_buf());
+        lead.prompt = String::new();
+        let r = ResolvedManifest {
+            max_parallel: 4,
+            halt_on_failure: false,
+            run_dir: PathBuf::from("."),
+            worktree_cleanup: WorktreeCleanup::OnSuccess,
+            emit_event_stream: false,
+            tasks: vec![],
+            lead: Some(lead),
+            max_workers: Some(4),
+            budget_usd: Some(1.0),
+            lead_timeout_secs: Some(600),
+            approval_policy: None,
+            notifications: vec![],
+            dump_shared_store: false,
+            require_plan_approval: false,
+            approval_rules: vec![],
+            container: None,
+            mcp_servers: vec![],
+        };
+        let err = validate(&r).unwrap_err().to_string();
+        assert!(
+            err.contains("prompt is required but is empty"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_lead_with_whitespace_only_prompt() {
+        let d = with_tmp_repo(true);
+        let mut lead = rl("l", d.path().to_path_buf());
+        lead.prompt = "   \t\n  ".to_string();
+        let r = ResolvedManifest {
+            max_parallel: 4,
+            halt_on_failure: false,
+            run_dir: PathBuf::from("."),
+            worktree_cleanup: WorktreeCleanup::OnSuccess,
+            emit_event_stream: false,
+            tasks: vec![],
+            lead: Some(lead),
+            max_workers: Some(4),
+            budget_usd: Some(1.0),
+            lead_timeout_secs: Some(600),
+            approval_policy: None,
+            notifications: vec![],
+            dump_shared_store: false,
+            require_plan_approval: false,
+            approval_rules: vec![],
+            container: None,
+            mcp_servers: vec![],
+        };
+        assert!(validate(&r).is_err());
     }
 
     #[test]

--- a/crates/pitboss-cli/src/mcp/approval.rs
+++ b/crates/pitboss-cli/src/mcp/approval.rs
@@ -359,6 +359,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -1143,6 +1143,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();
@@ -1209,6 +1210,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -744,6 +744,7 @@ async fn run_worker(
         &worker_mcp_config,
         &socket_path,
         &task_id,
+        &layer.manifest.mcp_servers,
     )
     .await
     {
@@ -1164,6 +1165,7 @@ pub async fn spawn_resume_worker(
         &worker_mcp_config_path,
         &socket_path,
         &task_id,
+        &state.root.manifest.mcp_servers,
     )
     .await
     {
@@ -2384,6 +2386,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();
@@ -2848,6 +2851,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();
@@ -3463,6 +3467,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let script = FakeScript::new().hold_until_signal();
@@ -3553,6 +3558,7 @@ mod tests {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let script = FakeScript::new().hold_until_signal();
@@ -3651,6 +3657,7 @@ mod tests {
             require_plan_approval,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let script = FakeScript::new().hold_until_signal();

--- a/crates/pitboss-cli/tests/control_flows.rs
+++ b/crates/pitboss-cli/tests/control_flows.rs
@@ -51,6 +51,7 @@ async fn pause_op_writes_events_jsonl() {
         require_plan_approval: false,
         approval_rules: vec![],
         container: None,
+        mcp_servers: vec![],
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -254,6 +255,7 @@ async fn block_policy_queue_drains_on_tui_connect() {
         require_plan_approval: false,
         approval_rules: vec![],
         container: None,
+        mcp_servers: vec![],
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -366,6 +368,7 @@ async fn auto_approve_policy_responds_without_tui() {
         require_plan_approval: false,
         approval_rules: vec![],
         container: None,
+        mcp_servers: vec![],
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -425,6 +428,7 @@ async fn auto_reject_policy_responds_without_tui() {
         require_plan_approval: false,
         approval_rules: vec![],
         container: None,
+        mcp_servers: vec![],
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -492,6 +496,7 @@ async fn propose_plan_end_to_end_unblocks_spawn_gate() {
         require_plan_approval: true,
         approval_rules: vec![],
         container: None,
+        mcp_servers: vec![],
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());

--- a/crates/pitboss-cli/tests/dogfood_fake_flows.rs
+++ b/crates/pitboss-cli/tests/dogfood_fake_flows.rs
@@ -91,6 +91,7 @@ fn mk_state_with_subleads() -> (TempDir, Arc<DispatchState>) {
         require_plan_approval: false,
         approval_rules: vec![],
         container: None,
+        mcp_servers: vec![],
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();
@@ -1038,6 +1039,7 @@ async fn dogfood_envelope_cap_rejection() {
             require_plan_approval: false,
             approval_rules: vec![],
             container: None,
+            mcp_servers: vec![],
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/tests/e2e_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_flows.rs
@@ -76,6 +76,7 @@ fn mk_state(
         require_plan_approval: false,
         approval_rules: vec![],
         container: None,
+        mcp_servers: vec![],
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(run_dir.to_path_buf()));
     // Worker-side spawner: emits a complete stream-json run then exits 0.
@@ -375,6 +376,7 @@ async fn e2e_lead_cancels_worker_mid_flight() {
         require_plan_approval: false,
         approval_rules: vec![],
         container: None,
+        mcp_servers: vec![],
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let hold_script = FakeScript::new().hold_until_signal();
@@ -628,6 +630,7 @@ async fn e2e_lead_reprompts_running_worker() {
         require_plan_approval: false,
         approval_rules: vec![],
         container: None,
+        mcp_servers: vec![],
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     // Worker script emits init+result so session_id gets captured via the
@@ -816,6 +819,7 @@ async fn e2e_lead_propose_plan_gate_unblocks_spawn() {
         require_plan_approval: true,
         approval_rules: vec![],
         container: None,
+        mcp_servers: vec![],
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let worker_script = FakeScript::new()
@@ -1114,6 +1118,7 @@ async fn e2e_freeze_pause_and_continue_real_subprocess_worker() {
         require_plan_approval: false,
         approval_rules: vec![],
         container: None,
+        mcp_servers: vec![],
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(FakeClaudeWorkerSpawner {

--- a/crates/pitboss-cli/tests/e2e_sublead_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_sublead_flows.rs
@@ -76,6 +76,7 @@ fn mk_state(dir: &std::path::Path) -> (Uuid, Arc<DispatchState>) {
         require_plan_approval: false,
         approval_rules: vec![],
         container: None,
+        mcp_servers: vec![],
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.to_path_buf()));
     let worker_script = FakeScript::new()
@@ -144,6 +145,7 @@ fn mk_state_hold_workers(dir: &std::path::Path) -> (Uuid, Arc<DispatchState>) {
         require_plan_approval: false,
         approval_rules: vec![],
         container: None,
+        mcp_servers: vec![],
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.to_path_buf()));
     let hold_script = FakeScript::new().hold_until_signal();
@@ -786,6 +788,7 @@ async fn sublead_session_spawns_runs_and_reconciles() {
         require_plan_approval: false,
         approval_rules: vec![],
         container: None,
+        mcp_servers: vec![],
     };
 
     let store: std::sync::Arc<dyn pitboss_core::store::SessionStore> = std::sync::Arc::new(

--- a/crates/pitboss-cli/tests/hierarchical_flows.rs
+++ b/crates/pitboss-cli/tests/hierarchical_flows.rs
@@ -59,6 +59,7 @@ fn mk_state() -> (TempDir, Arc<DispatchState>) {
         require_plan_approval: false,
         approval_rules: vec![],
         container: None,
+        mcp_servers: vec![],
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/tests/notify_flows.rs
+++ b/crates/pitboss-cli/tests/notify_flows.rs
@@ -253,6 +253,7 @@ async fn approval_pending_notification_fires_on_enqueue() {
         require_plan_approval: false,
         approval_rules: vec![],
         container: None,
+        mcp_servers: vec![],
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());

--- a/crates/pitboss-cli/tests/shared_store_flows.rs
+++ b/crates/pitboss-cli/tests/shared_store_flows.rs
@@ -461,6 +461,7 @@ async fn lease_released_when_mcp_connection_drops() {
         require_plan_approval: false,
         approval_rules: vec![],
         container: None,
+        mcp_servers: vec![],
     };
     let store_trait: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().into()));
     let run_id = Uuid::now_v7();
@@ -599,6 +600,7 @@ async fn run_global_lease_released_when_mcp_connection_drops() {
         require_plan_approval: false,
         approval_rules: vec![],
         container: None,
+        mcp_servers: vec![],
     };
     let store_trait: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().into()));
     let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/tests/sublead_flows.rs
+++ b/crates/pitboss-cli/tests/sublead_flows.rs
@@ -59,6 +59,7 @@ fn mk_state_with_subleads() -> (TempDir, Arc<DispatchState>) {
         require_plan_approval: false,
         approval_rules: vec![],
         container: None,
+        mcp_servers: vec![],
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();
@@ -124,6 +125,7 @@ fn mk_state_with_sublead_budget_cap(cap: f64) -> (TempDir, Arc<DispatchState>) {
         require_plan_approval: false,
         approval_rules: vec![],
         container: None,
+        mcp_servers: vec![],
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();


### PR DESCRIPTION
## Summary

Three independent improvements bundled as one manifest-quality PR.

### `[[mcp_server]]` — external MCP server injection

Operators can now declare external MCP servers in the manifest. They are injected into every actor's `--mcp-config` (lead, sub-leads, and workers) at dispatch time — no code changes in any actor needed.

**Before:** giving workers access to context7 required a KV-bridge: the lead pre-fetched docs and wrote them to `/ref/context7/<lib>`, workers read from KV. Operator-heavy and fragile.

**After:**
\`\`\`toml
[[mcp_server]]
id      = "context7"
command = "npx"
args    = ["-y", "@upstash/context7-mcp"]
\`\`\`

All actors receive the server. Per-actor scoping (lead-only, worker-only, etc.) is deferred — see roadmap.

### `pitboss validate` — detect promptless lead

A `[lead]` block whose `prompt =` key appears after a subtable declaration (e.g. `[lead.sublead_defaults]`) is silently reassigned by TOML, resolving to `""`. The lead spawns with no `-p` argument and exits in ~700ms with no useful error. `validate` now rejects empty/whitespace-only prompts with a clear message pointing at the TOML ordering issue.

### AGENTS.md corrections

- `[[lead]]` / `[lead]` heading updated to acknowledge both forms are valid and explain when to use each
- Added warning: `prompt =` must appear before any subtable declaration
- Added `[[mcp_server]]` reference section with field table and example

## Test plan

- [ ] `cargo test --workspace` passes
- [ ] `pitboss validate` on a manifest with `[[mcp_server]]` exits 0
- [ ] Dispatched lead receives the injected server in its `--mcp-config` and can call its tools
- [ ] Workers receive the injected server and can call its tools
- [ ] `pitboss validate` on a manifest with an empty `prompt =` exits non-zero with explanatory message

🤖 Generated with [Claude Code](https://claude.com/claude-code)