### PR TITLE
feat(cli): pitboss init scaffold (simple + full templates)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,18 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`pitboss init [output] [-t simple|full] [--force]`** — emit a starter
+  manifest TOML to stdout or a named file. Two hand-curated templates:
+  `simple` (one `[lead]` driving a flat worker pool — the 80% case) and
+  `full` (coordinator + sub-leads + workers with depth-2 controls and
+  `[sublead_defaults]` populated, plus `[[mcp_server]]` /
+  `[[approval_policy]]` / `[[template]]` / `[container]` commented at the
+  bottom for easy uncommenting). Both templates are valid v0.9 manifests
+  once placeholder paths and prompts are filled in. Refuses to overwrite
+  an existing file unless `--force` is passed. Drift-guard tests run each
+  template through `load_manifest_from_str` so a future schema change
+  that breaks a template surfaces immediately.
+
 - **`pitboss schema --format=example` + `docs/manifest-reference.toml`** —
   auto-generates a complete reference TOML in which every field declared by
   the v0.9 schema appears as an uncommented `key = placeholder` assignment.

--- a/crates/pitboss-cli/src/cli.rs
+++ b/crates/pitboss-cli/src/cli.rs
@@ -143,6 +143,27 @@ pub enum Command {
         #[arg(value_enum)]
         shell: clap_complete::Shell,
     },
+    /// Emit a starter manifest TOML to stdout or a named file.
+    ///
+    /// Two templates: `simple` (one [lead] driving a flat worker pool) and
+    /// `full` (coordinator + sub-leads + workers + commented optional
+    /// sections). Both are valid v0.9 manifests once you fill in the
+    /// placeholder paths and prompt. Use `pitboss validate` to verify
+    /// your edits.
+    ///
+    /// The complete reference (every field, no defaults hidden) lives at
+    /// `docs/manifest-reference.toml`; produce it with
+    /// `pitboss schema --format=example`.
+    Init {
+        /// Output path. If omitted, prints to stdout.
+        output: Option<PathBuf>,
+        /// Template to emit. `simple` is the default 80% case.
+        #[arg(short, long, value_enum, default_value_t = InitTemplateArg::Simple)]
+        template: InitTemplateArg,
+        /// Overwrite the output file if it already exists.
+        #[arg(short, long)]
+        force: bool,
+    },
     /// Emit machine-readable views of the manifest schema.
     ///
     /// Supported formats:
