### PR TITLE
fix(store, prune): crash-safe atomic writes for summary.json and meta.json (#184, #188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-*(nothing yet)*
+### Fixed
+
+- **Crash-safe writes for `summary.json` and `meta.json`** (#184, #188).
+  An interrupt mid-write (`SIGKILL`, OOM, host crash) could previously
+  produce a partial or truncated final file. All three call sites now
+  use a new `pitboss_core::atomic_write` helper that writes to a
+  sibling `.tmp`, `fsync`s, and atomically `rename`s onto the
+  destination. Callers affected: `JsonFileStore::finalize_run` and
+  `JsonFileStore::init_run` in `pitboss-core`, and
+  `pitboss prune --apply --synthesize`'s `synthesize_summary` in
+  `pitboss-cli`. The destination either reflects the prior contents or
+  the full new contents, never a half-flushed mix.
 
 ## [0.9.1] — 2026-04-27
 

--- a/crates/pitboss-cli/src/prune.rs
+++ b/crates/pitboss-cli/src/prune.rs
@@ -180,7 +180,8 @@ fn synthesize_summary(run_dir: &Path) -> Result<()> {
     let summary = build_synthesized_summary(run_dir)?;
     let json = serde_json::to_string_pretty(&summary).context("serialize synthesized summary")?;
     let path = run_dir.join("summary.json");
-    std::fs::write(&path, json).with_context(|| format!("write {}", path.display()))?;
+    pitboss_core::atomic_write::write_atomic_sync(&path, json.as_bytes())
+        .with_context(|| format!("write {}", path.display()))?;
     Ok(())
 }
 

--- a/crates/pitboss-core/src/atomic_write.rs
+++ b/crates/pitboss-core/src/atomic_write.rs
@@ -1,0 +1,128 @@
+//! Crash-safe file writes — write to a sibling `.tmp` then `rename`
+//! so a process death mid-write can never produce a partial or
+//! truncated final file. The destination either reflects the prior
+//! contents (if any) or the full new contents, never a half-flushed
+//! mix.
+//!
+//! `rename(2)` is atomic on Linux/Unix when source and destination
+//! sit on the same filesystem — placing the temp file as a sibling
+//! of the destination is what makes that hold.
+
+use std::path::{Path, PathBuf};
+
+fn tmp_path_for(path: &Path) -> PathBuf {
+    let mut name = path
+        .file_name()
+        .map(std::ffi::OsStr::to_os_string)
+        .unwrap_or_default();
+    name.push(".tmp");
+    path.with_file_name(name)
+}
+
+/// Synchronous atomic write. Caller must ensure `path.parent()` exists.
+pub fn write_atomic_sync(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    use std::io::Write as _;
+
+    let tmp = tmp_path_for(path);
+    {
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&tmp)?;
+        f.write_all(bytes)?;
+        f.sync_all()?;
+    }
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+    Ok(())
+}
+
+/// Async counterpart of [`write_atomic_sync`].
+pub async fn write_atomic_async(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    use tokio::io::AsyncWriteExt as _;
+
+    let tmp = tmp_path_for(path);
+    {
+        let mut f = tokio::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&tmp)
+            .await?;
+        f.write_all(bytes).await?;
+        f.sync_all().await?;
+    }
+    if let Err(e) = tokio::fs::rename(&tmp, path).await {
+        let _ = tokio::fs::remove_file(&tmp).await;
+        return Err(e);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn sync_writes_full_contents() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("out.json");
+        write_atomic_sync(&path, b"hello world").unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"hello world");
+        // No leftover .tmp sibling.
+        assert!(!tmp.path().join("out.json.tmp").exists());
+    }
+
+    #[test]
+    fn sync_overwrites_existing_file() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("out.json");
+        std::fs::write(&path, b"old").unwrap();
+        write_atomic_sync(&path, b"new contents").unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"new contents");
+    }
+
+    #[test]
+    fn sync_cleans_tmp_when_target_dir_is_invalid() {
+        // Rename across nonexistent parent dirs cannot be tested portably
+        // (rename to nonexistent dst dir on Linux returns ENOENT), so
+        // instead exercise the open() error path: make the tmp's parent
+        // unwritable by pointing at a non-directory.
+        let tmp = TempDir::new().unwrap();
+        let not_a_dir = tmp.path().join("file");
+        std::fs::write(&not_a_dir, b"x").unwrap();
+        let path = not_a_dir.join("nested.json");
+        // open() on `<file>/nested.json.tmp` should fail with ENOTDIR.
+        let err = write_atomic_sync(&path, b"data").unwrap_err();
+        assert!(
+            matches!(
+                err.kind(),
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::NotADirectory
+            ),
+            "expected NotFound or NotADirectory, got {:?}",
+            err.kind()
+        );
+    }
+
+    #[tokio::test]
+    async fn async_writes_full_contents() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("out.json");
+        write_atomic_async(&path, b"hello async").await.unwrap();
+        assert_eq!(tokio::fs::read(&path).await.unwrap(), b"hello async");
+        assert!(!tmp.path().join("out.json.tmp").exists());
+    }
+
+    #[tokio::test]
+    async fn async_overwrites_existing_file() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("out.json");
+        tokio::fs::write(&path, b"old").await.unwrap();
+        write_atomic_async(&path, b"new").await.unwrap();
+        assert_eq!(tokio::fs::read(&path).await.unwrap(), b"new");
+    }
+}

