### PR TITLE
feat(cli): pitboss list [--active] [--json] (#133-B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,18 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`pitboss list [--active] [--json]`** — flat-CLI inventory of recent runs
+  under `~/.local/share/pitboss/runs/`. Mirrors the `pitboss-tui list`
+  output but without depending on the TUI binary, so orchestrators (RacerX,
+  CI scripts, dashboards) can shell out to it directly. `--active` narrows
+  to runs whose dispatcher is alive right now (`status = running`); use
+  `pitboss prune --dry-run` to surface stale / orphaned entries instead.
+  `--json` emits a stable record array — `{run_id, run_dir, started_at,
+  tasks_total, tasks_failed, status}` — suitable for piping through `jq`
+  or consuming from a wrapping process. Companion to the parent-notify
+  hook (also #133): notifications give push observability, `pitboss list`
+  gives pull.
+
 - **Parent-orchestrator notification hook** — closes issue #133. Two new
   env vars give a wrapping orchestrator (Discord bot, dispatcher service,
   CI runner) visibility into runs the agent itself spawns from inside its

--- a/crates/pitboss-cli/src/cli.rs
+++ b/crates/pitboss-cli/src/cli.rs
@@ -164,6 +164,27 @@ pub enum Command {
         #[arg(long, value_name = "USD")]
         check: Option<f64>,
     },
+    /// Inventory of recent runs under `~/.local/share/pitboss/runs/`.
+    ///
+    /// Mirrors `pitboss-tui list` but as a flat-CLI subcommand orchestrators
+    /// can shell out to without depending on the TUI binary. `--active`
+    /// narrows to runs whose dispatcher is alive right now (`status =
+    /// running`); use `pitboss prune --dry-run` for stale / orphaned
+    /// entries. `--json` emits an array suitable for orchestrator
+    /// consumption (RacerX, CI scripts).
+    List {
+        /// Show only runs whose dispatcher is alive (status = running).
+        /// Excludes complete, stale, and aborted runs.
+        #[arg(long)]
+        active: bool,
+        /// Emit machine-readable JSON instead of a human table.
+        #[arg(long)]
+        json: bool,
+        /// Override the runs base directory. Defaults to
+        /// `~/.local/share/pitboss/runs`.
+        #[arg(long, value_name = "PATH")]
+        runs_dir: Option<PathBuf>,
+    },
     /// Sweep orphaned run directories.
     ///
     /// A run is *orphaned* when its dispatcher exited uncleanly

--- a/crates/pitboss-cli/src/lib.rs
+++ b/crates/pitboss-cli/src/lib.rs
@@ -10,6 +10,7 @@ pub mod cli;
 pub mod control;
 pub mod diff;
 pub mod dispatch;
+pub mod list;
 pub mod manifest;
 pub mod mcp;
 pub mod notify;

--- a/crates/pitboss-cli/src/list.rs
+++ b/crates/pitboss-cli/src/list.rs
@@ -1,0 +1,214 @@
+//! `pitboss list` — flat-CLI inventory of runs, designed for orchestrators.
+//!
+//! The pitboss-tui binary already has a `pitboss-tui list` subcommand that
+//! prints the same data, but orchestrators (RacerX, CI scripts) generally
+//! don't want to depend on the TUI binary just for a directory walk. This
+//! flat-CLI form gives them a stable surface to call:
+//!
+//! ```text
+//! $ pitboss list
+//! RUN ID                                  STARTED                 TASKS  FAILED  STATUS
+//! ────────────────────────────────────────────────────────────────────────────────
+//! 019d…                                   2026-04-26 17:00:00     5      0       complete
+//! 019c…                                   2026-04-26 16:45:00     8      1       running
+//!
+//! $ pitboss list --active
+//! ...only runs with status = "running"...
+//!
+//! $ pitboss list --json
+//! [{"run_id":"019d…","status":"complete","tasks_total":5, ...}, ...]
+//! ```
+//!
+//! Implementation reuses `crate::runs::collect_run_entries`, the same
+//! classifier the TUI and `pitboss prune` already share (PR #130).
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+use anyhow::Result;
+use serde::Serialize;
+
+use crate::runs;
+
+/// JSON shape emitted with `--json`. Stable contract for orchestrators —
+/// one record per run directory under `~/.local/share/pitboss/runs/`.
+#[derive(Debug, Serialize)]
+pub struct RunListEntry {
+    pub run_id: String,
+    pub run_dir: PathBuf,
+    /// Last modification time of the run dir, RFC 3339.
+    pub started_at: String,
+    pub tasks_total: usize,
+    pub tasks_failed: usize,
+    /// One of "complete", "running", "stale", "aborted".
+    pub status: &'static str,
+}
+
+impl From<&runs::RunEntry> for RunListEntry {
+    fn from(e: &runs::RunEntry) -> Self {
+        Self {
+            run_id: e.run_id.clone(),
+            run_dir: e.run_dir.clone(),
+            started_at: rfc3339(e.mtime),
+            tasks_total: e.tasks_total,
+            tasks_failed: e.tasks_failed,
+            status: e.status.label(),
+        }
+    }
+}
+
+/// Entry point for the `list` subcommand.
+///
+/// `runs_dir_override` mirrors the same flag on `pitboss prune` — defaults
+/// to `~/.local/share/pitboss/runs/` when `None`.
+pub fn run(json: bool, active: bool, runs_dir_override: Option<PathBuf>) -> Result<i32> {
+    let base = runs_dir_override.unwrap_or_else(runs::runs_base_dir);
+    if !base.exists() {
+        if json {
+            println!("[]");
+            return Ok(0);
+        }
+        eprintln!("No runs directory found at {}.", base.display());
+        eprintln!("Run `pitboss dispatch` first to create a run.");
+        return Ok(0);
+    }
+
+    let entries = runs::collect_run_entries(&base);
+    let filtered: Vec<&runs::RunEntry> = if active {
+        // `--active` strictly means "the dispatcher is alive and working
+        // right now" → only `Running`. Stale runs LOOK active but the
+        // dispatcher is gone; they belong to `pitboss prune --dry-run`.
+        // Aborted runs never produced output. Both excluded.
+        entries
+            .iter()
+            .filter(|e| matches!(e.status, runs::RunStatus::Running))
+            .collect()
+    } else {
+        entries.iter().collect()
+    };
+
+    if json {
+        let out: Vec<RunListEntry> = filtered.iter().map(|e| RunListEntry::from(*e)).collect();
+        println!("{}", serde_json::to_string_pretty(&out)?);
+        return Ok(0);
+    }
+
+    if filtered.is_empty() {
+        if active {
+            println!("No active runs.");
+        } else {
+            println!("No runs found under {}.", base.display());
+        }
+        return Ok(0);
+    }
+
+    let mut stdout = std::io::stdout();
+    writeln!(
+        stdout,
+        "{:<38}  {:<22}  {:>6}  {:>6}  STATUS",
+        "RUN ID", "STARTED", "TASKS", "FAILED"
+    )?;
+    writeln!(stdout, "{}", "─".repeat(80))?;
+    for e in &filtered {
+        let started = runs::format_mtime(e.mtime);
+        writeln!(
+            stdout,
+            "{:<38}  {:<22}  {:>6}  {:>6}  {}",
+            e.run_id,
+            started,
+            e.tasks_total,
+            e.tasks_failed,
+            e.status.label()
+        )?;
+    }
+    Ok(0)
+}
+
+/// RFC 3339 timestamp for `--json` output. `format_mtime` in the runs
+/// module returns a human "YYYY-MM-DD HH:MM:SS" form for table display;
+/// JSON consumers want the parseable RFC 3339 form.
+fn rfc3339(mtime: SystemTime) -> String {
+    let dt: chrono::DateTime<chrono::Utc> = mtime.into();
+    dt.to_rfc3339()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn make_run_dir(base: &std::path::Path, id: &str, with_summary: bool) -> PathBuf {
+        let dir = base.join(id);
+        fs::create_dir_all(&dir).unwrap();
+        if with_summary {
+            // Minimal valid summary.json for `Complete` classification.
+            fs::write(
+                dir.join("summary.json"),
+                br#"{"run_id":"00000000-0000-0000-0000-000000000000","manifest_path":"/tmp/m","pitboss_version":"x","claude_version":null,"started_at":"2026-04-26T00:00:00Z","ended_at":"2026-04-26T00:00:01Z","total_duration_ms":1000,"tasks_total":3,"tasks_failed":1,"was_interrupted":false,"tasks":[]}"#,
+            )
+            .unwrap();
+        }
+        dir
+    }
+
+    #[test]
+    fn list_default_lists_all_runs() {
+        let tmp = TempDir::new().unwrap();
+        make_run_dir(tmp.path(), "019d-aaaa", true);
+        make_run_dir(tmp.path(), "019d-bbbb", true);
+        let rc = run(false, false, Some(tmp.path().to_path_buf())).unwrap();
+        assert_eq!(rc, 0);
+    }
+
+    #[test]
+    fn list_json_emits_array_of_records() {
+        let tmp = TempDir::new().unwrap();
+        make_run_dir(tmp.path(), "019d-aaaa", true);
+        // Snapshot stdout via a child run to avoid pulling in libtest's
+        // capture infrastructure: just confirm the invocation succeeds and
+        // that JSON serialization round-trips through RunListEntry.
+        let entries = runs::collect_run_entries(tmp.path());
+        let json: Vec<RunListEntry> = entries.iter().map(RunListEntry::from).collect();
+        let s = serde_json::to_string(&json).unwrap();
+        assert!(s.starts_with('['));
+        assert!(s.contains("\"run_id\":\"019d-aaaa\""));
+        assert!(s.contains("\"status\":\"complete\""));
+        assert!(s.contains("\"tasks_total\":3"));
+    }
+
+    #[test]
+    fn list_active_excludes_complete_and_aborted() {
+        let tmp = TempDir::new().unwrap();
+        // Complete run.
+        make_run_dir(tmp.path(), "019d-aaaa", true);
+        // Aborted run (no summary.json, no jsonl, no socket).
+        make_run_dir(tmp.path(), "019d-bbbb", false);
+
+        let entries = runs::collect_run_entries(tmp.path());
+        let active: Vec<_> = entries
+            .iter()
+            .filter(|e| matches!(e.status, runs::RunStatus::Running))
+            .collect();
+        // Neither directory should pass the active filter.
+        assert!(
+            active.is_empty(),
+            "active filter should exclude complete + aborted"
+        );
+    }
+
+    #[test]
+    fn list_missing_runs_dir_returns_ok_with_empty_json() {
+        let tmp = TempDir::new().unwrap();
+        let nonexistent = tmp.path().join("does-not-exist");
+        let rc = run(true, false, Some(nonexistent)).unwrap();
+        assert_eq!(rc, 0);
+    }
+
+    #[test]
+    fn rfc3339_roundtrip_through_chrono() {
+        let s = rfc3339(SystemTime::UNIX_EPOCH);
+        assert!(s.starts_with("1970-01-01T00:00:00"));
+    }
+}

--- a/crates/pitboss-cli/src/main.rs
+++ b/crates/pitboss-cli/src/main.rs
@@ -1,7 +1,9 @@
 use anyhow::Result;
 use clap::Parser;
 
-use pitboss_cli::{agents_md, attach, cli, diff, dispatch, manifest, mcp, prune, status, tree};
+use pitboss_cli::{
+    agents_md, attach, cli, diff, dispatch, list, manifest, mcp, prune, status, tree,
+};
 
 use cli::{Cli, Command};
 
@@ -80,6 +82,13 @@ fn main() -> Result<()> {
         }
         Command::Tree { manifest, check } => {
             std::process::exit(tree::run(&manifest, check));
+        }
+        Command::List {
+            active,
+            json,
+            runs_dir,
+        } => {
+            std::process::exit(list::run(json, active, runs_dir)?);
         }
         Command::Prune {
             apply,


### PR DESCRIPTION
## Summary

Part B of the issue #133 follow-up split (the **pull** half of the observability story; the **push** half — `RunDispatched` / `RunFinished` events — already shipped in PR #135).

Adds a flat-CLI `pitboss list` subcommand that inventories recent runs under `~/.local/share/pitboss/runs/`. Mirrors what `pitboss-tui list` already prints, but as a flat-CLI form so orchestrators (RacerX, CI scripts, dashboards) can shell out to it without depending on the TUI binary.

## Surface

```text
$ pitboss list
RUN ID                                  STARTED                  TASKS  FAILED  STATUS
────────────────────────────────────────────────────────────────────────────────
019dc767-…                              2026-04-26 01:28:40 UTC      0       0  aborted
019dc43e-…                              2026-04-25 11:20:19 UTC     21       1  complete
…

$ pitboss list --active
No active runs.

$ pitboss list --json
[
  {
    "run_id": "019dc767-…",
    "run_dir": "/home/user/.local/share/pitboss/runs/019dc767-…",
    "started_at": "2026-04-26T01:28:40.896661852+00:00",
    "tasks_total": 0,
    "tasks_failed": 0,
    "status": "aborted"
  },
  ...
]
```

## Filter semantics

`--active` strictly means "the dispatcher is alive and working right now" → only `Running`. Stale runs LOOK active but the dispatcher is gone — those are cleanup candidates and belong to `pitboss prune --dry-run`. Aborted runs never produced output. Both excluded from `--active`.

## Implementation

- New `crate::list` module — ~130 LOC including tests
- Reuses `crate::runs::collect_run_entries` (the classifier shared with `pitboss-tui list` and `pitboss prune`, originally extracted in PR #130)
- New `RunListEntry` JSON shape — stable contract for orchestrators
- `--runs-dir <PATH>` override mirrors the same flag on `pitboss prune`

## Test plan

- [x] `cargo test --workspace` — all tests pass (5 new in `crate::list::tests`)
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Manual smoke against my real `~/.local/share/pitboss/runs/` — table render and `--json` both work; `--active` correctly returns "No active runs."
- [x] New tests cover: default lists all runs, `--json` round-trips through `RunListEntry`, `--active` excludes complete + aborted, missing runs dir returns ok with empty `[]` for `--json`, RFC 3339 timestamp formatting

## What this leaves for follow-ups

The remaining piece of the issue's "lifecycle observability" story is part **A** — the `[lifecycle]` schema with `survive_parent` + `notify` coupled validation. That's its own PR, going up next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)