### PR TITLE
feat(cli,docs): pitboss schema + auto-generated docs/manifest-map.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,12 @@ flamegraph.svg
 .env
 .env.*
 
-# Project-internal docs (kept locally; not shipped)
-/docs/
+# Project-internal docs (kept locally; not shipped) — except the auto-generated
+# manifest map, which is checked in and verified by `pitboss schema --check`.
+# Ignore *contents* not the directory itself, otherwise the !-exception below
+# can't re-include the one file we want under git.
+/docs/*
+!/docs/manifest-map.md
 
 # Git worktrees
 .worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,18 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`pitboss schema --format=map` + `docs/manifest-map.md`** — auto-generates
+  a per-field code-reference doc that maps every TOML key to its Rust
+  source location (`schema.rs:LINE`), label, help text, type, and
+  required/optional state. The checked-in file is verified by a unit-test
+  drift guard plus `pitboss schema --format=map --check docs/manifest-map.md`
+  for CI/contributor use. Driven entirely by the `field_metadata()`
+  registry from the prior change — adding a new schema field with
+  `#[field(label, help)]` flows automatically into the doc on regenerate.
+  Also fixed a derive bug exposed by this work: `#[serde(default)]` /
+  `#[serde(default = "...")]` fields now correctly render as optional
+  (previously only `Option<T>` did).
+
 - **Field-metadata derive (`pitboss-schema` + `pitboss-schema-derive`)** —
   schema structs now carry per-field metadata (label, help, form_type,
   enum_values, required) via `#[derive(FieldMetadata)]`. `required` is

--- a/crates/pitboss-cli/src/cli.rs
+++ b/crates/pitboss-cli/src/cli.rs
@@ -143,6 +143,28 @@ pub enum Command {
         #[arg(value_enum)]
         shell: clap_complete::Shell,
     },
+    /// Emit machine-readable views of the manifest schema. Currently
+    /// supports `--format=map` (a markdown reference checked in at
+    /// `docs/manifest-map.md`). The `--check <path>` mode regenerates and
+    /// diffs against an existing file — used in CI to catch drift.
+    Schema {
+        /// Output format. Only `map` is implemented today;
+        /// `n8n-form` is roadmapped.
+        #[arg(long, value_enum, default_value_t = SchemaFormat::Map)]
+        format: SchemaFormat,
+        /// If set, compare the generator output against the file at this
+        /// path and exit non-zero if they differ. Otherwise prints to stdout.
+        #[arg(long, value_name = "PATH")]
+        check: Option<PathBuf>,
+    },
+}
+
+/// Output formats supported by `pitboss schema`.
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+#[clap(rename_all = "kebab-case")]
+pub enum SchemaFormat {
+    /// Markdown manifest map (one row per field, with file:line refs).
+    Map,
 }
 
 #[cfg(test)]

--- a/crates/pitboss-cli/src/main.rs
+++ b/crates/pitboss-cli/src/main.rs
@@ -68,6 +68,47 @@ fn main() -> Result<()> {
             clap_complete::generate(shell, &mut cmd, "pitboss", &mut std::io::stdout());
             std::process::exit(0);
         }
+        Command::Schema { format, check } => {
+            std::process::exit(run_schema(format, check.as_deref()));
+        }
+    }
+}
+
+/// Drive `pitboss schema --format=...`. Returns the exit code.
+fn run_schema(format: cli::SchemaFormat, check: Option<&std::path::Path>) -> i32 {
+    let generated = match format {
+        cli::SchemaFormat::Map => crate::manifest::map_doc::render(),
+    };
+    match check {
+        None => {
+            print!("{generated}");
+            0
+        }
+        Some(path) => {
+            let existing = match std::fs::read_to_string(path) {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!(
+                        "pitboss schema --check: cannot read {}: {e}",
+                        path.display()
+                    );
+                    return 2;
+                }
+            };
+            if existing == generated {
+                eprintln!("pitboss schema --check: {} is up to date", path.display());
+                0
+            } else {
+                eprintln!(
+                    "pitboss schema --check: {} is stale.\n\
+                     Regenerate with:\n\
+                     \n    pitboss schema --format=map > {}\n",
+                    path.display(),
+                    path.display()
+                );
+                1
+            }
+        }
     }
 }
 

--- a/crates/pitboss-cli/src/manifest/map_doc.rs
+++ b/crates/pitboss-cli/src/manifest/map_doc.rs
@@ -1,0 +1,348 @@
+//! Auto-generates `docs/manifest-map.md` from the [`super::metadata`] registry.
+//!
+//! For every `[section]` in the v0.9 schema, the generator emits a markdown
+//! section containing per-field code references back to the Rust definitions
+//! in `super::schema`. The struct + field line numbers are resolved by a
+//! one-shot scan over a compile-time `include_str!` of `schema.rs` — this
+//! avoids the unstable `proc_macro2::Span::source_file()` API while still
+//! producing real, navigable line numbers.
+//!
+//! See `pitboss schema --help` for the user-facing CLI surface.
+
+use std::collections::HashMap;
+use std::fmt::Write as _;
+
+use pitboss_schema::{FieldDescriptor, FormType, SchemaSection};
+
+use super::metadata::sections;
+
+/// Compile-time copy of the schema source. Lets us resolve `(struct, field)
+/// → line number` without needing the source tree at runtime.
+const SCHEMA_SOURCE: &str = include_str!("schema.rs");
+
+/// Path that ends up in every `[file:line]` link. The doc lives at
+/// `docs/manifest-map.md`, so links are `../`-relative to walk up to repo
+/// root and back into `crates/`.
+const SCHEMA_PATH: &str = "../crates/pitboss-cli/src/manifest/schema.rs";
+
+/// Render the full `manifest-map.md` document body. Pure function — same
+/// inputs always produce identical output, which is what the `--check` mode
+/// in [`super::super::cli`] relies on.
+pub fn render() -> String {
+    let line_index = build_line_index(SCHEMA_SOURCE);
+    let mut out = String::new();
+    write_header(&mut out);
+    for section in sections() {
+        render_section(&mut out, &section, &line_index);
+    }
+    out
+}
+
+fn write_header(out: &mut String) {
+    out.push_str(
+        "# Pitboss manifest map\n\
+         \n\
+         > **Auto-generated. Do not edit by hand.** Regenerate with:\n\
+         > ```\n\
+         > pitboss schema --format=map > docs/manifest-map.md\n\
+         > ```\n\
+         > CI verifies the checked-in file matches the generator output via\n\
+         > `pitboss schema --format=map --check docs/manifest-map.md`.\n\
+         \n\
+         This document maps every TOML field in the v0.9 manifest schema to its\n\
+         Rust struct field and source location. For schema *explanations* see\n\
+         [`book/src/operator-guide/manifest-schema.md`](../book/src/operator-guide/manifest-schema.md).\n\
+         The annotated example lives at [`pitboss.example.toml`](../pitboss.example.toml).\n\
+         \n",
+    );
+}
+
+fn render_section(out: &mut String, section: &SchemaSection, lines: &LineIndex) {
+    let struct_line = lines.struct_line(section.type_name);
+    let _ = writeln!(
+        out,
+        "## `{}` — `{}`\n",
+        section.toml_path, section.type_name
+    );
+    if let Some(line) = struct_line {
+        let _ = writeln!(
+            out,
+            "Defined at [`{path}:{line}`]({path}#L{line}).\n",
+            path = SCHEMA_PATH,
+            line = line,
+        );
+    }
+
+    out.push_str("| Field | Type | Required | Help | Source |\n");
+    out.push_str("|---|---|---|---|---|\n");
+    for f in section.fields {
+        render_field_row(out, section.type_name, f, lines);
+    }
+    out.push('\n');
+}
+
+fn render_field_row(out: &mut String, type_name: &str, f: &FieldDescriptor, lines: &LineIndex) {
+    let req = if f.required { "**yes**" } else { "no" };
+    let ty = format_type_cell(f);
+    let help = if f.help.is_empty() {
+        "—".to_string()
+    } else {
+        escape_pipes(f.help)
+    };
+    let src = match lines.field_line(type_name, f.name) {
+        Some(line) => format!(
+            "[`{path}#L{line}`]({path}#L{line})",
+            path = SCHEMA_PATH,
+            line = line,
+        ),
+        None => "—".to_string(),
+    };
+    let _ = writeln!(
+        out,
+        "| `{}` | {} | {} | {} | {} |",
+        f.name, ty, req, help, src
+    );
+}
+
+fn format_type_cell(f: &FieldDescriptor) -> String {
+    let base = match f.form_type {
+        FormType::Text => "text".to_string(),
+        FormType::LongText => "text (multi-line)".to_string(),
+        FormType::Integer => "integer".to_string(),
+        FormType::Float => "float".to_string(),
+        FormType::Boolean => "boolean".to_string(),
+        FormType::Path => "path".to_string(),
+        FormType::EnumSelect => "enum".to_string(),
+        FormType::StringList => "string list".to_string(),
+        FormType::KeyValueMap => "key-value map".to_string(),
+    };
+    if !f.enum_values.is_empty() {
+        let opts = f
+            .enum_values
+            .iter()
+            .map(|v| format!("`{v}`"))
+            .collect::<Vec<_>>()
+            .join(" \\| ");
+        format!("{base} ({opts})")
+    } else {
+        base
+    }
+}
+
+/// Replace `|` with `\|` so help text containing pipes doesn't break the
+/// surrounding markdown table. Intentionally minimal — the field metadata
+/// is curated, not user-supplied.
+fn escape_pipes(s: &str) -> String {
+    s.replace('|', "\\|")
+}
+
+// ─── Line resolution ────────────────────────────────────────────────────────
+
+/// Maps `(struct_name, field_name)` to source line numbers within
+/// `schema.rs`. Built once per render call.
+struct LineIndex {
+    structs: HashMap<String, usize>,
+    fields: HashMap<(String, String), usize>,
+}
+
+impl LineIndex {
+    fn struct_line(&self, name: &str) -> Option<usize> {
+        self.structs.get(name).copied()
+    }
+    fn field_line(&self, struct_name: &str, field_name: &str) -> Option<usize> {
+        self.fields
+            .get(&(struct_name.to_string(), field_name.to_string()))
+            .copied()
+    }
+}
+
+/// Parse `schema.rs` once to build a struct→line and (struct, field)→line
+/// index. The grammar handled is intentionally narrow — only `pub struct
+/// Name { … }` blocks with `pub field:` declarations. `#[serde(rename = …)]`
+/// is honored so the TOML key (which is what the metadata registry uses)
+/// resolves to the line of the underlying Rust field.
+fn build_line_index(src: &str) -> LineIndex {
+    let mut structs = HashMap::new();
+    let mut fields = HashMap::new();
+
+    let mut current_struct: Option<String> = None;
+    let mut brace_depth: i32 = 0;
+    let mut pending_rename: Option<String> = None;
+
+    for (idx, raw_line) in src.lines().enumerate() {
+        let lineno = idx + 1;
+        let line = raw_line.trim();
+
+        if let Some(struct_name) = parse_struct_decl(line) {
+            current_struct = Some(struct_name.clone());
+            structs.insert(struct_name, lineno);
+            brace_depth = if line.contains('{') { 1 } else { 0 };
+            pending_rename = None;
+            continue;
+        }
+
+        if current_struct.is_some() {
+            // Track depth so we know when to leave the struct body.
+            for c in line.chars() {
+                match c {
+                    '{' => brace_depth += 1,
+                    '}' => brace_depth -= 1,
+                    _ => {}
+                }
+            }
+            if brace_depth <= 0 {
+                current_struct = None;
+                pending_rename = None;
+                brace_depth = 0;
+                continue;
+            }
+
+            if let Some(rename) = parse_serde_rename(line) {
+                pending_rename = Some(rename);
+                continue;
+            }
+
+            if let Some(field_name) = parse_field_decl(line) {
+                let key_name = pending_rename.take().unwrap_or(field_name);
+                if let Some(s) = current_struct.as_ref() {
+                    fields.insert((s.clone(), key_name), lineno);
+                }
+            }
+        }
+    }
+
+    LineIndex { structs, fields }
+}
+
+/// Return `Some("RunConfig")` for `pub struct RunConfig {`.
+fn parse_struct_decl(line: &str) -> Option<String> {
+    let s = line.strip_prefix("pub struct ")?;
+    let name_end = s
+        .find(|c: char| !(c.is_alphanumeric() || c == '_'))
+        .unwrap_or(s.len());
+    let name = &s[..name_end];
+    if name.is_empty() {
+        return None;
+    }
+    Some(name.to_string())
+}
+
+/// Return `Some("max_workers")` for `pub max_workers: Option<u32>,`.
+/// Skips `#[…]` lines and comments by virtue of the `pub` prefix.
+fn parse_field_decl(line: &str) -> Option<String> {
+    let s = line.strip_prefix("pub ")?;
+    let name_end = s.find(':')?;
+    let name = &s[..name_end].trim();
+    // Avoid catching `pub struct …` blocks (already handled) and
+    // `pub fn …` items.
+    if name.is_empty() || name.contains(' ') {
+        return None;
+    }
+    Some(name.to_string())
+}
+
+/// Parse `#[serde(rename = "task")]` (and `#[serde(default, rename = "x")]`)
+/// to yield `Some("task")`. Returns `None` for unrelated attributes.
+fn parse_serde_rename(line: &str) -> Option<String> {
+    if !line.starts_with("#[serde(") {
+        return None;
+    }
+    let rename_start = line.find("rename")?;
+    let after = &line[rename_start..];
+    let eq = after.find('=')?;
+    let after_eq = &after[eq + 1..];
+    let q1 = after_eq.find('"')?;
+    let after_q1 = &after_eq[q1 + 1..];
+    let q2 = after_q1.find('"')?;
+    Some(after_q1[..q2].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Smoke: render must succeed and contain every section's TOML path.
+    #[test]
+    fn render_contains_every_section() {
+        let doc = render();
+        for section in sections() {
+            assert!(
+                doc.contains(section.toml_path),
+                "rendered doc missing section header for {}",
+                section.toml_path
+            );
+        }
+    }
+
+    /// Drift guard: the generator must locate at least one source line for
+    /// every section's struct. If this fails, the schema scanner regressed.
+    #[test]
+    fn every_struct_resolves_to_a_line() {
+        let lines = build_line_index(SCHEMA_SOURCE);
+        for section in sections() {
+            assert!(
+                lines.struct_line(section.type_name).is_some(),
+                "no source line found for struct {}",
+                section.type_name
+            );
+        }
+    }
+
+    /// Drift guard: every registered field must resolve to a source line.
+    /// Catches: serde renames the macro can't see, fields removed from
+    /// schema.rs but left in the registry, scanner-grammar bugs.
+    #[test]
+    fn every_field_resolves_to_a_line() {
+        let lines = build_line_index(SCHEMA_SOURCE);
+        let mut missing: Vec<String> = Vec::new();
+        for section in sections() {
+            for f in section.fields {
+                if lines.field_line(section.type_name, f.name).is_none() {
+                    missing.push(format!("{}.{}", section.type_name, f.name));
+                }
+            }
+        }
+        assert!(
+            missing.is_empty(),
+            "fields with no source line: {:?}",
+            missing
+        );
+    }
+
+    /// Drift guard: the checked-in `docs/manifest-map.md` must match what
+    /// the generator currently emits. Runs as a fast unit test (no
+    /// subprocess), and is also wired up to the CLI as
+    /// `pitboss schema --format=map --check docs/manifest-map.md` for
+    /// CI / contributor use.
+    #[test]
+    fn checked_in_doc_matches_generator() {
+        // `include_str!` resolves relative to *this file's* directory.
+        // From `crates/pitboss-cli/src/manifest/map_doc.rs` to
+        // `<repo>/docs/manifest-map.md` is six "../" hops.
+        const CHECKED_IN: &str = include_str!("../../../../docs/manifest-map.md");
+        let generated = render();
+        if generated != CHECKED_IN {
+            panic!(
+                "docs/manifest-map.md is stale.\n\
+                 Regenerate with:\n\
+                 \n    cargo run -q --release -p pitboss-cli -- schema --format=map > docs/manifest-map.md\n"
+            );
+        }
+    }
+
+    /// `mounts: Vec<MountSpec>` is `#[serde(rename = "mount")]` — the rename
+    /// parser must surface that so the registry's `mount` field name
+    /// resolves to the right line.
+    #[test]
+    fn serde_rename_is_honored() {
+        // `mount` is on ContainerConfig.mounts. The registry tags it
+        // #[field(skip)] so it doesn't appear in sections() — but the
+        // line-index should still see it via the rename path. Probe the
+        // helper directly.
+        let lines = build_line_index(SCHEMA_SOURCE);
+        assert!(
+            lines.field_line("ContainerConfig", "mount").is_some(),
+            "expected ContainerConfig.mount (renamed from `mounts`) to be indexed"
+        );
+    }
+}

--- a/crates/pitboss-cli/src/manifest/metadata.rs
+++ b/crates/pitboss-cli/src/manifest/metadata.rs
@@ -154,6 +154,31 @@ mod tests {
         assert!(f.enum_values.contains(&"never"));
     }
 
+    /// `halt_on_failure: bool` carries `#[serde(default)]`, so even though
+    /// it's not wrapped in `Option`, it should render as optional in the
+    /// metadata. Catches a regression where the derive used to require
+    /// every non-Option field.
+    #[test]
+    fn serde_default_field_is_optional() {
+        let f = RunConfig::field_metadata()
+            .iter()
+            .find(|f| f.name == "halt_on_failure")
+            .expect("RunConfig must declare `halt_on_failure`");
+        assert!(
+            !f.required,
+            "halt_on_failure has #[serde(default)], should be optional"
+        );
+
+        let f = RunConfig::field_metadata()
+            .iter()
+            .find(|f| f.name == "worktree_cleanup")
+            .expect("RunConfig must declare `worktree_cleanup`");
+        assert!(
+            !f.required,
+            "worktree_cleanup has #[serde(default = ...)], should be optional"
+        );
+    }
+
     /// `default_approval_policy` is `Option<ApprovalPolicy>` — the derive
     /// can't introspect the foreign enum's variants, so we supply
     /// `enum_values` explicitly. Verify that worked and that `required`

--- a/crates/pitboss-cli/src/manifest/mod.rs
+++ b/crates/pitboss-cli/src/manifest/mod.rs
@@ -1,4 +1,5 @@
 pub mod load;
+pub mod map_doc;
 pub mod metadata;
 pub mod resolve;
 pub mod schema;

--- a/crates/pitboss-schema-derive/src/lib.rs
+++ b/crates/pitboss-schema-derive/src/lib.rs
@@ -162,13 +162,18 @@ fn build_entry(field: &syn::Field) -> syn::Result<Option<TokenStream2>> {
     }
 
     let is_optional = is_option_type(&field.ty);
+    let has_serde_default = field_has_serde_default(field);
     let inferred = if !enum_values.is_empty() {
         "enum_select"
     } else {
         infer_form_type(&field.ty)
     };
     let form_type_str = form_type.unwrap_or_else(|| inferred.to_string());
-    let required = required_override.unwrap_or(!is_optional);
+    // Required iff (a) not wrapped in Option AND (b) no `#[serde(default)]`
+    // / `#[serde(default = "...")]`. The serde-default branch matters for
+    // primitives like `bool`/`u32` that have a Rust default but should still
+    // render as optional in a form.
+    let required = required_override.unwrap_or(!(is_optional || has_serde_default));
 
     let label_str = label.unwrap_or_else(|| name_str.clone());
     let help_str = help.unwrap_or_default();
@@ -185,6 +190,33 @@ fn build_entry(field: &syn::Field) -> syn::Result<Option<TokenStream2>> {
             enum_values: &[ #( #enum_values_lits ),* ],
         }
     }))
+}
+
+/// `true` when the field carries any flavor of `#[serde(default)]` —
+/// either the bare `default` token or `default = "func"`. The serde
+/// attribute is parsed token-by-token rather than via `attr.parse_args`
+/// so we don't choke on combined attributes like
+/// `#[serde(default, rename = "task")]`.
+fn field_has_serde_default(field: &syn::Field) -> bool {
+    use syn::Meta;
+    for attr in &field.attrs {
+        if !attr.path().is_ident("serde") {
+            continue;
+        }
+        let Meta::List(list) = &attr.meta else {
+            continue;
+        };
+        // Walk the comma-separated nested meta items. `default` and
+        // `default = "..."` both signal a serde default.
+        for tok in list.tokens.clone() {
+            if let proc_macro2::TokenTree::Ident(ident) = &tok {
+                if ident == "default" {
+                    return true;
+                }
+            }
+        }
+    }
+    false
 }
 
 /// `true` when the type is `Option<T>` (any path ending in `Option`).

--- a/docs/manifest-map.md
+++ b/docs/manifest-map.md
@@ -1,0 +1,146 @@
+# Pitboss manifest map
+
+> **Auto-generated. Do not edit by hand.** Regenerate with:
+> ```
+> pitboss schema --format=map > docs/manifest-map.md
+> ```
+> CI verifies the checked-in file matches the generator output via
+> `pitboss schema --format=map --check docs/manifest-map.md`.
+
+This document maps every TOML field in the v0.9 manifest schema to its
+Rust struct field and source location. For schema *explanations* see
+[`book/src/operator-guide/manifest-schema.md`](../book/src/operator-guide/manifest-schema.md).
+The annotated example lives at [`pitboss.example.toml`](../pitboss.example.toml).
+
+## `[run]` — `RunConfig`
+
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:244`](../crates/pitboss-cli/src/manifest/schema.rs#L244).
+
+| Field | Type | Required | Help | Source |
+|---|---|---|---|---|
+| `max_parallel_tasks` | integer | no | Flat-mode concurrency cap for [[task]] runs. Default 4. Overridden by ANTHROPIC_MAX_CONCURRENT. | [`../crates/pitboss-cli/src/manifest/schema.rs#L251`](../crates/pitboss-cli/src/manifest/schema.rs#L251) |
+| `halt_on_failure` | boolean | no | Stop remaining flat-mode tasks on first failure. | [`../crates/pitboss-cli/src/manifest/schema.rs#L258`](../crates/pitboss-cli/src/manifest/schema.rs#L258) |
+| `run_dir` | path | no | Where per-run artifacts land. Default ~/.local/share/pitboss/runs. | [`../crates/pitboss-cli/src/manifest/schema.rs#L264`](../crates/pitboss-cli/src/manifest/schema.rs#L264) |
+| `worktree_cleanup` | enum (`always` \| `on_success` \| `never`) | no | What to do with each worker's git worktree after it finishes. | [`../crates/pitboss-cli/src/manifest/schema.rs#L272`](../crates/pitboss-cli/src/manifest/schema.rs#L272) |
+| `emit_event_stream` | boolean | no | Write a JSONL event stream alongside summary.jsonl. | [`../crates/pitboss-cli/src/manifest/schema.rs#L279`](../crates/pitboss-cli/src/manifest/schema.rs#L279) |
+| `default_approval_policy` | enum (`block` \| `auto_approve` \| `auto_reject`) | no | Default action for request_approval / propose_plan when no TUI is attached and no rule matches. | [`../crates/pitboss-cli/src/manifest/schema.rs#L290`](../crates/pitboss-cli/src/manifest/schema.rs#L290) |
+| `dump_shared_store` | boolean | no | Write shared-store.json into the run directory on finalize. | [`../crates/pitboss-cli/src/manifest/schema.rs#L298`](../crates/pitboss-cli/src/manifest/schema.rs#L298) |
+| `require_plan_approval` | boolean | no | When true, spawn_worker is blocked until propose_plan has been approved. | [`../crates/pitboss-cli/src/manifest/schema.rs#L306`](../crates/pitboss-cli/src/manifest/schema.rs#L306) |
+
+## `[defaults]` — `Defaults`
+
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:338`](../crates/pitboss-cli/src/manifest/schema.rs#L338).
+
+| Field | Type | Required | Help | Source |
+|---|---|---|---|---|
+| `model` | text | no | Claude model id (e.g. claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-7). | [`../crates/pitboss-cli/src/manifest/schema.rs#L343`](../crates/pitboss-cli/src/manifest/schema.rs#L343) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Maps to the claude --effort flag. | [`../crates/pitboss-cli/src/manifest/schema.rs#L349`](../crates/pitboss-cli/src/manifest/schema.rs#L349) |
+| `tools` | string list | no | Allowed tool surface. Pitboss auto-appends its MCP tools for leads and workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L354`](../crates/pitboss-cli/src/manifest/schema.rs#L354) |
+| `timeout_secs` | integer | no | Per-task wall-clock cap. No default (no cap). | [`../crates/pitboss-cli/src/manifest/schema.rs#L359`](../crates/pitboss-cli/src/manifest/schema.rs#L359) |
+| `use_worktree` | boolean | no | Isolate each worker in a git worktree. Default true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L364`](../crates/pitboss-cli/src/manifest/schema.rs#L364) |
+| `env` | key-value map | no | Environment variables passed to the claude subprocess. | [`../crates/pitboss-cli/src/manifest/schema.rs#L370`](../crates/pitboss-cli/src/manifest/schema.rs#L370) |
+
+## `[container]` — `ContainerConfig`
+
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:71`](../crates/pitboss-cli/src/manifest/schema.rs#L71).
+
+| Field | Type | Required | Help | Source |
+|---|---|---|---|---|
+| `image` | text | no | Container image reference. Defaults to ghcr.io/sds-mode/pitboss-with-claude:latest. | [`../crates/pitboss-cli/src/manifest/schema.rs#L77`](../crates/pitboss-cli/src/manifest/schema.rs#L77) |
+| `runtime` | enum (`docker` \| `podman` \| `auto`) | no | Container runtime to invoke. "auto" prefers podman. | [`../crates/pitboss-cli/src/manifest/schema.rs#L84`](../crates/pitboss-cli/src/manifest/schema.rs#L84) |
+| `extra_args` | string list | no | Args inserted verbatim before the image name in the run invocation. | [`../crates/pitboss-cli/src/manifest/schema.rs#L91`](../crates/pitboss-cli/src/manifest/schema.rs#L91) |
+| `workdir` | path | no | cwd inside the container; defaults to the first mount's container path. | [`../crates/pitboss-cli/src/manifest/schema.rs#L103`](../crates/pitboss-cli/src/manifest/schema.rs#L103) |
+
+## `[[container.mount]]` — `MountSpec`
+
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:109`](../crates/pitboss-cli/src/manifest/schema.rs#L109).
+
+| Field | Type | Required | Help | Source |
+|---|---|---|---|---|
+| `host` | path | **yes** | Absolute host path. ~ is expanded. | [`../crates/pitboss-cli/src/manifest/schema.rs#L112`](../crates/pitboss-cli/src/manifest/schema.rs#L112) |
+| `container` | path | **yes** | Absolute path inside the container. | [`../crates/pitboss-cli/src/manifest/schema.rs#L115`](../crates/pitboss-cli/src/manifest/schema.rs#L115) |
+| `readonly` | boolean | no | Mount read-only. | [`../crates/pitboss-cli/src/manifest/schema.rs#L119`](../crates/pitboss-cli/src/manifest/schema.rs#L119) |
+
+## `[[task]]` — `Task`
+
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:401`](../crates/pitboss-cli/src/manifest/schema.rs#L401).
+
+| Field | Type | Required | Help | Source |
+|---|---|---|---|---|
+| `id` | text | **yes** | Unique slug. Alphanumeric + _ + -. Used in logs and worktree names. | [`../crates/pitboss-cli/src/manifest/schema.rs#L406`](../crates/pitboss-cli/src/manifest/schema.rs#L406) |
+| `directory` | path | **yes** | Working directory. Must be inside a git repo if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L411`](../crates/pitboss-cli/src/manifest/schema.rs#L411) |
+| `prompt` | text (multi-line) | no | Prompt body sent to claude via -p. Mutually exclusive with `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L417`](../crates/pitboss-cli/src/manifest/schema.rs#L417) |
+| `template` | text | no | Reference to a [[template]] entry. Mutually exclusive with `prompt`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L422`](../crates/pitboss-cli/src/manifest/schema.rs#L422) |
+| `vars` | key-value map | no | Substitutions for {placeholders} when using `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L428`](../crates/pitboss-cli/src/manifest/schema.rs#L428) |
+| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L433`](../crates/pitboss-cli/src/manifest/schema.rs#L433) |
+| `model` | text | no | Per-task override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L435`](../crates/pitboss-cli/src/manifest/schema.rs#L435) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-task override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L441`](../crates/pitboss-cli/src/manifest/schema.rs#L441) |
+| `tools` | string list | no | Per-task override of [defaults].tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L443`](../crates/pitboss-cli/src/manifest/schema.rs#L443) |
+| `timeout_secs` | integer | no | Per-task wall-clock cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L445`](../crates/pitboss-cli/src/manifest/schema.rs#L445) |
+| `use_worktree` | boolean | no | Per-task override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L450`](../crates/pitboss-cli/src/manifest/schema.rs#L450) |
+| `env` | key-value map | no | Per-task env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L456`](../crates/pitboss-cli/src/manifest/schema.rs#L456) |
+
+## `[lead]` — `Lead`
+
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:466`](../crates/pitboss-cli/src/manifest/schema.rs#L466).
+
+| Field | Type | Required | Help | Source |
+|---|---|---|---|---|
+| `id` | text | **yes** | Unique slug used as the TUI tile label and in run artifact paths. | [`../crates/pitboss-cli/src/manifest/schema.rs#L473`](../crates/pitboss-cli/src/manifest/schema.rs#L473) |
+| `directory` | path | **yes** | Working directory for the lead's claude subprocess. Must be a git work-tree if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L480`](../crates/pitboss-cli/src/manifest/schema.rs#L480) |
+| `prompt` | text (multi-line) | **yes** | Operator instructions passed to claude via -p. Must appear before any [lead.X] subtable in the source. | [`../crates/pitboss-cli/src/manifest/schema.rs#L492`](../crates/pitboss-cli/src/manifest/schema.rs#L492) |
+| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L500`](../crates/pitboss-cli/src/manifest/schema.rs#L500) |
+| `model` | text | no | Per-lead override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L503`](../crates/pitboss-cli/src/manifest/schema.rs#L503) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-lead override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L510`](../crates/pitboss-cli/src/manifest/schema.rs#L510) |
+| `tools` | string list | no | Per-lead override of [defaults].tools. Pitboss auto-appends its MCP tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L516`](../crates/pitboss-cli/src/manifest/schema.rs#L516) |
+| `timeout_secs` | integer | no | Per-actor subprocess wall-clock cap (claude --timeout). | [`../crates/pitboss-cli/src/manifest/schema.rs#L522`](../crates/pitboss-cli/src/manifest/schema.rs#L522) |
+| `use_worktree` | boolean | no | Per-lead override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L528`](../crates/pitboss-cli/src/manifest/schema.rs#L528) |
+| `env` | key-value map | no | Per-lead env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L534`](../crates/pitboss-cli/src/manifest/schema.rs#L534) |
+| `max_workers` | integer | no | Hard cap on the lead's concurrent + queued worker pool (1–16). Required when the lead spawns workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L543`](../crates/pitboss-cli/src/manifest/schema.rs#L543) |
+| `budget_usd` | float | no | Soft cap on lead spend with reservation accounting. spawn_worker fails once spent + reserved + next_estimate > budget. | [`../crates/pitboss-cli/src/manifest/schema.rs#L552`](../crates/pitboss-cli/src/manifest/schema.rs#L552) |
+| `lead_timeout_secs` | integer | no | Wall-clock cap on the lead session. Default 3600. | [`../crates/pitboss-cli/src/manifest/schema.rs#L561`](../crates/pitboss-cli/src/manifest/schema.rs#L561) |
+| `permission_routing` | enum (`path_a` \| `path_b`) | no | path_a (default) makes pitboss the sole permission authority. path_b routes claude's gate through pitboss (rejected at validate time pending stabilization). | [`../crates/pitboss-cli/src/manifest/schema.rs#L574`](../crates/pitboss-cli/src/manifest/schema.rs#L574) |
+| `allow_subleads` | boolean | no | Expose spawn_sublead to the root lead. | [`../crates/pitboss-cli/src/manifest/schema.rs#L583`](../crates/pitboss-cli/src/manifest/schema.rs#L583) |
+| `max_subleads` | integer | no | Hard cap on total live sub-leads under this root. | [`../crates/pitboss-cli/src/manifest/schema.rs#L590`](../crates/pitboss-cli/src/manifest/schema.rs#L590) |
+| `max_sublead_budget_usd` | float | no | Cap on the per-sub-lead budget envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L597`](../crates/pitboss-cli/src/manifest/schema.rs#L597) |
+| `max_total_workers` | integer | no | Cap on total live workers across the entire tree (root + sub-trees). | [`../crates/pitboss-cli/src/manifest/schema.rs#L605`](../crates/pitboss-cli/src/manifest/schema.rs#L605) |
+
+## `[sublead_defaults]` — `SubleadDefaults`
+
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:612`](../crates/pitboss-cli/src/manifest/schema.rs#L612).
+
+| Field | Type | Required | Help | Source |
+|---|---|---|---|---|
+| `budget_usd` | float | no | Per-sub-lead envelope when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L617`](../crates/pitboss-cli/src/manifest/schema.rs#L617) |
+| `max_workers` | integer | no | Per-sub-lead worker pool when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L622`](../crates/pitboss-cli/src/manifest/schema.rs#L622) |
+| `lead_timeout_secs` | integer | no | Wall-clock cap for the sub-lead session. | [`../crates/pitboss-cli/src/manifest/schema.rs#L627`](../crates/pitboss-cli/src/manifest/schema.rs#L627) |
+| `read_down` | boolean | no | When true, sub-lead shares root's budget + worker pool instead of carving its own envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L633`](../crates/pitboss-cli/src/manifest/schema.rs#L633) |
+
+## `[[approval_policy]]` — `ApprovalRuleSpec`
+
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:202`](../crates/pitboss-cli/src/manifest/schema.rs#L202).
+
+| Field | Type | Required | Help | Source |
+|---|---|---|---|---|
+| `action` | enum (`auto_approve` \| `auto_reject` \| `block`) | **yes** | Action when this rule matches. | [`../crates/pitboss-cli/src/manifest/schema.rs#L213`](../crates/pitboss-cli/src/manifest/schema.rs#L213) |
+
+## `[[mcp_server]]` — `McpServerSpec`
+
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:137`](../crates/pitboss-cli/src/manifest/schema.rs#L137).
+
+| Field | Type | Required | Help | Source |
+|---|---|---|---|---|
+| `id` | text | **yes** | Key under mcpServers in the generated config. | [`../crates/pitboss-cli/src/manifest/schema.rs#L143`](../crates/pitboss-cli/src/manifest/schema.rs#L143) |
+| `command` | text | **yes** | Executable to launch (e.g. npx, uvx, or an absolute path). | [`../crates/pitboss-cli/src/manifest/schema.rs#L149`](../crates/pitboss-cli/src/manifest/schema.rs#L149) |
+| `args` | string list | no | Arguments passed to the command. | [`../crates/pitboss-cli/src/manifest/schema.rs#L153`](../crates/pitboss-cli/src/manifest/schema.rs#L153) |
+| `env` | key-value map | no | Environment variables injected into the MCP server process. | [`../crates/pitboss-cli/src/manifest/schema.rs#L160`](../crates/pitboss-cli/src/manifest/schema.rs#L160) |
+
+## `[[template]]` — `Template`
+
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:385`](../crates/pitboss-cli/src/manifest/schema.rs#L385).
+
+| Field | Type | Required | Help | Source |
+|---|---|---|---|---|
+| `id` | text | **yes** | Slug referenced from [[task]].template. | [`../crates/pitboss-cli/src/manifest/schema.rs#L390`](../crates/pitboss-cli/src/manifest/schema.rs#L390) |
+| `prompt` | text (multi-line) | **yes** | Prompt body. Supports {var} placeholders supplied by [[task]].vars. | [`../crates/pitboss-cli/src/manifest/schema.rs#L396`](../crates/pitboss-cli/src/manifest/schema.rs#L396) |
+


### PR DESCRIPTION
## Summary

PR 1.C of the manifest-redesign series. Adds a `pitboss schema` subcommand that auto-generates a per-field markdown reference from the `FieldMetadata` registry introduced in [PR #126](https://github.com/SDS-Mode/pitboss/pull/126), and checks the result in at `docs/manifest-map.md`.

This is the developer-facing companion to `book/src/operator-guide/manifest-schema.md` (which is the *user* reference). The map gives any contributor / agent / form-builder a single place to find the Rust source for any TOML key.

## CLI surface

```bash
pitboss schema --format=map                    # print to stdout
pitboss schema --format=map --check <path>     # diff vs file (CI mode)
```

`--check` exits 0 when the file matches generator output, 1 on drift, 2 on missing path.

## What's in `docs/manifest-map.md`

For each `[section]` of the v0.9 schema, a markdown table with one row per field:

| Field | Type | Required | Help | Source |
|---|---|---|---|---|
| `max_parallel_tasks` | integer | no | Flat-mode concurrency cap... | [`schema.rs#L251`](…) |

Section headers also link to each struct's definition line.

## Implementation notes

- **Pure render function.** `manifest::map_doc::render()` walks `manifest::metadata::sections()` and emits markdown deterministically. Same inputs → identical output (which is what `--check` relies on).
- **No proc-macro span instability.** Source line numbers come from a one-shot scan over a compile-time `include_str!` of `schema.rs`. Avoids the unstable `proc_macro2::Span::source_file()` API.
- **`#[serde(rename = "...")]` honored.** The scanner records pending renames so e.g. `mounts` (renamed to `mount`) resolves to the right line.
- **Drift guard.** `tests::checked_in_doc_matches_generator` calls `render()` in-process and compares against `include_str!("../../../../docs/manifest-map.md")`. Same logic shipped to the CLI as `--check` for CI / pre-push hook use.

## Schema-derive bug fix exposed by this work

`#[derive(FieldMetadata)]` was treating `bool` / `u32` fields with `#[serde(default)]` as required. Adding `field_has_serde_default()` (scans the serde attribute's token stream for the `default` ident) fixes this — both `#[serde(default)]` and `#[serde(default = "func")]` now correctly mark the field as optional. Two new metadata tests cover this.

## .gitignore tweak

`/docs/` was previously fully ignored ("project-internal docs"). Switched to `/docs/*` + an explicit `!/docs/manifest-map.md` exception so this single auto-generated file is the only thing in the directory under version control.

## Test plan

- [x] `cargo test --workspace` — 394 lib tests + integration suites green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `pitboss schema --format=map --check docs/manifest-map.md` exits 0
- [ ] Reviewer: skim the rendered `docs/manifest-map.md` for any field that should have richer help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)