### PR TITLE
feat(cli,docs): pitboss schema --format=example + auto-generated docs/manifest-reference.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,11 +29,12 @@ flamegraph.svg
 .env.*
 
 # Project-internal docs (kept locally; not shipped) — except the auto-generated
-# manifest map, which is checked in and verified by `pitboss schema --check`.
-# Ignore *contents* not the directory itself, otherwise the !-exception below
-# can't re-include the one file we want under git.
+# manifest artifacts, which are checked in and verified by
+# `pitboss schema --check`. Ignore *contents* not the directory itself,
+# otherwise the !-exceptions below can't re-include files we want under git.
 /docs/*
 !/docs/manifest-map.md
+!/docs/manifest-reference.toml
 
 # Git worktrees
 .worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,18 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`pitboss schema --format=example` + `docs/manifest-reference.toml`** —
+  auto-generates a complete reference TOML in which every field declared by
+  the v0.9 schema appears as an uncommented `key = placeholder` assignment.
+  Placeholders come from the field's inferred `FormType` (with `enum_values`
+  fields collapsing to their first variant). Companion to `--format=map`:
+  the map shows where each field lives in the source, the reference shows
+  what a fully-populated section looks like. Drift-guarded by a unit test
+  and `pitboss schema --format=example --check docs/manifest-reference.toml`
+  for CI. The output is valid TOML (parses cleanly) but is *not* a runnable
+  manifest — `[lead]` and `[[task]]` are mutually exclusive at dispatch time
+  even though both demonstrate happily side-by-side here.
+
 - **`pitboss schema --format=map` + `docs/manifest-map.md`** — auto-generates
   a per-field code-reference doc that maps every TOML key to its Rust
   source location (`schema.rs:LINE`), label, help text, type, and

--- a/crates/pitboss-cli/src/cli.rs
+++ b/crates/pitboss-cli/src/cli.rs
@@ -143,12 +143,19 @@ pub enum Command {
         #[arg(value_enum)]
         shell: clap_complete::Shell,
     },
-    /// Emit machine-readable views of the manifest schema. Currently
-    /// supports `--format=map` (a markdown reference checked in at
-    /// `docs/manifest-map.md`). The `--check <path>` mode regenerates and
-    /// diffs against an existing file — used in CI to catch drift.
+    /// Emit machine-readable views of the manifest schema.
+    ///
+    /// Supported formats:
+    ///   * `--format=map` — markdown field map, checked in at
+    ///     `docs/manifest-map.md`.
+    ///   * `--format=example` — complete reference TOML with every field
+    ///     present (placeholders), checked in at
+    ///     `docs/manifest-reference.toml`.
+    ///
+    /// The `--check <path>` mode regenerates and diffs against an existing
+    /// file — used in CI to catch drift.
     Schema {
-        /// Output format. Only `map` is implemented today;
+        /// Output format. `map` (default) and `example` are implemented;
         /// `n8n-form` is roadmapped.
         #[arg(long, value_enum, default_value_t = SchemaFormat::Map)]
         format: SchemaFormat,
@@ -165,6 +172,8 @@ pub enum Command {
 pub enum SchemaFormat {
     /// Markdown manifest map (one row per field, with file:line refs).
     Map,
+    /// Complete reference TOML — every field present as `key = placeholder`.
+    Example,
 }
 
 #[cfg(test)]

--- a/crates/pitboss-cli/src/main.rs
+++ b/crates/pitboss-cli/src/main.rs
@@ -76,8 +76,9 @@ fn main() -> Result<()> {
 
 /// Drive `pitboss schema --format=...`. Returns the exit code.
 fn run_schema(format: cli::SchemaFormat, check: Option<&std::path::Path>) -> i32 {
-    let generated = match format {
-        cli::SchemaFormat::Map => crate::manifest::map_doc::render(),
+    let (generated, format_flag) = match format {
+        cli::SchemaFormat::Map => (crate::manifest::map_doc::render(), "map"),
+        cli::SchemaFormat::Example => (crate::manifest::example_doc::render(), "example"),
     };
     match check {
         None => {
@@ -102,7 +103,7 @@ fn run_schema(format: cli::SchemaFormat, check: Option<&std::path::Path>) -> i32
                 eprintln!(
                     "pitboss schema --check: {} is stale.\n\
                      Regenerate with:\n\
-                     \n    pitboss schema --format=map > {}\n",
+                     \n    pitboss schema --format={format_flag} > {}\n",
                     path.display(),
                     path.display()
                 );

--- a/crates/pitboss-cli/src/manifest/example_doc.rs
+++ b/crates/pitboss-cli/src/manifest/example_doc.rs
@@ -1,0 +1,209 @@
+//! Auto-generates `docs/manifest-reference.toml` from the [`super::metadata`]
+//! registry.
+//!
+//! Unlike the hand-curated [`pitboss.example.toml`] at the repo root (which is
+//! organised pedagogically and uses commented-out fields to highlight defaults),
+//! this artifact emits every field as an uncommented `key = value` assignment
+//! using a placeholder derived from the field's [`FormType`]. Operators copy it
+//! as a starting point and replace placeholders with real values.
+//!
+//! Drift is verified by [`tests::checked_in_doc_matches_generator`] and by the
+//! CLI's `pitboss schema --format=example --check docs/manifest-reference.toml`
+//! invocation in CI.
+
+use std::fmt::Write as _;
+
+use pitboss_schema::{FieldDescriptor, FormType, SchemaSection};
+
+use super::metadata::sections;
+
+/// Render the full reference-TOML body. Pure function — same input always
+/// produces identical output, which the `--check` mode relies on.
+pub fn render() -> String {
+    let mut out = String::new();
+    write_header(&mut out);
+    for section in sections() {
+        render_section(&mut out, &section);
+    }
+    out
+}
+
+fn write_header(out: &mut String) {
+    out.push_str(
+        "# Pitboss manifest — complete reference\n\
+         #\n\
+         # Auto-generated. Do not edit by hand. Regenerate with:\n\
+         #   pitboss schema --format=example > docs/manifest-reference.toml\n\
+         #\n\
+         # Every field declared in the v0.9 schema is present below as an\n\
+         # uncommented `key = value` assignment using a placeholder derived\n\
+         # from the field's form type. This file demonstrates *structure*; it\n\
+         # is NOT a runnable manifest:\n\
+         #   * `[lead]` and `[[task]]` are mutually exclusive — pick one.\n\
+         #   * `[[mcp_server]]` / `[[approval_policy]]` / `[[template]]` are\n\
+         #     repeating sections; one example entry is shown.\n\
+         #   * Sub-sections that aren't surfaced through the FieldMetadata\n\
+         #     registry yet (e.g. `[approval_policy.match]`, `[[notification]]`)\n\
+         #     are omitted; see `pitboss.example.toml` for hand-curated\n\
+         #     coverage and `book/src/operator-guide/manifest-schema.md` for\n\
+         #     prose explanations.\n\
+         #\n\
+         # Each row's source-of-truth lives in\n\
+         # `crates/pitboss-cli/src/manifest/schema.rs`. The companion field\n\
+         # map at `docs/manifest-map.md` provides clickable file:line refs.\n\
+         \n",
+    );
+}
+
+fn render_section(out: &mut String, section: &SchemaSection) {
+    let _ = writeln!(out, "{}", section.toml_path);
+    for f in section.fields {
+        render_field_line(out, f);
+    }
+    out.push('\n');
+}
+
+fn render_field_line(out: &mut String, f: &FieldDescriptor) {
+    let value = render_placeholder(f);
+    let _ = writeln!(out, "{} = {}", f.name, value);
+}
+
+/// Map a [`FieldDescriptor`] to a TOML right-hand-side literal.
+///
+/// `enum_values` (when present) wins — the first variant is emitted as a
+/// quoted string. Otherwise the placeholder is derived from `form_type`.
+fn render_placeholder(f: &FieldDescriptor) -> String {
+    if !f.enum_values.is_empty() {
+        return format!("\"{}\"", f.enum_values[0]);
+    }
+    match f.form_type {
+        FormType::Text => "\"<value>\"".to_string(),
+        FormType::LongText => "\"\"\"\n  Replace with the actual prompt body.\n\"\"\"".to_string(),
+        FormType::Integer => "0".to_string(),
+        FormType::Float => "0.0".to_string(),
+        FormType::Boolean => "false".to_string(),
+        FormType::Path => "\"/path/to/value\"".to_string(),
+        // Reachable only when enum_values is empty — keep a sentinel so a
+        // missing `enum_values` annotation surfaces visibly in the output.
+        FormType::EnumSelect => "\"<enum>\"".to_string(),
+        FormType::StringList => "[]".to_string(),
+        FormType::KeyValueMap => "{ EXAMPLE_KEY = \"value\" }".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Smoke: render must succeed and contain every section's TOML path.
+    #[test]
+    fn render_contains_every_section() {
+        let doc = render();
+        for section in sections() {
+            assert!(
+                doc.contains(section.toml_path),
+                "rendered reference missing section header for {}",
+                section.toml_path
+            );
+        }
+    }
+
+    /// The emitted doc must contain every registered field as a `key =`
+    /// assignment. Catches regressions where a section is rendered with the
+    /// header but no field rows.
+    #[test]
+    fn render_contains_every_field() {
+        let doc = render();
+        let mut missing: Vec<String> = Vec::new();
+        for section in sections() {
+            for f in section.fields {
+                let needle = format!("\n{} = ", f.name);
+                if !doc.contains(&needle) {
+                    missing.push(format!("{}.{}", section.type_name, f.name));
+                }
+            }
+        }
+        assert!(
+            missing.is_empty(),
+            "fields missing from reference output: {:?}",
+            missing
+        );
+    }
+
+    /// Enum fields must use the first declared `enum_values` variant (quoted)
+    /// rather than the generic `"<enum>"` sentinel. Drift guard against the
+    /// `enum_values` priority branch in `render_placeholder` regressing.
+    #[test]
+    fn enum_fields_use_first_variant() {
+        let doc = render();
+        // worktree_cleanup declares ["always", "on_success", "never"].
+        assert!(
+            doc.contains("worktree_cleanup = \"always\""),
+            "expected worktree_cleanup to render as \"always\", got:\n{}",
+            doc
+        );
+        // permission_routing declares ["path_a", "path_b"].
+        assert!(
+            doc.contains("permission_routing = \"path_a\""),
+            "expected permission_routing to render as \"path_a\""
+        );
+    }
+
+    /// `Lead.prompt` is `LongText` — the emitter must use a triple-quoted
+    /// multi-line string so newlines in the placeholder don't break the
+    /// surrounding TOML.
+    #[test]
+    fn long_text_uses_triple_quoted_block() {
+        let doc = render();
+        assert!(
+            doc.contains("prompt = \"\"\"\n"),
+            "expected prompt to use triple-quoted block; got:\n{}",
+            doc
+        );
+    }
+
+    /// `HashMap<String, String>` fields must emit an inline table — not an
+    /// empty `{}` and not a separate `[parent.env]` sub-section (which would
+    /// disrupt the linear emission order).
+    #[test]
+    fn key_value_maps_render_as_inline_tables() {
+        let doc = render();
+        assert!(
+            doc.contains("env = { EXAMPLE_KEY = \"value\" }"),
+            "expected env field to render as inline table"
+        );
+    }
+
+    /// The full output must be valid TOML so operators can copy a section
+    /// out and parse it directly. We chunk per-section because `[lead]` and
+    /// `[[task]]` are mutually exclusive (the doc explains this in the
+    /// header) and toml-rs will accept both as a single document only by
+    /// coincidence — we want a stronger guarantee here.
+    #[test]
+    fn whole_document_parses_as_toml() {
+        let doc = render();
+        // The header comment + all sections together must parse. The
+        // mutually-exclusive `[lead]` / `[[task]]` sections coexist as
+        // valid TOML even if `pitboss validate` would reject the
+        // combination as a manifest — that's fine for a reference doc.
+        let _: toml::Value = toml::from_str(&doc)
+            .unwrap_or_else(|e| panic!("reference doc must parse as TOML: {e}\n---\n{doc}"));
+    }
+
+    /// Drift guard: the checked-in `docs/manifest-reference.toml` must
+    /// match what the generator currently emits. Mirrored at the CLI
+    /// surface as `pitboss schema --format=example --check
+    /// docs/manifest-reference.toml`.
+    #[test]
+    fn checked_in_doc_matches_generator() {
+        const CHECKED_IN: &str = include_str!("../../../../docs/manifest-reference.toml");
+        let generated = render();
+        if generated != CHECKED_IN {
+            panic!(
+                "docs/manifest-reference.toml is stale.\n\
+                 Regenerate with:\n\
+                 \n    cargo run -q --release -p pitboss-cli -- schema --format=example > docs/manifest-reference.toml\n"
+            );
+        }
+    }
+}

--- a/crates/pitboss-cli/src/manifest/mod.rs
+++ b/crates/pitboss-cli/src/manifest/mod.rs
@@ -1,3 +1,4 @@
+pub mod example_doc;
 pub mod load;
 pub mod map_doc;
 pub mod metadata;

--- a/docs/manifest-reference.toml
+++ b/docs/manifest-reference.toml
@@ -1,0 +1,110 @@
+# Pitboss manifest — complete reference
+#
+# Auto-generated. Do not edit by hand. Regenerate with:
+#   pitboss schema --format=example > docs/manifest-reference.toml
+#
+# Every field declared in the v0.9 schema is present below as an
+# uncommented `key = value` assignment using a placeholder derived
+# from the field's form type. This file demonstrates *structure*; it
+# is NOT a runnable manifest:
+#   * `[lead]` and `[[task]]` are mutually exclusive — pick one.
+#   * `[[mcp_server]]` / `[[approval_policy]]` / `[[template]]` are
+#     repeating sections; one example entry is shown.
+#   * Sub-sections that aren't surfaced through the FieldMetadata
+#     registry yet (e.g. `[approval_policy.match]`, `[[notification]]`)
+#     are omitted; see `pitboss.example.toml` for hand-curated
+#     coverage and `book/src/operator-guide/manifest-schema.md` for
+#     prose explanations.
+#
+# Each row's source-of-truth lives in
+# `crates/pitboss-cli/src/manifest/schema.rs`. The companion field
+# map at `docs/manifest-map.md` provides clickable file:line refs.
+
+[run]
+max_parallel_tasks = 0
+halt_on_failure = false
+run_dir = "/path/to/value"
+worktree_cleanup = "always"
+emit_event_stream = false
+default_approval_policy = "block"
+dump_shared_store = false
+require_plan_approval = false
+
+[defaults]
+model = "<value>"
+effort = "low"
+tools = []
+timeout_secs = 0
+use_worktree = false
+env = { EXAMPLE_KEY = "value" }
+
+[container]
+image = "<value>"
+runtime = "docker"
+extra_args = []
+workdir = "/path/to/value"
+
+[[container.mount]]
+host = "/path/to/value"
+container = "/path/to/value"
+readonly = false
+
+[[task]]
+id = "<value>"
+directory = "/path/to/value"
+prompt = """
+  Replace with the actual prompt body.
+"""
+template = "<value>"
+vars = { EXAMPLE_KEY = "value" }
+branch = "<value>"
+model = "<value>"
+effort = "low"
+tools = []
+timeout_secs = 0
+use_worktree = false
+env = { EXAMPLE_KEY = "value" }
+
+[lead]
+id = "<value>"
+directory = "/path/to/value"
+prompt = """
+  Replace with the actual prompt body.
+"""
+branch = "<value>"
+model = "<value>"
+effort = "low"
+tools = []
+timeout_secs = 0
+use_worktree = false
+env = { EXAMPLE_KEY = "value" }
+max_workers = 0
+budget_usd = 0.0
+lead_timeout_secs = 0
+permission_routing = "path_a"
+allow_subleads = false
+max_subleads = 0
+max_sublead_budget_usd = 0.0
+max_total_workers = 0
+
+[sublead_defaults]
+budget_usd = 0.0
+max_workers = 0
+lead_timeout_secs = 0
+read_down = false
+
+[[approval_policy]]
+action = "auto_approve"
+
+[[mcp_server]]
+id = "<value>"
+command = "<value>"
+args = []
+env = { EXAMPLE_KEY = "value" }
+
+[[template]]
+id = "<value>"
+prompt = """
+  Replace with the actual prompt body.
+"""
+


### PR DESCRIPTION
## Summary

PR 1.D of the manifest TOML redesign series. Adds a second `pitboss schema` output: `--format=example` emits a complete reference TOML where every v0.9 schema field appears as an uncommented `key = placeholder` assignment. Companion to PR #127's `--format=map`:

- `docs/manifest-map.md` — *where* each field lives (file:line refs)
- `docs/manifest-reference.toml` — *what* a fully-populated section looks like

Driven entirely by the existing `FieldMetadata` registry from PRs 1.B / 1.C — adding a new schema field with `#[field(label, help)]` flows automatically into the reference doc on regenerate. Zero new attributes; placeholders are derived from the inferred `FormType` (with `enum_values` collapsing to the first variant).

## What's in this PR

- `crates/pitboss-cli/src/manifest/example_doc.rs` (~190 lines) — the emitter and 7 unit tests.
- `crates/pitboss-cli/src/cli.rs` — adds `SchemaFormat::Example` variant.
- `crates/pitboss-cli/src/main.rs` — dispatch + `--check` mode wired so the regenerate hint reflects the active format.
- `docs/manifest-reference.toml` (110 lines) — the checked-in artifact.
- `.gitignore` — exception for the new artifact, alongside the existing `manifest-map.md` exception.
- `CHANGELOG.md` — Added entry.

## Drift guards

| Guard | Where |
|---|---|
| Unit-test `include_str!` snapshot diff | `example_doc::tests::checked_in_doc_matches_generator` |
| CLI `--check` mode (CI / contributor use) | `pitboss schema --format=example --check docs/manifest-reference.toml` |

Plus six other unit tests covering: every section is rendered, every field is rendered, enum fields use the first variant, LongText uses triple-quoted blocks, HashMaps render inline, and the whole document parses as valid TOML.

## Why "not a runnable manifest"

`[lead]` and `[[task]]` are mutually exclusive at dispatch — but coexist happily in TOML syntax. The reference doc demonstrates *both* (so operators see every section regardless of mode). The header comment spells this out, and `pitboss validate` would still reject the combined doc as a manifest. The TOML-parse unit test guards against the structure ever becoming syntactically broken.

## Known gaps (deferred)

Sub-sections that aren't surfaced through the `FieldMetadata` registry yet are documented as gaps rather than addressed here, to keep PR 1.D scoped:

- `[approval_policy.match]` — `ApprovalMatchSpec` derives `FieldMetadata` but isn't registered as a section.
- `[[notification]]` — `NotificationConfig` lives in another module and doesn't derive `FieldMetadata`.

Both are clean follow-up adds (each a small `metadata::sections()` extension) and would also benefit the map doc.

## Test plan

- [x] `cargo test --workspace --lib` — 599 lib tests pass (114 + 84 + 401 across crates)
- [x] `cargo fmt --all -- --check` — clean
- [x] `RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets --no-deps` — clean
- [x] `pitboss schema --format=example --check docs/manifest-reference.toml` exits 0
- [x] `pitboss schema --help` shows both `map` and `example` values
- [ ] CI required checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)