### PR TITLE
fix(notify): write journal line before bumping failed_emits_total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Notify — write `notifications.jsonl` line before bumping
+  `failed_emits_total`.** `NotificationRouter::dispatch`'s spawned
+  emit-failure path used to increment the counter and then `await` the
+  journal write, so external observers (tests, status APIs) using the
+  counter as a synchronization barrier could read `notifications.jsonl`
+  before the line landed and see ENOENT. Surfaced as flaky CI failures
+  in `router_records_failed_emit_metric_and_journal_line` under
+  slow-FS conditions on GH Actions runners. Swap the order: write the
+  audit-trail line first, then bump the counter. The journal write is
+  bounded and swallows its own errors, so this ordering can't deadlock
+  the spawn.
+
 - **MCP — `wait_for_any` fail-fast on all-unknown task ids,
   approval-queue-full bridge cleanup, sub-tree `worker_prompts` read**
   (#151). `handle_wait_for_any` used to subscribe to `done_tx` and

--- a/crates/pitboss-cli/src/notify/mod.rs
+++ b/crates/pitboss-cli/src/notify/mod.rs
@@ -301,10 +301,21 @@ impl NotificationRouter {
                         error = %e,
                         "notification emit failed after retries"
                     );
-                    counter.fetch_add(1, Ordering::Relaxed);
+                    // Write the audit-trail line BEFORE bumping the counter.
+                    // External observers (tests, status APIs) treat
+                    // `failed_emits_total` as a synchronization barrier — a
+                    // post-bump read of `notifications.jsonl` must see the
+                    // line. With the previous order the counter could
+                    // increment while the journal write was still in flight,
+                    // producing flaky reads in
+                    // `router_records_failed_emit_metric_and_journal_line`
+                    // under slow-FS conditions on CI. The journal write is
+                    // bounded and swallows its own errors, so this ordering
+                    // can't deadlock the spawn.
                     if let Some(subdir) = run_subdir.as_ref() {
                         record_notification_failure(subdir, &sink, &env, &e).await;
                     }
+                    counter.fetch_add(1, Ordering::Relaxed);
                 }
             });
         }


### PR DESCRIPTION
## Summary

Fixes the recurring CI flake in `router_records_failed_emit_metric_and_journal_line` (last seen on PR #197 and on the re-run of the same job).

The race lived in `NotificationRouter::dispatch`'s spawned emit-failure path:

```rust
counter.fetch_add(1, Ordering::Relaxed);                  // observable now
record_notification_failure(subdir, ...).await;           // file write happens after
```

Tests (and any future status API) treat \`failed_emits_total\` as a synchronization barrier — poll the counter, read the journal. Under slow-FS conditions on GH Actions runners, the read raced ahead of the write and the test panicked with \`ENOENT\` on \`notifications.jsonl\`.

Swap the order so the counter becomes a fully-durable signal: write the audit-trail line first, then bump the counter. The journal write is bounded (open → write → flush) and swallows its own errors via \`tracing::warn!\`, so this ordering can't deadlock the spawn.

## Test plan

- [x] \`cargo test -p pitboss-cli --lib notify::tests::router_records_failed_emit_metric_and_journal_line\` — 10/10 stress-runs pass
- [x] \`cargo test -p pitboss-cli --lib notify\` — 81 passed
- [x] \`cargo lint\` clean
- [x] \`cargo tidy\` clean

## Related

- PR #196 (cancel-cascade tests) and #197 (roadmap docs) both off the same base; both saw \`test+lint+fmt\` go red on this single test in independent runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)