--- a/crates/pitboss-core/src/lib.rs
+++ b/crates/pitboss-core/src/lib.rs
@@ -4,6 +4,7 @@
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(clippy::module_name_repetitions, clippy::missing_errors_doc)]
 
+pub mod atomic_write;
 pub mod error;
 pub mod fmt;
 pub mod parser;

--- a/crates/pitboss-core/src/store/json_file.rs
+++ b/crates/pitboss-core/src/store/json_file.rs
@@ -40,7 +40,7 @@ impl SessionStore for JsonFileStore {
         let dir = self.run_dir(meta.run_id);
         fs::create_dir_all(&dir).await?;
         let bytes = serde_json::to_vec_pretty(meta)?;
-        fs::write(self.meta_json(meta.run_id), bytes).await?;
+        crate::atomic_write::write_atomic_async(&self.meta_json(meta.run_id), &bytes).await?;
         OpenOptions::new()
             .create(true)
             .append(true)
@@ -65,7 +65,7 @@ impl SessionStore for JsonFileStore {
     async fn finalize_run(&self, summary: &RunSummary) -> Result<(), StoreError> {
         let bytes = serde_json::to_vec_pretty(summary)?;
         let path = self.summary_json(summary.run_id);
-        fs::write(path, bytes).await?;
+        crate::atomic_write::write_atomic_async(&path, &bytes).await?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Closes two HIGH-severity findings from the 2026-04-27 code-to-docs audit pass — both flag the same crash-safety gap in different call sites:

- **#188** — `crates/pitboss-core/src/store/json_file.rs:65-69` `JsonFileStore::finalize_run` writes `summary.json` via `fs::write(path, bytes)` directly. An interrupt mid-write (`SIGKILL`, OOM, host crash) produces a partial / truncated final file with no recovery path.
- **#184** — `crates/pitboss-cli/src/prune.rs:179-184` `synthesize_summary` has the identical gap when `pitboss prune --apply` materialises a Cancelled summary for an orphaned run.

Both now route through a new `pitboss_core::atomic_write` helper (sync + async variants) that writes to a sibling `.tmp` file, `fsync`s, then atomically `rename`s onto the destination. The destination either reflects the prior contents or the full new contents — never a half-flushed mix.

`JsonFileStore::init_run`'s `meta.json` write was hardened the same way as a defensive follow-up — same atomicity class, same one-line fix, no reason to leave it exposed.

## Changes

- **New**: `crates/pitboss-core/src/atomic_write.rs` — `write_atomic_sync` and `write_atomic_async` helpers, 5 unit tests covering happy path, overwrite, and tmp-cleanup-on-error.
- `crates/pitboss-core/src/store/json_file.rs` — `finalize_run` (#188) + `init_run` (defensive) now atomic.
- `crates/pitboss-cli/src/prune.rs` — `synthesize_summary` (#184) now atomic.
- `CHANGELOG.md` — `[Unreleased]` entry under Fixed.

## Test plan

- [x] `cargo test --workspace --features pitboss-core/test-support` — all green; new `atomic_write` module adds 5 unit tests; existing store integration tests (`init_and_append_and_finalize_round_trip`, `load_orphan_run_marks_interrupted`) and prune tests (`run_apply_synthesize_writes_summary`, `synthesize_with_jsonl_preserves_partial_records`, etc.) continue to pass — they exercise both `init_run` and `finalize_run` end-to-end through the new helper.
- [x] `cargo lint` clean.
- [x] `cargo tidy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)