### PR TITLE
release: v0.9.1 (republish v0.9.0 + release-pipeline fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,24 @@ jobs:
           dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > plan-dist-manifest.json
           echo "dist ran successfully"
           cat plan-dist-manifest.json
-          echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
+          # Strip free-form prose fields (announcement_changelog,
+          # announcement_github_body, announcement_title) before setting the
+          # `manifest` step output. GHA's secret-scanning heuristic
+          # (introduced 2025) flags long prose blobs as "may contain
+          # secret" and skips the output entirely — which makes downstream
+          # `fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix`
+          # gates evaluate to null, silently skipping every build job. The
+          # `announce` job re-derives the prose from a fresh
+          # `dist host --steps=announce` against the file artifact below,
+          # and `publish-homebrew-formula` only consumes structural fields
+          # (`releases[].artifacts`, `app_version`), so stripping prose
+          # is lossless for downstream consumption. Keep the full manifest
+          # available as the `artifacts-plan-dist-manifest` artifact for
+          # any future job that needs it.
+          jq -c \
+            'del(.announcement_changelog) | del(.announcement_github_body) | del(.announcement_title)' \
+            plan-dist-manifest.json > plan-dist-manifest.compact.json
+          echo "manifest=$(cat plan-dist-manifest.compact.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
         uses: actions/upload-artifact@v7
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 ---
 document: pitboss-agent-instructions
 schema_version: 1
-pitboss_version: 0.9.0
+pitboss_version: 0.9.1
 last_updated: 2026-04-27
 audience: ai-agent
 canonical_url: https://github.com/SDS-Mode/pitboss/blob/main/AGENTS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 *(nothing yet)*
 
+## [0.9.1] — 2026-04-27
+
+Republishes the v0.9.0 platform artifacts after a release-pipeline fix.
+v0.9.0's tag and code shipped fine — container images, docs site, and
+Homebrew tap update were unaffected — but the cargo-dist `release.yml`
+plan-step output was rejected by GHA's secret-scanning heuristic
+(introduced 2025), which silently skipped every build matrix job. The
+v0.9.0 GitHub Release was created with only `dist-manifest.json`
+attached, so nothing on the [releases page](https://github.com/SDS-Mode/pitboss/releases)
+was actually installable via the shell installer or direct tarball
+download. **There are no functional changes in v0.9.1 vs v0.9.0** —
+upgrade only if you tried to install v0.9.0 from tarball/installer
+and hit the missing artifacts.
+
+### Fixed
+
+- **`release.yml`: strip free-form prose from `plan` step output.** The
+  cargo-dist plan manifest's `announcement_changelog`,
+  `announcement_github_body`, and `announcement_title` fields are
+  removed from the GHA step output (`needs.plan.outputs.val`) before
+  downstream gates evaluate. The full manifest is preserved as the
+  `artifacts-plan-dist-manifest` artifact for any consumer that needs
+  it, and the `announce` job re-derives prose from a fresh
+  `dist host --steps=announce` call. Stripping is required because
+  GHA's secret-scanner started flagging long prose blobs as "may
+  contain secret" and silently skipping the output, which made
+  `fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix` null
+  and bypassed the build matrix entirely. This is a structural
+  workaround — cargo-dist 0.32+ moves to artifact-based plan
+  distribution and should obsolete it.
+
 ## [0.9.0] — 2026-04-27
 
 The web operational console release. Pitboss now ships a single-binary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1562,7 +1562,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitboss-cli"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1600,7 +1600,7 @@ dependencies = [
 
 [[package]]
 name = "pitboss-core"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "pitboss-schema"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "pitboss-schema-derive",
  "serde",
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "pitboss-schema-derive"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "pitboss-tui"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1658,7 +1658,7 @@ dependencies = [
 
 [[package]]
 name = "pitboss-web"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version     = "0.9.0"
+version     = "0.9.1"
 edition     = "2021"
 rust-version = "1.82"
 license     = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ To browse offline:
     cargo install mdbook  # one time
     mdbook serve --open
 
-**v0.9.0** is the web operational console release. Pitboss now ships a
+**v0.9.1** is the web operational console release (republished from
+v0.9.0 after a release-pipeline fix; no functional changes). Pitboss now ships a
 single-binary HTTP server (`pitboss-web`) with an embedded SvelteKit
 SPA that gives the dispatcher a full browser surface alongside the TUI:
 live SSE event streams from in-flight runs, control writes (cancel /

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 Capture of deferred work. Items here are scoped but unscheduled — grab
 one when you're ready, or file issues to formalize priority.
 
-**Last refresh: v0.9.0 (2026-04-27).** Everything shipped through v0.9.0
+**Last refresh: v0.9.1 (2026-04-27).** Everything shipped through v0.9.1
 has been removed from this file — check `CHANGELOG.md` for per-version
 history. If you're about to add an item, slot it into one of the tiered
 sections below (biggest effort first).

--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -26,6 +26,6 @@ Language models are stochastic. A well-run pit is not.
 
 ## Current version
 
-**v0.9.0** — web operational console. New `pitboss-web` binary (single-binary axum + embedded SvelteKit SPA) gives the dispatcher a full browser surface alongside the TUI: live SSE event streams, control writes (cancel / pause / reprompt / approve), manifest authoring through a 5-step guided wizard with schema-driven hover tooltips, and a cross-run failures dashboard with Drain-lite clustering of error templates. New `[run].name` field surfaces a human-readable label so related runs group together in the console.
+**v0.9.1** — web operational console (republished from v0.9.0 after a release-pipeline fix; no functional changes). New `pitboss-web` binary (single-binary axum + embedded SvelteKit SPA) gives the dispatcher a full browser surface alongside the TUI: live SSE event streams, control writes (cancel / pause / reprompt / approve), manifest authoring through a 5-step guided wizard with schema-driven hover tooltips, and a cross-run failures dashboard with Drain-lite clustering of error templates. New `[run].name` field surfaces a human-readable label so related runs group together in the console.
 
 See [Changelog](./reference/changelog.md) for the full version history.


### PR DESCRIPTION
## Summary

v0.9.0's release pipeline produced a partial release: cargo-dist's
plan step's `manifest` GHA output was silently dropped by GHA's
secret-scanning heuristic (it flags long prose blobs as "may contain
secret"), which made downstream
`fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include`
evaluate to `null` and skip every build matrix job. The v0.9.0
GitHub Release was created with only `dist-manifest.json` attached —
no platform tarballs, no installer scripts, no Homebrew formula push.

This PR republishes the same code as v0.9.1 with the workflow fix
in place.

## Changes
- `.github/workflows/release.yml` — plan step strips
  `announcement_changelog`, `announcement_github_body`,
  `announcement_title` from the step output before downstream gates
  evaluate. Full manifest preserved as the
  `artifacts-plan-dist-manifest` artifact. `allow-dirty = ["ci"]`
  permits this manual divergence from cargo-dist 0.28.7's
  autogeneration.
- `Cargo.toml` workspace version → `0.9.1`
- `Cargo.lock` refreshed
- `AGENTS.md` frontmatter → `0.9.1`
- `CHANGELOG.md` — `[0.9.1]` entry explains republication + the
  workflow fix
- `README.md`, `ROADMAP.md`, `book/src/intro.md` — version-highlight
  rewritten to flag this as the v0.9.0 republication

## What's verified
- ✅ v0.9.0 container images on `ghcr.io` (built via the working CI workflow on the v0.9.0 tag)
- ✅ Docs site already deployed at v0.9.0 content
- ❌ v0.9.0 platform tarballs missing — this PR fixes that for v0.9.1
- ❌ Homebrew tap stuck on v0.8.0 — this PR fixes that for v0.9.1

## Test plan
- [ ] CI green
- [ ] After merge: `git tag -a v0.9.1 -m "v0.9.1"`, `git push origin v0.9.1`
- [ ] Watch release.yml — confirm `build-local-artifacts` matrix actually expands and runs
- [ ] Confirm GitHub Release v0.9.1 has full asset list (tarballs, installers, formula)
- [ ] Homebrew formula commit lands in tap repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)