### PR TITLE
fix(core): process-group signaling + immediate PID slot clear (#147 #148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -369,6 +369,38 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+**pitboss-core (child supervision):**
+- `pitboss-core::session::handle` — PID slot now cleared the moment
+  `child.wait()` resolves, before the up-to-30 s stream-drain await. The
+  previous ordering left the reaped child's PID published for the entire
+  drain window; on busy systems where the kernel recycled that PID within
+  milliseconds, any signal the dispatcher's freeze-pause path sent during
+  the window could land on an unrelated process. Closes #147.
+- `pitboss-core::process::tokio_impl` — children are now spawned with
+  `process_group(0)` (each child becomes its own group leader, PGID == PID)
+  and `terminate()`/`kill()` signal `-pgid` instead of the bare child PID.
+  This propagates SIGTERM/SIGKILL to the entire `claude` subtree (Bash
+  subshells, sub-agents, MCP servers) instead of orphaning them to PID 1
+  where they would keep holding worktree locks and burning budget. ESRCH
+  on an empty group is collapsed to `Ok` so terminate-after-exit stays a
+  no-op. `kill()` and `terminate()` are now symmetric (both use the same
+  group-targeted `libc::kill` path), addressing the legacy asymmetry where
+  one used `start_kill` and the other used raw `libc::kill`. Closes #148.
+- `pitboss-cli::dispatch::signals` — `freeze`/`resume_stopped`
+  (SIGSTOP/SIGCONT) now signal the worker's process group as well, so the
+  whole subtree halts and resumes together rather than leaving claude's
+  children running while the parent is frozen.
+
+**pitboss-core (audit follow-ups, low-severity):**
+- `session::handle::stream_loop` — assistant-text length comparison changed
+  from `>=` to `>` so equal-length later messages don't silently displace
+  the first-seen winner (claude's tail confirmations cluster at similar
+  short lengths and were occasionally clobbering the substantive answer).
+- `session::handle::stream_loop` — `parse_line_all` errors and `try_send`
+  drops on the `session_id` channel now emit `tracing::debug!` lines
+  instead of being swallowed silently, giving operators a diagnostic trail
+  when subprocess output is malformed or the session-id receiver vanishes.
+
 **TUI:**
 - Completed page Detail view always showed the same log regardless of which
   row was selected — `enter_detail_for` now updates `state.focus` so the

--- a/crates/pitboss-cli/src/dispatch/signals.rs
+++ b/crates/pitboss-cli/src/dispatch/signals.rs
@@ -25,31 +25,42 @@ const SECOND_SIGINT_WINDOW: Duration = Duration::from_secs(5);
 // transitive dep and this is a two-function use case. Pitboss is
 // Linux/macOS only so POSIX signal semantics are available
 // unconditionally.
+//
+// Workers are spawned with `process_group(0)` (see
+// `pitboss_core::process::tokio_impl`), so `pid` is also the PGID. We
+// signal `-pgid` so freeze/resume reach the entire claude subtree
+// (Bash subshells, sub-agents, MCP servers) — otherwise SIGSTOP on the
+// parent alone leaves grandchildren running and the freeze illusion
+// breaks down (the parent can't service its children's stdio while
+// stopped, but the children themselves keep burning CPU and tokens).
 
-/// Suspend the process with `pid` using SIGSTOP. Returns an error for
-/// `pid == 0` (slot not yet populated) or if the syscall fails
-/// (process already exited, permission denied, etc).
+/// Suspend the worker process group rooted at `pid` using SIGSTOP.
+/// Returns an error for `pid == 0` (slot not yet populated) or if the
+/// syscall fails (group already gone, permission denied, etc).
 pub fn freeze(pid: u32) -> Result<()> {
-    send_signal(pid, libc::SIGSTOP, "SIGSTOP")
+    send_group_signal(pid, libc::SIGSTOP, "SIGSTOP")
 }
 
-/// Resume a previously-frozen process with SIGCONT.
+/// Resume a previously-frozen worker process group with SIGCONT.
 pub fn resume_stopped(pid: u32) -> Result<()> {
-    send_signal(pid, libc::SIGCONT, "SIGCONT")
+    send_group_signal(pid, libc::SIGCONT, "SIGCONT")
 }
 
-fn send_signal(pid: u32, sig: libc::c_int, name: &'static str) -> Result<()> {
+fn send_group_signal(pid: u32, sig: libc::c_int, name: &'static str) -> Result<()> {
     if pid == 0 {
         bail!("{name}: pid is 0 (worker not yet spawned?)");
     }
-    // SAFETY: `kill(2)` accepts any pid_t + valid signo; no memory is
-    // dereferenced. The cast is libc's expected pid_t shape.
-    let rc = unsafe { libc::kill(pid as libc::pid_t, sig) };
+    #[allow(clippy::cast_possible_wrap)]
+    let pgid = pid as libc::pid_t;
+    // SAFETY: `kill(2)` with a negative pid signals the process group;
+    // pgid was published by the spawner after `process_group(0)`, so it
+    // is a PGID we own. No memory is dereferenced.
+    let rc = unsafe { libc::kill(-pgid, sig) };
     if rc == 0 {
         return Ok(());
     }
     let err = std::io::Error::last_os_error();
-    bail!("{name} to pid {pid} failed: {err}")
+    bail!("{name} to pgid {pid} failed: {err}")
 }
 
 /// Spawn a task that watches for Ctrl-C in two phases:
@@ -267,9 +278,16 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn freeze_then_resume_flips_proc_state() {
+        use std::os::unix::process::CommandExt;
         use std::process::Command;
 
-        let mut child = Command::new("sleep").arg("30").spawn().unwrap();
+        // Spawn the test child in its own process group (matches what
+        // TokioSpawner does in production). freeze()/resume_stopped()
+        // signal `-pgid` so without this the test would deliver SIGSTOP
+        // to the cargo-test process group itself.
+        let mut cmd = Command::new("sleep");
+        cmd.arg("30").process_group(0);
+        let mut child = cmd.spawn().unwrap();
         let pid = child.id();
 
         freeze(pid).unwrap();

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -3268,12 +3268,18 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn freeze_and_thaw_transition_via_handler() {
+        use std::os::unix::process::CommandExt;
         use std::process::Command;
 
         let state = test_state().await;
 
         // Spawn a real long-sleep child we can safely SIGSTOP/SIGCONT.
-        let child = Command::new("sleep").arg("30").spawn().unwrap();
+        // Process-group-isolated so freeze() (which signals `-pgid`) does
+        // not deliver SIGSTOP to the cargo-test runner itself — matches
+        // what TokioSpawner does in production.
+        let mut cmd = Command::new("sleep");
+        cmd.arg("30").process_group(0);
+        let child = cmd.spawn().unwrap();
         let pid = child.id();
 
         // Register the pid + Running state.

--- a/crates/pitboss-core/src/process/tokio_impl.rs
+++ b/crates/pitboss-core/src/process/tokio_impl.rs
@@ -41,35 +41,50 @@ impl ChildProcess for TokioChild {
         self.inner.wait().await
     }
 
-    #[allow(unsafe_code)]
     fn terminate(&mut self) -> std::io::Result<()> {
-        #[cfg(unix)]
-        {
-            if let Some(pid) = self.pid() {
-                // SAFETY: libc::kill is a well-defined POSIX call; pid comes from a
-                // subprocess we spawned via tokio::process::Command, so it's a valid
-                // process id for the current process group.
-                #[allow(clippy::cast_possible_wrap)]
-                let rc = unsafe { libc::kill(pid as i32, libc::SIGTERM) };
-                if rc != 0 {
-                    return Err(std::io::Error::last_os_error());
-                }
-            }
-            Ok(())
-        }
-        #[cfg(not(unix))]
-        {
-            self.inner.start_kill()
-        }
+        signal_group(self.pid(), libc::SIGTERM)
     }
 
     fn kill(&mut self) -> std::io::Result<()> {
-        self.inner.start_kill()
+        signal_group(self.pid(), libc::SIGKILL)
     }
 
     fn pid(&self) -> Option<u32> {
         self.inner.id()
     }
+}
+
+/// Send `sig` to the process group whose leader is `pid`. `pid` is also the
+/// PGID because we spawn every child with `process_group(0)` (the child
+/// becomes its own group leader, PGID == PID). Signaling `-pgid` reaches the
+/// child plus every descendant that hasn't called `setsid()` to escape — which
+/// covers the entire `claude` subtree (Bash subshells, sub-agents, MCP
+/// servers).
+///
+/// Without this, SIGTERM/SIGKILL only hit the immediate `claude` process and
+/// orphan its children to PID 1, where they keep holding worktree file
+/// handles and consuming budget.
+#[allow(unsafe_code)]
+fn signal_group(maybe_pid: Option<u32>, sig: libc::c_int) -> std::io::Result<()> {
+    let Some(group_leader) = maybe_pid else {
+        return Ok(());
+    };
+    #[allow(clippy::cast_possible_wrap)]
+    let pgid = group_leader as i32;
+    // SAFETY: libc::kill with a negative pid sends to the process group;
+    // pgid was returned by tokio::process::Child::id() for a child we
+    // spawned with process_group(0), so it is a valid PGID we own.
+    let rc = unsafe { libc::kill(-pgid, sig) };
+    if rc != 0 {
+        let err = std::io::Error::last_os_error();
+        // ESRCH = group already gone (every member exited). Treat as success
+        // since the desired post-condition (no surviving processes) holds.
+        if err.raw_os_error() == Some(libc::ESRCH) {
+            return Ok(());
+        }
+        return Err(err);
+    }
+    Ok(())
 }
 
 #[async_trait]
@@ -84,6 +99,14 @@ impl ProcessSpawner for TokioSpawner {
             .stderr(Stdio::piped())
             .envs(cmd.env.iter().map(|(k, v)| (k.as_str(), v.as_str())));
 
+        // Put the child in its own process group so that SIGTERM/SIGKILL
+        // (sent via signal_group) reach the entire claude subtree, not just
+        // the immediate child. process_group(0) makes the spawned process a
+        // group leader whose PGID equals its PID — see signal_group() for
+        // the matching teardown logic.
+        #[cfg(unix)]
+        command.process_group(0);
+
         let child = command.spawn().map_err(|e| {
             if e.kind() == std::io::ErrorKind::NotFound {
                 SpawnError::BinaryNotFound {
@@ -95,5 +118,82 @@ impl ProcessSpawner for TokioSpawner {
         })?;
 
         Ok(Box::new(TokioChild { inner: child }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+    use std::time::Duration;
+
+    /// Spawn a child shell that backgrounds a long-running grandchild,
+    /// terminate the parent, and confirm the grandchild was also killed.
+    /// Without process-group signaling the grandchild would survive,
+    /// re-parented to PID 1.
+    #[cfg(unix)]
+    #[allow(unsafe_code)]
+    #[tokio::test]
+    async fn terminate_kills_grandchildren() {
+        use tokio::io::{AsyncBufReadExt, BufReader};
+        let spawner = TokioSpawner::new();
+        // sh -c 'sleep 60 & echo $! ; wait' — prints the grandchild's PID
+        // on stdout, then waits forever (until the parent itself receives
+        // SIGTERM). The parent process is the shell; the grandchild is
+        // the backgrounded `sleep 60`.
+        let cmd = SpawnCmd {
+            program: PathBuf::from("/bin/sh"),
+            args: vec!["-c".into(), "sleep 60 & echo $! ; wait".into()],
+            cwd: PathBuf::from("/tmp"),
+            env: HashMap::new(),
+        };
+        let mut child = spawner.spawn(cmd).await.expect("spawn shell");
+
+        // Read the grandchild PID off stdout.
+        let stdout = child.take_stdout().expect("stdout piped");
+        let mut lines = BufReader::new(stdout).lines();
+        let pid_line = tokio::time::timeout(Duration::from_secs(5), lines.next_line())
+            .await
+            .expect("read grandchild pid in time")
+            .expect("io ok")
+            .expect("got a line");
+        let grandchild_pid: i32 = pid_line.trim().parse().expect("pid parses");
+
+        // Terminate the parent — should also reach the grandchild.
+        child.terminate().expect("terminate sends SIGTERM");
+        let _ = tokio::time::timeout(Duration::from_secs(5), child.wait())
+            .await
+            .expect("parent reaps in time");
+
+        // Give the kernel a beat to deliver the signal and reap.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // SAFETY: kill(pid, 0) is a no-op probe; returns 0 if the process
+        // exists, -1 with ESRCH if not.
+        let alive = unsafe { libc::kill(grandchild_pid, 0) } == 0;
+        assert!(
+            !alive,
+            "grandchild pid {grandchild_pid} survived parent SIGTERM — process group not wired"
+        );
+    }
+
+    /// Sanity: terminate on an already-exited child should not return an
+    /// error (ESRCH is collapsed to Ok).
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn terminate_after_exit_is_ok() {
+        let spawner = TokioSpawner::new();
+        let cmd = SpawnCmd {
+            program: PathBuf::from("/bin/true"),
+            args: vec![],
+            cwd: PathBuf::from("/tmp"),
+            env: HashMap::new(),
+        };
+        let mut child = spawner.spawn(cmd).await.expect("spawn /bin/true");
+        let _ = child.wait().await.expect("wait ok");
+        // Process group is now empty; libc::kill(-pgid, SIGTERM) returns
+        // ESRCH which signal_group() collapses.
+        child.terminate().expect("terminate after exit is ok");
     }
 }

--- a/crates/pitboss-core/src/session/handle.rs
+++ b/crates/pitboss-core/src/session/handle.rs
@@ -207,6 +207,17 @@ impl SessionHandle {
             }
         };
 
+        // Clear the pid slot the moment the child is reaped, *before* the
+        // stream-drain await below. The OS may recycle the now-free pid for
+        // an unrelated process within milliseconds; any reader that still
+        // observed the published value during the 30-second drain window
+        // would signal the wrong target. Drain depends on stdout/stderr fds,
+        // not on the pid, so clearing here is safe. `Release` pairs with the
+        // `Acquire` loads at signal sites (see `dispatch::signals`).
+        if let Some(slot) = &self.pid_slot {
+            slot.store(0, std::sync::atomic::Ordering::Release);
+        }
+
         // Let the stream + stderr drain tasks finish. Stdout/stderr EOF is
         // guaranteed once the child is reaped, so we can wait generously
         // — a premature timeout here would throw away the final
@@ -226,16 +237,6 @@ impl SessionHandle {
         }
         if let Some(t) = stderr_task {
             let _ = tokio::time::timeout(STREAM_DRAIN_TIMEOUT, t).await;
-        }
-
-        // Clear the pid slot now that the child has been reaped. Leaving
-        // the old pid published creates a use-after-free race: the OS may
-        // recycle that pid to an unrelated process, and a signal-sending
-        // reader that still observes the slot would then hit the wrong
-        // process. `Release` pairs with the `Acquire` loads at signal
-        // sites so a reader that sees 0 won't signal anything.
-        if let Some(slot) = &self.pid_slot {
-            slot.store(0, std::sync::atomic::Ordering::Release);
         }
 
         let exit_code = exit_status
@@ -305,8 +306,16 @@ async fn stream_loop(
                     let _ = w.write_all(line.as_bytes()).await;
                     let _ = w.write_all(b"\n").await;
                 }
-                let Ok(events) = parse_line_all(line.as_bytes()) else {
-                    continue;
+                let events = match parse_line_all(line.as_bytes()) {
+                    Ok(evs) => evs,
+                    Err(e) => {
+                        tracing::debug!(
+                            error = %e,
+                            len = line.len(),
+                            "stream_loop: parse_line_all failed; line skipped"
+                        );
+                        continue;
+                    }
                 };
                 for ev in events {
                     match ev {
@@ -318,9 +327,15 @@ async fn stream_loop(
                             // real content. A length-keyed winner avoids that. Stored
                             // untruncated so consumers reading `final_message` see the
                             // complete text — preview is built once at outcome time.
+                            //
+                            // Strict `>` so equal-length later messages do not displace
+                            // the first-seen winner — when two assistant blocks have the
+                            // same length, the earlier one is closer to the substantive
+                            // answer (claude's tail confirmations cluster around the
+                            // same short length).
                             let trimmed_len = text.trim().len();
                             let current_len = a.last_text.as_deref().map_or(0, |t| t.trim().len());
-                            if trimmed_len >= current_len {
+                            if trimmed_len > current_len {
                                 a.last_text = Some(text);
                             }
                         }
@@ -332,7 +347,13 @@ async fn stream_loop(
                             let mut a = accum.lock().await;
                             if let Some(tx) = &session_id_tx {
                                 // Best-effort: if receiver is closed or full, drop the send.
-                                let _ = tx.try_send(sid.clone());
+                                if let Err(e) = tx.try_send(sid.clone()) {
+                                    tracing::debug!(
+                                        error = %e,
+                                        session_id = %sid,
+                                        "stream_loop: session_id channel send dropped"
+                                    );
+                                }
                             }
                             a.session_id = Some(sid);
                             a.usage.add(&u);
@@ -449,5 +470,46 @@ mod session_id_tests {
             .expect("channel fires before deadline")
             .expect("sender not dropped");
         assert_eq!(got, "sess-xyz");
+    }
+}
+
+#[cfg(test)]
+mod pid_slot_tests {
+    use super::*;
+    use crate::process::fake::{FakeScript, FakeSpawner};
+    use crate::process::ProcessSpawner;
+    use crate::session::CancelToken;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    /// Regression for #147: the PID slot must be cleared promptly after the
+    /// child reaps, not at the end of the (up-to-30s) stream-drain window.
+    /// We can't observe the exact timing across the boundary cheaply, but
+    /// the post-condition (slot == 0 on return) and bounded total runtime
+    /// together guard against regression to the "clear after drain" form.
+    #[tokio::test]
+    async fn pid_slot_is_cleared_after_run() {
+        let script = FakeScript::new()
+            .stdout_line(r#"{"type":"result","session_id":"s","usage":{"input_tokens":1,"output_tokens":1}}"#)
+            .exit_code(0);
+        let spawner: Arc<dyn ProcessSpawner> = Arc::new(FakeSpawner::new(script));
+        let cmd = crate::process::SpawnCmd {
+            program: std::path::PathBuf::from("fake-claude"),
+            args: vec![],
+            cwd: std::path::PathBuf::from("/tmp"),
+            env: std::collections::HashMap::new(),
+        };
+        let slot = Arc::new(AtomicU32::new(0));
+        let handle = SessionHandle::new("t", spawner, cmd).with_pid_slot(slot.clone());
+        let _outcome = handle
+            .run_to_completion(CancelToken::new(), Duration::from_secs(5))
+            .await;
+        assert_eq!(
+            slot.load(Ordering::Acquire),
+            0,
+            "pid slot should be cleared on return so signal sites cannot \
+             target a recycled pid",
+        );
     }
 }


### PR DESCRIPTION
## Summary

Two pitboss-core child supervision bugs from the audit, plus four low-severity follow-ups in the same files.

### #147 — PID slot stays published 30s after reap

`session::handle::run_to_completion` cleared the PID slot at the end of the up-to-30 s `STREAM_DRAIN_TIMEOUT` window, *not* immediately after `child.wait()` returned. Once the kernel reaped the child it could recycle that PID for an unrelated process within milliseconds, and any signal the dispatcher's freeze-pause path (`dispatch::signals`) sent during the window would land on the wrong target.

**Fix:** `slot.store(0, Release)` moved to the line right after the exit-status match, before the drain await. Stream drain is keyed on stdout/stderr fds, not on the PID, so reordering is safe. Added `pid_slot_tests::pid_slot_is_cleared_after_run` as a regression guard on the post-condition.

### #148 — SIGTERM/SIGKILL only target the immediate child

`process::tokio_impl::TokioChild::{terminate, kill}` signaled only the immediate `claude` PID. claude routinely spawns Bash subshells, sub-agents, and nested MCP servers; on cancel/timeout the parent died but the grandchildren were re-parented to PID 1 where they kept holding worktree file handles and burning budget.

**Fix:** spawn every child with `process_group(0)` (each becomes its own group leader, PGID == PID), then signal `-pgid` on `terminate()` and `kill()`. ESRCH on an empty group is collapsed to `Ok` so terminate-after-exit stays a no-op. New `tokio_impl::tests::terminate_kills_grandchildren` e2e test spawns a backgrounded `sleep` grandchild and confirms it dies when the shell parent is terminated.

`dispatch::signals::freeze` / `resume_stopped` (SIGSTOP / SIGCONT) updated to signal `-pgid` for the same reason — otherwise SIGSTOP on the parent leaves grandchildren CPU-bound while the freeze illusion appears to hold.

### Low-sev follow-ups (same files, from tracker #149)

- `process/tokio_impl.rs:66-68` — `kill()` and `terminate()` now symmetric (both go through the group-targeted `libc::kill` helper). Resolves the legacy asymmetry where one used `start_kill` and the other used raw `libc::kill`.
- `session/handle.rs:313-326` — assistant-text length comparison changed from `>=` to `>` so equal-length later messages don't silently displace the first-seen winner.
- `session/handle.rs:308-310` — `parse_line_all` errors now logged at `debug!` instead of being swallowed.
- `session/handle.rs:333-336` — `try_send` drops on the `session_id` channel now logged at `debug!` instead of being swallowed.

### Test changes for the new signaling semantics

Two existing freeze-pause tests (`signals::tests::freeze_then_resume_flips_proc_state` and `mcp::tools::tests::freeze_and_thaw_transition_via_handler`) spawn `sleep` children directly via `std::process::Command`. Without `process_group(0)` the new `-pgid` send would deliver SIGSTOP to the cargo-test runner itself. Both updated to use `CommandExt::process_group(0)` to mirror the production spawn path.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — all green (487 cli + 91 core + others; previously-failing `freeze_and_thaw_transition_via_handler` now passes with the test-side `process_group(0)`)
- [x] New regression tests: `terminate_kills_grandchildren`, `terminate_after_exit_is_ok`, `pid_slot_is_cleared_after_run`
- [ ] Manual: cancel a real claude run mid-Bash-tool, confirm via `ps` that no orphaned `bash`/`claude-mcp-*` processes remain (covered indirectly by the e2e grandchild test, but worth a manual smoke before tagging)

Closes #147, closes #148. Picks off four items from #149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)