@@ -174,6 +195,29 @@ pub enum SchemaFormat {
     Map,
     /// Complete reference TOML — every field present as `key = placeholder`.
     Example,
+}
+
+/// Starter templates supported by `pitboss init`.
+///
+/// Mirrors [`crate::manifest::init_template::InitTemplate`] — kept separate so
+/// the clap surface doesn't depend on `clap::ValueEnum` leaking into the
+/// `manifest` module.
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+#[clap(rename_all = "kebab-case")]
+pub enum InitTemplateArg {
+    /// One [lead] driving a flat worker pool. Two levels deep.
+    Simple,
+    /// Coordinator + sub-leads + workers + commented optional sections.
+    Full,
+}
+
+impl From<InitTemplateArg> for crate::manifest::init_template::InitTemplate {
+    fn from(arg: InitTemplateArg) -> Self {
+        match arg {
+            InitTemplateArg::Simple => Self::Simple,
+            InitTemplateArg::Full => Self::Full,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/pitboss-cli/src/main.rs
+++ b/crates/pitboss-cli/src/main.rs
@@ -71,6 +71,52 @@ fn main() -> Result<()> {
         Command::Schema { format, check } => {
             std::process::exit(run_schema(format, check.as_deref()));
         }
+        Command::Init {
+            output,
+            template,
+            force,
+        } => {
+            std::process::exit(run_init(template.into(), output.as_deref(), force));
+        }
+    }
+}
+
+/// Drive `pitboss init`. Returns the exit code.
+///
+/// Exit codes:
+///   0 — wrote the template (or printed it to stdout)
+///   1 — output path already exists and `--force` was not supplied
+///   2 — write failed (parent missing, permissions, …)
+fn run_init(
+    template: crate::manifest::init_template::InitTemplate,
+    output: Option<&std::path::Path>,
+    force: bool,
+) -> i32 {
+    let body = template.render();
+    match output {
+        None => {
+            print!("{body}");
+            0
+        }
+        Some(path) => {
+            if path.exists() && !force {
+                eprintln!(
+                    "pitboss init: refusing to overwrite {} (pass --force to allow)",
+                    path.display()
+                );
+                return 1;
+            }
+            if let Err(e) = std::fs::write(path, body) {
+                eprintln!("pitboss init: writing {}: {e}", path.display());
+                return 2;
+            }
+            eprintln!(
+                "pitboss init: wrote {} template to {}",
+                template.slug(),
+                path.display()
+            );
+            0
+        }
     }
 }
 

--- a/crates/pitboss-cli/src/manifest/init_template.rs
+++ b/crates/pitboss-cli/src/manifest/init_template.rs
@@ -1,0 +1,240 @@
+//! Hand-curated starter manifests for `pitboss init`.
+//!
+//! Two tiers, kept deliberately small and prescriptive:
+//!
+//! * [`InitTemplate::Simple`] — one root `[lead]` driving a flat worker
+//!   pool. Two levels deep at most. The 80% case for new operators.
+//! * [`InitTemplate::Full`] — coordinator + sub-leads + workers + KV/budget
+//!   fields, with the optional sections (`[[mcp_server]]`,
+//!   `[[approval_policy]]`, `[[template]]`, `[container]`) commented out
+//!   so they survive copy-paste editing.
+//!
+//! Why hand-curated rather than registry-derived: a template is opinionated
+//! teaching code. It needs comments, sensible defaults, and a "fill these
+//! placeholders" through-line that the [`super::example_doc`] reference
+//! generator (PR 1.D) intentionally lacks. The drift guard tests below run
+//! each template through `load_manifest_from_str` so a v0.9 schema change
+//! that breaks a template surfaces immediately.
+
+/// Which canned manifest to emit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InitTemplate {
+    Simple,
+    Full,
+}
+
+impl InitTemplate {
+    /// Render the template body as TOML. Returns a `&'static str` because
+    /// both templates are compile-time embedded — no per-call allocation.
+    pub fn render(self) -> &'static str {
+        match self {
+            Self::Simple => SIMPLE,
+            Self::Full => FULL,
+        }
+    }
+
+    /// Short slug suitable for filenames / log output / regenerate hints.
+    pub fn slug(self) -> &'static str {
+        match self {
+            Self::Simple => "simple",
+            Self::Full => "full",
+        }
+    }
+}
+
+const SIMPLE: &str = r#"# Pitboss manifest — simple template.
+#
+# One root [lead] driving a flat worker pool (no sub-leads). Edit the
+# placeholders below, then run `pitboss validate <this-file>` to verify.
+# For every available field, see `docs/manifest-reference.toml`.
+
+[run]
+worktree_cleanup = "on_success"
+
+[defaults]
+model        = "claude-sonnet-4-6"
+effort       = "medium"
+tools        = ["Read", "Grep", "Glob", "Bash"]
+use_worktree = true
+
+[lead]
+id        = "coordinator"
+directory = "/path/to/your/project"
+prompt    = """
+Replace this with operator instructions for the lead.
+Describe the goal, constraints, and how to delegate to workers.
+"""
+
+# Lead-level caps (required when the lead spawns workers).
+max_workers       = 4
+budget_usd        = 5.00
+lead_timeout_secs = 1800
+"#;
+
+const FULL: &str = r#"# Pitboss manifest — full template.
+#
+# Coordinator + sub-leads + workers, with depth-2 controls and
+# [sublead_defaults] populated. Optional sections (MCP servers,
+# approval policy, prompt templates, container dispatch) are
+# commented at the bottom — uncomment as needed.
+#
+# Edit the placeholders below, then run `pitboss validate <this-file>`.
+# For every available field, see `docs/manifest-reference.toml`.
+
+[run]
+worktree_cleanup      = "on_success"
+emit_event_stream     = true
+require_plan_approval = false  # Set true to gate spawn_worker on propose_plan.
+
+[defaults]
+model        = "claude-sonnet-4-6"
+effort       = "medium"
+tools        = ["Read", "Grep", "Glob", "Bash"]
+use_worktree = true
+timeout_secs = 1800
+
+[lead]
+id        = "coordinator"
+directory = "/path/to/your/project"
+prompt    = """
+Replace this with operator instructions for the root lead.
+Plan the work via propose_plan, then delegate to sub-leads
+(one per work-stream) and workers as appropriate.
+"""
+
+# Lead-level caps.
+max_workers       = 8
+budget_usd        = 20.00
+lead_timeout_secs = 7200
+
+# Depth-2 controls.
+allow_subleads         = true
+max_subleads           = 3
+max_sublead_budget_usd = 5.00
+max_total_workers      = 16
+
+[sublead_defaults]
+budget_usd        = 5.00
+max_workers       = 4
+lead_timeout_secs = 3600
+read_down         = false  # When true, sub-leads share the root's pool.
+
+# ── Optional sections (uncomment as needed) ─────────────────────────────
+
+# [[mcp_server]]
+# id      = "context7"
+# command = "npx"
+# args    = ["-y", "@upstash/context7-mcp"]
+
+# [[approval_policy]]
+# action = "auto_approve"
+# match  = { actor = "root", category = "tool_use" }
+
+# [[template]]
+# id     = "audit"
+# prompt = "Audit {pkg} in {dir}."
+
+# [container]
+# image   = "ghcr.io/sds-mode/pitboss-with-claude:latest"
+# runtime = "auto"
+#
+# [[container.mount]]
+# host      = "/path/to/project"
+# container = "/home/pitboss/project"
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::load::load_manifest_from_str;
+
+    /// Drift guard: each template must parse + resolve under the v0.9
+    /// schema. If a future schema change breaks a template, this test
+    /// flags it before the broken `init` output reaches a user.
+    #[test]
+    fn simple_template_parses_and_resolves() {
+        let r = load_manifest_from_str(InitTemplate::Simple.render())
+            .expect("simple template should parse and resolve");
+        let lead = r.lead.expect("simple template must have a [lead]");
+        assert_eq!(lead.id, "coordinator");
+        assert_eq!(r.max_workers, Some(4));
+        assert_eq!(r.budget_usd, Some(5.00));
+    }
+
+    /// Same drift guard for the full template, with extra checks on the
+    /// depth-2 fields the simple template omits.
+    #[test]
+    fn full_template_parses_and_resolves() {
+        let r = load_manifest_from_str(InitTemplate::Full.render())
+            .expect("full template should parse and resolve");
+        let lead = r.lead.expect("full template must have a [lead]");
+        assert_eq!(lead.id, "coordinator");
+        assert_eq!(r.max_workers, Some(8));
+        assert_eq!(r.budget_usd, Some(20.00));
+        assert!(
+            lead.allow_subleads,
+            "full template should set allow_subleads = true"
+        );
+        assert_eq!(lead.max_subleads, Some(3));
+        assert_eq!(lead.max_total_workers, Some(16));
+        let sd = lead
+            .sublead_defaults
+            .as_ref()
+            .expect("full template must declare [sublead_defaults]");
+        assert_eq!(sd.max_workers, Some(4));
+    }
+
+    /// Templates must not contain v0.8 fields. A copy-paste regression
+    /// where the wrong field name lands in a template would silently
+    /// reach users — guard against the ones that changed in v0.9.
+    #[test]
+    fn templates_avoid_legacy_field_names() {
+        const FORBIDDEN: &[&str] = &[
+            "max_workers_across_tree", // → max_total_workers
+            "max_parallel ", // → max_parallel_tasks (note trailing space anchors the key, not max_parallel_tasks)
+            "approval_policy =", // [run] field; renamed to default_approval_policy
+            "[lead.sublead_defaults]", // promoted to top-level [sublead_defaults]
+            "[[lead]]",      // array form is gone
+        ];
+        for kind in [InitTemplate::Simple, InitTemplate::Full] {
+            let body = kind.render();
+            for needle in FORBIDDEN {
+                assert!(
+                    !body.contains(needle),
+                    "{} template contains legacy fragment {:?}",
+                    kind.slug(),
+                    needle
+                );
+            }
+        }
+    }
+
+    /// Each template must explain itself — a header comment, the
+    /// `pitboss validate` reminder, and a pointer to the reference doc.
+    /// Catches the classic regression where someone strips comments to
+    /// "clean up" the template.
+    #[test]
+    fn templates_have_orientation_comments() {
+        for kind in [InitTemplate::Simple, InitTemplate::Full] {
+            let body = kind.render();
+            assert!(
+                body.contains("pitboss validate"),
+                "{} template should mention `pitboss validate`",
+                kind.slug()
+            );
+            assert!(
+                body.contains("docs/manifest-reference.toml"),
+                "{} template should point at the reference doc",
+                kind.slug()
+            );
+        }
+    }
+
+    /// Slug stability — these strings show up in the CLI's clap value-enum
+    /// and in error messages, so a rename here is a user-visible change.
+    #[test]
+    fn template_slugs_are_stable() {
+        assert_eq!(InitTemplate::Simple.slug(), "simple");
+        assert_eq!(InitTemplate::Full.slug(), "full");
+    }
+}

