### PR TITLE
docs: surface --background dispatch in AGENTS.md and README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -336,6 +336,42 @@ Blocks until all tasks finish. Exit codes:
 - `2` — manifest error, claude binary missing, etc.
 - `130` — interrupted (Ctrl-C drained gracefully)
 
+### Background dispatch (v0.10+)
+
+```bash
+pitboss dispatch pitboss.toml --background
+# {"run_id":"019d…","manifest_path":"pitboss.toml","started_at":"…","child_pid":12345}
+```
+
+`nohup`-equivalent: detaches the dispatcher and returns immediately
+with a JSON announcement on stdout. Exit code is 0 on successful spawn;
+the run's actual outcome is observed out-of-band.
+
+Use this when you (the agent) are wrapping pitboss for an orchestrator
+context — a Discord bot's slash-command handler, a webhook receiver,
+a CI script — that needs to dispatch and stay responsive rather than
+block for the duration of the run.
+
+The flag is mode-agnostic: works with both flat (`[[task]]`) and
+hierarchical (`[lead]`) manifests. Whether a lead claude wraps the
+dispatch is a manifest authoring decision, kept orthogonal to this
+flag's attached-vs-detached lifecycle concern.
+
+To learn how a backgrounded run finishes, three out-of-band channels:
+
+| Channel | When to use |
+|---|---|
+| `[lifecycle].notify` webhook | Push delivery on `RunFinished` (no polling) |
+| `pitboss list --active` | Survey of currently-running dispatchers |
+| `pitboss status <run-id>` | On-demand snapshot of one run's task table |
+
+The announced `run_id` matches the id that lands in `summary.json`
+byte-for-byte (the parent pre-mints and forwards it to the child),
+so orchestrators can correlate the parent's stdout with later
+notifications and on-disk artifacts using a single key.
+
+`--background --dry-run` is rejected — they're nonsensical together.
+
 ### Resume
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -124,12 +124,13 @@ cargo install --path crates/pitboss-tui
 
 ```
 pitboss validate <manifest>               parse + resolve + validate, exit non-zero on error
-pitboss dispatch <manifest>               deal a run
+pitboss dispatch <manifest>               deal a run; --background detaches & returns a run-id
 pitboss resume <run-id>                   re-deal a prior run, reusing claude_session_id
 pitboss attach <run-id> <task-id>         follow-mode log viewer for a single worker
 pitboss diff <run-a> <run-b>              compare two runs side-by-side
 pitboss container-dispatch <manifest>     run dispatch inside a Docker/Podman container
 pitboss status <run-id>                   snapshot task table for any run; supports --json
+pitboss list                              inventory of recent runs; --active narrows to live
 pitboss agents-md                         print the bundled AGENTS.md reference
 pitboss completions <shell>               print shell completion script
 pitboss version                           print version


### PR DESCRIPTION
## Summary

Doc-only follow-up to #138. Two surfaces still claimed pitboss dispatch always blocks until completion — now they note \`--background\` as the nohup-equivalent for orchestrator integration.

- **AGENTS.md**: new \`### Background dispatch (v0.10+)\` subsection between Dispatch and Resume. Covers the JSON announcement contract, mode-agnostic semantics, three out-of-band completion channels (\`[lifecycle].notify\` / \`list --active\` / \`status\`), and the run-id correlation guarantee. Re-exports automatically via \`pitboss agents-md\` (the file is \`include_str!\`-bundled into the binary at compile time).
- **README.md**: subcommand listing now mentions \`--background\` on the dispatch line and adds the missing \`pitboss list\` row (shipped in #136 but never made it to the README index).

## Test plan

- [x] \`cargo build -p pitboss-cli\` — confirms the bundled AGENTS.md re-includes
- [x] \`./target/debug/pitboss agents-md | grep -A3 'Background dispatch'\` — verifies the new section ships in the binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)