### PR TITLE
feat(manifest): [lifecycle] section + survive_parent (#133-A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,57 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`[lifecycle]` manifest section + `survive_parent` declaration** —
+  follow-up A from issue #133. Lets a manifest formally declare that this
+  dispatch should be allowed to outlive its parent process (use case: an
+  agent's `pitboss dispatch <child.toml>` from inside its task worktree
+  needs to keep running after the agent's lead claude exits or times
+  out). Two coupled controls:
+
+  ```toml
+  [lifecycle]
+  survive_parent = true
+  notify = { kind = "webhook", url = "https://orchestrator.internal/events", events = ["run_dispatched", "run_finished"] }
+  ```
+
+  The `notify` field is optional and inline (same shape as
+  `[[notification]]`); when present it's validated by the same SSRF rules
+  as the top-level form. `pitboss validate` enforces the coupling:
+  `survive_parent = true` requires AT LEAST ONE notification target
+  (inline `[lifecycle].notify` or a top-level `[[notification]]` section),
+  so the orchestrator that's losing process-level control of the run can
+  still observe its outcome. Operators delivering events solely via
+  `PITBOSS_PARENT_NOTIFY_URL` (the env-var path shipped earlier in
+  v0.10) need to declare a no-cost `kind = "log"` block to satisfy the
+  validate-time gate, since validate runs against the manifest in
+  isolation and cannot see env vars.
+
+  The inline `[lifecycle].notify` goes through the same SSRF guard as
+  `[[notification]]` (https-only, no loopback). For loopback orchestrator
+  delivery, use `PITBOSS_PARENT_NOTIFY_URL` — that env-var path is
+  operator-trusted and bypasses the manifest-author SSRF guard for
+  exactly that case.
+
+  The `RunDispatched` event payload now carries `survive_parent: bool`
+  so the orchestrator can decide whether to include this run's process
+  group in any cancel-tree-walk it performs:
+
+  ```json
+  {
+    "kind":           "run_dispatched",
+    "run_id":         "019d...",
+    "parent_run_id":  "019c...",
+    "manifest_path":  "/work/child.toml",
+    "mode":           "flat",
+    "survive_parent": true
+  }
+  ```
+
+  No actual cancel-cascade behavior change ships in this PR — the
+  manifest declares intent; how the orchestrator acts on it (tree-walk
+  exclusion, signal handling) is the orchestrator's call. The
+  RacerX-side plumbing for tree-walk exclusion is tracked separately.
+
 - **`pitboss list [--active] [--json]`** — flat-CLI inventory of recent runs
   under `~/.local/share/pitboss/runs/`. Mirrors the `pitboss-tui list`
   output but without depending on the TUI binary, so orchestrators (RacerX,

--- a/book/src/operator-guide/notifications.md
+++ b/book/src/operator-guide/notifications.md
@@ -134,3 +134,47 @@ Sample `run_dispatched` payload:
 ```
 
 `parent_run_id` is `null` for top-level dispatches.
+
+## `[lifecycle]` section: surviving the parent (v0.10+)
+
+A second control on the same orchestrator-visibility theme: the optional
+`[lifecycle]` section lets a manifest formally declare that this dispatch
+is allowed to outlive the process that spawned it. Use case: an agent's
+`pitboss dispatch <child.toml>` from inside its task worktree needs to
+keep running after the agent's lead claude exits or hits the orchestrator's
+task timeout.
+
+```toml
+[lifecycle]
+survive_parent = true
+notify = { kind = "webhook", url = "https://orchestrator.internal/events", events = ["run_dispatched", "run_finished"] }
+```
+
+`survive_parent`
+: Default `false` (matching pitboss's existing "dies with parent" posture). When set to `true`, the dispatcher communicates the intent via the `RunDispatched` event payload's `survive_parent` field — the orchestrator decides whether to exclude this run's process group from any cancel-tree-walk it performs.
+
+`notify` (optional)
+: Inline `[[notification]]`-style sink. Same shape and same SSRF rules (https-only, no loopback). When present, gets merged into the run's notification router alongside any top-level `[[notification]]` sections.
+
+### Validate-time coupling
+
+`pitboss validate` rejects `survive_parent = true` without a notification target. Either an inline `[lifecycle].notify` OR at least one top-level `[[notification]]` section satisfies the rule. The reasoning: an orchestrator that's losing process-level control of the run needs *some* signal that the run actually finished — a naked detachment with no out-of-band notify is the worst-orphan case the schema aims to prevent.
+
+If you intend to deliver lifecycle events solely via `PITBOSS_PARENT_NOTIFY_URL`, declare a no-cost `kind = "log"` notification block to satisfy the validate gate (the env-var sink is configured at dispatch-time and validate cannot see it):
+
+```toml
+[lifecycle]
+survive_parent = true
+
+[[notification]]
+kind = "log"
+events = ["run_dispatched", "run_finished"]
+```
+
+### When to use which
+
+| Case | Use |
+|---|---|
+| Loopback orchestrator on the same host | `PITBOSS_PARENT_NOTIFY_URL` env var (operator-trusted, bypasses SSRF guard) |
+| HTTPS endpoint on a non-loopback host | `[lifecycle].notify` or `[[notification]]` with `kind = "webhook"` |
+| Just want to cleanly outlive the parent | `[lifecycle].survive_parent = true` + any of the above |

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -1040,6 +1040,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -1415,6 +1416,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
         let sub_layer = std::sync::Arc::new(LayerState::new(
             run_id,

--- a/crates/pitboss-cli/src/dispatch/failure_detection.rs
+++ b/crates/pitboss-cli/src/dispatch/failure_detection.rs
@@ -687,6 +687,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
         let store: Arc<dyn pitboss_core::store::SessionStore> =
             Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
@@ -775,6 +776,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
         let store: Arc<dyn pitboss_core::store::SessionStore> =
             Arc::new(JsonFileStore::new(dir.path().to_path_buf()));

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -116,6 +116,10 @@ pub async fn run_hierarchical(
                 parent_run_id: parent_run_id.clone(),
                 manifest_path: manifest_path.display().to_string(),
                 mode: "hierarchical".to_string(),
+                survive_parent: resolved
+                    .lifecycle
+                    .as_ref()
+                    .is_some_and(|l| l.survive_parent),
             },
             Utc::now(),
         );

--- a/crates/pitboss-cli/src/dispatch/layer.rs
+++ b/crates/pitboss-cli/src/dispatch/layer.rs
@@ -423,6 +423,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(FakeSpawner::new(FakeScript::new()));

--- a/crates/pitboss-cli/src/dispatch/resume.rs
+++ b/crates/pitboss-cli/src/dispatch/resume.rs
@@ -541,6 +541,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
         std::fs::write(
             run_dir.join("resolved.json"),
@@ -648,6 +649,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
         std::fs::write(
             run_dir.join("resolved.json"),
@@ -758,6 +760,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
         std::fs::write(
             run_dir.join("resolved.json"),

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -275,6 +275,10 @@ pub async fn execute(
                 parent_run_id: parent_run_id.clone(),
                 manifest_path: manifest_path.display().to_string(),
                 mode: "flat".to_string(),
+                survive_parent: resolved
+                    .lifecycle
+                    .as_ref()
+                    .is_some_and(|l| l.survive_parent),
             },
             Utc::now(),
         );
@@ -1086,6 +1090,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         }
     }
 
@@ -1228,6 +1233,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
 
         // Script: first call succeeds, second call fails. FakeSpawner is single-shot,
@@ -1318,6 +1324,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
 
         let spawner = Arc::new(CyclingFake(
@@ -1421,6 +1428,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
 
         let spawner = Arc::new(CyclingFake(

--- a/crates/pitboss-cli/src/dispatch/signals.rs
+++ b/crates/pitboss-cli/src/dispatch/signals.rs
@@ -325,6 +325,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -410,6 +411,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -496,6 +496,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/src/manifest/metadata.rs
+++ b/crates/pitboss-cli/src/manifest/metadata.rs
@@ -13,8 +13,8 @@
 use pitboss_schema::SchemaSection;
 
 use super::schema::{
-    ApprovalRuleSpec, ContainerConfig, Defaults, Lead, McpServerSpec, MountSpec, RunConfig,
-    SubleadDefaults, Task, Template,
+    ApprovalRuleSpec, ContainerConfig, Defaults, Lead, Lifecycle, McpServerSpec, MountSpec,
+    RunConfig, SubleadDefaults, Task, Template,
 };
 
 /// Walk every section of the v0.9 manifest schema in declaration order.
@@ -73,6 +73,11 @@ pub fn sections() -> Vec<SchemaSection> {
             toml_path: "[[template]]",
             type_name: "Template",
             fields: Template::field_metadata(),
+        },
+        SchemaSection {
+            toml_path: "[lifecycle]",
+            type_name: "Lifecycle",
+            fields: Lifecycle::field_metadata(),
         },
     ]
 }

--- a/crates/pitboss-cli/src/manifest/resolve.rs
+++ b/crates/pitboss-cli/src/manifest/resolve.rs
@@ -125,6 +125,11 @@ pub struct ResolvedManifest {
     pub container: Option<ContainerConfig>,
     #[serde(default)]
     pub mcp_servers: Vec<crate::manifest::schema::McpServerSpec>,
+    /// Resolved `[lifecycle]` section. `None` when the manifest omits it
+    /// entirely (the common case — pitboss's default semantics apply: dies
+    /// with parent, no out-of-band lifecycle notify expected).
+    #[serde(default)]
+    pub lifecycle: Option<crate::manifest::schema::Lifecycle>,
 }
 
 const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
@@ -213,6 +218,7 @@ pub fn resolve(
         approval_rules,
         container: manifest.container,
         mcp_servers: manifest.mcp_servers,
+        lifecycle: manifest.lifecycle,
     })
 }
 

--- a/crates/pitboss-cli/src/manifest/schema.rs
+++ b/crates/pitboss-cli/src/manifest/schema.rs
@@ -195,6 +195,66 @@ pub struct Manifest {
     /// External MCP servers injected into all actor configs.
     #[serde(default, rename = "mcp_server")]
     pub mcp_servers: Vec<McpServerSpec>,
+    /// Optional `[lifecycle]` section: declares run-survival semantics and
+    /// orchestrator notification expectations. See [`Lifecycle`] for the
+    /// coupling rules enforced at validate time.
+    #[serde(default)]
+    pub lifecycle: Option<Lifecycle>,
+}
+
+/// `[lifecycle]` manifest section. Two coupled controls:
+///
+/// - `survive_parent` — opt in to outliving the process that spawned this
+///   `pitboss dispatch`. Default `false` (the dispatch dies with its parent,
+///   matching pitboss's existing "controlled cancellation" posture).
+///
+/// - `notify` — optional inline `[[notification]]`-style sink declaration,
+///   convenient for "I want this run's lifecycle events sent to a specific
+///   place without needing a separate `[[notification]]` block." Reuses the
+///   existing [`crate::notify::config::NotificationConfig`] shape, so the
+///   same SSRF rules apply (https-only, no loopback). Operators wanting
+///   loopback orchestrator delivery should use `PITBOSS_PARENT_NOTIFY_URL`
+///   instead — the env-var path is operator-trusted and bypasses the
+///   manifest-author SSRF guard.
+///
+/// Coupling enforced at [`crate::manifest::validate`] time:
+/// `survive_parent = true` requires AT LEAST ONE of:
+///   - this section's `notify` field set, OR
+///   - at least one `[[notification]]` section declared at the manifest top
+///     level
+///
+/// A naked `survive_parent = true` with no notification target is rejected
+/// because the orchestrator that's losing process-level control over the
+/// run needs SOME signal that the run actually finished.
+///
+/// Why we don't ALSO accept `PITBOSS_PARENT_NOTIFY_URL` as satisfying the
+/// coupling at validate time: validate runs against the manifest in
+/// isolation (CI gate, pre-flight check) and cannot see the env vars that
+/// will be present at the eventual `pitboss dispatch` invocation. The
+/// dispatch-time check (in addition) verifies a router actually got built;
+/// if the operator relies solely on the env-var path, the manifest must
+/// still declare at least a no-cost `kind = "log"` notification to satisfy
+/// the validate gate.
+#[derive(Debug, Clone, Deserialize, Serialize, Default, FieldMetadata)]
+#[serde(deny_unknown_fields)]
+pub struct Lifecycle {
+    /// Opt-in: this dispatch is allowed to outlive its parent process.
+    /// Pitboss communicates the intent via the [`crate::notify::PitbossEvent::RunDispatched`]
+    /// event payload; the orchestrator decides whether to exclude the
+    /// sub-pitboss process group from any cancel-tree-walk it performs.
+    /// Default: `false`.
+    #[serde(default)]
+    #[field(
+        label = "Survive parent",
+        help = "Allow this dispatch to outlive its parent process. Requires a notify target."
+    )]
+    pub survive_parent: bool,
+    /// Optional inline `[[notification]]`-style sink. When present, gets
+    /// merged into the run's notification router alongside any top-level
+    /// `[[notification]]` sections.
+    #[serde(default)]
+    #[field(skip)]
+    pub notify: Option<crate::notify::config::NotificationConfig>,
 }
 
 /// TOML schema for a single `[[approval_policy]]` rule.

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -24,6 +24,7 @@ fn validate_inner(resolved: &ResolvedManifest, skip_dir_check: bool) -> Result<(
     for cfg in &resolved.notifications {
         crate::notify::config::validate(cfg)?;
     }
+    validate_lifecycle(resolved)?;
     if resolved.lead.is_some() {
         validate_lead(resolved, skip_dir_check)?;
         validate_hierarchical_ranges(resolved)?;
@@ -35,6 +36,43 @@ fn validate_inner(resolved: &ResolvedManifest, skip_dir_check: bool) -> Result<(
         }
         validate_branch_conflicts(resolved)?;
         validate_ranges(resolved)?;
+    }
+    Ok(())
+}
+
+/// Enforce the `[lifecycle]` coupling rule (issue #133): a manifest that
+/// declares `survive_parent = true` must declare at least one notification
+/// target so the orchestrator can observe the run's outcome after losing
+/// process-level control of it. Either an inline `[lifecycle].notify` or a
+/// top-level `[[notification]]` section satisfies the rule.
+///
+/// Validates the inline notify spec (when present) using the same SSRF /
+/// scheme rules as `[[notification]]`. The error explicitly points at the
+/// fix so an operator using only `PITBOSS_PARENT_NOTIFY_URL` knows to add a
+/// no-cost `kind = "log"` notification block.
+fn validate_lifecycle(r: &ResolvedManifest) -> Result<()> {
+    let Some(lifecycle) = &r.lifecycle else {
+        return Ok(());
+    };
+    if let Some(notify) = &lifecycle.notify {
+        crate::notify::config::validate(notify)?;
+    }
+    if lifecycle.survive_parent {
+        let has_inline_notify = lifecycle.notify.is_some();
+        let has_top_level_notify = !r.notifications.is_empty();
+        if !has_inline_notify && !has_top_level_notify {
+            bail!(
+                "[lifecycle] survive_parent = true requires a notification target so the \
+                 orchestrator can observe run completion. Add either:\n  \
+                 - a [lifecycle.notify] inline sink (same shape as [[notification]]), or\n  \
+                 - at least one top-level [[notification]] section.\n\
+                 If you intend to deliver lifecycle events via the \
+                 PITBOSS_PARENT_NOTIFY_URL env var, also declare a no-cost \
+                 [[notification]]\n  kind = \"log\"\n\
+                 to satisfy this validate-time gate (the env-var sink is configured at \
+                 dispatch-time and validate cannot see it)."
+            );
+        }
     }
     Ok(())
 }
@@ -452,6 +490,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         }
     }
 
@@ -478,6 +517,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
         f(&mut m);
         m
@@ -560,6 +600,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
         let err = validate(&r).unwrap_err().to_string();
         assert!(
@@ -589,6 +630,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
         assert!(validate(&r).is_err());
     }
@@ -614,6 +656,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
         assert!(validate(&r).is_err());
     }
@@ -644,6 +687,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
         (d, r)
     }
@@ -755,6 +799,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
         let err = validate(&r).unwrap_err().to_string();
         assert!(err.contains("empty manifest"), "got: {err}");
@@ -805,6 +850,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
         let err = validate(&r).unwrap_err().to_string();
         assert!(
@@ -836,6 +882,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
         assert!(validate(&r).is_err());
     }
@@ -915,5 +962,94 @@ mod tests {
         let parse_err: Result<super::super::schema::Manifest, _> = toml::from_str(src);
         let translated = translate_legacy_parse_error(&parse_err.unwrap_err(), src);
         assert!(translated.is_none());
+    }
+
+    fn log_notification() -> crate::notify::config::NotificationConfig {
+        crate::notify::config::NotificationConfig {
+            kind: crate::notify::config::SinkKind::Log,
+            url: None,
+            events: None,
+            severity_min: crate::notify::Severity::Info,
+        }
+    }
+
+    #[test]
+    fn lifecycle_survive_parent_with_top_level_notification_is_ok() {
+        let d = with_tmp_repo(true);
+        let mut m = rm(vec![rt("t", d.path().to_path_buf(), false, None)]);
+        m.notifications.push(log_notification());
+        m.lifecycle = Some(crate::manifest::schema::Lifecycle {
+            survive_parent: true,
+            notify: None,
+        });
+        validate(&m).expect("top-level notification satisfies the coupling");
+    }
+
+    #[test]
+    fn lifecycle_survive_parent_with_inline_notify_is_ok() {
+        let d = with_tmp_repo(true);
+        let mut m = rm(vec![rt("t", d.path().to_path_buf(), false, None)]);
+        m.lifecycle = Some(crate::manifest::schema::Lifecycle {
+            survive_parent: true,
+            notify: Some(log_notification()),
+        });
+        validate(&m).expect("inline lifecycle.notify satisfies the coupling");
+    }
+
+    #[test]
+    fn lifecycle_survive_parent_without_any_notification_is_rejected() {
+        let d = with_tmp_repo(true);
+        let mut m = rm(vec![rt("t", d.path().to_path_buf(), false, None)]);
+        m.lifecycle = Some(crate::manifest::schema::Lifecycle {
+            survive_parent: true,
+            notify: None,
+        });
+        let err = validate(&m).expect_err("naked survive_parent must fail");
+        let msg = format!("{err:?}");
+        assert!(msg.contains("survive_parent = true"), "msg: {msg}");
+        assert!(msg.contains("notification target"), "msg: {msg}");
+        assert!(msg.contains("PITBOSS_PARENT_NOTIFY_URL"), "msg: {msg}");
+    }
+
+    #[test]
+    fn lifecycle_survive_parent_false_does_not_require_notify() {
+        let d = with_tmp_repo(true);
+        let mut m = rm(vec![rt("t", d.path().to_path_buf(), false, None)]);
+        m.lifecycle = Some(crate::manifest::schema::Lifecycle {
+            survive_parent: false,
+            notify: None,
+        });
+        validate(&m).expect("survive_parent=false has no coupling requirement");
+    }
+
+    #[test]
+    fn lifecycle_inline_notify_runs_through_ssrf_guard() {
+        let d = with_tmp_repo(true);
+        let mut m = rm(vec![rt("t", d.path().to_path_buf(), false, None)]);
+        m.lifecycle = Some(crate::manifest::schema::Lifecycle {
+            survive_parent: true,
+            notify: Some(crate::notify::config::NotificationConfig {
+                kind: crate::notify::config::SinkKind::Webhook,
+                url: Some("http://localhost/hook".to_string()),
+                events: None,
+                severity_min: crate::notify::Severity::Info,
+            }),
+        });
+        // The inline notify gets validated by the same logic as
+        // [[notification]] — http:// + loopback should be refused. Operators
+        // who need loopback should use PITBOSS_PARENT_NOTIFY_URL.
+        let err = validate(&m).expect_err("inline notify must obey SSRF rules");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("https://") || msg.contains("loopback"),
+            "msg: {msg}"
+        );
+    }
+
+    #[test]
+    fn lifecycle_omitted_section_is_unchanged_behavior() {
+        let d = with_tmp_repo(true);
+        let m = rm(vec![rt("t", d.path().to_path_buf(), false, None)]);
+        validate(&m).expect("manifests without [lifecycle] continue to validate");
     }
 }

--- a/crates/pitboss-cli/src/mcp/approval.rs
+++ b/crates/pitboss-cli/src/mcp/approval.rs
@@ -360,6 +360,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -1144,6 +1144,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();
@@ -1211,6 +1212,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -2390,6 +2390,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();
@@ -2857,6 +2858,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();
@@ -3474,6 +3476,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let script = FakeScript::new().hold_until_signal();
@@ -3565,6 +3568,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let script = FakeScript::new().hold_until_signal();
@@ -3664,6 +3668,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let script = FakeScript::new().hold_until_signal();

--- a/crates/pitboss-cli/src/notify/mod.rs
+++ b/crates/pitboss-cli/src/notify/mod.rs
@@ -55,6 +55,12 @@ pub enum PitbossEvent {
         manifest_path: String,
         /// "flat" or "hierarchical".
         mode: String,
+        /// Resolved value of `[lifecycle].survive_parent` from the manifest.
+        /// `false` for manifests without a `[lifecycle]` section. Lets the
+        /// orchestrator decide whether to include this run's process group
+        /// in any cancel-tree-walk it performs (issue #133-A).
+        #[serde(default)]
+        survive_parent: bool,
     },
     RunFinished {
         run_id: String,
@@ -317,6 +323,46 @@ mod tests {
         let s = serde_json::to_string(&ev).unwrap();
         assert!(s.contains("\"kind\":\"run_finished\""));
         assert!(s.contains("\"tasks_failed\":1"));
+    }
+
+    #[test]
+    fn pitboss_event_run_dispatched_roundtrip_carries_survive_parent() {
+        // Regression for issue #133-A: the `survive_parent` field must
+        // serialize so the orchestrator can decide whether to include this
+        // run's process group in any cancel-tree-walk it performs.
+        let ev = PitbossEvent::RunDispatched {
+            run_id: "019d-child".into(),
+            parent_run_id: Some("019c-parent".into()),
+            manifest_path: "/work/c.toml".into(),
+            mode: "flat".into(),
+            survive_parent: true,
+        };
+        let s = serde_json::to_string(&ev).unwrap();
+        assert!(s.contains("\"kind\":\"run_dispatched\""));
+        assert!(s.contains("\"survive_parent\":true"));
+        let back: PitbossEvent = serde_json::from_str(&s).unwrap();
+        match back {
+            PitbossEvent::RunDispatched { survive_parent, .. } => assert!(survive_parent),
+            other => panic!("expected RunDispatched, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pitboss_event_run_dispatched_back_compat_default_survive_parent_false() {
+        // A pre-#133-A producer that omits `survive_parent` must still
+        // deserialize cleanly with the field defaulting to false.
+        let json = r#"{
+            "kind":"run_dispatched",
+            "run_id":"019d-x",
+            "parent_run_id":null,
+            "manifest_path":"/x",
+            "mode":"flat"
+        }"#;
+        let ev: PitbossEvent = serde_json::from_str(json).unwrap();
+        match ev {
+            PitbossEvent::RunDispatched { survive_parent, .. } => assert!(!survive_parent),
+            other => panic!("expected RunDispatched, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/pitboss-cli/src/notify/parent.rs
+++ b/crates/pitboss-cli/src/notify/parent.rs
@@ -223,6 +223,7 @@ mod tests {
                 parent_run_id: Some("parent-run-7".into()),
                 manifest_path: "/work/child.toml".into(),
                 mode: "flat".into(),
+                survive_parent: false,
             },
             Utc::now(),
         );

--- a/crates/pitboss-cli/src/notify/sinks/discord.rs
+++ b/crates/pitboss-cli/src/notify/sinks/discord.rs
@@ -67,16 +67,23 @@ impl DiscordSink {
                 parent_run_id,
                 manifest_path,
                 mode,
+                survive_parent,
             } => {
                 let parent_line = parent_run_id.as_deref().map_or(String::new(), |p| {
                     format!("\n**Parent:** {}", escape_discord_md(p))
                 });
+                let survive_line = if *survive_parent {
+                    "\n**Survives parent:** yes".to_string()
+                } else {
+                    String::new()
+                };
                 let desc = format!(
-                    "**Run:** {}\n**Manifest:** {}\n**Mode:** {}{}",
+                    "**Run:** {}\n**Manifest:** {}\n**Mode:** {}{}{}",
                     escape_discord_md(run_id),
                     escape_discord_md(manifest_path),
                     escape_discord_md(mode),
                     parent_line,
+                    survive_line,
                 );
                 ("🚀 Pitboss run dispatched".to_string(), desc)
             }

--- a/crates/pitboss-cli/src/notify/sinks/slack.rs
+++ b/crates/pitboss-cli/src/notify/sinks/slack.rs
@@ -67,17 +67,24 @@ impl SlackSink {
                 parent_run_id,
                 manifest_path,
                 mode,
+                survive_parent,
             } => {
                 let header = format!("{} Pitboss run dispatched", emoji);
                 let parent_line = parent_run_id.as_deref().map_or(String::new(), |p| {
                     format!("\n*Parent:* {}", escape_slack_mrkdwn(p))
                 });
+                let survive_line = if *survive_parent {
+                    "\n*Survives parent:* yes".to_string()
+                } else {
+                    String::new()
+                };
                 let detail = format!(
-                    "*Run:* {}\n*Manifest:* {}\n*Mode:* {}{}",
+                    "*Run:* {}\n*Manifest:* {}\n*Mode:* {}{}{}",
                     escape_slack_mrkdwn(run_id),
                     escape_slack_mrkdwn(manifest_path),
                     escape_slack_mrkdwn(mode),
                     parent_line,
+                    survive_line,
                 );
                 (header, detail)
             }

--- a/crates/pitboss-cli/tests/control_flows.rs
+++ b/crates/pitboss-cli/tests/control_flows.rs
@@ -52,6 +52,7 @@ async fn pause_op_writes_events_jsonl() {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -256,6 +257,7 @@ async fn block_policy_queue_drains_on_tui_connect() {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -369,6 +371,7 @@ async fn auto_approve_policy_responds_without_tui() {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -429,6 +432,7 @@ async fn auto_reject_policy_responds_without_tui() {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -497,6 +501,7 @@ async fn propose_plan_end_to_end_unblocks_spawn_gate() {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());

--- a/crates/pitboss-cli/tests/dogfood_fake_flows.rs
+++ b/crates/pitboss-cli/tests/dogfood_fake_flows.rs
@@ -92,6 +92,7 @@ fn mk_state_with_subleads() -> (TempDir, Arc<DispatchState>) {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();
@@ -1040,6 +1041,7 @@ async fn dogfood_envelope_cap_rejection() {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            lifecycle: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/tests/e2e_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_flows.rs
@@ -77,6 +77,7 @@ fn mk_state(
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(run_dir.to_path_buf()));
     // Worker-side spawner: emits a complete stream-json run then exits 0.
@@ -377,6 +378,7 @@ async fn e2e_lead_cancels_worker_mid_flight() {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let hold_script = FakeScript::new().hold_until_signal();
@@ -631,6 +633,7 @@ async fn e2e_lead_reprompts_running_worker() {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     // Worker script emits init+result so session_id gets captured via the
@@ -820,6 +823,7 @@ async fn e2e_lead_propose_plan_gate_unblocks_spawn() {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let worker_script = FakeScript::new()
@@ -1119,6 +1123,7 @@ async fn e2e_freeze_pause_and_continue_real_subprocess_worker() {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(FakeClaudeWorkerSpawner {

--- a/crates/pitboss-cli/tests/e2e_sublead_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_sublead_flows.rs
@@ -77,6 +77,7 @@ fn mk_state(dir: &std::path::Path) -> (Uuid, Arc<DispatchState>) {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.to_path_buf()));
     let worker_script = FakeScript::new()
@@ -146,6 +147,7 @@ fn mk_state_hold_workers(dir: &std::path::Path) -> (Uuid, Arc<DispatchState>) {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.to_path_buf()));
     let hold_script = FakeScript::new().hold_until_signal();
@@ -789,6 +791,7 @@ async fn sublead_session_spawns_runs_and_reconciles() {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        lifecycle: None,
     };
 
     let store: std::sync::Arc<dyn pitboss_core::store::SessionStore> = std::sync::Arc::new(

--- a/crates/pitboss-cli/tests/hierarchical_flows.rs
+++ b/crates/pitboss-cli/tests/hierarchical_flows.rs
@@ -60,6 +60,7 @@ fn mk_state() -> (TempDir, Arc<DispatchState>) {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/tests/notify_flows.rs
+++ b/crates/pitboss-cli/tests/notify_flows.rs
@@ -254,6 +254,7 @@ async fn approval_pending_notification_fires_on_enqueue() {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());

--- a/crates/pitboss-cli/tests/shared_store_flows.rs
+++ b/crates/pitboss-cli/tests/shared_store_flows.rs
@@ -462,6 +462,7 @@ async fn lease_released_when_mcp_connection_drops() {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        lifecycle: None,
     };
     let store_trait: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().into()));
     let run_id = Uuid::now_v7();
@@ -601,6 +602,7 @@ async fn run_global_lease_released_when_mcp_connection_drops() {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        lifecycle: None,
     };
     let store_trait: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().into()));
     let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/tests/sublead_flows.rs
+++ b/crates/pitboss-cli/tests/sublead_flows.rs
@@ -60,6 +60,7 @@ fn mk_state_with_subleads() -> (TempDir, Arc<DispatchState>) {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();
@@ -126,6 +127,7 @@ fn mk_state_with_sublead_budget_cap(cap: f64) -> (TempDir, Arc<DispatchState>) {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();

--- a/docs/manifest-map.md
+++ b/docs/manifest-map.md
@@ -14,31 +14,31 @@ The annotated example lives at [`pitboss.example.toml`](../pitboss.example.toml)
 
 ## `[run]` — `RunConfig`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:244`](../crates/pitboss-cli/src/manifest/schema.rs#L244).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:304`](../crates/pitboss-cli/src/manifest/schema.rs#L304).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `max_parallel_tasks` | integer | no | Flat-mode concurrency cap for [[task]] runs. Default 4. Overridden by ANTHROPIC_MAX_CONCURRENT. | [`../crates/pitboss-cli/src/manifest/schema.rs#L251`](../crates/pitboss-cli/src/manifest/schema.rs#L251) |
-| `halt_on_failure` | boolean | no | Stop remaining flat-mode tasks on first failure. | [`../crates/pitboss-cli/src/manifest/schema.rs#L258`](../crates/pitboss-cli/src/manifest/schema.rs#L258) |
-| `run_dir` | path | no | Where per-run artifacts land. Default ~/.local/share/pitboss/runs. | [`../crates/pitboss-cli/src/manifest/schema.rs#L264`](../crates/pitboss-cli/src/manifest/schema.rs#L264) |
-| `worktree_cleanup` | enum (`always` \| `on_success` \| `never`) | no | What to do with each worker's git worktree after it finishes. | [`../crates/pitboss-cli/src/manifest/schema.rs#L272`](../crates/pitboss-cli/src/manifest/schema.rs#L272) |
-| `emit_event_stream` | boolean | no | Write a JSONL event stream alongside summary.jsonl. | [`../crates/pitboss-cli/src/manifest/schema.rs#L279`](../crates/pitboss-cli/src/manifest/schema.rs#L279) |
-| `default_approval_policy` | enum (`block` \| `auto_approve` \| `auto_reject`) | no | Default action for request_approval / propose_plan when no TUI is attached and no rule matches. | [`../crates/pitboss-cli/src/manifest/schema.rs#L290`](../crates/pitboss-cli/src/manifest/schema.rs#L290) |
-| `dump_shared_store` | boolean | no | Write shared-store.json into the run directory on finalize. | [`../crates/pitboss-cli/src/manifest/schema.rs#L298`](../crates/pitboss-cli/src/manifest/schema.rs#L298) |
-| `require_plan_approval` | boolean | no | When true, spawn_worker is blocked until propose_plan has been approved. | [`../crates/pitboss-cli/src/manifest/schema.rs#L306`](../crates/pitboss-cli/src/manifest/schema.rs#L306) |
+| `max_parallel_tasks` | integer | no | Flat-mode concurrency cap for [[task]] runs. Default 4. Overridden by ANTHROPIC_MAX_CONCURRENT. | [`../crates/pitboss-cli/src/manifest/schema.rs#L311`](../crates/pitboss-cli/src/manifest/schema.rs#L311) |
+| `halt_on_failure` | boolean | no | Stop remaining flat-mode tasks on first failure. | [`../crates/pitboss-cli/src/manifest/schema.rs#L318`](../crates/pitboss-cli/src/manifest/schema.rs#L318) |
+| `run_dir` | path | no | Where per-run artifacts land. Default ~/.local/share/pitboss/runs. | [`../crates/pitboss-cli/src/manifest/schema.rs#L324`](../crates/pitboss-cli/src/manifest/schema.rs#L324) |
+| `worktree_cleanup` | enum (`always` \| `on_success` \| `never`) | no | What to do with each worker's git worktree after it finishes. | [`../crates/pitboss-cli/src/manifest/schema.rs#L332`](../crates/pitboss-cli/src/manifest/schema.rs#L332) |
+| `emit_event_stream` | boolean | no | Write a JSONL event stream alongside summary.jsonl. | [`../crates/pitboss-cli/src/manifest/schema.rs#L339`](../crates/pitboss-cli/src/manifest/schema.rs#L339) |
+| `default_approval_policy` | enum (`block` \| `auto_approve` \| `auto_reject`) | no | Default action for request_approval / propose_plan when no TUI is attached and no rule matches. | [`../crates/pitboss-cli/src/manifest/schema.rs#L350`](../crates/pitboss-cli/src/manifest/schema.rs#L350) |
+| `dump_shared_store` | boolean | no | Write shared-store.json into the run directory on finalize. | [`../crates/pitboss-cli/src/manifest/schema.rs#L358`](../crates/pitboss-cli/src/manifest/schema.rs#L358) |
+| `require_plan_approval` | boolean | no | When true, spawn_worker is blocked until propose_plan has been approved. | [`../crates/pitboss-cli/src/manifest/schema.rs#L366`](../crates/pitboss-cli/src/manifest/schema.rs#L366) |
 
 ## `[defaults]` — `Defaults`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:338`](../crates/pitboss-cli/src/manifest/schema.rs#L338).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:398`](../crates/pitboss-cli/src/manifest/schema.rs#L398).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `model` | text | no | Claude model id (e.g. claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-7). | [`../crates/pitboss-cli/src/manifest/schema.rs#L343`](../crates/pitboss-cli/src/manifest/schema.rs#L343) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Maps to the claude --effort flag. | [`../crates/pitboss-cli/src/manifest/schema.rs#L349`](../crates/pitboss-cli/src/manifest/schema.rs#L349) |
-| `tools` | string list | no | Allowed tool surface. Pitboss auto-appends its MCP tools for leads and workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L354`](../crates/pitboss-cli/src/manifest/schema.rs#L354) |
-| `timeout_secs` | integer | no | Per-task wall-clock cap. No default (no cap). | [`../crates/pitboss-cli/src/manifest/schema.rs#L359`](../crates/pitboss-cli/src/manifest/schema.rs#L359) |
-| `use_worktree` | boolean | no | Isolate each worker in a git worktree. Default true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L364`](../crates/pitboss-cli/src/manifest/schema.rs#L364) |
-| `env` | key-value map | no | Environment variables passed to the claude subprocess. | [`../crates/pitboss-cli/src/manifest/schema.rs#L370`](../crates/pitboss-cli/src/manifest/schema.rs#L370) |
+| `model` | text | no | Claude model id (e.g. claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-7). | [`../crates/pitboss-cli/src/manifest/schema.rs#L403`](../crates/pitboss-cli/src/manifest/schema.rs#L403) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Maps to the claude --effort flag. | [`../crates/pitboss-cli/src/manifest/schema.rs#L409`](../crates/pitboss-cli/src/manifest/schema.rs#L409) |
+| `tools` | string list | no | Allowed tool surface. Pitboss auto-appends its MCP tools for leads and workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L414`](../crates/pitboss-cli/src/manifest/schema.rs#L414) |
+| `timeout_secs` | integer | no | Per-task wall-clock cap. No default (no cap). | [`../crates/pitboss-cli/src/manifest/schema.rs#L419`](../crates/pitboss-cli/src/manifest/schema.rs#L419) |
+| `use_worktree` | boolean | no | Isolate each worker in a git worktree. Default true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L424`](../crates/pitboss-cli/src/manifest/schema.rs#L424) |
+| `env` | key-value map | no | Environment variables passed to the claude subprocess. | [`../crates/pitboss-cli/src/manifest/schema.rs#L430`](../crates/pitboss-cli/src/manifest/schema.rs#L430) |
 
 ## `[container]` — `ContainerConfig`
 
@@ -63,66 +63,66 @@ Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:109`](../crates/pitbos
 
 ## `[[task]]` — `Task`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:401`](../crates/pitboss-cli/src/manifest/schema.rs#L401).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:461`](../crates/pitboss-cli/src/manifest/schema.rs#L461).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique slug. Alphanumeric + _ + -. Used in logs and worktree names. | [`../crates/pitboss-cli/src/manifest/schema.rs#L406`](../crates/pitboss-cli/src/manifest/schema.rs#L406) |
-| `directory` | path | **yes** | Working directory. Must be inside a git repo if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L411`](../crates/pitboss-cli/src/manifest/schema.rs#L411) |
-| `prompt` | text (multi-line) | no | Prompt body sent to claude via -p. Mutually exclusive with `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L417`](../crates/pitboss-cli/src/manifest/schema.rs#L417) |
-| `template` | text | no | Reference to a [[template]] entry. Mutually exclusive with `prompt`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L422`](../crates/pitboss-cli/src/manifest/schema.rs#L422) |
-| `vars` | key-value map | no | Substitutions for {placeholders} when using `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L428`](../crates/pitboss-cli/src/manifest/schema.rs#L428) |
-| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L433`](../crates/pitboss-cli/src/manifest/schema.rs#L433) |
-| `model` | text | no | Per-task override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L435`](../crates/pitboss-cli/src/manifest/schema.rs#L435) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-task override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L441`](../crates/pitboss-cli/src/manifest/schema.rs#L441) |
-| `tools` | string list | no | Per-task override of [defaults].tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L443`](../crates/pitboss-cli/src/manifest/schema.rs#L443) |
-| `timeout_secs` | integer | no | Per-task wall-clock cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L445`](../crates/pitboss-cli/src/manifest/schema.rs#L445) |
-| `use_worktree` | boolean | no | Per-task override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L450`](../crates/pitboss-cli/src/manifest/schema.rs#L450) |
-| `env` | key-value map | no | Per-task env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L456`](../crates/pitboss-cli/src/manifest/schema.rs#L456) |
+| `id` | text | **yes** | Unique slug. Alphanumeric + _ + -. Used in logs and worktree names. | [`../crates/pitboss-cli/src/manifest/schema.rs#L466`](../crates/pitboss-cli/src/manifest/schema.rs#L466) |
+| `directory` | path | **yes** | Working directory. Must be inside a git repo if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L471`](../crates/pitboss-cli/src/manifest/schema.rs#L471) |
+| `prompt` | text (multi-line) | no | Prompt body sent to claude via -p. Mutually exclusive with `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L477`](../crates/pitboss-cli/src/manifest/schema.rs#L477) |
+| `template` | text | no | Reference to a [[template]] entry. Mutually exclusive with `prompt`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L482`](../crates/pitboss-cli/src/manifest/schema.rs#L482) |
+| `vars` | key-value map | no | Substitutions for {placeholders} when using `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L488`](../crates/pitboss-cli/src/manifest/schema.rs#L488) |
+| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L493`](../crates/pitboss-cli/src/manifest/schema.rs#L493) |
+| `model` | text | no | Per-task override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L495`](../crates/pitboss-cli/src/manifest/schema.rs#L495) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-task override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L501`](../crates/pitboss-cli/src/manifest/schema.rs#L501) |
+| `tools` | string list | no | Per-task override of [defaults].tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L503`](../crates/pitboss-cli/src/manifest/schema.rs#L503) |
+| `timeout_secs` | integer | no | Per-task wall-clock cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L505`](../crates/pitboss-cli/src/manifest/schema.rs#L505) |
+| `use_worktree` | boolean | no | Per-task override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L510`](../crates/pitboss-cli/src/manifest/schema.rs#L510) |
+| `env` | key-value map | no | Per-task env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L516`](../crates/pitboss-cli/src/manifest/schema.rs#L516) |
 
 ## `[lead]` — `Lead`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:466`](../crates/pitboss-cli/src/manifest/schema.rs#L466).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:526`](../crates/pitboss-cli/src/manifest/schema.rs#L526).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique slug used as the TUI tile label and in run artifact paths. | [`../crates/pitboss-cli/src/manifest/schema.rs#L473`](../crates/pitboss-cli/src/manifest/schema.rs#L473) |
-| `directory` | path | **yes** | Working directory for the lead's claude subprocess. Must be a git work-tree if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L480`](../crates/pitboss-cli/src/manifest/schema.rs#L480) |
-| `prompt` | text (multi-line) | **yes** | Operator instructions passed to claude via -p. Must appear before any [lead.X] subtable in the source. | [`../crates/pitboss-cli/src/manifest/schema.rs#L492`](../crates/pitboss-cli/src/manifest/schema.rs#L492) |
-| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L500`](../crates/pitboss-cli/src/manifest/schema.rs#L500) |
-| `model` | text | no | Per-lead override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L503`](../crates/pitboss-cli/src/manifest/schema.rs#L503) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-lead override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L510`](../crates/pitboss-cli/src/manifest/schema.rs#L510) |
-| `tools` | string list | no | Per-lead override of [defaults].tools. Pitboss auto-appends its MCP tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L516`](../crates/pitboss-cli/src/manifest/schema.rs#L516) |
-| `timeout_secs` | integer | no | Per-actor subprocess wall-clock cap (claude --timeout). | [`../crates/pitboss-cli/src/manifest/schema.rs#L522`](../crates/pitboss-cli/src/manifest/schema.rs#L522) |
-| `use_worktree` | boolean | no | Per-lead override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L528`](../crates/pitboss-cli/src/manifest/schema.rs#L528) |
-| `env` | key-value map | no | Per-lead env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L534`](../crates/pitboss-cli/src/manifest/schema.rs#L534) |
-| `max_workers` | integer | no | Hard cap on the lead's concurrent + queued worker pool (1–16). Required when the lead spawns workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L543`](../crates/pitboss-cli/src/manifest/schema.rs#L543) |
-| `budget_usd` | float | no | Soft cap on lead spend with reservation accounting. spawn_worker fails once spent + reserved + next_estimate > budget. | [`../crates/pitboss-cli/src/manifest/schema.rs#L552`](../crates/pitboss-cli/src/manifest/schema.rs#L552) |
-| `lead_timeout_secs` | integer | no | Wall-clock cap on the lead session. Default 3600. | [`../crates/pitboss-cli/src/manifest/schema.rs#L561`](../crates/pitboss-cli/src/manifest/schema.rs#L561) |
-| `permission_routing` | enum (`path_a` \| `path_b`) | no | path_a (default) makes pitboss the sole permission authority. path_b routes claude's gate through pitboss (rejected at validate time pending stabilization). | [`../crates/pitboss-cli/src/manifest/schema.rs#L574`](../crates/pitboss-cli/src/manifest/schema.rs#L574) |
-| `allow_subleads` | boolean | no | Expose spawn_sublead to the root lead. | [`../crates/pitboss-cli/src/manifest/schema.rs#L583`](../crates/pitboss-cli/src/manifest/schema.rs#L583) |
-| `max_subleads` | integer | no | Hard cap on total live sub-leads under this root. | [`../crates/pitboss-cli/src/manifest/schema.rs#L590`](../crates/pitboss-cli/src/manifest/schema.rs#L590) |
-| `max_sublead_budget_usd` | float | no | Cap on the per-sub-lead budget envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L597`](../crates/pitboss-cli/src/manifest/schema.rs#L597) |
-| `max_total_workers` | integer | no | Cap on total live workers across the entire tree (root + sub-trees). | [`../crates/pitboss-cli/src/manifest/schema.rs#L605`](../crates/pitboss-cli/src/manifest/schema.rs#L605) |
+| `id` | text | **yes** | Unique slug used as the TUI tile label and in run artifact paths. | [`../crates/pitboss-cli/src/manifest/schema.rs#L533`](../crates/pitboss-cli/src/manifest/schema.rs#L533) |
+| `directory` | path | **yes** | Working directory for the lead's claude subprocess. Must be a git work-tree if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L540`](../crates/pitboss-cli/src/manifest/schema.rs#L540) |
+| `prompt` | text (multi-line) | **yes** | Operator instructions passed to claude via -p. Must appear before any [lead.X] subtable in the source. | [`../crates/pitboss-cli/src/manifest/schema.rs#L552`](../crates/pitboss-cli/src/manifest/schema.rs#L552) |
+| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L560`](../crates/pitboss-cli/src/manifest/schema.rs#L560) |
+| `model` | text | no | Per-lead override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L563`](../crates/pitboss-cli/src/manifest/schema.rs#L563) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-lead override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L570`](../crates/pitboss-cli/src/manifest/schema.rs#L570) |
+| `tools` | string list | no | Per-lead override of [defaults].tools. Pitboss auto-appends its MCP tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L576`](../crates/pitboss-cli/src/manifest/schema.rs#L576) |
+| `timeout_secs` | integer | no | Per-actor subprocess wall-clock cap (claude --timeout). | [`../crates/pitboss-cli/src/manifest/schema.rs#L582`](../crates/pitboss-cli/src/manifest/schema.rs#L582) |
+| `use_worktree` | boolean | no | Per-lead override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L588`](../crates/pitboss-cli/src/manifest/schema.rs#L588) |
+| `env` | key-value map | no | Per-lead env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L594`](../crates/pitboss-cli/src/manifest/schema.rs#L594) |
+| `max_workers` | integer | no | Hard cap on the lead's concurrent + queued worker pool (1–16). Required when the lead spawns workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L603`](../crates/pitboss-cli/src/manifest/schema.rs#L603) |
+| `budget_usd` | float | no | Soft cap on lead spend with reservation accounting. spawn_worker fails once spent + reserved + next_estimate > budget. | [`../crates/pitboss-cli/src/manifest/schema.rs#L612`](../crates/pitboss-cli/src/manifest/schema.rs#L612) |
+| `lead_timeout_secs` | integer | no | Wall-clock cap on the lead session. Default 3600. | [`../crates/pitboss-cli/src/manifest/schema.rs#L621`](../crates/pitboss-cli/src/manifest/schema.rs#L621) |
+| `permission_routing` | enum (`path_a` \| `path_b`) | no | path_a (default) makes pitboss the sole permission authority. path_b routes claude's gate through pitboss (rejected at validate time pending stabilization). | [`../crates/pitboss-cli/src/manifest/schema.rs#L634`](../crates/pitboss-cli/src/manifest/schema.rs#L634) |
+| `allow_subleads` | boolean | no | Expose spawn_sublead to the root lead. | [`../crates/pitboss-cli/src/manifest/schema.rs#L643`](../crates/pitboss-cli/src/manifest/schema.rs#L643) |
+| `max_subleads` | integer | no | Hard cap on total live sub-leads under this root. | [`../crates/pitboss-cli/src/manifest/schema.rs#L650`](../crates/pitboss-cli/src/manifest/schema.rs#L650) |
+| `max_sublead_budget_usd` | float | no | Cap on the per-sub-lead budget envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L657`](../crates/pitboss-cli/src/manifest/schema.rs#L657) |
+| `max_total_workers` | integer | no | Cap on total live workers across the entire tree (root + sub-trees). | [`../crates/pitboss-cli/src/manifest/schema.rs#L665`](../crates/pitboss-cli/src/manifest/schema.rs#L665) |
 
 ## `[sublead_defaults]` — `SubleadDefaults`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:612`](../crates/pitboss-cli/src/manifest/schema.rs#L612).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:672`](../crates/pitboss-cli/src/manifest/schema.rs#L672).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `budget_usd` | float | no | Per-sub-lead envelope when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L617`](../crates/pitboss-cli/src/manifest/schema.rs#L617) |
-| `max_workers` | integer | no | Per-sub-lead worker pool when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L622`](../crates/pitboss-cli/src/manifest/schema.rs#L622) |
-| `lead_timeout_secs` | integer | no | Wall-clock cap for the sub-lead session. | [`../crates/pitboss-cli/src/manifest/schema.rs#L627`](../crates/pitboss-cli/src/manifest/schema.rs#L627) |
-| `read_down` | boolean | no | When true, sub-lead shares root's budget + worker pool instead of carving its own envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L633`](../crates/pitboss-cli/src/manifest/schema.rs#L633) |
+| `budget_usd` | float | no | Per-sub-lead envelope when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L677`](../crates/pitboss-cli/src/manifest/schema.rs#L677) |
+| `max_workers` | integer | no | Per-sub-lead worker pool when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L682`](../crates/pitboss-cli/src/manifest/schema.rs#L682) |
+| `lead_timeout_secs` | integer | no | Wall-clock cap for the sub-lead session. | [`../crates/pitboss-cli/src/manifest/schema.rs#L687`](../crates/pitboss-cli/src/manifest/schema.rs#L687) |
+| `read_down` | boolean | no | When true, sub-lead shares root's budget + worker pool instead of carving its own envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L693`](../crates/pitboss-cli/src/manifest/schema.rs#L693) |
 
 ## `[[approval_policy]]` — `ApprovalRuleSpec`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:202`](../crates/pitboss-cli/src/manifest/schema.rs#L202).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:262`](../crates/pitboss-cli/src/manifest/schema.rs#L262).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `action` | enum (`auto_approve` \| `auto_reject` \| `block`) | **yes** | Action when this rule matches. | [`../crates/pitboss-cli/src/manifest/schema.rs#L213`](../crates/pitboss-cli/src/manifest/schema.rs#L213) |
+| `action` | enum (`auto_approve` \| `auto_reject` \| `block`) | **yes** | Action when this rule matches. | [`../crates/pitboss-cli/src/manifest/schema.rs#L273`](../crates/pitboss-cli/src/manifest/schema.rs#L273) |
 
 ## `[[mcp_server]]` — `McpServerSpec`
 
@@ -137,10 +137,18 @@ Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:137`](../crates/pitbos
 
 ## `[[template]]` — `Template`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:385`](../crates/pitboss-cli/src/manifest/schema.rs#L385).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:445`](../crates/pitboss-cli/src/manifest/schema.rs#L445).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Slug referenced from [[task]].template. | [`../crates/pitboss-cli/src/manifest/schema.rs#L390`](../crates/pitboss-cli/src/manifest/schema.rs#L390) |
-| `prompt` | text (multi-line) | **yes** | Prompt body. Supports {var} placeholders supplied by [[task]].vars. | [`../crates/pitboss-cli/src/manifest/schema.rs#L396`](../crates/pitboss-cli/src/manifest/schema.rs#L396) |
+| `id` | text | **yes** | Slug referenced from [[task]].template. | [`../crates/pitboss-cli/src/manifest/schema.rs#L450`](../crates/pitboss-cli/src/manifest/schema.rs#L450) |
+| `prompt` | text (multi-line) | **yes** | Prompt body. Supports {var} placeholders supplied by [[task]].vars. | [`../crates/pitboss-cli/src/manifest/schema.rs#L456`](../crates/pitboss-cli/src/manifest/schema.rs#L456) |
+
+## `[lifecycle]` — `Lifecycle`
+
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:240`](../crates/pitboss-cli/src/manifest/schema.rs#L240).
+
+| Field | Type | Required | Help | Source |
+|---|---|---|---|---|
+| `survive_parent` | boolean | no | Allow this dispatch to outlive its parent process. Requires a notify target. | [`../crates/pitboss-cli/src/manifest/schema.rs#L251`](../crates/pitboss-cli/src/manifest/schema.rs#L251) |
 

--- a/docs/manifest-reference.toml
+++ b/docs/manifest-reference.toml
@@ -108,3 +108,6 @@ prompt = """
   Replace with the actual prompt body.
 """
 
+[lifecycle]
+survive_parent = false
+


### PR DESCRIPTION
## Summary

Part A of the issue #133 follow-up split. Adds an optional `[lifecycle]` manifest section that lets a manifest formally declare it should be allowed to outlive the parent process that spawned `pitboss dispatch`. Use case: an agent's nested `pitboss dispatch <child.toml>` from inside its task worktree needs to keep running after the agent's lead claude exits or hits the orchestrator's task timeout (the concrete failure mode from the post-mortem in [issue #133 comment 2](https://github.com/SDS-Mode/pitboss/issues/133#issuecomment-4322558206) — only 3.3% of true spend was visible to the orchestrator).

## Schema

```toml
[lifecycle]
survive_parent = true
notify = { kind = "webhook", url = "https://orchestrator.internal/events", events = ["run_dispatched", "run_finished"] }
```

Both fields optional. The `notify` field is an inline `[[notification]]`-style sink; when present it gets merged into the run's notification router alongside any top-level `[[notification]]` sections.

## Validate-time coupling (the load-bearing piece)

`pitboss validate` rejects `survive_parent = true` without a notification target. Either an inline `[lifecycle].notify` OR at least one top-level `[[notification]]` section satisfies the rule. The reasoning: an orchestrator that's losing process-level control of the run needs *some* signal that the run actually finished — a naked detachment with no out-of-band notify is the worst-orphan case the schema aims to prevent.

The error message explicitly tells operators what to do:

```
[lifecycle] survive_parent = true requires a notification target so the orchestrator can observe run completion. Add either:
  - a [lifecycle.notify] inline sink (same shape as [[notification]]), or
  - at least one top-level [[notification]] section.
If you intend to deliver lifecycle events via the PITBOSS_PARENT_NOTIFY_URL env var, also declare a no-cost [[notification]]
  kind = "log"
to satisfy this validate-time gate (the env-var sink is configured at dispatch-time and validate cannot see it).
```

## SSRF / scheme rules

The inline `[lifecycle].notify` goes through the same `validate_webhook_url` guard as `[[notification]]` — https-only, no loopback / private addresses. For loopback orchestrator delivery, operators use `PITBOSS_PARENT_NOTIFY_URL` (already shipped in #135) — that env-var path is operator-trusted and bypasses the manifest-author SSRF guard for exactly the localhost-orchestrator case.

## Event payload

`RunDispatched` now carries `survive_parent: bool`:

```json
{
  "kind":           "run_dispatched",
  "run_id":         "019d...",
  "parent_run_id":  "019c...",
  "manifest_path":  "/work/child.toml",
  "mode":           "flat",
  "survive_parent": true
}
```

`#[serde(default)]` preserves back-compat: pre-#133-A producers that omit the field still deserialize cleanly with `survive_parent = false`.

## What this PR does NOT change

No actual cancel-cascade behavior change ships here. The manifest declares intent; how the orchestrator acts on it (process-group exclusion, signal handling, tree-walk decision) is the orchestrator's call. The RacerX-side plumbing is tracked separately on the RacerX roadmap.

## Test plan

- [x] `cargo test --workspace` — all tests pass (8 new: 6 in `manifest::validate::tests::lifecycle_*`, 2 in `notify::tests::pitboss_event_run_dispatched_*`)
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Manual: `pitboss validate <manifest with naked survive_parent>` → fails with the explicit error
- [x] Manual: `pitboss schema --format=map | grep lifecycle` → renders the new section
- [x] Manual: `pitboss schema --format=example | grep -A1 lifecycle` → emits the placeholder block

## Companion PRs

- **PR #135** (merged) — env-var notify hook + RunDispatched event base
- **PR #136** (queued) — companion: `pitboss list --active` flat-CLI
- **(C) deferred** — `pitboss dispatch --leadless` (no lead-claude wrapper). [See naming note on #133.](https://github.com/SDS-Mode/pitboss/issues/133#issuecomment-4322666474)

🤖 Generated with [Claude Code](https://claude.com/claude-code)