--- a/crates/pitboss-cli/src/manifest/mod.rs
+++ b/crates/pitboss-cli/src/manifest/mod.rs
@@ -1,4 +1,5 @@
 pub mod example_doc;
+pub mod init_template;
 pub mod load;
 pub mod map_doc;
 pub mod metadata;


### PR DESCRIPTION
## Summary

PR 1.E — final piece of the manifest TOML redesign series. Adds a `pitboss init` subcommand that emits a starter manifest to stdout or a named file. Closes the [`pitboss scaffold` / `pitboss init` template generator](../blob/main/ROADMAP.md) entry.

Two hand-curated templates:

- **`simple`** — one `[lead]` driving a flat worker pool. The 80% case for new operators.
- **`full`** — coordinator + sub-leads + workers with depth-2 controls and `[sublead_defaults]` populated, plus `[[mcp_server]]` / `[[approval_policy]]` / `[[template]]` / `[container]` commented at the bottom for trivial uncommenting.

Both templates are valid v0.9 manifests once placeholder paths and prompts are filled in. Refuses to overwrite an existing output file unless `--force` is passed.

## Series recap

| PR | Lands | What |
|---|---|---|
| 1.A | #123 | TOML schema redesign (single canonical `[lead]`, top-level `[sublead_defaults]`, renamed fields) |
| 1.B | #126 | `#[derive(FieldMetadata)]` proc-macro + `pitboss-schema` types crate |
| 1.C | #127 | `pitboss schema --format=map` + `docs/manifest-map.md` (per-field code refs) |
| 1.D | #128 | `pitboss schema --format=example` + `docs/manifest-reference.toml` (every field uncommented) |
| 1.E | this | `pitboss init [-t simple\|full]` (opinionated starter templates) |

