### PR TITLE
fix(cli): runs.rs socket-path double-nesting + #157 audit follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -369,6 +369,43 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+**CLI (active-run liveness + audit follow-ups):**
+- `runs::resolve_socket_path` — fallback path no longer joins `run_id` a
+  second time. The runs-discovery caller already passes the per-run
+  subdirectory (`<base>/<uuid>/`), but the fallback was constructing
+  `<base>/<uuid>/<uuid>/control.sock` — a path the dispatcher never
+  writes. On any system without `$XDG_RUNTIME_DIR` (containers without
+  a login session, minimal init, some CI runners) the liveness probe
+  silently failed for every run and `pitboss list --active` reported
+  the system as idle while runs were actively executing. Closes #141.
+- `main::run_validate` — exits `2` on validation failure instead of
+  `1`, matching the dispatch-side convention. Scripts wrapping
+  `pitboss validate` can now distinguish a missing binary (OS error,
+  exit 1) from a bad manifest (validation error, exit 2). (Item from #157.)
+- `cli::Command::Diff` / `cli::Command::Attach` — added `--run-dir`
+  override, mirroring `status` / `resume` / `list` / `prune`. Operators
+  with a custom runs directory no longer have to drop down to
+  `pitboss list --json` to find the absolute path before running
+  `attach` or `diff`. (Item from #157.)
+- `cli::Command::Dispatch` — `--background` / `--dry-run` /
+  `--internal-run-id` mutual-exclusions are now declared via clap
+  `conflicts_with` / `conflicts_with_all` so the conflicts surface in
+  `--help`, shell completions, and parse-time errors instead of an
+  opaque exit-2 mid-handler. The redundant runtime checks in
+  `main.rs` were removed. (Item from #157.)
+- `runs::collect_run_entry` — a `summary.json` that exists but fails
+  to deserialize is now classified as `Aborted` with a `tracing::warn`
+  surfacing the parse error. Previously the call silently fell through
+  to jsonl classification, which would happily report a corrupted
+  finalised run as `Running` if the jsonl mtime was recent — actively
+  misleading the orchestrator. (Item from #157.)
+- `list::RunListEntry.status` — typed as `runs::RunStatus` (with
+  `Serialize` and `serde(rename_all = "lowercase")`) instead of
+  `&'static str`. The wire format is unchanged, but renaming a
+  variant or its label is now a type-checked breaking change for
+  consumers of the JSON enum-string set rather than a silent flip.
+  (Item from #157.)
+
 **Manifest (container-dispatch unblock + audit follow-ups):**
 - `manifest::validate::validate_lead` — `is_in_git_repo` probe now
   gated on `!skip_dir_check`, mirroring the directory-existence check.

--- a/crates/pitboss-cli/src/attach.rs
+++ b/crates/pitboss-cli/src/attach.rs
@@ -43,17 +43,35 @@ const CAP_TOOL_RESULT: usize = 3000;
 /// tokio runtime for the Ctrl-C handler then drives the sync polling
 /// loop inline. Returns a process exit code: 0 on clean completion /
 /// Ctrl-C, non-zero on resolution / IO errors.
-pub fn run(run_id_prefix: &str, task_id: &str, raw: bool, lines: usize) -> Result<i32> {
+pub fn run(
+    run_id_prefix: &str,
+    task_id: &str,
+    raw: bool,
+    lines: usize,
+    runs_dir_override: Option<PathBuf>,
+) -> Result<i32> {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .context("build tokio runtime")?;
-    rt.block_on(run_async(run_id_prefix, task_id, raw, lines))
+    rt.block_on(run_async(
+        run_id_prefix,
+        task_id,
+        raw,
+        lines,
+        runs_dir_override,
+    ))
 }
 
-async fn run_async(run_id_prefix: &str, task_id: &str, raw: bool, lines: usize) -> Result<i32> {
+async fn run_async(
+    run_id_prefix: &str,
+    task_id: &str,
+    raw: bool,
+    lines: usize,
+    runs_dir_override: Option<PathBuf>,
+) -> Result<i32> {
     validate_task_id(task_id)?;
-    let base = default_runs_dir();
+    let base = runs_dir_override.unwrap_or_else(default_runs_dir);
     let run_dir = resolve_run_dir(&base, run_id_prefix)?;
     let tasks_root = run_dir.join("tasks");
     let task_dir = tasks_root.join(task_id);

--- a/crates/pitboss-cli/src/cli.rs
+++ b/crates/pitboss-cli/src/cli.rs
@@ -49,7 +49,7 @@ pub enum Command {
         #[arg(long)]
         run_dir: Option<PathBuf>,
         /// Print the resolved claude spawn commands and exit.
-        #[arg(long)]
+        #[arg(long, conflicts_with_all = ["background", "internal_run_id"])]
         dry_run: bool,
         /// Detach the dispatcher to run in the background (`nohup`-equivalent).
         /// Mints a `run_id`, spawns the dispatcher as a session-leader child
@@ -65,12 +65,16 @@ pub enum Command {
         ///
         /// Mode-agnostic: works with both flat (`[[task]]`) and
         /// hierarchical (`[lead]`) manifests.
-        #[arg(long)]
+        #[arg(long, conflicts_with = "internal_run_id")]
         background: bool,
         /// Internal: re-use this UUID as the run id instead of minting one.
         /// Set automatically when `--background` re-spawns the dispatcher
         /// as a detached child so the parent's announced `run_id` matches
         /// what the child writes to disk. Not for direct human use.
+        ///
+        /// Mutually exclusive with `--background` (clap-enforced) so the
+        /// conflict surfaces in `--help` and shell completions rather
+        /// than as an opaque exit-2 mid-handler. (#157)
         #[arg(long, hide = true, value_name = "UUID")]
         internal_run_id: Option<String>,
     },
@@ -91,6 +95,13 @@ pub enum Command {
         /// Emit machine-readable JSON instead of a table.
         #[arg(long)]
         json: bool,
+        /// Override the runs base directory. Defaults to
+        /// `~/.local/share/pitboss/runs`. Same semantics as `status`,
+        /// `resume`, `list`, `prune` so operators with a custom runs
+        /// directory don't have to drop down to `pitboss list --json`
+        /// to find the absolute path. (#157)
+        #[arg(long, value_name = "PATH")]
+        run_dir: Option<PathBuf>,
     },
     /// Tail a specific worker's output live (`docker logs -f` shape).
     /// Resolves a run id (full UUID or unique prefix) + task id against
@@ -109,6 +120,11 @@ pub enum Command {
         /// Seed with the last N historical lines before following.
         #[arg(long, default_value_t = 20)]
         lines: usize,
+        /// Override the runs base directory. Defaults to
+        /// `~/.local/share/pitboss/runs`. Same semantics as `status`,
+        /// `resume`, `list`, `prune`. (#157)
+        #[arg(long, value_name = "PATH")]
+        run_dir: Option<PathBuf>,
     },
     /// Print version information.
     Version,
@@ -332,6 +348,63 @@ impl From<InitTemplateArg> for crate::manifest::init_template::InitTemplate {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── #157: clap conflicts_with surfaces --background mutual-exclusions ──
+
+    #[test]
+    fn dispatch_rejects_background_with_dry_run() {
+        // Both flags together should fail at parse time, not deep in the
+        // dispatcher. Surfaces in --help and shell completions.
+        let err = Cli::try_parse_from([
+            "pitboss",
+            "dispatch",
+            "manifest.toml",
+            "--background",
+            "--dry-run",
+        ])
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--dry-run") || msg.contains("--background"),
+            "expected mutual-exclusion error mentioning --background/--dry-run, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn dispatch_rejects_background_with_internal_run_id() {
+        let err = Cli::try_parse_from([
+            "pitboss",
+            "dispatch",
+            "manifest.toml",
+            "--background",
+            "--internal-run-id",
+            "00000000-0000-0000-0000-000000000000",
+        ])
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--internal-run-id") || msg.contains("--background"),
+            "expected mutual-exclusion error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn dispatch_rejects_dry_run_with_internal_run_id() {
+        let err = Cli::try_parse_from([
+            "pitboss",
+            "dispatch",
+            "manifest.toml",
+            "--dry-run",
+            "--internal-run-id",
+            "00000000-0000-0000-0000-000000000000",
+        ])
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--internal-run-id") || msg.contains("--dry-run"),
+            "expected mutual-exclusion error, got: {msg}"
+        );
+    }
 
     #[test]
     fn completions_bash_contains_pitboss_name() {

--- a/crates/pitboss-cli/src/diff.rs
+++ b/crates/pitboss-cli/src/diff.rs
@@ -29,7 +29,11 @@ fn runs_base_dir() -> PathBuf {
         .join(".local/share/pitboss/runs")
 }
 
-fn resolve_run_under(base: &Path, id_or_prefix: &str) -> Result<PathBuf> {
+/// Locate a run directory by UUID prefix under an explicit base directory.
+///
+/// Used by `pitboss diff --run-dir <PATH>` to point at an alternate runs
+/// store (mirrors the same flag on `status`/`resume`/`list`/`prune`).
+pub fn resolve_run_under(base: &Path, id_or_prefix: &str) -> Result<PathBuf> {
     // Exact match first.
     let exact = base.join(id_or_prefix);
     if exact.is_dir() {

--- a/crates/pitboss-cli/src/list.rs
+++ b/crates/pitboss-cli/src/list.rs
@@ -33,6 +33,12 @@ use crate::runs;
 
 /// JSON shape emitted with `--json`. Stable contract for orchestrators —
 /// one record per run directory under `~/.local/share/pitboss/runs/`.
+///
+/// `status` carries the typed [`runs::RunStatus`] enum (serialized lowercase
+/// so it matches `RunStatus::label()`'s string form). Using the enum
+/// rather than a `&'static str` means renaming a variant or its label is a
+/// type-checked breaking change for consumers, not a silent JSON-shape
+/// flip.
 #[derive(Debug, Serialize)]
 pub struct RunListEntry {
     pub run_id: String,
@@ -41,8 +47,9 @@ pub struct RunListEntry {
     pub started_at: String,
     pub tasks_total: usize,
     pub tasks_failed: usize,
-    /// One of "complete", "running", "stale", "aborted".
-    pub status: &'static str,
+    /// Run status — serialised as one of `"complete"`, `"running"`,
+    /// `"stale"`, `"aborted"`.
+    pub status: runs::RunStatus,
 }
 
 impl From<&runs::RunEntry> for RunListEntry {
@@ -53,7 +60,7 @@ impl From<&runs::RunEntry> for RunListEntry {
             started_at: rfc3339(e.mtime),
             tasks_total: e.tasks_total,
             tasks_failed: e.tasks_failed,
-            status: e.status.label(),
+            status: e.status,
         }
     }
 }
@@ -204,6 +211,19 @@ mod tests {
         let nonexistent = tmp.path().join("does-not-exist");
         let rc = run(true, false, Some(nonexistent)).unwrap();
         assert_eq!(rc, 0);
+    }
+
+    #[test]
+    fn list_json_status_serializes_as_lowercase_string() {
+        // The wire format must remain a lowercase string ("complete",
+        // "running", "stale", "aborted") — switching to the typed
+        // RunStatus enum was a refactor, not a behavior change.
+        let tmp = TempDir::new().unwrap();
+        make_run_dir(tmp.path(), "019d-aaaa", true);
+        let entries = runs::collect_run_entries(tmp.path());
+        let out: Vec<RunListEntry> = entries.iter().map(RunListEntry::from).collect();
+        let json = serde_json::to_string(&out).unwrap();
+        assert!(json.contains("\"status\":\"complete\""), "got: {json}");
     }
 
     #[test]

--- a/crates/pitboss-cli/src/main.rs
+++ b/crates/pitboss-cli/src/main.rs
@@ -20,7 +20,9 @@ fn main() -> Result<()> {
             agents_md::print_agents_md();
             Ok(())
         }
-        Command::Validate { manifest } => run_validate(&manifest),
+        Command::Validate { manifest } => {
+            std::process::exit(run_validate(&manifest));
+        }
         Command::Dispatch {
             manifest,
             run_dir,
@@ -33,23 +35,13 @@ fn main() -> Result<()> {
             // JSON announcement on stdout. The child invocation receives
             // `--internal-run-id` so the announced and on-disk run ids
             // match. See `dispatch::background` for the full mechanism.
+            //
+            // The `--background`/`--dry-run`/`--internal-run-id`
+            // mutual-exclusions are enforced by `conflicts_with` /
+            // `conflicts_with_all` on the clap arg definitions, so by
+            // the time we reach this branch the combinations are
+            // guaranteed safe — no extra runtime checks needed.
             if background {
-                if dry_run {
-                    eprintln!("--background and --dry-run are mutually exclusive");
-                    std::process::exit(2);
-                }
-                if internal_run_id.is_some() {
-                    // Ambiguous: the parent already pre-mints and forwards
-                    // via --internal-run-id, so combining them means the
-                    // operator is asking us to re-detach an already-detached
-                    // dispatch. Reject rather than silently double-spawn.
-                    eprintln!(
-                        "--background and --internal-run-id are mutually exclusive\n\
-                         (--internal-run-id is set automatically by --background's \
-                         self-respawn; not for direct human use)"
-                    );
-                    std::process::exit(2);
-                }
                 match dispatch::background::run_background(&manifest, run_dir) {
                     Ok(code) => std::process::exit(code),
                     Err(e) => {
@@ -73,16 +65,22 @@ fn main() -> Result<()> {
         Command::Resume { run_id, run_dir } => {
             run_resume(&run_id, run_dir);
         }
-        Command::Diff { run_a, run_b, json } => {
-            run_diff(&run_a, &run_b, json);
+        Command::Diff {
+            run_a,
+            run_b,
+            json,
+            run_dir,
+        } => {
+            run_diff(&run_a, &run_b, json, run_dir);
         }
         Command::Attach {
             run_id,
             task_id,
             raw,
             lines,
+            run_dir,
         } => {
-            std::process::exit(attach::run(&run_id, &task_id, raw, lines)?);
+            std::process::exit(attach::run(&run_id, &task_id, raw, lines, run_dir)?);
         }
         Command::Status {
             run_id,
@@ -282,9 +280,24 @@ fn init_tracing(verbose: u8, quiet: bool) {
         .init();
 }
 
-fn run_validate(manifest: &std::path::Path) -> Result<()> {
+/// Drive `pitboss validate`. Returns the exit code so scripts wrapping
+/// `pitboss validate` can distinguish:
+///   * `0` — manifest valid
+///   * `2` — manifest failed validation (parse error, schema violation,
+///     missing field, …); all user-fixable cases land here so a CI step
+///     can hard-gate on `exit == 2`. Previously these were exit 1, which
+///     overlapped with the OS-level "binary not found" exit code and made
+///     it impossible to distinguish a missing `pitboss` binary from a bad
+///     manifest. (#157)
+fn run_validate(manifest: &std::path::Path) -> i32 {
     let env_mp = parse_env_max_parallel();
-    let r = manifest::load_manifest(manifest, env_mp)?;
+    let r = match manifest::load_manifest(manifest, env_mp) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("validation failed: {e:#}");
+            return 2;
+        }
+    };
     if let Some(lead) = &r.lead {
         println!(
             "OK (hierarchical) — lead='{}', max_workers={}, budget=${:.2}",
@@ -299,7 +312,7 @@ fn run_validate(manifest: &std::path::Path) -> Result<()> {
             r.max_parallel_tasks
         );
     }
-    Ok(())
+    0
 }
 
 fn run_dispatch(
@@ -436,15 +449,24 @@ fn parse_env_max_parallel() -> Option<u32> {
         .and_then(|s| s.parse().ok())
 }
 
-fn run_diff(run_a: &str, run_b: &str, json: bool) -> ! {
-    let dir_a = match diff::resolve_run(run_a) {
+fn run_diff(
+    run_a: &str,
+    run_b: &str,
+    json: bool,
+    run_dir_override: Option<std::path::PathBuf>,
+) -> ! {
+    let resolve = |id: &str| match &run_dir_override {
+        Some(base) => diff::resolve_run_under(base, id),
+        None => diff::resolve_run(id),
+    };
+    let dir_a = match resolve(run_a) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("pitboss diff: run A: {e:#}");
             std::process::exit(1);
         }
     };
-    let dir_b = match diff::resolve_run(run_b) {
+    let dir_b = match resolve(run_b) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("pitboss diff: run B: {e:#}");

--- a/crates/pitboss-cli/src/runs.rs
+++ b/crates/pitboss-cli/src/runs.rs
@@ -50,7 +50,8 @@ use std::time::{Duration, SystemTime};
 pub const STALENESS_THRESHOLD: Duration = Duration::from_secs(4 * 3600);
 
 /// Status of a discovered run directory.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum RunStatus {
     /// `summary.json` exists and parsed — run finalized cleanly.
     Complete,
@@ -142,26 +143,55 @@ pub fn collect_run_entries(base: &Path) -> Vec<RunEntry> {
 /// Build a [`RunEntry`] for one run directory.
 pub fn collect_run_entry(run_dir: &Path, run_id: String, mtime: SystemTime) -> RunEntry {
     let summary_json = run_dir.join("summary.json");
-    if let Ok(bytes) = std::fs::read(&summary_json) {
-        if let Ok(s) = serde_json::from_slice::<pitboss_core::store::RunSummary>(&bytes) {
-            return RunEntry {
-                run_id,
-                run_dir: run_dir.to_path_buf(),
-                mtime,
-                tasks_total: s.tasks_total,
-                tasks_failed: s.tasks_failed,
-                status: RunStatus::Complete,
-            };
-        }
-    }
+    let summary_json_state = match std::fs::read(&summary_json) {
+        Ok(bytes) => match serde_json::from_slice::<pitboss_core::store::RunSummary>(&bytes) {
+            Ok(s) => {
+                return RunEntry {
+                    run_id,
+                    run_dir: run_dir.to_path_buf(),
+                    mtime,
+                    tasks_total: s.tasks_total,
+                    tasks_failed: s.tasks_failed,
+                    status: RunStatus::Complete,
+                };
+            }
+            Err(e) => {
+                // The dispatcher wrote summary.json but the contents are
+                // unparseable (truncated mid-write, format skew, disk
+                // corruption). The earlier code silently fell through to
+                // jsonl classification, which would happily classify a
+                // recent run as Running even though the dispatcher is
+                // gone — actively misleading. Surface the parse error and
+                // treat the run as Aborted: the dispatcher's exit signal
+                // is more authoritative than jsonl mtime. (#157)
+                tracing::warn!(
+                    path = %summary_json.display(),
+                    error = %e,
+                    "summary.json present but unparseable — classifying as Aborted",
+                );
+                Some(())
+            }
+        },
+        Err(_) => None,
+    };
 
     let jsonl = run_dir.join("summary.jsonl");
     let (settled_total, failed) = count_jsonl_tasks(&jsonl);
-    let live = control_socket_is_live(&run_id, run_dir);
-
     let spawned_count = count_tasks_subdirs(run_dir);
     let total = settled_total.max(spawned_count);
 
+    if summary_json_state.is_some() {
+        return RunEntry {
+            run_id,
+            run_dir: run_dir.to_path_buf(),
+            mtime,
+            tasks_total: total,
+            tasks_failed: failed,
+            status: RunStatus::Aborted,
+        };
+    }
+
+    let live = control_socket_is_live(&run_id, run_dir);
     let status = classify_status(live, settled_total, jsonl_recent(&jsonl));
     RunEntry {
         run_id,
@@ -234,6 +264,14 @@ pub fn control_socket_is_live(run_id: &str, run_dir: &Path) -> bool {
 /// Mirror of `pitboss_cli::control::control_socket_path` for the case
 /// where we have a `run_id` string (not a `Uuid`) — the runs-discovery
 /// caller reads run IDs out of directory names.
+///
+/// `run_dir` is already the per-run subdirectory
+/// (`<base>/<uuid>/`), matching what the writer side passes:
+/// `control_socket_path(uuid, base)` produces `<base>/<uuid>/control.sock`.
+/// The earlier implementation double-nested the UUID
+/// (`<base>/<uuid>/<uuid>/control.sock`), so on systems without
+/// `$XDG_RUNTIME_DIR` the fallback never matched the real socket and
+/// every running run was misclassified as Stale/Aborted (#141).
 fn resolve_socket_path(run_id: &str, run_dir: &Path) -> Option<PathBuf> {
     if let Some(xdg) = std::env::var_os("XDG_RUNTIME_DIR") {
         let p = PathBuf::from(xdg)
@@ -243,8 +281,7 @@ fn resolve_socket_path(run_id: &str, run_dir: &Path) -> Option<PathBuf> {
             return Some(p);
         }
     }
-    let fallback = run_dir.join(run_id).join("control.sock");
-    Some(fallback)
+    Some(run_dir.join("control.sock"))
 }
 
 /// `true` when `summary.jsonl` has been written within
@@ -455,6 +492,60 @@ mod tests {
         assert!(!RunStatus::Stale.is_complete());
         assert!(!RunStatus::Aborted.is_complete());
         assert!(!RunStatus::Running.is_complete());
+    }
+
+    // ── #141: socket-path resolution doesn't double-nest the run id ─────
+
+    #[test]
+    fn resolve_socket_path_does_not_double_nest_run_id() {
+        // Simulate the no-XDG case where the fallback path matters.
+        // Stash and restore the env so the test is hermetic regardless of
+        // the host's XDG_RUNTIME_DIR.
+        let prior = std::env::var_os("XDG_RUNTIME_DIR");
+        std::env::remove_var("XDG_RUNTIME_DIR");
+
+        let tmp = TempDir::new().unwrap();
+        let run_dir = tmp.path().join("run-uuid-1");
+        fs::create_dir_all(&run_dir).unwrap();
+        let got = resolve_socket_path("run-uuid-1", &run_dir).unwrap();
+
+        assert_eq!(
+            got,
+            run_dir.join("control.sock"),
+            "fallback must be <run_dir>/control.sock — joining run_id again \
+             produces a path that never matches what the writer creates (#141)"
+        );
+
+        if let Some(v) = prior {
+            std::env::set_var("XDG_RUNTIME_DIR", v);
+        }
+    }
+
+    // ── #157: corrupted summary.json is surfaced as Aborted, not Running ──
+
+    #[test]
+    fn collect_run_entry_with_corrupt_summary_json_is_aborted() {
+        let tmp = TempDir::new().unwrap();
+        let run_dir = make_run_dir(tmp.path(), "run-bad");
+        // summary.json exists but is unparseable garbage.
+        fs::write(run_dir.join("summary.json"), b"{not json").unwrap();
+        // Recent jsonl mtime — without the fix, classify_status would
+        // return Running here. The fix overrides to Aborted because the
+        // dispatcher's terminal write attempt is more authoritative than
+        // any jsonl recency.
+        fs::write(
+            run_dir.join("summary.jsonl"),
+            br#"{"task_id":"t","status":"failure","error":"x","cost_usd":0,"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}
+"#,
+        )
+        .unwrap();
+
+        let entry = collect_run_entry(&run_dir, "run-bad".to_string(), SystemTime::now());
+        assert_eq!(
+            entry.status,
+            RunStatus::Aborted,
+            "corrupt summary.json must classify as Aborted, not Running"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Closes #141 — `runs::resolve_socket_path` no longer joins the run id a second time, so `pitboss list --active` actually finds live runs on systems without `\$XDG_RUNTIME_DIR`.
- Drains all 5 items from #157 (CLI medium+low audit tracker).

## Changes

| Area | Change | Issue |
|---|---|---|
| Liveness probe | `runs::resolve_socket_path` no longer double-nests run_id in the fallback path | #141 |
| Validate exit code | `pitboss validate` exits 2 on validation failure (was 1) so OS-level vs schema errors are distinguishable | #157 |
| `--run-dir` flag | added to `attach` and `diff`, matching `status`/`resume`/`list`/`prune` | #157 |
| Mutual-exclusions | `--background` / `--dry-run` / `--internal-run-id` now declared via clap `conflicts_with` so they appear in `--help` and shell completions | #157 |
| Corrupt summary.json | classified as `Aborted` with a `tracing::warn` instead of silently falling through to jsonl-based `Running` | #157 |
| `RunListEntry.status` | typed as `runs::RunStatus` (Serialize + lowercase rename) instead of `&'static str` — wire format unchanged | #157 |

## Test plan

- [x] `cargo test --workspace` — 515 lib unit + integration tests pass
- [x] New tests cover the socket-path fix, the corrupt-summary classification, the JSON shape stability, and all three clap mutual-exclusion combinations
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)