### PR TITLE
fix(manifest): unblock container-dispatch hierarchical manifests + audit cleanup (#142)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -369,6 +369,46 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+**Manifest (container-dispatch unblock + audit follow-ups):**
+- `manifest::validate::validate_lead` — `is_in_git_repo` probe now
+  gated on `!skip_dir_check`, mirroring the directory-existence check.
+  Container-dispatch manifests carry container-side paths
+  (`/workspace/foo`) that don't exist on the host, so the prior
+  unconditional `git2::Repository::discover` call rejected every
+  hierarchical container manifest with the default `use_worktree = true`.
+  Closes #142.
+- `manifest::schema::ApprovalRuleSpec` /
+  `manifest::schema::ApprovalMatchSpec` — added `#[serde(deny_unknown_fields)]`.
+  A typo'd field in an `[[approval_policy]]` block (e.g. `catagory`
+  instead of `category`) used to silently parse with no match filter,
+  matching every event. (Item from #155.)
+- `manifest::validate::validate_hierarchical_ranges` — removed the
+  meaningless `max_parallel_tasks == 0` check. That field is a flat-mode
+  ([[task]]) concurrency cap, and `ResolvedManifest.max_parallel_tasks`
+  always carries the resolver default
+  (`schema::DEFAULT_MAX_PARALLEL_TASKS`), so the assertion never fired
+  for properly-resolved manifests and was misleading to read in lead-mode
+  validation. The legitimate range check stays in `validate_ranges`
+  (flat-mode path). (Item from #155.)
+- `manifest::validate::translate_legacy_parse_error` scanners
+  (`has_top_level_array_table`, `has_field_in_section`, `has_subtable`)
+  — now skip `#`-prefixed comment lines. A commented-out v0.8 field
+  inside `[run]` (e.g. `# approval_policy = "block"`) used to trigger a
+  false-positive migration hint, and `# [[lead]]` in a leading docstring
+  used to satisfy the array-table probe. (Two items from #155.)
+- `manifest::validate::validate_lifecycle` — error message rewritten so
+  the inline `[[notification]] / kind = "log"` snippet renders as a
+  separate indented block rather than as flowing prose; an operator
+  copy-pasting the message no longer ends up with text fragments
+  embedded next to the TOML keys. (Item from #155.)
+- `manifest::schema` — promoted `DEFAULT_MAX_PARALLEL_TASKS` to a
+  `pub const` in `schema.rs` (re-imported by `resolve.rs`) so the
+  effective default is discoverable from the schema source by form
+  renderers, `pitboss schema` consumers, and doc generators without
+  reading resolver internals. Also added `#[serde(default)]` to
+  `RunConfig.max_parallel_tasks` for parity with the other optional
+  fields. (Item from #155.)
+
 **Notify (webhook secret hygiene + SSRF blocklist):**
 - `notify::config::redact_webhook_url` (new helper) — strips path, query,
   and fragment from any webhook URL before it lands in an error message

--- a/crates/pitboss-cli/src/manifest/resolve.rs
+++ b/crates/pitboss-cli/src/manifest/resolve.rs
@@ -135,7 +135,7 @@ pub struct ResolvedManifest {
 const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
 const DEFAULT_EFFORT: Effort = Effort::High;
 const DEFAULT_TIMEOUT_SECS: u64 = 3600;
-const DEFAULT_MAX_PARALLEL_TASKS: u32 = 4;
+use super::schema::DEFAULT_MAX_PARALLEL_TASKS;
 fn default_tools() -> Vec<String> {
     ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
         .iter()

--- a/crates/pitboss-cli/src/manifest/schema.rs
+++ b/crates/pitboss-cli/src/manifest/schema.rs
@@ -259,6 +259,7 @@ pub struct Lifecycle {
 
 /// TOML schema for a single `[[approval_policy]]` rule.
 #[derive(Debug, Clone, Deserialize, Serialize, FieldMetadata)]
+#[serde(deny_unknown_fields)]
 pub struct ApprovalRuleSpec {
     #[serde(default, rename = "match")]
     #[field(skip)]
@@ -275,6 +276,7 @@ pub struct ApprovalRuleSpec {
 
 /// TOML schema for the `[match]` sub-table within an `[[approval_policy]]` rule.
 #[derive(Debug, Clone, Deserialize, Serialize, Default, FieldMetadata)]
+#[serde(deny_unknown_fields)]
 pub struct ApprovalMatchSpec {
     #[field(
         label = "Actor",
@@ -295,6 +297,13 @@ pub struct ApprovalMatchSpec {
     pub cost_over: Option<f64>,
 }
 
+/// Effective default for [`RunConfig::max_parallel_tasks`] when neither
+/// the manifest nor the `ANTHROPIC_MAX_CONCURRENT` env var sets it.
+/// Re-exported from `resolve` so consumers reading just this schema
+/// file (form renderers, `pitboss schema` output, doc generators) can
+/// discover the default without grepping the resolver.
+pub const DEFAULT_MAX_PARALLEL_TASKS: u32 = 4;
+
 /// Run-wide infrastructure config (NOT lead-specific).
 ///
 /// Lead-specific caps moved to `[lead]` in v0.9 (`max_workers`, `budget_usd`,
@@ -303,7 +312,9 @@ pub struct ApprovalMatchSpec {
 #[serde(deny_unknown_fields)]
 pub struct RunConfig {
     /// Concurrency cap for `[[task]]` flat mode. Renamed from `max_parallel`
-    /// in v0.9. Overridden by `ANTHROPIC_MAX_CONCURRENT` env var. Default: 4.
+    /// in v0.9. Overridden by `ANTHROPIC_MAX_CONCURRENT` env var. Default:
+    /// [`DEFAULT_MAX_PARALLEL_TASKS`] (4).
+    #[serde(default)]
     #[field(
         label = "Max parallel tasks",
         help = "Flat-mode concurrency cap for [[task]] runs. Default 4. Overridden by ANTHROPIC_MAX_CONCURRENT."

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -65,12 +65,13 @@ fn validate_lifecycle(r: &ResolvedManifest) -> Result<()> {
                 "[lifecycle] survive_parent = true requires a notification target so the \
                  orchestrator can observe run completion. Add either:\n  \
                  - a [lifecycle.notify] inline sink (same shape as [[notification]]), or\n  \
-                 - at least one top-level [[notification]] section.\n\
+                 - at least one top-level [[notification]] section.\n\n\
                  If you intend to deliver lifecycle events via the \
-                 PITBOSS_PARENT_NOTIFY_URL env var, also declare a no-cost \
-                 [[notification]]\n  kind = \"log\"\n\
-                 to satisfy this validate-time gate (the env-var sink is configured at \
-                 dispatch-time and validate cannot see it)."
+                 PITBOSS_PARENT_NOTIFY_URL env var, add a no-cost log block to satisfy \
+                 this validate-time gate (the env-var sink is configured at dispatch-time \
+                 and validate cannot see it):\n\n    \
+                 [[notification]]\n    \
+                 kind = \"log\"\n"
             );
         }
     }
@@ -134,7 +135,13 @@ fn validate_lead(r: &ResolvedManifest, skip_dir_check: bool) -> Result<()> {
             lead.directory.display()
         );
     }
-    if lead.use_worktree && !is_in_git_repo(&lead.directory) {
+    // skip_dir_check also gates the git-repo probe — container-dispatch
+    // manifests use container-side paths (`/workspace/foo`) that don't
+    // exist on the host, so `git2::Repository::discover` would always
+    // fail and reject every hierarchical container manifest with the
+    // default `use_worktree = true`. Mirrors the existing flat-mode
+    // gating in `validate_directories`.
+    if !skip_dir_check && lead.use_worktree && !is_in_git_repo(&lead.directory) {
         bail!(
             "lead has use_worktree=true but directory is not a git work-tree: {}",
             lead.directory.display()
@@ -201,9 +208,13 @@ fn validate_hierarchical_ranges(r: &ResolvedManifest) -> Result<()> {
             bail!("[lead].lead_timeout_secs must be > 0");
         }
     }
-    if r.max_parallel_tasks == 0 {
-        bail!("[run].max_parallel_tasks must be > 0");
-    }
+    // No `max_parallel_tasks == 0` check here: that's a flat-mode
+    // ([[task]]) concurrency cap. In hierarchical mode the lead's own
+    // `[lead].max_workers` governs concurrency, and the resolved
+    // ResolvedManifest.max_parallel_tasks always has the resolver
+    // default (DEFAULT_MAX_PARALLEL_TASKS) applied, so an `== 0`
+    // assertion here would never fire. The legitimate range check
+    // lives in validate_ranges (flat-mode path) instead.
     Ok(())
 }
 
@@ -373,20 +384,29 @@ pub fn translate_legacy_parse_error(parse_err: &toml::de::Error, src: &str) -> O
 }
 
 /// Returns true iff the source contains a `[[<name>]]` array-of-tables marker
-/// (with optional whitespace) at the start of a line.
+/// (with optional whitespace) at the start of a line. Skips comment lines so
+/// `# [[lead]] (legacy)` in a docstring doesn't false-positive.
 fn has_top_level_array_table(src: &str, name: &str) -> bool {
     let needle = format!("[[{name}]]");
-    src.lines()
-        .any(|line| line.trim_start().starts_with(&needle))
+    src.lines().any(|line| {
+        let trimmed = line.trim_start();
+        !trimmed.starts_with('#') && trimmed.starts_with(&needle)
+    })
 }
 
 /// Returns true iff the source contains a top-level `[<section>]` table
-/// containing a `<field> =` assignment before the next `[` line.
+/// containing a `<field> =` assignment before the next `[` line. Comment
+/// lines (`# …`) are skipped entirely so a commented-out legacy field
+/// (`# approval_policy = "block"`) doesn't trigger a false migration hint
+/// and `# [run]` doesn't mistakenly enter or leave the target section.
 fn has_field_in_section(src: &str, section: &str, field: &str) -> bool {
     let header = format!("[{section}]");
     let mut in_section = false;
     for line in src.lines() {
         let trimmed = line.trim_start();
+        if trimmed.starts_with('#') {
+            continue;
+        }
         if trimmed.starts_with('[') {
             // Entering a new table — true if we hit the target header,
             // false on any other table (including subtables of the section).
@@ -406,11 +426,14 @@ fn has_field_in_section(src: &str, section: &str, field: &str) -> bool {
     false
 }
 
-/// Returns true iff the source contains a `[<parent>.<child>]` subtable header.
+/// Returns true iff the source contains a `[<parent>.<child>]` subtable
+/// header. Skips comment lines (see [`has_top_level_array_table`]).
 fn has_subtable(src: &str, parent: &str, child: &str) -> bool {
     let needle = format!("[{parent}.{child}]");
-    src.lines()
-        .any(|line| line.trim_start().starts_with(&needle))
+    src.lines().any(|line| {
+        let trimmed = line.trim_start();
+        !trimmed.starts_with('#') && trimmed.starts_with(&needle)
+    })
 }
 
 #[cfg(test)]
@@ -1051,5 +1074,101 @@ mod tests {
         let d = with_tmp_repo(true);
         let m = rm(vec![rt("t", d.path().to_path_buf(), false, None)]);
         validate(&m).expect("manifests without [lifecycle] continue to validate");
+    }
+
+    #[test]
+    fn skip_dir_check_skips_git_repo_probe_for_lead() {
+        // Regression for #142: container-dispatch hierarchical manifests
+        // carry container-side directories (`/workspace/foo`) that don't
+        // exist on the host, so the lead's git-repo probe must be gated
+        // on `skip_dir_check` just like the directory-existence check.
+        // Pre-fix this validate path would fail with
+        // "directory is not a git work-tree" for every container manifest.
+        let mut lead = rl("lead", PathBuf::from("/workspace/does-not-exist-on-host"));
+        lead.use_worktree = true;
+        let mut m = ResolvedManifest {
+            max_parallel_tasks: 4,
+            halt_on_failure: false,
+            run_dir: PathBuf::from("."),
+            worktree_cleanup: WorktreeCleanup::OnSuccess,
+            emit_event_stream: false,
+            tasks: vec![],
+            lead: Some(lead),
+            max_workers: Some(4),
+            budget_usd: Some(1.0),
+            lead_timeout_secs: Some(600),
+            default_approval_policy: None,
+            notifications: vec![],
+            dump_shared_store: false,
+            require_plan_approval: false,
+            approval_rules: vec![],
+            container: None,
+            mcp_servers: vec![],
+            lifecycle: None,
+        };
+        // Sanity: with skip_dir_check=false the validator rejects (the
+        // host-side path is bogus).
+        assert!(validate(&m).is_err());
+        // The container-dispatch entry point must accept this manifest:
+        // the probe is gated on skip_dir_check so a host-side absence
+        // doesn't leak into validation.
+        validate_skip_dir_check(&m)
+            .expect("skip_dir_check must skip the git-repo probe for container-dispatch manifests");
+        // Same when use_worktree is false — the gate covers both paths.
+        m.lead.as_mut().unwrap().use_worktree = false;
+        validate_skip_dir_check(&m).expect("skip_dir_check skips dir checks unconditionally");
+    }
+
+    #[test]
+    fn translator_ignores_legacy_field_in_comment_lines() {
+        // #155: a commented-out v0.8 field name in [run] must not trigger
+        // a false-positive migration hint. Pre-fix the line scanner did
+        // a prefix match without skipping `#` lines.
+        let src = "# previously: max_workers = 4\n[run]\n# approval_policy = \"block\"\nmax_parallel_tasks = 2\n";
+        let parse_err: Result<super::super::schema::Manifest, _> = toml::from_str(src);
+        // The [[run]] body is otherwise valid v0.9, so toml may or may
+        // not error — only run the scanner if it did.
+        if let Err(e) = parse_err {
+            let translated = translate_legacy_parse_error(&e, src);
+            assert!(
+                translated.is_none(),
+                "comment-only mentions of legacy fields must not be translated as migration hints: {translated:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn translator_scanner_skips_commented_section_brackets() {
+        // `# [[lead]]` in a leading comment used to satisfy
+        // has_top_level_array_table; now it must not.
+        let src =
+            "# legacy syntax: [[lead]]\n[lead]\nid = \"x\"\ndirectory = \"/tmp\"\nprompt = \"p\"\n";
+        let parse_err: Result<super::super::schema::Manifest, _> = toml::from_str(src);
+        if let Err(e) = parse_err {
+            let translated = translate_legacy_parse_error(&e, src);
+            assert!(
+                translated.is_none(),
+                "commented-out [[lead]] must not be flagged as legacy: {translated:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn approval_rule_rejects_unknown_fields() {
+        // #155: ApprovalRuleSpec lacked deny_unknown_fields, so a typo'd
+        // sub-field would silently pass through.
+        let src = r#"actoin = "auto_approve""#;
+        let err: Result<super::super::schema::ApprovalRuleSpec, _> = toml::from_str(src);
+        assert!(err.is_err(), "unknown field 'actoin' must be rejected");
+    }
+
+    #[test]
+    fn approval_match_rejects_unknown_fields() {
+        // The classic typo from the audit: `catagory` instead of `category`.
+        // Without deny_unknown_fields, the rule parses with no match filter
+        // (every field None) and silently matches every event.
+        let src = r#"catagory = "tool_use""#;
+        let err: Result<super::super::schema::ApprovalMatchSpec, _> = toml::from_str(src);
+        assert!(err.is_err(), "unknown field 'catagory' must be rejected");
     }
 }

--- a/docs/manifest-map.md
+++ b/docs/manifest-map.md
@@ -14,31 +14,31 @@ The annotated example lives at [`pitboss.example.toml`](../pitboss.example.toml)
 
 ## `[run]` — `RunConfig`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:304`](../crates/pitboss-cli/src/manifest/schema.rs#L304).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:313`](../crates/pitboss-cli/src/manifest/schema.rs#L313).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `max_parallel_tasks` | integer | no | Flat-mode concurrency cap for [[task]] runs. Default 4. Overridden by ANTHROPIC_MAX_CONCURRENT. | [`../crates/pitboss-cli/src/manifest/schema.rs#L311`](../crates/pitboss-cli/src/manifest/schema.rs#L311) |
-| `halt_on_failure` | boolean | no | Stop remaining flat-mode tasks on first failure. | [`../crates/pitboss-cli/src/manifest/schema.rs#L318`](../crates/pitboss-cli/src/manifest/schema.rs#L318) |
-| `run_dir` | path | no | Where per-run artifacts land. Default ~/.local/share/pitboss/runs. | [`../crates/pitboss-cli/src/manifest/schema.rs#L324`](../crates/pitboss-cli/src/manifest/schema.rs#L324) |
-| `worktree_cleanup` | enum (`always` \| `on_success` \| `never`) | no | What to do with each worker's git worktree after it finishes. | [`../crates/pitboss-cli/src/manifest/schema.rs#L332`](../crates/pitboss-cli/src/manifest/schema.rs#L332) |
-| `emit_event_stream` | boolean | no | Write a JSONL event stream alongside summary.jsonl. | [`../crates/pitboss-cli/src/manifest/schema.rs#L339`](../crates/pitboss-cli/src/manifest/schema.rs#L339) |
-| `default_approval_policy` | enum (`block` \| `auto_approve` \| `auto_reject`) | no | Default action for request_approval / propose_plan when no TUI is attached and no rule matches. | [`../crates/pitboss-cli/src/manifest/schema.rs#L350`](../crates/pitboss-cli/src/manifest/schema.rs#L350) |
-| `dump_shared_store` | boolean | no | Write shared-store.json into the run directory on finalize. | [`../crates/pitboss-cli/src/manifest/schema.rs#L358`](../crates/pitboss-cli/src/manifest/schema.rs#L358) |
-| `require_plan_approval` | boolean | no | When true, spawn_worker is blocked until propose_plan has been approved. | [`../crates/pitboss-cli/src/manifest/schema.rs#L366`](../crates/pitboss-cli/src/manifest/schema.rs#L366) |
+| `max_parallel_tasks` | integer | no | Flat-mode concurrency cap for [[task]] runs. Default 4. Overridden by ANTHROPIC_MAX_CONCURRENT. | [`../crates/pitboss-cli/src/manifest/schema.rs#L322`](../crates/pitboss-cli/src/manifest/schema.rs#L322) |
+| `halt_on_failure` | boolean | no | Stop remaining flat-mode tasks on first failure. | [`../crates/pitboss-cli/src/manifest/schema.rs#L329`](../crates/pitboss-cli/src/manifest/schema.rs#L329) |
+| `run_dir` | path | no | Where per-run artifacts land. Default ~/.local/share/pitboss/runs. | [`../crates/pitboss-cli/src/manifest/schema.rs#L335`](../crates/pitboss-cli/src/manifest/schema.rs#L335) |
+| `worktree_cleanup` | enum (`always` \| `on_success` \| `never`) | no | What to do with each worker's git worktree after it finishes. | [`../crates/pitboss-cli/src/manifest/schema.rs#L343`](../crates/pitboss-cli/src/manifest/schema.rs#L343) |
+| `emit_event_stream` | boolean | no | Write a JSONL event stream alongside summary.jsonl. | [`../crates/pitboss-cli/src/manifest/schema.rs#L350`](../crates/pitboss-cli/src/manifest/schema.rs#L350) |
+| `default_approval_policy` | enum (`block` \| `auto_approve` \| `auto_reject`) | no | Default action for request_approval / propose_plan when no TUI is attached and no rule matches. | [`../crates/pitboss-cli/src/manifest/schema.rs#L361`](../crates/pitboss-cli/src/manifest/schema.rs#L361) |
+| `dump_shared_store` | boolean | no | Write shared-store.json into the run directory on finalize. | [`../crates/pitboss-cli/src/manifest/schema.rs#L369`](../crates/pitboss-cli/src/manifest/schema.rs#L369) |
+| `require_plan_approval` | boolean | no | When true, spawn_worker is blocked until propose_plan has been approved. | [`../crates/pitboss-cli/src/manifest/schema.rs#L377`](../crates/pitboss-cli/src/manifest/schema.rs#L377) |
 
 ## `[defaults]` — `Defaults`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:398`](../crates/pitboss-cli/src/manifest/schema.rs#L398).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:409`](../crates/pitboss-cli/src/manifest/schema.rs#L409).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `model` | text | no | Claude model id (e.g. claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-7). | [`../crates/pitboss-cli/src/manifest/schema.rs#L403`](../crates/pitboss-cli/src/manifest/schema.rs#L403) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Maps to the claude --effort flag. | [`../crates/pitboss-cli/src/manifest/schema.rs#L409`](../crates/pitboss-cli/src/manifest/schema.rs#L409) |
-| `tools` | string list | no | Allowed tool surface. Pitboss auto-appends its MCP tools for leads and workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L414`](../crates/pitboss-cli/src/manifest/schema.rs#L414) |
-| `timeout_secs` | integer | no | Per-task wall-clock cap. No default (no cap). | [`../crates/pitboss-cli/src/manifest/schema.rs#L419`](../crates/pitboss-cli/src/manifest/schema.rs#L419) |
-| `use_worktree` | boolean | no | Isolate each worker in a git worktree. Default true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L424`](../crates/pitboss-cli/src/manifest/schema.rs#L424) |
-| `env` | key-value map | no | Environment variables passed to the claude subprocess. | [`../crates/pitboss-cli/src/manifest/schema.rs#L430`](../crates/pitboss-cli/src/manifest/schema.rs#L430) |
+| `model` | text | no | Claude model id (e.g. claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-7). | [`../crates/pitboss-cli/src/manifest/schema.rs#L414`](../crates/pitboss-cli/src/manifest/schema.rs#L414) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Maps to the claude --effort flag. | [`../crates/pitboss-cli/src/manifest/schema.rs#L420`](../crates/pitboss-cli/src/manifest/schema.rs#L420) |
+| `tools` | string list | no | Allowed tool surface. Pitboss auto-appends its MCP tools for leads and workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L425`](../crates/pitboss-cli/src/manifest/schema.rs#L425) |
+| `timeout_secs` | integer | no | Per-task wall-clock cap. No default (no cap). | [`../crates/pitboss-cli/src/manifest/schema.rs#L430`](../crates/pitboss-cli/src/manifest/schema.rs#L430) |
+| `use_worktree` | boolean | no | Isolate each worker in a git worktree. Default true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L435`](../crates/pitboss-cli/src/manifest/schema.rs#L435) |
+| `env` | key-value map | no | Environment variables passed to the claude subprocess. | [`../crates/pitboss-cli/src/manifest/schema.rs#L441`](../crates/pitboss-cli/src/manifest/schema.rs#L441) |
 
 ## `[container]` — `ContainerConfig`
 
@@ -63,66 +63,66 @@ Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:109`](../crates/pitbos
 
 ## `[[task]]` — `Task`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:461`](../crates/pitboss-cli/src/manifest/schema.rs#L461).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:472`](../crates/pitboss-cli/src/manifest/schema.rs#L472).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique slug. Alphanumeric + _ + -. Used in logs and worktree names. | [`../crates/pitboss-cli/src/manifest/schema.rs#L466`](../crates/pitboss-cli/src/manifest/schema.rs#L466) |
-| `directory` | path | **yes** | Working directory. Must be inside a git repo if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L471`](../crates/pitboss-cli/src/manifest/schema.rs#L471) |
-| `prompt` | text (multi-line) | no | Prompt body sent to claude via -p. Mutually exclusive with `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L477`](../crates/pitboss-cli/src/manifest/schema.rs#L477) |
-| `template` | text | no | Reference to a [[template]] entry. Mutually exclusive with `prompt`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L482`](../crates/pitboss-cli/src/manifest/schema.rs#L482) |
-| `vars` | key-value map | no | Substitutions for {placeholders} when using `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L488`](../crates/pitboss-cli/src/manifest/schema.rs#L488) |
-| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L493`](../crates/pitboss-cli/src/manifest/schema.rs#L493) |
-| `model` | text | no | Per-task override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L495`](../crates/pitboss-cli/src/manifest/schema.rs#L495) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-task override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L501`](../crates/pitboss-cli/src/manifest/schema.rs#L501) |
-| `tools` | string list | no | Per-task override of [defaults].tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L503`](../crates/pitboss-cli/src/manifest/schema.rs#L503) |
-| `timeout_secs` | integer | no | Per-task wall-clock cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L505`](../crates/pitboss-cli/src/manifest/schema.rs#L505) |
-| `use_worktree` | boolean | no | Per-task override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L510`](../crates/pitboss-cli/src/manifest/schema.rs#L510) |
-| `env` | key-value map | no | Per-task env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L516`](../crates/pitboss-cli/src/manifest/schema.rs#L516) |
+| `id` | text | **yes** | Unique slug. Alphanumeric + _ + -. Used in logs and worktree names. | [`../crates/pitboss-cli/src/manifest/schema.rs#L477`](../crates/pitboss-cli/src/manifest/schema.rs#L477) |
+| `directory` | path | **yes** | Working directory. Must be inside a git repo if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L482`](../crates/pitboss-cli/src/manifest/schema.rs#L482) |
+| `prompt` | text (multi-line) | no | Prompt body sent to claude via -p. Mutually exclusive with `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L488`](../crates/pitboss-cli/src/manifest/schema.rs#L488) |
+| `template` | text | no | Reference to a [[template]] entry. Mutually exclusive with `prompt`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L493`](../crates/pitboss-cli/src/manifest/schema.rs#L493) |
+| `vars` | key-value map | no | Substitutions for {placeholders} when using `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L499`](../crates/pitboss-cli/src/manifest/schema.rs#L499) |
+| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L504`](../crates/pitboss-cli/src/manifest/schema.rs#L504) |
+| `model` | text | no | Per-task override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L506`](../crates/pitboss-cli/src/manifest/schema.rs#L506) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-task override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L512`](../crates/pitboss-cli/src/manifest/schema.rs#L512) |
+| `tools` | string list | no | Per-task override of [defaults].tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L514`](../crates/pitboss-cli/src/manifest/schema.rs#L514) |
+| `timeout_secs` | integer | no | Per-task wall-clock cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L516`](../crates/pitboss-cli/src/manifest/schema.rs#L516) |
+| `use_worktree` | boolean | no | Per-task override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L521`](../crates/pitboss-cli/src/manifest/schema.rs#L521) |
+| `env` | key-value map | no | Per-task env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L527`](../crates/pitboss-cli/src/manifest/schema.rs#L527) |
 
 ## `[lead]` — `Lead`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:526`](../crates/pitboss-cli/src/manifest/schema.rs#L526).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:537`](../crates/pitboss-cli/src/manifest/schema.rs#L537).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique slug used as the TUI tile label and in run artifact paths. | [`../crates/pitboss-cli/src/manifest/schema.rs#L533`](../crates/pitboss-cli/src/manifest/schema.rs#L533) |
-| `directory` | path | **yes** | Working directory for the lead's claude subprocess. Must be a git work-tree if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L540`](../crates/pitboss-cli/src/manifest/schema.rs#L540) |
-| `prompt` | text (multi-line) | **yes** | Operator instructions passed to claude via -p. Must appear before any [lead.X] subtable in the source. | [`../crates/pitboss-cli/src/manifest/schema.rs#L552`](../crates/pitboss-cli/src/manifest/schema.rs#L552) |
-| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L560`](../crates/pitboss-cli/src/manifest/schema.rs#L560) |
-| `model` | text | no | Per-lead override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L563`](../crates/pitboss-cli/src/manifest/schema.rs#L563) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-lead override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L570`](../crates/pitboss-cli/src/manifest/schema.rs#L570) |
-| `tools` | string list | no | Per-lead override of [defaults].tools. Pitboss auto-appends its MCP tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L576`](../crates/pitboss-cli/src/manifest/schema.rs#L576) |
-| `timeout_secs` | integer | no | Per-actor subprocess wall-clock cap (claude --timeout). | [`../crates/pitboss-cli/src/manifest/schema.rs#L582`](../crates/pitboss-cli/src/manifest/schema.rs#L582) |
-| `use_worktree` | boolean | no | Per-lead override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L588`](../crates/pitboss-cli/src/manifest/schema.rs#L588) |
-| `env` | key-value map | no | Per-lead env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L594`](../crates/pitboss-cli/src/manifest/schema.rs#L594) |
-| `max_workers` | integer | no | Hard cap on the lead's concurrent + queued worker pool (1–16). Required when the lead spawns workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L603`](../crates/pitboss-cli/src/manifest/schema.rs#L603) |
-| `budget_usd` | float | no | Soft cap on lead spend with reservation accounting. spawn_worker fails once spent + reserved + next_estimate > budget. | [`../crates/pitboss-cli/src/manifest/schema.rs#L612`](../crates/pitboss-cli/src/manifest/schema.rs#L612) |
-| `lead_timeout_secs` | integer | no | Wall-clock cap on the lead session. Default 3600. | [`../crates/pitboss-cli/src/manifest/schema.rs#L621`](../crates/pitboss-cli/src/manifest/schema.rs#L621) |
-| `permission_routing` | enum (`path_a` \| `path_b`) | no | path_a (default) makes pitboss the sole permission authority. path_b routes claude's gate through pitboss (rejected at validate time pending stabilization). | [`../crates/pitboss-cli/src/manifest/schema.rs#L634`](../crates/pitboss-cli/src/manifest/schema.rs#L634) |
-| `allow_subleads` | boolean | no | Expose spawn_sublead to the root lead. | [`../crates/pitboss-cli/src/manifest/schema.rs#L643`](../crates/pitboss-cli/src/manifest/schema.rs#L643) |
-| `max_subleads` | integer | no | Hard cap on total live sub-leads under this root. | [`../crates/pitboss-cli/src/manifest/schema.rs#L650`](../crates/pitboss-cli/src/manifest/schema.rs#L650) |
-| `max_sublead_budget_usd` | float | no | Cap on the per-sub-lead budget envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L657`](../crates/pitboss-cli/src/manifest/schema.rs#L657) |
-| `max_total_workers` | integer | no | Cap on total live workers across the entire tree (root + sub-trees). | [`../crates/pitboss-cli/src/manifest/schema.rs#L665`](../crates/pitboss-cli/src/manifest/schema.rs#L665) |
+| `id` | text | **yes** | Unique slug used as the TUI tile label and in run artifact paths. | [`../crates/pitboss-cli/src/manifest/schema.rs#L544`](../crates/pitboss-cli/src/manifest/schema.rs#L544) |
+| `directory` | path | **yes** | Working directory for the lead's claude subprocess. Must be a git work-tree if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L551`](../crates/pitboss-cli/src/manifest/schema.rs#L551) |
+| `prompt` | text (multi-line) | **yes** | Operator instructions passed to claude via -p. Must appear before any [lead.X] subtable in the source. | [`../crates/pitboss-cli/src/manifest/schema.rs#L563`](../crates/pitboss-cli/src/manifest/schema.rs#L563) |
+| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L571`](../crates/pitboss-cli/src/manifest/schema.rs#L571) |
+| `model` | text | no | Per-lead override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L574`](../crates/pitboss-cli/src/manifest/schema.rs#L574) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-lead override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L581`](../crates/pitboss-cli/src/manifest/schema.rs#L581) |
+| `tools` | string list | no | Per-lead override of [defaults].tools. Pitboss auto-appends its MCP tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L587`](../crates/pitboss-cli/src/manifest/schema.rs#L587) |
+| `timeout_secs` | integer | no | Per-actor subprocess wall-clock cap (claude --timeout). | [`../crates/pitboss-cli/src/manifest/schema.rs#L593`](../crates/pitboss-cli/src/manifest/schema.rs#L593) |
+| `use_worktree` | boolean | no | Per-lead override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L599`](../crates/pitboss-cli/src/manifest/schema.rs#L599) |
+| `env` | key-value map | no | Per-lead env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L605`](../crates/pitboss-cli/src/manifest/schema.rs#L605) |
+| `max_workers` | integer | no | Hard cap on the lead's concurrent + queued worker pool (1–16). Required when the lead spawns workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L614`](../crates/pitboss-cli/src/manifest/schema.rs#L614) |
+| `budget_usd` | float | no | Soft cap on lead spend with reservation accounting. spawn_worker fails once spent + reserved + next_estimate > budget. | [`../crates/pitboss-cli/src/manifest/schema.rs#L623`](../crates/pitboss-cli/src/manifest/schema.rs#L623) |
+| `lead_timeout_secs` | integer | no | Wall-clock cap on the lead session. Default 3600. | [`../crates/pitboss-cli/src/manifest/schema.rs#L632`](../crates/pitboss-cli/src/manifest/schema.rs#L632) |
+| `permission_routing` | enum (`path_a` \| `path_b`) | no | path_a (default) makes pitboss the sole permission authority. path_b routes claude's gate through pitboss (rejected at validate time pending stabilization). | [`../crates/pitboss-cli/src/manifest/schema.rs#L645`](../crates/pitboss-cli/src/manifest/schema.rs#L645) |
+| `allow_subleads` | boolean | no | Expose spawn_sublead to the root lead. | [`../crates/pitboss-cli/src/manifest/schema.rs#L654`](../crates/pitboss-cli/src/manifest/schema.rs#L654) |
+| `max_subleads` | integer | no | Hard cap on total live sub-leads under this root. | [`../crates/pitboss-cli/src/manifest/schema.rs#L661`](../crates/pitboss-cli/src/manifest/schema.rs#L661) |
+| `max_sublead_budget_usd` | float | no | Cap on the per-sub-lead budget envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L668`](../crates/pitboss-cli/src/manifest/schema.rs#L668) |
+| `max_total_workers` | integer | no | Cap on total live workers across the entire tree (root + sub-trees). | [`../crates/pitboss-cli/src/manifest/schema.rs#L676`](../crates/pitboss-cli/src/manifest/schema.rs#L676) |
 
 ## `[sublead_defaults]` — `SubleadDefaults`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:672`](../crates/pitboss-cli/src/manifest/schema.rs#L672).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:683`](../crates/pitboss-cli/src/manifest/schema.rs#L683).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `budget_usd` | float | no | Per-sub-lead envelope when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L677`](../crates/pitboss-cli/src/manifest/schema.rs#L677) |
-| `max_workers` | integer | no | Per-sub-lead worker pool when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L682`](../crates/pitboss-cli/src/manifest/schema.rs#L682) |
-| `lead_timeout_secs` | integer | no | Wall-clock cap for the sub-lead session. | [`../crates/pitboss-cli/src/manifest/schema.rs#L687`](../crates/pitboss-cli/src/manifest/schema.rs#L687) |
-| `read_down` | boolean | no | When true, sub-lead shares root's budget + worker pool instead of carving its own envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L693`](../crates/pitboss-cli/src/manifest/schema.rs#L693) |
+| `budget_usd` | float | no | Per-sub-lead envelope when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L688`](../crates/pitboss-cli/src/manifest/schema.rs#L688) |
+| `max_workers` | integer | no | Per-sub-lead worker pool when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L693`](../crates/pitboss-cli/src/manifest/schema.rs#L693) |
+| `lead_timeout_secs` | integer | no | Wall-clock cap for the sub-lead session. | [`../crates/pitboss-cli/src/manifest/schema.rs#L698`](../crates/pitboss-cli/src/manifest/schema.rs#L698) |
+| `read_down` | boolean | no | When true, sub-lead shares root's budget + worker pool instead of carving its own envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L704`](../crates/pitboss-cli/src/manifest/schema.rs#L704) |
 
 ## `[[approval_policy]]` — `ApprovalRuleSpec`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:262`](../crates/pitboss-cli/src/manifest/schema.rs#L262).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:263`](../crates/pitboss-cli/src/manifest/schema.rs#L263).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `action` | enum (`auto_approve` \| `auto_reject` \| `block`) | **yes** | Action when this rule matches. | [`../crates/pitboss-cli/src/manifest/schema.rs#L273`](../crates/pitboss-cli/src/manifest/schema.rs#L273) |
+| `action` | enum (`auto_approve` \| `auto_reject` \| `block`) | **yes** | Action when this rule matches. | [`../crates/pitboss-cli/src/manifest/schema.rs#L274`](../crates/pitboss-cli/src/manifest/schema.rs#L274) |
 
 ## `[[mcp_server]]` — `McpServerSpec`
 
@@ -137,12 +137,12 @@ Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:137`](../crates/pitbos
 
 ## `[[template]]` — `Template`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:445`](../crates/pitboss-cli/src/manifest/schema.rs#L445).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:456`](../crates/pitboss-cli/src/manifest/schema.rs#L456).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Slug referenced from [[task]].template. | [`../crates/pitboss-cli/src/manifest/schema.rs#L450`](../crates/pitboss-cli/src/manifest/schema.rs#L450) |
-| `prompt` | text (multi-line) | **yes** | Prompt body. Supports {var} placeholders supplied by [[task]].vars. | [`../crates/pitboss-cli/src/manifest/schema.rs#L456`](../crates/pitboss-cli/src/manifest/schema.rs#L456) |
+| `id` | text | **yes** | Slug referenced from [[task]].template. | [`../crates/pitboss-cli/src/manifest/schema.rs#L461`](../crates/pitboss-cli/src/manifest/schema.rs#L461) |
+| `prompt` | text (multi-line) | **yes** | Prompt body. Supports {var} placeholders supplied by [[task]].vars. | [`../crates/pitboss-cli/src/manifest/schema.rs#L467`](../crates/pitboss-cli/src/manifest/schema.rs#L467) |
 
 ## `[lifecycle]` — `Lifecycle`
 


### PR DESCRIPTION
## Summary

- **#142 (high):** `validate_lead`'s `is_in_git_repo` probe ran unconditionally even on the `skip_dir_check` entry point used by `pitboss container-dispatch`. Container manifests carry container-side directory paths that don't exist on the host, so `git2::Repository::discover` fails and rejects every hierarchical container manifest with the default `use_worktree = true`. Gate the probe on `!skip_dir_check`, mirroring the existing flat-mode gating in `validate_directories`.
- **#155 (5 of 6 items in same files):** `deny_unknown_fields` on `ApprovalRule`/`Match` (defeats the `catagory`-typo silent-match), removed misleading `max_parallel_tasks == 0` check from hierarchical validation, scanner-skip-`#`-comments in the legacy-parse translator (defeats false-positive migration hints), lifecycle error message reformatted as a real code block, `DEFAULT_MAX_PARALLEL_TASKS` hoisted to `schema.rs` for discoverability.

## Test plan

- [x] `cargo test --workspace` — all green (509 lib + integration, +5 new)
- [x] `cargo clippy --workspace --all-targets --no-deps -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] New `skip_dir_check_skips_git_repo_probe_for_lead` regression test exercises the `#142` fix path
- [x] `translator_ignores_legacy_field_in_comment_lines` + `translator_scanner_skips_commented_section_brackets` cover the comment-skip changes
- [x] `approval_rule_rejects_unknown_fields` + `approval_match_rejects_unknown_fields` cover the schema tightening
- [x] `docs/manifest-map.md` regenerated by the auto-doc CI gate (line-number drift only)

## What's NOT in this PR (separate focused work)

From #155 — one item that touches different code:
- `map_doc.rs` / `example_doc.rs` CI gate uses `include_str!` byte equality; on Windows/CRLF git configs it fails on every run, and the brace-depth scanner doesn't skip doc-comment lines containing `{` or `}`. Different module, different shape — better as a focused PR.

Closes #142. Picks off 5 items from tracker #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)