## Why hand-curated, not registry-derived

A template is opinionated teaching code. It needs explanatory comments, sensible defaults, and a "fill these placeholders" through-line that the PR 1.D `--format=example` reference intentionally lacks (that one is exhaustive and robotic by design).

Drift between the templates and the live schema is caught by tests that run each template through `load_manifest_from_str` — a future v0.9 → v1.0 schema change that breaks a template fails CI before any user sees the broken `init` output.

## Drift guards

- `simple_template_parses_and_resolves` / `full_template_parses_and_resolves` — each template must round-trip through the loader. If a future schema change renames a field that's hard-coded in a template, this test surfaces it immediately.
- `templates_avoid_legacy_field_names` — explicit denylist of v0.8 fragments (`[[lead]]`, `max_workers_across_tree`, `approval_policy =`, etc.) so a copy-paste regression from older docs gets caught.
- `templates_have_orientation_comments` — both templates must mention `pitboss validate` and link the reference doc.
- `template_slugs_are_stable` — `simple` / `full` are user-visible CLI value-enum strings; rename = breaking change.

## Test plan

- [x] `cargo test --workspace --lib` — 604 lib tests pass (5 new init_template tests; 406 + 84 + 114 across crates)
- [x] `cargo fmt --all -- --check` — clean
- [x] `RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets --no-deps` — clean
- [x] `pitboss init --help` shows both templates
- [x] `pitboss init <new-path>` writes simple template (default)
- [x] `pitboss init -t full <new-path>` writes full template
- [x] `pitboss init <existing-path>` refuses (exit 1)
- [x] `pitboss init --force <existing-path>` overwrites
- [x] `pitboss validate <generated>` reports the placeholder directory as the first thing to fix (the intended teaching moment)
- [ ] CI required checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)