### PR TITLE
release: v0.9.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 ---
 document: pitboss-agent-instructions
 schema_version: 1
-pitboss_version: 0.8.0
-last_updated: 2026-04-24
+pitboss_version: 0.9.0
+last_updated: 2026-04-27
 audience: ai-agent
 canonical_url: https://github.com/SDS-Mode/pitboss/blob/main/AGENTS.md
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+*(nothing yet)*
+
+## [0.9.0] — 2026-04-27
+
+The web operational console release. Pitboss now ships a single-binary
+HTTP server (`pitboss-web`) with an embedded SvelteKit SPA that gives
+the dispatcher a full browser surface — read every run's filesystem
+artefacts, drive live runs through their control sockets, author and
+import manifests via a guided wizard, and track failure patterns
+across runs with a Drain-lite clustering dashboard. The TUI and the
+web console are now first-class peers against the same
+`~/.local/share/pitboss/runs` directory.
+
+Highlights:
+- **Web operational console (Phases 1–5 + tile grid + flow graph).**
+  Read endpoints, SSE event stream, control writes (cancel / pause /
+  reprompt / approve), manifest authoring, dispatch from browser, fork
+  from completed runs.
+- **Manifests wizard.** 5-step Guided / Import / Export flow on
+  `/manifests`, with hover tooltips sourced from the canonical
+  `FieldDescriptor.help` strings — single source of truth with the
+  schema docs.
+- **Cross-run insights + Drain-lite failure clustering.** New
+  `/insights/failures` dashboard with ECharts bar + heatmap, top
+  clusters with template-pill rendering, manifest-health rollup. New
+  `[run].name` field surfaces a human-readable label for grouping
+  related runs.
+- **macOS-aware runs_base_dir.** TUI, CLI, and web console now share a
+  default base on macOS without operators having to pass `--runs-dir`.
+
 ### Fixed
 
 - **`pitboss-cli::runs::runs_base_dir()` is now macOS-aware.** Resolves

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1498,7 +1498,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitboss-cli"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "pitboss-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "pitboss-schema"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "pitboss-schema-derive",
  "serde",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "pitboss-schema-derive"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "pitboss-tui"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "pitboss-web"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version     = "0.8.0"
+version     = "0.9.0"
 edition     = "2021"
 rust-version = "1.82"
 license     = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -16,18 +16,20 @@ To browse offline:
     cargo install mdbook  # one time
     mdbook serve --open
 
-**v0.8.0** is the correctness hardening and new-capabilities release.
-All 34 medium- and high-severity bugs catalogued since v0.7 are resolved.
-New subcommands: `pitboss container-dispatch` (run dispatch inside a
-Docker/Podman container with declarative bind mounts) and `pitboss status`
-(snapshot task table for any run, in-flight or finalized). The TUI gains a
-live policy editor (`P`) for editing `[[approval_policy]]` rules without
-restarting. Approval TTL is now fully wired end-to-end — `ApprovalTimedOut`
-correctly fires even when a TUI was connected during the approval window.
-`DispatchState` no longer implements `Deref` — layer misrouting is now a
-compile error. Per-sub-tree cancel cascade closes the second-Ctrl-C gap for
-sub-lead workers. See `CHANGELOG.md` for the full per-version history and
-`AGENTS.md` for the MCP tool reference, keybindings, and manifest schema.
+**v0.9.0** is the web operational console release. Pitboss now ships a
+single-binary HTTP server (`pitboss-web`) with an embedded SvelteKit
+SPA that gives the dispatcher a full browser surface alongside the TUI:
+live SSE event streams from in-flight runs, control writes (cancel /
+pause / reprompt / approve) over per-run sockets, manifest authoring
+through a 5-step guided wizard with hover tooltips sourced from the
+canonical schema metadata, and a cross-run failures dashboard with
+Drain-lite clustering of error templates. New `[run].name` field
+surfaces a human-readable label so related runs group together in the
+console. The TUI and the web console are first-class peers against the
+same `~/.local/share/pitboss/runs` directory; pick whichever fits the
+moment. See `CHANGELOG.md` for the full per-version history and
+`AGENTS.md` for the MCP tool reference, keybindings, and manifest
+schema.
 
 Rust toolkit for running and observing parallel Claude Code sessions. A
 dispatcher (`pitboss`) fans out `claude` subprocesses under a concurrency

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,10 +3,10 @@
 Capture of deferred work. Items here are scoped but unscheduled — grab
 one when you're ready, or file issues to formalize priority.
 
