### PR TITLE
feat: pitboss dispatch --background for non-blocking dispatch (#133-C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,40 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`pitboss dispatch --background`** — `nohup`-equivalent, non-blocking
+  dispatch (issue #133-C). The parent process pre-mints a `run_id`,
+  spawns the dispatcher as a session-leader child (`setsid()` via
+  `pre_exec`, stdio nulled), prints a single JSON line on stdout, and
+  exits 0 — without waiting for the run to complete:
+
+  ```
+  $ pitboss dispatch --background ./manifest.toml
+  {"run_id":"019d…","manifest_path":"./manifest.toml","started_at":"2026-04-26T17:00:00Z","child_pid":12345}
+  $
+  ```
+
+  Designed for orchestrators (Discord bots, web dashboards, CI scripts)
+  that need to dispatch a manifest and return to availability immediately
+  rather than tie up an event loop for the duration of the run. Concrete
+  example from issue #133: a Discord bot's `/dispatch <manifest>` slash
+  command can now hand the manifest off and respond to the user in
+  milliseconds; the run grinds in the background and reports back via
+  `[lifecycle].notify` (PR #137) or polling `pitboss list --active` /
+  `pitboss status <run_id>`.
+
+  Mode-agnostic by design: works with both flat (`[[task]]`) and
+  hierarchical (`[lead]`) manifests. The decision of whether a lead
+  claude wraps the dispatch is a manifest authoring concern (omit
+  `[lead]` to skip the lead-claude cost), kept orthogonal to this
+  flag's attached-vs-detached lifecycle concern.
+
+  Mechanism uses a hidden `--internal-run-id <UUID>` flag for the
+  parent→child handoff so the announced and on-disk run ids match
+  byte-for-byte (the standard correlation contract orchestrators
+  already rely on for `RunDispatched` / `RunFinished` webhooks).
+  `--background --dry-run` and `--background --internal-run-id` are
+  rejected at parse time as nonsensical combinations.
+
 - **`[lifecycle]` manifest section + `survive_parent` declaration** —
   follow-up A from issue #133. Lets a manifest formally declare that this
   dispatch should be allowed to outlive its parent process (use case: an

--- a/book/src/operator-guide/notifications.md
+++ b/book/src/operator-guide/notifications.md
@@ -178,3 +178,80 @@ events = ["run_dispatched", "run_finished"]
 | Loopback orchestrator on the same host | `PITBOSS_PARENT_NOTIFY_URL` env var (operator-trusted, bypasses SSRF guard) |
 | HTTPS endpoint on a non-loopback host | `[lifecycle].notify` or `[[notification]]` with `kind = "webhook"` |
 | Just want to cleanly outlive the parent | `[lifecycle].survive_parent = true` + any of the above |
+
+## `pitboss dispatch --background` (v0.10+)
+
+`--background` detaches the dispatcher and returns immediately, like
+`nohup pitboss dispatch & disown`. The parent prints a single JSON line
+identifying the run, then exits 0. The detached child runs the standard
+dispatch path until completion.
+
+```
+$ pitboss dispatch --background ./manifest.toml
+{"run_id":"019d…","manifest_path":"./manifest.toml","started_at":"2026-04-26T17:00:00Z","child_pid":12345}
+$
+```
+
+Designed for orchestrators that need to dispatch and stay responsive: a
+Discord bot's `/dispatch` slash command can hand the manifest to pitboss
+and reply to the user in milliseconds while the run grinds in the
+background.
+
+### What it does, and what it doesn't
+
+`--background` controls the **lifecycle** of the dispatch process — that
+is the only concern. It does not change *what* runs:
+
+- **Lead vs. flat is a manifest authoring decision.** Write a flat-mode
+  manifest (`[[task]]`-only, no `[lead]`) when you don't need claude
+  reasoning to fan tasks out; write a hierarchical manifest (`[lead]`)
+  when you do. `--background` works with either.
+- **Cost optimization is upstream of this flag.** If your bot dispatches
+  static task lists, the lead's per-run token cost is avoided by
+  authoring flat manifests, not by passing `--background`.
+
+### Composing with `[lifecycle].notify`
+
+`--background` pairs naturally with the `[lifecycle].notify` machinery
+above: detach the dispatch, declare a webhook, and the orchestrator
+gets `RunFinished` delivered when the run actually finishes — no
+polling required:
+
+```toml
+[lifecycle]
+notify = { kind = "webhook", url = "https://orchestrator.internal/events", events = ["run_finished"] }
+```
+
+Run-id correlation is automatic. The orchestrator stored the `run_id`
+the parent printed; the webhook payload carries the same id.
+
+### Observing background runs
+
+Three out-of-band channels expose detached run state:
+
+| Channel | When to use |
+|---|---|
+| `[lifecycle].notify` webhook | Push delivery; reacts to lifecycle transitions |
+| `pitboss list --active` | Survey of currently-running dispatchers |
+| `pitboss status <run_id>` | On-demand snapshot of one run's task table |
+
+### Mechanism
+
+The parent pre-mints a UUID v7 `run_id`, then re-spawns itself with the
+hidden `--internal-run-id <uuid>` flag so the child honors the same id
+that was announced on stdout. The child is detached via `setsid()` (new
+session, no controlling tty) with stdin/stdout/stderr nulled. Once the
+parent exits the child is reparented to PID 1 (init/systemd), which
+auto-reaps it on completion. No double-fork is needed because the child
+never opens a tty device.
+
+### Edge cases
+
+- `--background --dry-run` is rejected (nonsensical).
+- `--background --internal-run-id <UUID>` is rejected (the parent already
+  pre-mints; combining them would re-detach an already-detached invocation).
+- The parent does **not** wait to verify the child boots successfully.
+  If the manifest fails to validate or the child crashes during startup,
+  the parent has already exited 0 with a `run_id` that will never see
+  a `summary.json`. Operators that need confirmation should poll
+  `pitboss status` or rely on the `RunDispatched` notification firing.

--- a/crates/pitboss-cli/src/cli.rs
+++ b/crates/pitboss-cli/src/cli.rs
@@ -51,6 +51,28 @@ pub enum Command {
         /// Print the resolved claude spawn commands and exit.
         #[arg(long)]
         dry_run: bool,
+        /// Detach the dispatcher to run in the background (`nohup`-equivalent).
+        /// Mints a `run_id`, spawns the dispatcher as a session-leader child
+        /// process with stdio nulled, prints `{run_id, manifest_path,
+        /// started_at, child_pid}` JSON to stdout, and exits 0 — without
+        /// waiting for completion.
+        ///
+        /// Designed for orchestrators (Discord bots, web dashboards, CI)
+        /// that need to dispatch a manifest and return to availability
+        /// immediately. Pair with `[lifecycle].notify` to learn about run
+        /// completion via webhook, or poll `pitboss list --active` /
+        /// `pitboss status <run_id>`.
+        ///
+        /// Mode-agnostic: works with both flat (`[[task]]`) and
+        /// hierarchical (`[lead]`) manifests.
+        #[arg(long)]
+        background: bool,
+        /// Internal: re-use this UUID as the run id instead of minting one.
+        /// Set automatically when `--background` re-spawns the dispatcher
+        /// as a detached child so the parent's announced `run_id` matches
+        /// what the child writes to disk. Not for direct human use.
+        #[arg(long, hide = true, value_name = "UUID")]
+        internal_run_id: Option<String>,
     },
     /// Re-run a prior dispatch, reusing claude_session_id for each task.
     Resume {

--- a/crates/pitboss-cli/src/dispatch/background.rs
+++ b/crates/pitboss-cli/src/dispatch/background.rs
@@ -1,0 +1,149 @@
+//! `pitboss dispatch --background` — detached, non-blocking dispatch entry.
+//!
+//! ## Why this module exists
+//!
+//! Orchestrators that wrap pitboss (Discord bots, web dashboards, CI scripts)
+//! need to dispatch a manifest and return to availability immediately rather
+//! than block on completion. Issue #133-C frames the use case: a Discord bot
+//! that calls `pitboss dispatch <manifest>` from inside a slash-command
+//! handler ties up its event loop for the entire run; with `--background`
+//! the bot fires the dispatch, gets a `run_id` back, and the run grinds in
+//! the background while the bot stays interactive.
+//!
+//! ## Mechanism
+//!
+//! The flag is mode-agnostic: it works for both flat-mode (`[[task]]`) and
+//! hierarchical (`[lead]`) manifests. The decision of whether a lead claude
+//! runs is a manifest authoring concern, kept orthogonal to the
+//! attached-vs-detached lifecycle concern this flag controls.
+//!
+//! Implementation:
+//! 1. Parent pre-mints the `run_id` (UUID v7, same scheme the dispatcher
+//!    uses internally).
+//! 2. Parent re-spawns itself with the standard `dispatch` subcommand plus
+//!    the hidden `--internal-run-id <uuid>` flag, which tells the child
+//!    dispatcher to honor the pre-minted id instead of generating its own
+//!    — so the `run_id` the parent prints matches what lands in
+//!    `summary.json` on completion.
+//! 3. Child stdio is nulled and `setsid()` is called via `pre_exec` so the
+//!    child becomes its own session leader, fully detached from the parent's
+//!    controlling terminal. Ctrl-C in the parent's TTY won't reach the
+//!    child.
+//! 4. Parent prints `{run_id, manifest_path, started_at, child_pid}` JSON
+//!    to stdout and exits 0. The child runs the standard dispatch path.
+//!
+//! When the parent exits, the child is reparented to PID 1 (init/systemd),
+//! which auto-reaps it on completion. No explicit double-fork is needed
+//! on Linux.
+//!
+//! ## Composes with PR #137 lifecycle
+//!
+//! Background dispatch pairs naturally with `[lifecycle].notify` and
+//! `[lifecycle].survive_parent`: orchestrators that detach via
+//! `--background` and want completion notifications declare a webhook in
+//! the manifest, then `RunFinished` lands at the orchestrator's URL when
+//! the detached run finishes. Run-id correlation is automatic — the
+//! orchestrator stored the `run_id` it got back from the parent, and the
+//! webhook payload carries the same id.
+//!
+//! ## Why not double-fork
+//!
+//! Classical Unix daemonization uses double-fork to prevent the daemon from
+//! re-acquiring a controlling terminal. We don't need that guarantee here:
+//! the child is a `pitboss dispatch` process that never `open()`s a tty
+//! device. `setsid()` alone (which puts the child in a new session with no
+//! controlling tty) is sufficient and keeps the spawn logic
+//! straightforward.
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use serde_json::json;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use uuid::Uuid;
+
+/// Spawn a detached dispatch child and return immediately. Prints a JSON
+/// line `{run_id, manifest_path, started_at, child_pid}` to stdout on
+/// success.
+///
+/// Returns the parent's exit code (0 on successful spawn, non-zero on
+/// spawn failure). The child's success/failure is observed out-of-band
+/// via `pitboss list --active`, `pitboss status <run_id>`, or the
+/// manifest's `[lifecycle].notify` webhook.
+pub fn run_background(manifest_path: &Path, run_dir_override: Option<PathBuf>) -> Result<i32> {
+    let run_id = Uuid::now_v7();
+    let run_id_str = run_id.to_string();
+    let started_at = Utc::now();
+
+    let exe = std::env::current_exe().context("locate current pitboss binary")?;
+
+    let mut cmd = std::process::Command::new(&exe);
+    cmd.arg("dispatch")
+        .arg(manifest_path)
+        .args(["--internal-run-id", &run_id_str]);
+    if let Some(ref dir) = run_dir_override {
+        cmd.arg("--run-dir").arg(dir);
+    }
+
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    // SAFETY: `pre_exec` runs in the forked child between fork() and
+    // exec(). `setsid()` is async-signal-safe per POSIX, which is the only
+    // restriction in this hook (no allocations, no locks, no Rust-stdlib
+    // calls that touch shared state).
+    unsafe {
+        cmd.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+
+    let child = cmd
+        .spawn()
+        .with_context(|| format!("spawn detached dispatcher (binary: {})", exe.display()))?;
+    let child_pid = child.id();
+    // Drop the Child handle without waiting. On parent exit the child is
+    // reparented to PID 1 which auto-reaps it. We keep no reference so
+    // the parent can exit immediately after printing the announcement.
+    drop(child);
+
+    let payload = json!({
+        "run_id": run_id_str,
+        "manifest_path": manifest_path.to_string_lossy(),
+        "started_at": started_at.to_rfc3339(),
+        "child_pid": child_pid,
+    });
+    println!("{payload}");
+
+    Ok(0)
+}
+
+/// Parse a `--internal-run-id` argument into a `Uuid`. Used by `main.rs`
+/// when forwarding the value into [`crate::dispatch::run_dispatch_inner`]
+/// or [`crate::dispatch::hierarchical::run_hierarchical`].
+pub fn parse_internal_run_id(s: &str) -> Result<Uuid> {
+    Uuid::parse_str(s).with_context(|| format!("--internal-run-id: invalid UUID: {s}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_internal_run_id_accepts_uuid_v7() {
+        let v7 = Uuid::now_v7();
+        let parsed = parse_internal_run_id(&v7.to_string()).expect("valid UUID parses");
+        assert_eq!(parsed, v7);
+    }
+
+    #[test]
+    fn parse_internal_run_id_rejects_garbage() {
+        assert!(parse_internal_run_id("not-a-uuid").is_err());
+        assert!(parse_internal_run_id("").is_err());
+    }
+}

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -31,6 +31,7 @@ pub async fn run_hierarchical(
     run_dir_override: Option<PathBuf>,
     dry_run: bool,
     sublead_sessions: std::collections::HashMap<String, String>,
+    pre_minted_run_id: Option<Uuid>,
 ) -> Result<i32> {
     // Surface headless approval-gate mis-configurations early, before any
     // claude subprocess launches. Runs silently if stdout is a TTY (the
@@ -41,7 +42,9 @@ pub async fn run_hierarchical(
     // when one exists) BEFORE we overwrite it with our own. See `notify::parent`
     // for the env-var contract introduced for issue #133.
     let parent_run_id = crate::notify::parent::parent_run_id();
-    let run_id = Uuid::now_v7();
+    // Honor a pre-minted id from `--background` (issue #133-C); otherwise
+    // mint fresh.
+    let run_id = pre_minted_run_id.unwrap_or_else(Uuid::now_v7);
     crate::notify::parent::set_run_id_env(&run_id.to_string());
 
     let run_dir = run_dir_override.unwrap_or_else(|| resolved.run_dir.clone());

--- a/crates/pitboss-cli/src/dispatch/mod.rs
+++ b/crates/pitboss-cli/src/dispatch/mod.rs
@@ -1,4 +1,5 @@
 pub mod actor;
+pub mod background;
 pub mod container;
 pub mod events;
 pub mod failure_detection;

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -160,6 +160,12 @@ fn cleanup_policy_from(w: crate::manifest::schema::WorktreeCleanup) -> CleanupPo
 }
 
 /// Public entry — main.rs calls this. Constructs production spawner + store.
+///
+/// `pre_minted_run_id` is `Some` only when the dispatcher was re-spawned
+/// by `pitboss dispatch --background` (which mints the id in the parent so
+/// it can announce it on stdout before exiting). `None` for normal
+/// foreground dispatch — the run id is generated inside [`execute`].
+#[allow(clippy::too_many_arguments)]
 pub async fn run_dispatch_inner(
     resolved: ResolvedManifest,
     manifest_text: String,
@@ -168,6 +174,7 @@ pub async fn run_dispatch_inner(
     claude_version: Option<String>,
     run_dir_override: Option<PathBuf>,
     dry_run: bool,
+    pre_minted_run_id: Option<Uuid>,
 ) -> Result<i32> {
     // Flat manifests rarely use `[[approval_policy]]` or `propose_plan`,
     // but if they do, the same headless-gate warnings apply. Silent on TTY.
@@ -187,6 +194,7 @@ pub async fn run_dispatch_inner(
         spawner,
         store,
         dry_run,
+        pre_minted_run_id,
     )
     .await
 }
@@ -202,6 +210,7 @@ pub async fn execute(
     spawner: Arc<dyn ProcessSpawner>,
     store: Arc<dyn SessionStore>,
     dry_run: bool,
+    pre_minted_run_id: Option<Uuid>,
 ) -> Result<i32> {
     // Snapshot any `PITBOSS_RUN_ID` already in our env BEFORE we overwrite it
     // with our own run_id. If we're running under a parent orchestrator (or as
@@ -209,7 +218,10 @@ pub async fn execute(
     // value is the parent run id reported on `RunDispatched`. See the
     // `notify::parent` module for the full env-var contract (issue #133).
     let parent_run_id = crate::notify::parent::parent_run_id();
-    let run_id = Uuid::now_v7();
+    // Honor a pre-minted id from `--background` (issue #133-C); otherwise
+    // mint fresh as before. Background pre-mints in the parent so it can
+    // announce the id on stdout before the detached child boots.
+    let run_id = pre_minted_run_id.unwrap_or_else(Uuid::now_v7);
     crate::notify::parent::set_run_id_env(&run_id.to_string());
 
     let run_dir = resolved.run_dir.clone();
@@ -1260,6 +1272,7 @@ mod tests {
             spawner,
             store.clone(),
             false,
+            None,
         )
         .await
         .unwrap();
@@ -1347,6 +1360,7 @@ mod tests {
             spawner,
             store.clone(),
             false,
+            None,
         )
         .await
         .unwrap();
@@ -1447,6 +1461,7 @@ mod tests {
             spawner,
             store.clone(),
             false,
+            None,
         )
         .await
         .unwrap();

--- a/crates/pitboss-cli/src/main.rs
+++ b/crates/pitboss-cli/src/main.rs
@@ -25,8 +25,50 @@ fn main() -> Result<()> {
             manifest,
             run_dir,
             dry_run,
+            background,
+            internal_run_id,
         } => {
-            run_dispatch(&manifest, run_dir, dry_run);
+            // `--background` short-circuits before the normal dispatch
+            // path: parent re-spawns itself detached and exits 0 with a
+            // JSON announcement on stdout. The child invocation receives
+            // `--internal-run-id` so the announced and on-disk run ids
+            // match. See `dispatch::background` for the full mechanism.
+            if background {
+                if dry_run {
+                    eprintln!("--background and --dry-run are mutually exclusive");
+                    std::process::exit(2);
+                }
+                if internal_run_id.is_some() {
+                    // Ambiguous: the parent already pre-mints and forwards
+                    // via --internal-run-id, so combining them means the
+                    // operator is asking us to re-detach an already-detached
+                    // dispatch. Reject rather than silently double-spawn.
+                    eprintln!(
+                        "--background and --internal-run-id are mutually exclusive\n\
+                         (--internal-run-id is set automatically by --background's \
+                         self-respawn; not for direct human use)"
+                    );
+                    std::process::exit(2);
+                }
+                match dispatch::background::run_background(&manifest, run_dir) {
+                    Ok(code) => std::process::exit(code),
+                    Err(e) => {
+                        eprintln!("background dispatch: {e:#}");
+                        std::process::exit(1);
+                    }
+                }
+            }
+            let pre_minted = match internal_run_id.as_deref() {
+                None => None,
+                Some(s) => match dispatch::background::parse_internal_run_id(s) {
+                    Ok(u) => Some(u),
+                    Err(e) => {
+                        eprintln!("{e:#}");
+                        std::process::exit(2);
+                    }
+                },
+            };
+            run_dispatch(&manifest, run_dir, dry_run, pre_minted);
         }
         Command::Resume { run_id, run_dir } => {
             run_resume(&run_id, run_dir);
@@ -260,6 +302,7 @@ fn run_dispatch(
     manifest: &std::path::Path,
     run_dir_override: Option<std::path::PathBuf>,
     dry_run: bool,
+    pre_minted_run_id: Option<uuid::Uuid>,
 ) -> ! {
     let env_mp = parse_env_max_parallel();
     let manifest_text = match std::fs::read_to_string(manifest) {
@@ -314,6 +357,7 @@ fn run_dispatch(
                 run_dir_override,
                 dry_run,
                 std::collections::HashMap::new(),
+                pre_minted_run_id,
             )
             .await
             {
@@ -332,6 +376,7 @@ fn run_dispatch(
             claude_version,
             run_dir_override,
             dry_run,
+            pre_minted_run_id,
         )
         .await
         {
@@ -564,6 +609,7 @@ fn run_resume(run_id_prefix: &str, run_dir_override: Option<std::path::PathBuf>)
                 Some(effective_run_dir),
                 false,
                 sublead_sessions,
+                None,
             )
             .await
             {
@@ -582,6 +628,7 @@ fn run_resume(run_id_prefix: &str, run_dir_override: Option<std::path::PathBuf>)
             claude_version,
             Some(effective_run_dir),
             false,
+            None,
         )
         .await
         {

--- a/crates/pitboss-cli/tests/background_flows.rs
+++ b/crates/pitboss-cli/tests/background_flows.rs
@@ -1,0 +1,289 @@
+//! End-to-end tests for `pitboss dispatch --background` (issue #133-C).
+//!
+//! These tests drive `pitboss dispatch --background` as a real subprocess
+//! and verify the detach contract:
+//!   1. Parent returns within ~1s with exit 0.
+//!   2. Stdout contains a single JSON line `{run_id, manifest_path,
+//!      started_at, child_pid}`.
+//!   3. The child runs to completion in the background, writing
+//!      `summary.json` with the *same* `run_id` the parent announced.
+//!   4. The hidden `--internal-run-id` flag is honored (foreground
+//!      dispatch with that flag uses the supplied id).
+//!
+//! Fake-claude scripts keep these tests deterministic and fast (no
+//! Anthropic API calls).
+
+mod support;
+
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+use support::*;
+use tempfile::TempDir;
+
+/// The CI-friendly upper bound on how long the parent should take to
+/// return. Spawning a child + writing one JSON line should be well under
+/// 500ms in practice; 5s gives plenty of slack on a loaded test runner.
+const PARENT_RETURN_BUDGET: Duration = Duration::from_secs(5);
+
+/// Wait for `summary.json` to land at the expected path. Background
+/// dispatch finishes asynchronously, so tests poll instead of blocking
+/// on the spawn handle (which we deliberately dropped in the parent).
+fn wait_for_summary(path: &std::path::Path, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if path.exists() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    false
+}
+
+#[test]
+fn background_returns_immediately_with_run_id_and_completes_async() {
+    ensure_built();
+    let repo = TempDir::new().unwrap();
+    init_git_repo(repo.path());
+    let run_dir = TempDir::new().unwrap();
+
+    let manifest_path = repo.path().join("pitboss.toml");
+    std::fs::write(
+        &manifest_path,
+        format!(
+            r#"
+[run]
+max_parallel_tasks = 1
+run_dir = "{run_dir}"
+worktree_cleanup = "always"
+
+[defaults]
+use_worktree = false
+
+[[task]]
+id = "t1"
+directory = "{repo}"
+prompt = "p"
+"#,
+            run_dir = run_dir.path().display(),
+            repo = repo.path().display()
+        ),
+    )
+    .unwrap();
+
+    let start = Instant::now();
+    let mut cmd = Command::new(pitboss_binary());
+    cmd.arg("dispatch")
+        .arg(&manifest_path)
+        .arg("--background")
+        .env("PITBOSS_CLAUDE_BINARY", fake_claude_path())
+        .env("PITBOSS_FAKE_SCRIPT", fixture("success.jsonl"))
+        .env("PITBOSS_FAKE_EXIT_CODE", "0")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let out = cmd.output().expect("spawn pitboss --background");
+    let parent_elapsed = start.elapsed();
+
+    assert!(
+        out.status.success(),
+        "parent should exit 0; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        parent_elapsed < PARENT_RETURN_BUDGET,
+        "parent must return within {}s; took {}ms",
+        PARENT_RETURN_BUDGET.as_secs(),
+        parent_elapsed.as_millis()
+    );
+
+    // Parse the JSON announcement on stdout.
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let announce: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("stdout is not single JSON line: {stdout:?} ({e})"));
+    let announced_run_id = announce["run_id"]
+        .as_str()
+        .expect("run_id field present")
+        .to_string();
+    assert!(
+        uuid::Uuid::parse_str(&announced_run_id).is_ok(),
+        "run_id is a valid UUID: {announced_run_id}"
+    );
+    assert_eq!(
+        announce["manifest_path"].as_str().unwrap(),
+        manifest_path.to_string_lossy()
+    );
+    assert!(announce["started_at"].as_str().is_some());
+    assert!(announce["child_pid"].as_u64().is_some());
+
+    // Wait for the detached child to land summary.json. Use the announced
+    // run_id to predict the directory name — if these match, the
+    // pre-mint → child handoff is working end-to-end.
+    let summary = run_dir.path().join(&announced_run_id).join("summary.json");
+    assert!(
+        wait_for_summary(&summary, Duration::from_secs(30)),
+        "background child never wrote summary.json at {} (run_dir contents: {:?})",
+        summary.display(),
+        std::fs::read_dir(run_dir.path())
+            .ok()
+            .map(|d| d.flatten().map(|e| e.file_name()).collect::<Vec<_>>())
+    );
+
+    let s: serde_json::Value = serde_json::from_slice(&std::fs::read(&summary).unwrap()).unwrap();
+    // run_id in summary.json must match what the parent announced — that's
+    // the whole point of the pre-mint mechanism.
+    assert_eq!(
+        s["run_id"].as_str().unwrap(),
+        announced_run_id,
+        "summary.json run_id must match parent's announcement"
+    );
+    assert_eq!(s["tasks_total"].as_u64().unwrap(), 1);
+}
+
+#[test]
+fn internal_run_id_flag_is_honored_in_foreground_dispatch() {
+    // Sanity check that --internal-run-id (the hidden mechanism --background
+    // uses to align parent's announced id with child's on-disk id) actually
+    // wires through to the dispatcher when invoked directly. If this breaks,
+    // --background's correlation contract silently breaks too.
+    ensure_built();
+    let repo = TempDir::new().unwrap();
+    init_git_repo(repo.path());
+    let run_dir = TempDir::new().unwrap();
+
+    let manifest_path = repo.path().join("pitboss.toml");
+    std::fs::write(
+        &manifest_path,
+        format!(
+            r#"
+[run]
+max_parallel_tasks = 1
+run_dir = "{run_dir}"
+worktree_cleanup = "always"
+
+[defaults]
+use_worktree = false
+
+[[task]]
+id = "t1"
+directory = "{repo}"
+prompt = "p"
+"#,
+            run_dir = run_dir.path().display(),
+            repo = repo.path().display()
+        ),
+    )
+    .unwrap();
+
+    let preset_run_id = uuid::Uuid::now_v7().to_string();
+
+    let mut cmd = Command::new(pitboss_binary());
+    cmd.arg("dispatch")
+        .arg(&manifest_path)
+        .args(["--internal-run-id", &preset_run_id])
+        .env("PITBOSS_CLAUDE_BINARY", fake_claude_path())
+        .env("PITBOSS_FAKE_SCRIPT", fixture("success.jsonl"))
+        .env("PITBOSS_FAKE_EXIT_CODE", "0");
+    let out = cmd.output().unwrap();
+    assert!(
+        out.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let summary = run_dir.path().join(&preset_run_id).join("summary.json");
+    assert!(
+        summary.exists(),
+        "summary.json must land at the supplied run id, not a fresh one. \
+         Looked at {}; run_dir contents: {:?}",
+        summary.display(),
+        std::fs::read_dir(run_dir.path())
+            .ok()
+            .map(|d| d.flatten().map(|e| e.file_name()).collect::<Vec<_>>())
+    );
+    let s: serde_json::Value = serde_json::from_slice(&std::fs::read(&summary).unwrap()).unwrap();
+    assert_eq!(s["run_id"].as_str().unwrap(), preset_run_id);
+}
+
+#[test]
+fn background_with_dry_run_is_rejected() {
+    // --background spawns a detached child to do real work; --dry-run only
+    // prints what would run. Combining them is meaningless, so the CLI
+    // should reject explicitly rather than silently picking one.
+    ensure_built();
+    let repo = TempDir::new().unwrap();
+    init_git_repo(repo.path());
+    let run_dir = TempDir::new().unwrap();
+
+    let manifest_path = repo.path().join("pitboss.toml");
+    std::fs::write(
+        &manifest_path,
+        format!(
+            r#"
+[[task]]
+id = "t1"
+directory = "{repo}"
+prompt = "p"
+"#,
+            repo = repo.path().display()
+        ),
+    )
+    .unwrap();
+
+    let mut cmd = Command::new(pitboss_binary());
+    cmd.arg("dispatch")
+        .arg(&manifest_path)
+        .arg("--background")
+        .arg("--dry-run")
+        .arg("--run-dir")
+        .arg(run_dir.path());
+    let out = cmd.output().unwrap();
+    assert!(!out.status.success(), "expected non-zero exit");
+    assert_eq!(out.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--background") && stderr.contains("--dry-run"),
+        "stderr should explain the conflict; got: {stderr}"
+    );
+}
+
+#[test]
+fn background_with_internal_run_id_is_rejected() {
+    // --internal-run-id is the parent→child handoff token; combining it
+    // with --background means the operator is asking us to re-detach an
+    // already-detached invocation. Reject explicitly.
+    ensure_built();
+    let repo = TempDir::new().unwrap();
+    init_git_repo(repo.path());
+    let run_dir = TempDir::new().unwrap();
+
+    let manifest_path = repo.path().join("pitboss.toml");
+    std::fs::write(
+        &manifest_path,
+        format!(
+            r#"
+[[task]]
+id = "t1"
+directory = "{repo}"
+prompt = "p"
+"#,
+            repo = repo.path().display()
+        ),
+    )
+    .unwrap();
+
+    let mut cmd = Command::new(pitboss_binary());
+    cmd.arg("dispatch")
+        .arg(&manifest_path)
+        .arg("--background")
+        .args(["--internal-run-id", &uuid::Uuid::now_v7().to_string()])
+        .arg("--run-dir")
+        .arg(run_dir.path());
+    let out = cmd.output().unwrap();
+    assert!(!out.status.success());
+    assert_eq!(out.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--background") && stderr.contains("--internal-run-id"),
+        "stderr should explain the conflict; got: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes the third and final follow-up from #133. Adds `pitboss dispatch --background` — a `nohup`-equivalent flag that detaches the dispatcher and returns immediately with a JSON announcement on stdout.

```
$ pitboss dispatch --background ./manifest.toml
{\"run_id\":\"019d…\",\"manifest_path\":\"./manifest.toml\",\"started_at\":\"2026-04-26T17:00:00Z\",\"child_pid\":12345}
$
```

Designed for orchestrators (Discord bots, web dashboards, CI scripts) that need to dispatch a manifest and stay responsive — a Discord bot's `/dispatch` slash command can hand the manifest off and reply to the user in milliseconds while the run grinds in the background.

### Naming

The issue's earlier comment proposed `--leadless`. During planning we sharpened the decomposition: the lead-vs-no-lead concern is a manifest authoring decision (write `[[task]]` instead of `[lead]`), and the actually-missing functionality is the detach mechanism. `--background` names that single concern accurately, works with both flat and hierarchical manifests, and stays orthogonal to the manifest schema.

### Mechanism

- Parent pre-mints UUID v7 `run_id`
- Parent re-spawns self with hidden `--internal-run-id <uuid>` flag so the announced and on-disk ids match byte-for-byte
- Child detaches via `setsid()` (`pre_exec` hook, async-signal-safe) with stdio nulled
- On parent exit the child reparents to PID 1 which auto-reaps. No double-fork needed since the child never opens a tty device
- Threading: `pre_minted_run_id: Option<Uuid>` plumbed through both `run_dispatch_inner` (flat) and `run_hierarchical` so either mode honors the pre-mint

### Composes with PR #137 lifecycle

Background dispatch pairs naturally with `[lifecycle].notify`: declare a webhook, detach the dispatch, and `RunFinished` lands at the orchestrator's URL when the detached run actually finishes. Run-id correlation is automatic — the orchestrator stored the id from the parent's stdout, and the webhook payload carries the same id.

### Edge cases rejected at parse time

- `--background --dry-run` (nonsensical)
- `--background --internal-run-id <UUID>` (would re-detach an already-detached invocation)

## Test plan

- [x] `cargo test -p pitboss-cli --lib` (475 passed)
- [x] `cargo test -p pitboss-cli --test background_flows` (4 new e2e tests)
  - `background_returns_immediately_with_run_id_and_completes_async` — parent returns within 5s, child completes async, summary.json lands at announced run_id
  - `internal_run_id_flag_is_honored_in_foreground_dispatch` — sanity check on the hidden parent→child handoff
  - `background_with_dry_run_is_rejected`
  - `background_with_internal_run_id_is_rejected`
- [x] `cargo clippy -p pitboss-cli --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)