### PR TITLE
fix(manifest): typed schema-version + alias regression test for resolved.json snapshots (#186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Manifest snapshot durability — typed schema-version mismatch + alias
+  regression test** (#186). `ResolvedManifest` now carries a
+  `manifest_schema_version: u32` (current = `1`) that's serialized into
+  every `resolved.json` snapshot. The resume loader (`build_resume_manifest`,
+  `build_resume_hierarchical`) refuses to deserialize a snapshot whose
+  version exceeds what this build supports, surfacing a typed
+  `ManifestError::IncompatibleVersion { found, supported }` instead of
+  an opaque serde failure when an older pitboss tries to resume a run
+  produced by a newer one. Pre-versioning snapshots (the v0.9.0/v0.9.1
+  era, where the field is absent) default to `0` and remain resumable
+  on a best-effort basis. Bumps to `CURRENT_MANIFEST_SCHEMA_VERSION` are
+  reserved for breaking changes that `#[serde(alias)]` cannot cover.
+  A new test (`resolved_manifest_accepts_legacy_serde_aliases`) locks
+  in deserialization of every renamed field's pre-v0.9 JSON name —
+  if a future rename drops its alias, the test breaks loudly.
+
 - **Crash-safe writes for `summary.json` and `meta.json`** (#184, #188).
   An interrupt mid-write (`SIGKILL`, OOM, host crash) could previously
   produce a partial or truncated final file. All three call sites now

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -1191,6 +1191,7 @@ mod tests {
 
     fn mk_state(dir: &Path, run_id: Uuid) -> Arc<DispatchState> {
         let manifest = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,
@@ -1608,6 +1609,7 @@ mod tests {
         let sub_w1 = pitboss_core::session::CancelToken::new();
         let sub_w2 = pitboss_core::session::CancelToken::new();
         let sub_manifest = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,
@@ -2091,6 +2093,7 @@ mod tests {
         );
 
         let sub_manifest = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,
@@ -2188,6 +2191,7 @@ mod tests {
         let state = mk_state(dir.path(), run_id);
 
         let sub_manifest = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,

--- a/crates/pitboss-cli/src/dispatch/failure_detection.rs
+++ b/crates/pitboss-cli/src/dispatch/failure_detection.rs
@@ -670,6 +670,7 @@ mod tests {
 
         let dir = tempfile::TempDir::new().unwrap();
         let manifest = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,
@@ -760,6 +761,7 @@ mod tests {
 
         let dir = tempfile::TempDir::new().unwrap();
         let manifest = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,

--- a/crates/pitboss-cli/src/dispatch/layer.rs
+++ b/crates/pitboss-cli/src/dispatch/layer.rs
@@ -406,6 +406,7 @@ mod tests {
     fn mk_layer() -> (TempDir, LayerState) {
         let dir = TempDir::new().unwrap();
         let manifest = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,

--- a/crates/pitboss-cli/src/dispatch/resume.rs
+++ b/crates/pitboss-cli/src/dispatch/resume.rs
@@ -6,7 +6,31 @@ use std::path::Path;
 use anyhow::{anyhow, bail, Context, Result};
 use pitboss_core::store::RunSummary;
 
-use crate::manifest::resolve::{ResolvedManifest, ResolvedTask};
+use crate::manifest::error::ManifestError;
+use crate::manifest::resolve::{ResolvedManifest, ResolvedTask, CURRENT_MANIFEST_SCHEMA_VERSION};
+
+/// Read `resolved.json` and parse into a [`ResolvedManifest`], rejecting
+/// snapshots whose `manifest_schema_version` exceeds what this build
+/// supports. Older / unversioned snapshots (`< CURRENT`, including the
+/// pre-v0.9.2 era where the field is absent) are accepted.
+fn read_resolved_manifest(path: &Path) -> Result<ResolvedManifest> {
+    let bytes = std::fs::read(path).with_context(|| format!("reading {}", path.display()))?;
+    let raw: serde_json::Value = serde_json::from_slice(&bytes)
+        .with_context(|| format!("parsing {} as JSON", path.display()))?;
+    let snapshot_ver = raw
+        .get("manifest_schema_version")
+        .and_then(serde_json::Value::as_u64)
+        .map_or(0u32, |v| u32::try_from(v).unwrap_or(u32::MAX));
+    if snapshot_ver > CURRENT_MANIFEST_SCHEMA_VERSION {
+        return Err(ManifestError::IncompatibleVersion {
+            found: snapshot_ver,
+            supported: CURRENT_MANIFEST_SCHEMA_VERSION,
+        }
+        .into());
+    }
+    serde_json::from_value(raw)
+        .with_context(|| format!("parsing {} as ResolvedManifest", path.display()))
+}
 
 /// Max length for a `claude --resume <id>` value. Real Claude session IDs
 /// are UUIDs (36 chars); we allow a generous upper bound while still refusing
@@ -58,14 +82,13 @@ fn validate_session_id(sid: &str) -> Result<()> {
 pub fn build_resume_manifest(run_dir: &Path) -> Result<ResolvedManifest> {
     // --- load resolved.json ------------------------------------------------
     let resolved_path = run_dir.join("resolved.json");
-    let resolved_bytes = std::fs::read(&resolved_path).with_context(|| {
-        format!(
+    if !resolved_path.exists() {
+        bail!(
             "resolved.json not found at {}; run may predate v0.1.0 or was never started",
             resolved_path.display()
-        )
-    })?;
-    let mut base: ResolvedManifest = serde_json::from_slice(&resolved_bytes)
-        .with_context(|| format!("parsing resolved.json at {}", resolved_path.display()))?;
+        );
+    }
+    let mut base = read_resolved_manifest(&resolved_path)?;
 
     // --- load summary.json -------------------------------------------------
     let summary_path = run_dir.join("summary.json");
@@ -169,10 +192,7 @@ pub fn build_resume_hierarchical(
     run_dir: &Path,
 ) -> Result<(ResolvedManifest, HashMap<String, String>)> {
     let resolved_path = run_dir.join("resolved.json");
-    let bytes = std::fs::read(&resolved_path)
-        .with_context(|| format!("reading {}", resolved_path.display()))?;
-    let mut resolved: ResolvedManifest = serde_json::from_slice(&bytes)
-        .with_context(|| format!("parsing {}", resolved_path.display()))?;
+    let mut resolved = read_resolved_manifest(&resolved_path)?;
 
     let lead = resolved
         .lead
@@ -551,6 +571,7 @@ mod tests {
 
         // Synthesize resolved.json with a lead.
         let mut resolved = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,
@@ -661,6 +682,7 @@ mod tests {
 
         // Write a bare-bones resolved.json.
         let resolved = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,
@@ -774,6 +796,7 @@ mod tests {
         let run_dir = dir.path();
 
         let resolved = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,
@@ -889,5 +912,58 @@ mod tests {
             sessions.get("sublead-bbb").map(String::as_str),
             Some("sub-sess-bbb")
         );
+    }
+
+    /// `resolved.json` snapshots without `manifest_schema_version`
+    /// (everything written before v0.9.2) must keep deserializing as
+    /// legacy so existing runs remain resumable across the upgrade.
+    #[test]
+    fn read_resolved_manifest_accepts_unversioned_legacy_snapshot() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("resolved.json");
+        let v = serde_json::json!({
+            "max_parallel_tasks": 1,
+            "halt_on_failure": false,
+            "run_dir": "/tmp/runs",
+            "worktree_cleanup": "on_success",
+            "emit_event_stream": false,
+            "tasks": []
+        });
+        std::fs::write(&path, serde_json::to_vec_pretty(&v).unwrap()).unwrap();
+        let m = read_resolved_manifest(&path).expect("legacy snapshot must load");
+        assert_eq!(m.manifest_schema_version, 0);
+    }
+
+    /// A snapshot whose `manifest_schema_version` is greater than this
+    /// build's `CURRENT_MANIFEST_SCHEMA_VERSION` must surface a typed
+    /// `ManifestError::IncompatibleVersion`, not an opaque serde error.
+    /// This is what tells operators "your pitboss is older than the run
+    /// you're trying to resume".
+    #[test]
+    fn read_resolved_manifest_rejects_future_schema_version() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("resolved.json");
+        let future = CURRENT_MANIFEST_SCHEMA_VERSION + 99;
+        let v = serde_json::json!({
+            "manifest_schema_version": future,
+            "max_parallel_tasks": 1,
+            "halt_on_failure": false,
+            "run_dir": "/tmp/runs",
+            "worktree_cleanup": "on_success",
+            "emit_event_stream": false,
+            "tasks": []
+        });
+        std::fs::write(&path, serde_json::to_vec_pretty(&v).unwrap()).unwrap();
+
+        let err = read_resolved_manifest(&path).unwrap_err();
+        let typed = err
+            .downcast_ref::<ManifestError>()
+            .expect("must surface ManifestError::IncompatibleVersion, not anyhow::Other");
+        match typed {
+            ManifestError::IncompatibleVersion { found, supported } => {
+                assert_eq!(*found, future);
+                assert_eq!(*supported, CURRENT_MANIFEST_SCHEMA_VERSION);
+            }
+        }
     }
 }

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -1092,6 +1092,7 @@ mod tests {
 
     fn minimal_manifest() -> ResolvedManifest {
         ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 1,
             halt_on_failure: false,
@@ -1209,6 +1210,7 @@ mod tests {
         let run_dir = TempDir::new().unwrap();
 
         let resolved = crate::manifest::resolve::ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 2,
             halt_on_failure: false,
@@ -1329,6 +1331,7 @@ mod tests {
         };
 
         let resolved = crate::manifest::resolve::ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 1, // serialize so ordering is deterministic
             halt_on_failure: true,
@@ -1408,6 +1411,7 @@ mod tests {
         let run_dir = TempDir::new().unwrap();
 
         let resolved = crate::manifest::resolve::ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 1,
             halt_on_failure: false,

--- a/crates/pitboss-cli/src/dispatch/signals.rs
+++ b/crates/pitboss-cli/src/dispatch/signals.rs
@@ -326,6 +326,7 @@ mod tests {
 
         let dir = TempDir::new().unwrap();
         let manifest = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 1,
             halt_on_failure: false,
@@ -413,6 +414,7 @@ mod tests {
 
         let dir = TempDir::new().unwrap();
         let manifest = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 1,
             halt_on_failure: false,

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -527,6 +527,7 @@ mod tests {
     fn mk_state(budget: Option<f64>, max_workers: Option<u32>) -> Arc<DispatchState> {
         let dir = TempDir::new().unwrap();
         let manifest = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,

--- a/crates/pitboss-cli/src/manifest/error.rs
+++ b/crates/pitboss-cli/src/manifest/error.rs
@@ -1,0 +1,18 @@
+//! Typed manifest errors. Currently scoped to snapshot version
+//! incompatibility — the rest of the manifest pipeline still uses
+//! `anyhow::Error` for terse one-off bails.
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ManifestError {
+    /// The snapshot on disk was produced by a newer pitboss release that
+    /// declared a higher `manifest_schema_version` than this binary supports.
+    /// Older snapshots (lower version, including missing → treated as `0`)
+    /// are accepted on a best-effort basis and never raise this error.
+    #[error(
+        "incompatible manifest schema in snapshot: snapshot is v{found}, this pitboss supports up to v{supported}. \
+         The run was likely produced by a newer pitboss release; upgrade pitboss or re-run from scratch."
+    )]
+    IncompatibleVersion { found: u32, supported: u32 },
+}

--- a/crates/pitboss-cli/src/manifest/mod.rs
+++ b/crates/pitboss-cli/src/manifest/mod.rs
@@ -1,3 +1,4 @@
+pub mod error;
 pub mod example_doc;
 pub mod init_template;
 pub mod load;
@@ -6,6 +7,9 @@ pub mod metadata;
 pub mod resolve;
 pub mod schema;
 pub mod validate;
+
+#[allow(unused_imports)]
+pub use error::ManifestError;
 
 #[allow(unused_imports)]
 pub use load::{load_manifest, load_manifest_from_str, load_manifest_skip_dir_check};

--- a/crates/pitboss-cli/src/manifest/resolve.rs
+++ b/crates/pitboss-cli/src/manifest/resolve.rs
@@ -87,8 +87,36 @@ pub struct ResolvedSubleadDefaults {
     pub read_down: bool,
 }
 
+/// Schema version baked into every `resolved.json` snapshot written by
+/// this build. **Bump on any breaking change** to `ResolvedManifest`,
+/// `ResolvedTask`, or `ResolvedLead` that pre-existing snapshots cannot
+/// faithfully express via `#[serde(alias)]` — e.g. a removed field, a
+/// changed type, or a semantic re-interpretation of an existing value.
+/// Renames that ship with an `alias` are NOT breaking and do NOT require
+/// a bump (they round-trip via the alias).
+///
+/// The resume loader rejects any snapshot with a version greater than
+/// this constant, surfacing a typed
+/// [`ManifestError::IncompatibleVersion`](crate::manifest::error::ManifestError)
+/// instead of an opaque serde failure.
+pub const CURRENT_MANIFEST_SCHEMA_VERSION: u32 = 1;
+
+/// Default for the `manifest_schema_version` field when absent from a
+/// snapshot. v0.9 snapshots predate this field; treating missing as `0`
+/// (legacy) lets them resume on a best-effort basis. New snapshots
+/// always carry [`CURRENT_MANIFEST_SCHEMA_VERSION`].
+fn default_legacy_manifest_schema_version() -> u32 {
+    0
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResolvedManifest {
+    /// Discriminator written by [`resolve()`] so [`crate::dispatch::resume`]
+    /// can reject snapshots produced by a newer pitboss whose schema this
+    /// build cannot deserialize. Defaults to `0` for pre-versioning
+    /// snapshots (anything written before v0.9.2).
+    #[serde(default = "default_legacy_manifest_schema_version")]
+    pub manifest_schema_version: u32,
     /// Human-readable label from `[run].name`. Surfaced into `RunSummary`
     /// so the operational console can group related runs without re-reading
     /// `manifest.snapshot.toml` per digest. `None` when the manifest omits
@@ -207,6 +235,7 @@ pub fn resolve(
     };
 
     Ok(ResolvedManifest {
+        manifest_schema_version: CURRENT_MANIFEST_SCHEMA_VERSION,
         name: manifest.run.name.clone(),
         max_parallel_tasks,
         halt_on_failure: manifest.run.halt_on_failure,
@@ -832,6 +861,89 @@ category = "tool_use"
         assert!(
             rule.r#match.cost_over.is_none(),
             "match.cost_over should be absent"
+        );
+    }
+
+    /// Every fresh `resolve()` must stamp the snapshot with the current
+    /// schema version so the resume loader can later reject future
+    /// snapshots produced by a newer pitboss with a typed
+    /// `IncompatibleVersion` error rather than an opaque serde failure.
+    #[test]
+    fn resolve_stamps_current_schema_version() {
+        let m = man(r#"
+            [defaults]
+            model = "claude-sonnet-4-6"
+
+            [[task]]
+            id = "t1"
+            directory = "/tmp"
+            prompt = "x"
+            "#);
+        let r = resolve(m, None).unwrap();
+        assert_eq!(
+            r.manifest_schema_version, CURRENT_MANIFEST_SCHEMA_VERSION,
+            "resolve() must stamp manifest_schema_version with CURRENT"
+        );
+    }
+
+    /// Regression test for serde alias coverage on every renamed field
+    /// of `ResolvedManifest` / `ResolvedLead`. If a future rename drops
+    /// the corresponding `#[serde(alias = "<old name>")]`, this test
+    /// fails loudly — the contributor must either restore the alias
+    /// (preferred) or remove the legacy key from the fixture below AND
+    /// bump `CURRENT_MANIFEST_SCHEMA_VERSION` so resume rejects pre-rename
+    /// snapshots with a typed error rather than silently succeeding with
+    /// a default.
+    ///
+    /// Each row in the fixture exercises one historic JSON key. When you
+    /// rename a field, add the old key here.
+    #[test]
+    fn resolved_manifest_accepts_legacy_serde_aliases() {
+        // Pre-v0.9 snapshot using ALL legacy field names. No
+        // `manifest_schema_version` field — defaults to 0 (legacy era).
+        let legacy = serde_json::json!({
+            "max_parallel": 7,                          // → max_parallel_tasks
+            "halt_on_failure": true,
+            "run_dir": "/tmp/runs",
+            "worktree_cleanup": "on_success",
+            "emit_event_stream": false,
+            "tasks": [],
+            "approval_policy": null,                    // → default_approval_policy
+            "lead": {
+                "id": "root",
+                "directory": "/tmp",
+                "prompt": "go",
+                "branch": null,
+                "model": "claude-sonnet-4-6",
+                "effort": "high",
+                "tools": [],
+                "timeout_secs": 1800,
+                "use_worktree": false,
+                "env": {},
+                "max_workers_across_tree": 12           // → max_total_workers
+            }
+        });
+
+        let r: ResolvedManifest =
+            serde_json::from_value(legacy).expect("legacy snapshot must deserialize via aliases");
+
+        assert_eq!(
+            r.manifest_schema_version, 0,
+            "snapshot without the field must default to 0 (legacy)"
+        );
+        assert_eq!(
+            r.max_parallel_tasks, 7,
+            "alias `max_parallel` must populate max_parallel_tasks"
+        );
+        assert!(
+            r.default_approval_policy.is_none(),
+            "alias `approval_policy` must populate default_approval_policy"
+        );
+        let lead = r.lead.as_ref().expect("lead deserialized");
+        assert_eq!(
+            lead.max_total_workers,
+            Some(12),
+            "alias `max_workers_across_tree` must populate max_total_workers"
         );
     }
 }

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -496,6 +496,7 @@ mod tests {
 
     fn rm(tasks: Vec<ResolvedTask>) -> ResolvedManifest {
         ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,
@@ -524,6 +525,7 @@ mod tests {
     {
         let d = with_tmp_repo(true);
         let mut m = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,
@@ -608,6 +610,7 @@ mod tests {
     fn rejects_mixing_tasks_and_lead() {
         let d = with_tmp_repo(true);
         let r = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,
@@ -639,6 +642,7 @@ mod tests {
     fn rejects_max_workers_out_of_range() {
         let d = with_tmp_repo(true);
         let r = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,
@@ -666,6 +670,7 @@ mod tests {
     fn rejects_non_positive_budget() {
         let d = with_tmp_repo(true);
         let r = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,
@@ -698,6 +703,7 @@ mod tests {
         lead.allow_subleads = allow_subleads;
         lead.sublead_defaults = sublead_defaults;
         let r = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,
@@ -811,6 +817,7 @@ mod tests {
     #[test]
     fn rejects_manifest_with_no_tasks_and_no_lead() {
         let r = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,
@@ -863,6 +870,7 @@ mod tests {
         let mut lead = rl("l", d.path().to_path_buf());
         lead.prompt = String::new();
         let r = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,
@@ -896,6 +904,7 @@ mod tests {
         let mut lead = rl("l", d.path().to_path_buf());
         lead.prompt = "   \t\n  ".to_string();
         let r = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,
@@ -1100,6 +1109,7 @@ mod tests {
         let mut lead = rl("lead", PathBuf::from("/workspace/does-not-exist-on-host"));
         lead.use_worktree = true;
         let mut m = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,

--- a/crates/pitboss-cli/src/mcp/approval.rs
+++ b/crates/pitboss-cli/src/mcp/approval.rs
@@ -343,6 +343,7 @@ mod tests {
     async fn mk_state(policy: ApprovalPolicy) -> Arc<DispatchState> {
         let dir = TempDir::new().unwrap();
         let manifest = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -1349,6 +1349,7 @@ mod tests {
 
         let dir = TempDir::new().unwrap();
         let manifest = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,
@@ -1418,6 +1419,7 @@ mod tests {
 
         let dir = TempDir::new().unwrap();
         let manifest = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,
@@ -1563,6 +1565,7 @@ mod tests {
 
         let dir = TempDir::new().unwrap();
         let manifest = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -2452,6 +2452,7 @@ mod tests {
             sublead_defaults: None,
         };
         let manifest = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,
@@ -2921,6 +2922,7 @@ mod tests {
             sublead_defaults: None,
         };
         let manifest = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,
@@ -3766,6 +3768,7 @@ mod tests {
             sublead_defaults: None,
         };
         let manifest = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,
@@ -3859,6 +3862,7 @@ mod tests {
             sublead_defaults: None,
         };
         let manifest = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,
@@ -3960,6 +3964,7 @@ mod tests {
             sublead_defaults: None,
         };
         let manifest = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 4,
             halt_on_failure: false,

--- a/crates/pitboss-cli/tests/control_flows.rs
+++ b/crates/pitboss-cli/tests/control_flows.rs
@@ -35,6 +35,7 @@ async fn pause_op_writes_events_jsonl() {
     let run_subdir = dir.path().join(run_id.to_string());
     tokio::fs::create_dir_all(&run_subdir).await.unwrap();
     let manifest = ResolvedManifest {
+        manifest_schema_version: 0,
         name: None,
         max_parallel_tasks: 4,
         halt_on_failure: false,
@@ -241,6 +242,7 @@ async fn block_policy_queue_drains_on_tui_connect() {
     let dir = TempDir::new().unwrap();
     let run_id = uuid::Uuid::now_v7();
     let manifest = ResolvedManifest {
+        manifest_schema_version: 0,
         name: None,
         max_parallel_tasks: 4,
         halt_on_failure: false,
@@ -356,6 +358,7 @@ async fn auto_approve_policy_responds_without_tui() {
     let dir = TempDir::new().unwrap();
     let run_id = uuid::Uuid::now_v7();
     let manifest = ResolvedManifest {
+        manifest_schema_version: 0,
         name: None,
         max_parallel_tasks: 4,
         halt_on_failure: false,
@@ -418,6 +421,7 @@ async fn auto_reject_policy_responds_without_tui() {
     let dir = TempDir::new().unwrap();
     let run_id = uuid::Uuid::now_v7();
     let manifest = ResolvedManifest {
+        manifest_schema_version: 0,
         name: None,
         max_parallel_tasks: 4,
         halt_on_failure: false,
@@ -488,6 +492,7 @@ async fn propose_plan_end_to_end_unblocks_spawn_gate() {
     let run_subdir = dir.path().join(run_id.to_string());
     tokio::fs::create_dir_all(&run_subdir).await.unwrap();
     let manifest = ResolvedManifest {
+        manifest_schema_version: 0,
         name: None,
         max_parallel_tasks: 4,
         halt_on_failure: false,

--- a/crates/pitboss-cli/tests/dogfood_fake_flows.rs
+++ b/crates/pitboss-cli/tests/dogfood_fake_flows.rs
@@ -75,6 +75,7 @@ fn mk_state_with_subleads() -> (TempDir, Arc<DispatchState>) {
         sublead_defaults: None,
     };
     let manifest = ResolvedManifest {
+        manifest_schema_version: 0,
         name: None,
         max_parallel_tasks: 8,
         halt_on_failure: false,
@@ -1025,6 +1026,7 @@ async fn dogfood_envelope_cap_rejection() {
             sublead_defaults: None,
         };
         let manifest = ResolvedManifest {
+            manifest_schema_version: 0,
             name: None,
             max_parallel_tasks: 8,
             halt_on_failure: false,

--- a/crates/pitboss-cli/tests/e2e_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_flows.rs
@@ -60,6 +60,7 @@ fn mk_state(
         sublead_defaults: None,
     };
     let manifest = ResolvedManifest {
+        manifest_schema_version: 0,
         name: None,
         max_parallel_tasks: 4,
         halt_on_failure: false,
@@ -362,6 +363,7 @@ async fn e2e_lead_cancels_worker_mid_flight() {
         sublead_defaults: None,
     };
     let manifest = ResolvedManifest {
+        manifest_schema_version: 0,
         name: None,
         max_parallel_tasks: 4,
         halt_on_failure: false,
@@ -618,6 +620,7 @@ async fn e2e_lead_reprompts_running_worker() {
         sublead_defaults: None,
     };
     let manifest = ResolvedManifest {
+        manifest_schema_version: 0,
         name: None,
         max_parallel_tasks: 4,
         halt_on_failure: false,
@@ -813,6 +816,7 @@ async fn e2e_lead_propose_plan_gate_unblocks_spawn() {
         sublead_defaults: None,
     };
     let manifest = ResolvedManifest {
+        manifest_schema_version: 0,
         name: None,
         max_parallel_tasks: 4,
         halt_on_failure: false,
@@ -1114,6 +1118,7 @@ async fn e2e_freeze_pause_and_continue_real_subprocess_worker() {
         sublead_defaults: None,
     };
     let manifest = ResolvedManifest {
+        manifest_schema_version: 0,
         name: None,
         max_parallel_tasks: 4,
         halt_on_failure: false,

--- a/crates/pitboss-cli/tests/e2e_sublead_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_sublead_flows.rs
@@ -60,6 +60,7 @@ fn mk_state(dir: &std::path::Path) -> (Uuid, Arc<DispatchState>) {
         sublead_defaults: None,
     };
     let manifest = ResolvedManifest {
+        manifest_schema_version: 0,
         name: None,
         max_parallel_tasks: 4,
         halt_on_failure: false,
@@ -131,6 +132,7 @@ fn mk_state_hold_workers(dir: &std::path::Path) -> (Uuid, Arc<DispatchState>) {
         sublead_defaults: None,
     };
     let manifest = ResolvedManifest {
+        manifest_schema_version: 0,
         name: None,
         max_parallel_tasks: 4,
         halt_on_failure: false,
@@ -776,6 +778,7 @@ async fn sublead_session_spawns_runs_and_reconciles() {
         sublead_defaults: None,
     };
     let manifest = ResolvedManifest {
+        manifest_schema_version: 0,
         name: None,
         max_parallel_tasks: 4,
         halt_on_failure: false,

--- a/crates/pitboss-cli/tests/hierarchical_flows.rs
+++ b/crates/pitboss-cli/tests/hierarchical_flows.rs
@@ -43,6 +43,7 @@ fn mk_state() -> (TempDir, Arc<DispatchState>) {
         sublead_defaults: None,
     };
     let manifest = ResolvedManifest {
+        manifest_schema_version: 0,
         name: None,
         max_parallel_tasks: 4,
         halt_on_failure: false,

--- a/crates/pitboss-cli/tests/notify_flows.rs
+++ b/crates/pitboss-cli/tests/notify_flows.rs
@@ -237,6 +237,7 @@ async fn approval_pending_notification_fires_on_enqueue() {
     // Set up dispatch state with the notification router
     let dir = TempDir::new().unwrap();
     let manifest = ResolvedManifest {
+        manifest_schema_version: 0,
         name: None,
         max_parallel_tasks: 4,
         halt_on_failure: false,

--- a/crates/pitboss-cli/tests/shared_store_flows.rs
+++ b/crates/pitboss-cli/tests/shared_store_flows.rs
@@ -445,6 +445,7 @@ async fn lease_released_when_mcp_connection_drops() {
         sublead_defaults: None,
     };
     let manifest = ResolvedManifest {
+        manifest_schema_version: 0,
         name: None,
         max_parallel_tasks: 4,
         halt_on_failure: false,
@@ -586,6 +587,7 @@ async fn run_global_lease_released_when_mcp_connection_drops() {
         sublead_defaults: None,
     };
     let manifest = ResolvedManifest {
+        manifest_schema_version: 0,
         name: None,
         max_parallel_tasks: 4,
         halt_on_failure: false,

--- a/crates/pitboss-cli/tests/sublead_flows.rs
+++ b/crates/pitboss-cli/tests/sublead_flows.rs
@@ -43,6 +43,7 @@ fn mk_state_with_subleads() -> (TempDir, Arc<DispatchState>) {
         sublead_defaults: None,
     };
     let manifest = ResolvedManifest {
+        manifest_schema_version: 0,
         name: None,
         max_parallel_tasks: 8,
         halt_on_failure: false,
@@ -111,6 +112,7 @@ fn mk_state_with_sublead_budget_cap(cap: f64) -> (TempDir, Arc<DispatchState>) {
         sublead_defaults: None,
     };
     let manifest = ResolvedManifest {
+        manifest_schema_version: 0,
         name: None,
         max_parallel_tasks: 8,
         halt_on_failure: false,


### PR DESCRIPTION
## Summary

Closes the two HIGH-severity findings in the 2026-04-27 audit's Manifest tracker (#186) — both concern \`resolved.json\` snapshot durability across pitboss versions:

### 1. \`manifest_schema_version\` discriminator on \`ResolvedManifest\`

Snapshots had no version field. When a future schema change ships, an older pitboss trying to resume a newer run would surface an opaque serde error rather than a meaningful \"this snapshot is from a newer version\" message. This PR adds:

- \`pub const CURRENT_MANIFEST_SCHEMA_VERSION: u32 = 1\` in \`manifest::resolve\`
- New field \`manifest_schema_version: u32\` on \`ResolvedManifest\`, with \`#[serde(default = ...)]\` returning \`0\` for pre-v0.9.2 snapshots (the v0.9.0/v0.9.1 era predates this field; treating absent as \`0\` keeps existing runs resumable on a best-effort basis)
- Stamp on construction in \`resolve()\` so every fresh snapshot writes \`CURRENT\`
- A typed \`ManifestError::IncompatibleVersion { found, supported }\` (new \`manifest::error\` module) emitted by the resume loaders when the on-disk version exceeds \`CURRENT\`
- A new \`read_resolved_manifest\` helper in \`dispatch::resume\` that pre-checks version before full deserialize. Both \`build_resume_manifest\` (flat) and \`build_resume_hierarchical\` route through it.

The audit-cited snapshot writers (\`hierarchical.rs:56\`, \`runner.rs:231\`) need no edit — they serialize the same \`ResolvedManifest\` whose \`resolve()\` constructor now stamps the version.

### 2. Regression test for serde alias coverage

Three v0.9 renames already ship \`#[serde(alias = ...)]\` to keep pre-v0.9 snapshots resumable: \`max_parallel\` → \`max_parallel_tasks\`, \`approval_policy\` → \`default_approval_policy\`, \`max_workers_across_tree\` → \`max_total_workers\`. There was nothing stopping a future rename from silently dropping the alias and breaking pre-rename runs.

Added \`resolved_manifest_accepts_legacy_serde_aliases\` — a fixture-driven test that deserializes a JSON blob using every renamed field's pre-v0.9 name and asserts the new field is populated. If a future rename drops its alias, the test breaks loudly; the contributor must either restore the alias OR explicitly bump \`CURRENT_MANIFEST_SCHEMA_VERSION\` and remove the row from the fixture.

Also added \`resolve_stamps_current_schema_version\` to lock in the stamp-on-construction invariant.

## Changes

- **New**: \`crates/pitboss-cli/src/manifest/error.rs\` — \`ManifestError::IncompatibleVersion\`
- \`manifest/resolve.rs\` — \`CURRENT_MANIFEST_SCHEMA_VERSION\` constant, new field, stamp in \`resolve()\`
- \`dispatch/resume.rs\` — \`read_resolved_manifest\` helper, both resume builders use it
- \`manifest/mod.rs\` — re-export \`ManifestError\`
- \`CHANGELOG.md\` — \`[Unreleased]\` entry under Fixed
- 37 in-source + 21 integration-test \`ResolvedManifest {...}\` literals gained the new field (mechanical, scripted)

## Test plan

- [x] \`cargo test --workspace --features pitboss-core/test-support\` — all green; pitboss-cli unit tests went from 537 → 541 (+4 new tests for Bundle B)
- [x] \`cargo lint\` clean
- [x] \`cargo tidy\` clean
- [x] **New tests**:
  - \`manifest::resolve::tests::resolve_stamps_current_schema_version\`
  - \`manifest::resolve::tests::resolved_manifest_accepts_legacy_serde_aliases\`
  - \`dispatch::resume::tests::read_resolved_manifest_accepts_unversioned_legacy_snapshot\`
  - \`dispatch::resume::tests::read_resolved_manifest_rejects_future_schema_version\`
- [x] Existing resume integration tests (\`build_resume_hierarchical_*\`, \`happy_path_populates_resume_session_ids\`, etc.) continue to pass — they exercise the new code path end-to-end through a fixture \`resolved.json\` (which omits \`manifest_schema_version\`, so it defaults to \`0\` legacy and is accepted)

## Compatibility

Existing v0.9.0/v0.9.1 \`resolved.json\` snapshots on disk continue to load — the missing field defaults to \`0\` and is accepted (\`0 ≤ CURRENT = 1\`). New runs from this build write version \`1\`, which still resumes cleanly on this and later builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)