-**Last refresh: 2026-04-25 (post-v0.8.0 session).** Everything shipped through
-v0.8.0 has been removed from this file — check `CHANGELOG.md` for
-per-version history. If you're about to add an item, slot it into one
-of the tiered sections below (biggest effort first).
+**Last refresh: v0.9.0 (2026-04-27).** Everything shipped through v0.9.0
+has been removed from this file — check `CHANGELOG.md` for per-version
+history. If you're about to add an item, slot it into one of the tiered
+sections below (biggest effort first).
 
 ---
 
@@ -383,9 +383,9 @@ form explicitly retired.
 
 ---
 
-## Deferred from v0.8.0 (targeting v0.9+)
+## Deferred from v0.9.0 (targeting v0.10+)
 
-Items that were scoped or considered during v0.8 development but
+Items that were scoped or considered during v0.8 / v0.9 development but
 explicitly deferred. These are reasonably well-understood problems,
 not blue-sky ideas.
 

--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -26,6 +26,6 @@ Language models are stochastic. A well-run pit is not.
 
 ## Current version
 
-**v0.8.0** — correctness hardening and new capabilities. All 34 medium/high-severity issues from the post-v0.7 audit resolved. New subcommands: `pitboss container-dispatch` (declarative bind-mount container dispatch), `pitboss status` (task snapshot table). TUI live policy editor (`P`). Full `ApprovalTimedOut` TTL wiring via `BridgeEntry`. `DispatchState` Deref removed — layer misrouting is now a compile error. Per-sub-tree cancel cascade. Sub-lead resume. Slack Block Kit notifications.
+**v0.9.0** — web operational console. New `pitboss-web` binary (single-binary axum + embedded SvelteKit SPA) gives the dispatcher a full browser surface alongside the TUI: live SSE event streams, control writes (cancel / pause / reprompt / approve), manifest authoring through a 5-step guided wizard with schema-driven hover tooltips, and a cross-run failures dashboard with Drain-lite clustering of error templates. New `[run].name` field surfaces a human-readable label so related runs group together in the console.
 
 See [Changelog](./reference/changelog.md) for the full version history.


### PR DESCRIPTION
## Summary

Release-prep PR for **v0.9.0** — the web operational console release.

Mechanical changes only (version bump + doc rotation per `RELEASE.md`).
All feature work shipped in #169 (merged moments ago).

## Files touched
- `Cargo.toml` workspace version → `0.9.0`
- `Cargo.lock` refreshed
- `AGENTS.md` frontmatter → `0.9.0` / `2026-04-27`
- `CHANGELOG.md` — promoted `[Unreleased]` to `[0.9.0]` with headline
  + highlights; existing `### Fixed`/`### Added`/etc. subsections move
  verbatim under the new heading
- `README.md` — version-highlight paragraph rewritten
- `ROADMAP.md` — "Last refresh" line + "Deferred from" section title
  bumped to v0.9.0
- `book/src/intro.md` — "Current version" rewritten

## Highlights (full notes in `CHANGELOG.md` → [0.9.0])
- **Web operational console (Phases 1–5 + tile grid + flow graph).**
- **Manifests wizard.** 5-step Guided / Import / Export with hover
  tooltips sourced from the canonical schema metadata.
- **Cross-run insights + Drain-lite failure clustering.** New
  `/insights/failures` dashboard.
- **`[run].name` field.** Human-readable label for cross-run grouping.
- **macOS-aware `runs_base_dir`.**

## Test plan
- [ ] CI green
- [ ] After merge: `git tag -a v0.9.0`, `git push origin v0.9.0`
- [ ] Watch release.yml + container.yml + book.yml workflows
- [ ] Post-release sanity: `pitboss --version`, container labels,
      Homebrew tap, Pages site

🤖 Generated with [Claude Code](https://claude.com/claude-code)