### PR TITLE
test(control): serialize hello/approve handshake to fix flaky approve_op_completes_pending_request

### DIFF
--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -1385,29 +1385,34 @@ mod tests {
         .unwrap();
 
         let mut stream = tokio::net::UnixStream::connect(&sock).await.unwrap();
-        stream
-            .write_all(b"{\"op\":\"hello\",\"client_version\":\"0.4.0\"}\n")
-            .await
-            .unwrap();
-        stream
-            .write_all(
-                b"{\"op\":\"approve\",\"request_id\":\"req-1\",\"approved\":true,\"edited_summary\":\"go\"}\n",
-            )
-            .await
-            .unwrap();
-
-        let (r, _w) = stream.split();
+        let (r, mut w) = stream.split();
         let mut lines = BufReader::new(r).lines();
+
+        // Send `hello` and drain BOTH the hello ack AND the bridge-replay
+        // event (#102: server replays live bridge entries on Hello)
+        // *before* sending `approve`. Without this serialization, the
+        // server may process the approve op — which removes the bridge
+        // entry — ahead of the hello-triggered replay enumeration, so the
+        // replay sees an empty map and the ApprovalRequest event never
+        // reaches the wire. CI hit this race on a slower scheduler; local
+        // dev machines reliably win it but the bug is in the test, not in
+        // production.
+        w.write_all(b"{\"op\":\"hello\",\"client_version\":\"0.4.0\"}\n")
+            .await
+            .unwrap();
         let _hello = lines.next_line().await.unwrap();
-        // #102: server now replays live bridge entries on Hello. The pre-seed
-        // at the top of this test pushes one ApprovalRequest before the
-        // approve ack arrives.
         let replay_line = lines.next_line().await.unwrap().unwrap();
         let replay: ControlEvent = serde_json::from_str(&replay_line).unwrap();
         assert!(matches!(
             replay,
             ControlEvent::ApprovalRequest { ref request_id, .. } if request_id == "req-1"
         ));
+
+        w.write_all(
+            b"{\"op\":\"approve\",\"request_id\":\"req-1\",\"approved\":true,\"edited_summary\":\"go\"}\n",
+        )
+        .await
+        .unwrap();
         let reply_line = lines.next_line().await.unwrap().unwrap();
         let reply: ControlEvent = serde_json::from_str(&reply_line).unwrap();
         assert!(matches!(


### PR DESCRIPTION
## Summary

Fixes a race in the test \`control::server::tests::approve_op_completes_pending_request\` that flaked on the post-#190 main CI run ([job 73298493203](https://github.com/SDS-Mode/pitboss/actions/runs/25026451379/job/73298493203)). **No production-code changes** — the bug is in the test, not in the server.

## The race

The test wrote \`hello\` and \`approve\` ops back-to-back without waiting for the hello ack:

\`\`\`rust
stream.write_all(b\"...hello...\").await.unwrap();
stream.write_all(b\"...approve...\").await.unwrap();   // sent immediately
// ...then reads three lines expecting [hello_ack, ApprovalRequest_replay, OpAcked]
\`\`\`

The server's response to \`hello\` is to enumerate the approval bridge map and replay any pending entries as \`ApprovalRequest\` events (#102 — \"ghost approval\" regression coverage). The pre-seed at the top of this test inserts a \`req-1\` \`BridgeEntry\` precisely so the replay has something to emit.

When the server processes the \`approve\` op concurrently with the replay, the approve handler **removes** the \`req-1\` bridge entry. If that removal happens before the replay enumeration walks the map, the replay sees an empty map and never emits the \`ApprovalRequest\`. Line 2 of the wire becomes \`OpAcked\` instead — exactly what the failing assertion observed.

A real TUI client either holds outgoing ops until \`hello\` is acked, or serializes them via its own event loop. The test was just sloppy.

## The fix

Read the hello ack + replay event **before** sending \`approve\`. Same logical handshake, deterministic ordering.

\`\`\`rust
let (r, mut w) = stream.split();
let mut lines = BufReader::new(r).lines();

w.write_all(hello).await.unwrap();
let _hello_ack = lines.next_line().await.unwrap();
let replay_line = lines.next_line().await.unwrap().unwrap();
// assert replay is ApprovalRequest for req-1

w.write_all(approve).await.unwrap();
let reply_line = lines.next_line().await.unwrap().unwrap();
// assert reply is OpAcked for approve
\`\`\`

## Test plan

- [x] **50/50 local stress runs pass** with the fix:
  \`\`\`
  for i in $(seq 1 50); do
    cargo test -p pitboss-cli --features pitboss-cli/test-support --lib \\
      'control::server::tests::approve_op_completes_pending_request' 2>&1 \\
      | grep \"test result\"
  done
  # → \"fails: 0 / 50\"
  \`\`\`
- [x] Full workspace test suite still green (541 pitboss-cli, +0 since this is a test-only edit)
- [x] \`cargo lint\` clean
- [x] \`cargo tidy\` clean

## Why not bundle this with the MCP sweep (#151)?

It's a one-line conceptual fix that should not be blocked behind unrelated cleanup work. Smaller PRs land faster and are easier to bisect. The MCP sweep (#17 in our internal task list) addresses different races in \`mcp/approval.rs\` — that's a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)