### PR TITLE
refactor(dispatch): centralize cancel-cascade through CancelToken::cascade_to (#100, PR 100.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Centralize cancel-cascade primitive** (#100, PR 100.2). Adds
+  `CancelToken::cascade_to(&CancelToken)` in `pitboss-core` (terminate
+  dominates drain) and threads it through four new methods —
+  `LayerState::register_worker_cancel`, `LayerState::cascade_to_workers`,
+  `DispatchState::register_sublead`, `DispatchState::cascade_to_subleads`.
+  The previously-inlined cascade patterns at `mcp/tools.rs:506-521`
+  (worker registration eager check) and `dispatch/sublead.rs:340-383`
+  (sub-lead spawn insert + watcher install + eager check) now route
+  through these helpers, and the fire-once watcher tasks in
+  `dispatch/signals.rs` funnel through `cascade_to_workers` /
+  `cascade_to_subleads` so the terminate-dominates-drain rule lives in
+  exactly one place. No external behavior change: PR 100.1's
+  `cancel_cascade_flows` integration tests and the existing
+  `signals::tests::sublead_watcher_*` unit tests pin the contract;
+  4 new unit tests on `CancelToken::cascade_to` lock the primitive.
+
 ### Tests
 
 - **Pin late-registration cancel-cascade contract** (#100, PR 100.1).

--- a/crates/pitboss-cli/src/dispatch/layer.rs
+++ b/crates/pitboss-cli/src/dispatch/layer.rs
@@ -390,6 +390,39 @@ impl LayerState {
         let spent = *self.spent_usd.lock().await;
         Some((budget - spent).max(0.0))
     }
+
+    /// Register a worker's `CancelToken` under `task_id` and immediately
+    /// propagate any in-flight drain/terminate state from this layer's
+    /// `cancel` to the worker's token. Centralizes the previously-inlined
+    /// pattern at `mcp/tools.rs` (insert into `worker_cancels`, then
+    /// check `target_layer.cancel.is_terminated()` / `is_draining()`).
+    ///
+    /// The eager propagation is what closes the post-register cascade
+    /// gap (#99): the per-sublead watcher (`install_sublead_cancel_watcher`)
+    /// is fire-once, so a worker registered after the watcher has fired
+    /// would otherwise miss the cancel signal. Pinned by the integration
+    /// tests in `tests/cancel_cascade_flows.rs`.
+    pub async fn register_worker_cancel(&self, task_id: String, token: CancelToken) {
+        self.worker_cancels
+            .write()
+            .await
+            .insert(task_id, token.clone());
+        self.cancel.cascade_to(&token);
+    }
+
+    /// Walk every registered `worker_cancels` entry and cascade this
+    /// layer's current cancel state to it via `CancelToken::cascade_to`.
+    /// Used by the per-sublead watcher tasks installed by
+    /// `install_sublead_cancel_watcher` — both the drain and terminate
+    /// watchers funnel through this method so the cascade rule
+    /// (terminate dominates drain) is encoded in exactly one place.
+    pub async fn cascade_to_workers(&self) {
+        let workers = self.worker_cancels.read().await;
+        for (worker_id, tok) in workers.iter() {
+            tracing::debug!(worker_id = %worker_id, "cascading cancel state to sub-tree worker");
+            self.cancel.cascade_to(tok);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/pitboss-cli/src/dispatch/signals.rs
+++ b/crates/pitboss-cli/src/dispatch/signals.rs
@@ -196,34 +196,30 @@ async fn cancel_and_find_parent(
 /// Spawns two background tasks that mirror the per-layer variant of the root
 /// cascade watcher:
 ///
-/// * **drain watcher**: fires when `sub_layer.cancel` is drained → drains
-///   every worker cancel token registered on that layer at that moment.
+/// * **drain watcher**: fires when `sub_layer.cancel` is drained →
+///   `cascade_to_workers` walks `worker_cancels` and propagates this layer's
+///   current cancel state to each.
 /// * **terminate watcher**: fires when `sub_layer.cancel` is terminated →
-///   terminates every worker cancel token registered on that layer.
+///   same `cascade_to_workers` call.
 ///
-/// Call exactly once at sub-lead spawn time (see `spawn_sublead`).  The root
-/// cascade watcher (`install_cascade_cancel_watcher`) only needs to signal
-/// `sub_layer.cancel`; this function handles the worker cascade so
-/// `DispatchState` never touches `sub_layer.worker_cancels` directly.
+/// Both watchers funnel through `LayerState::cascade_to_workers` so the
+/// terminate-dominates-drain rule lives in exactly one place
+/// (`CancelToken::cascade_to`).  Call exactly once at sub-lead spawn time
+/// (see `DispatchState::register_sublead`).  The root cascade watcher
+/// (`install_cascade_cancel_watcher`) only needs to signal `sub_layer.cancel`;
+/// this function handles the worker cascade so `DispatchState` never touches
+/// `sub_layer.worker_cancels` directly.
 pub fn install_sublead_cancel_watcher(sub_layer: Arc<crate::dispatch::layer::LayerState>) {
     let layer_drain = sub_layer.clone();
     tokio::spawn(async move {
         layer_drain.cancel.await_drain().await;
-        let worker_cancels = layer_drain.worker_cancels.read().await;
-        for (worker_id, tok) in worker_cancels.iter() {
-            tracing::debug!(worker_id = %worker_id, "cascading drain to sub-tree worker");
-            tok.drain();
-        }
+        layer_drain.cascade_to_workers().await;
     });
 
     let layer_term = sub_layer;
     tokio::spawn(async move {
         layer_term.cancel.await_terminate().await;
-        let worker_cancels = layer_term.worker_cancels.read().await;
-        for (worker_id, tok) in worker_cancels.iter() {
-            tracing::debug!(worker_id = %worker_id, "cascading terminate to sub-tree worker");
-            tok.terminate();
-        }
+        layer_term.cascade_to_workers().await;
     });
 }
 
@@ -242,25 +238,15 @@ pub fn install_sublead_cancel_watcher(sub_layer: Arc<crate::dispatch::layer::Lay
 /// fire — re-installing after the cascade has fired will not catch sub-trees
 /// registered post-cascade. For that, see the spawn-time check in `spawn_sublead`.
 pub fn install_cascade_cancel_watcher(state: Arc<DispatchState>) {
-    let root_cancel_drain = state.root.cancel.clone();
     let state_drain = state.clone();
     tokio::spawn(async move {
-        root_cancel_drain.await_drain().await;
-        let subleads = state_drain.subleads.read().await;
-        for (sublead_id, sub_layer) in subleads.iter() {
-            tracing::info!(sublead_id = %sublead_id, "cascading drain to sub-tree");
-            sub_layer.cancel.drain();
-        }
+        state_drain.root.cancel.await_drain().await;
+        state_drain.cascade_to_subleads().await;
     });
 
-    let root_cancel_term = state.root.cancel.clone();
     tokio::spawn(async move {
-        root_cancel_term.await_terminate().await;
-        let subleads = state.subleads.read().await;
-        for (sublead_id, sub_layer) in subleads.iter() {
-            tracing::info!(sublead_id = %sublead_id, "cascading terminate to sub-tree");
-            sub_layer.cancel.terminate();
-        }
+        state.root.cancel.await_terminate().await;
+        state.cascade_to_subleads().await;
     });
 }
 

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -423,6 +423,40 @@ impl DispatchState {
         }
     }
 
+    /// Register a freshly-built sub-tree `LayerState` under `sublead_id`.
+    /// Performs three coupled side-effects atomically (from the caller's
+    /// perspective): (1) inserts the layer into `self.subleads`,
+    /// (2) installs the per-sublead cancel-cascade watcher, and
+    /// (3) propagates any in-flight drain/terminate state from
+    /// `self.root.cancel` to the new sub-layer's cancel.
+    ///
+    /// Centralizes the previously-inlined sequence at
+    /// `dispatch/sublead.rs:340-383` so the watcher install + eager
+    /// cascade can never drift out of order.  Pinned by the integration
+    /// tests in `tests/cancel_cascade_flows.rs`.
+    pub async fn register_sublead(&self, sublead_id: String, sub_layer: Arc<LayerState>) {
+        self.subleads
+            .write()
+            .await
+            .insert(sublead_id, sub_layer.clone());
+        crate::dispatch::signals::install_sublead_cancel_watcher(sub_layer.clone());
+        self.root.cancel.cascade_to(&sub_layer.cancel);
+    }
+
+    /// Walk every registered sub-tree layer and cascade the root's
+    /// current cancel state to it via `CancelToken::cascade_to`.  Used
+    /// by the root cascade-watcher tasks installed by
+    /// `install_cascade_cancel_watcher` — both the drain and terminate
+    /// watchers funnel through this method so the cascade rule
+    /// (terminate dominates drain) is encoded in exactly one place.
+    pub async fn cascade_to_subleads(&self) {
+        let subleads = self.subleads.read().await;
+        for (sublead_id, sub_layer) in subleads.iter() {
+            tracing::info!(sublead_id = %sublead_id, "cascading cancel state to sub-tree");
+            self.root.cancel.cascade_to(&sub_layer.cancel);
+        }
+    }
+
     /// Mint a fresh authentication token bound to the (actor_id, role)
     /// pair. The token is later embedded into the actor's
     /// mcp-config.json (consumed by `pitboss mcp-bridge --token <hex>`)

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -337,17 +337,15 @@ pub async fn spawn_sublead(
             reserved_amount,
         ));
 
-        // 8. Register sub-tree LayerState on root DispatchState.
+        // 8. Register sub-tree LayerState on root DispatchState. Inserts into
+        // `state.subleads`, installs the per-sublead cancel-cascade watcher,
+        // AND eagerly propagates any in-flight root drain/terminate signal
+        // to `sub_layer.cancel`.  Centralizing these three coupled steps in
+        // `DispatchState::register_sublead` keeps the post-#99 contract from
+        // drifting; pinned by `tests/cancel_cascade_flows.rs`.
         state
-            .subleads
-            .write()
-            .await
-            .insert(sublead_id.clone(), sub_layer.clone());
-
-        // Install the per-sublead cancel cascade watcher so that draining /
-        // terminating sub_layer.cancel propagates to its workers without the
-        // root cascade watcher needing to reach into worker_cancels directly.
-        crate::dispatch::signals::install_sublead_cancel_watcher(sub_layer.clone());
+            .register_sublead(sublead_id.clone(), sub_layer.clone())
+            .await;
 
         // Emit SubleadSpawned lifecycle event to the control plane.
         {
@@ -369,17 +367,6 @@ pub async fn spawn_sublead(
                 },
             };
             state.root.broadcast_control_event(ev).await;
-        }
-
-        // I-1: If root has entered cascade-drain or cascade-terminate phase AFTER this
-        // read-lock snapshot, immediately propagate to the new sub-tree so it doesn't
-        // miss the cascade-watcher snapshot (which only fires once per run).
-        if state.root.cancel.is_terminated() {
-            sub_layer.cancel.terminate();
-            tracing::info!(sublead_id = %sublead_id, "spawned during cascade terminate; immediate cascade applied");
-        } else if state.root.cancel.is_draining() {
-            sub_layer.cancel.drain();
-            tracing::info!(sublead_id = %sublead_id, "spawned during cascade drain; immediate cascade applied");
         }
 
         // 9. Spawn the sub-lead's Claude session (wired in Task 2.3).

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -496,29 +496,16 @@ pub async fn handle_spawn_worker(
         .await
         .insert(task_id.clone(), layer_index_value);
 
+    // Register the worker's CancelToken on the target layer. This both
+    // inserts into `worker_cancels` and eagerly propagates any in-flight
+    // drain/terminate state from `target_layer.cancel` to the new token —
+    // the post-#99 cascade gap fix lives inside `register_worker_cancel`
+    // so the watcher / registration paths share one cascade rule
+    // (terminate dominates drain). Pinned by `tests/cancel_cascade_flows.rs`.
     let worker_cancel = pitboss_core::session::CancelToken::new();
     target_layer
-        .worker_cancels
-        .write()
-        .await
-        .insert(task_id.clone(), worker_cancel);
-
-    // Plug the post-register cascade gap (#99): `install_sublead_cancel_watcher`
-    // is fire-once — it snapshots `worker_cancels`, propagates, then exits. A
-    // worker registered after the watcher has already fired never receives the
-    // signal. Check the target layer's cancel state now and propagate eagerly
-    // before the background task starts. `is_terminated` is checked first
-    // since terminate subsumes drain.
-    {
-        let cancels = target_layer.worker_cancels.read().await;
-        if let Some(w) = cancels.get(&task_id) {
-            if target_layer.cancel.is_terminated() {
-                w.terminate();
-            } else if target_layer.cancel.is_draining() {
-                w.drain();
-            }
-        }
-    }
+        .register_worker_cancel(task_id.clone(), worker_cancel)
+        .await;
 
     // Record the prompt preview before spawning the background task.
     let prompt_preview: String = args.prompt.chars().take(80).collect();

--- a/crates/pitboss-core/src/session/cancel.rs
+++ b/crates/pitboss-core/src/session/cancel.rs
@@ -59,6 +59,24 @@ impl CancelToken {
             }
         }
     }
+
+    /// Propagate this token's in-flight cancel state to `child`. If this
+    /// token is terminated, terminate `child`. Otherwise if this token is
+    /// draining, drain `child`. No-op if neither.
+    ///
+    /// Terminate dominates drain — when both are set on the parent, the
+    /// child receives terminate so the more permissive signal is never
+    /// applied while the stricter one is in flight. This matches the
+    /// semantics used by the eager-propagation paths in
+    /// `pitboss-cli::dispatch` (sub-lead spawn after root cancel; worker
+    /// registration in a cancelled sub-tree).
+    pub fn cascade_to(&self, child: &CancelToken) {
+        if self.is_terminated() {
+            child.terminate();
+        } else if self.is_draining() {
+            child.drain();
+        }
+    }
 }
 
 impl Default for CancelToken {
@@ -92,5 +110,51 @@ mod tests {
         t.terminate();
         assert!(t.is_terminated());
         assert!(!t.is_draining());
+    }
+
+    #[test]
+    fn cascade_to_pristine_parent_is_noop() {
+        let parent = CancelToken::new();
+        let child = CancelToken::new();
+        parent.cascade_to(&child);
+        assert!(!child.is_draining());
+        assert!(!child.is_terminated());
+    }
+
+    #[test]
+    fn cascade_to_drains_child_when_parent_drained() {
+        let parent = CancelToken::new();
+        let child = CancelToken::new();
+        parent.drain();
+        parent.cascade_to(&child);
+        assert!(child.is_draining());
+        assert!(!child.is_terminated());
+    }
+
+    #[test]
+    fn cascade_to_terminates_child_when_parent_terminated() {
+        let parent = CancelToken::new();
+        let child = CancelToken::new();
+        parent.terminate();
+        parent.cascade_to(&child);
+        assert!(child.is_terminated());
+        // Whether `is_draining` is also true depends on whether
+        // terminate implicitly sets drain; we deliberately only assert
+        // terminate here because that's the dominant signal.
+    }
+
+    #[test]
+    fn cascade_to_terminate_dominates_drain() {
+        let parent = CancelToken::new();
+        let child = CancelToken::new();
+        parent.drain();
+        parent.terminate();
+        parent.cascade_to(&child);
+        assert!(child.is_terminated());
+        // Crucially, drain is NOT applied to the child when terminate
+        // is also set on the parent — the stricter signal wins, so we
+        // never tell the child "you may finish current work" while the
+        // parent has already said "stop now".
+        assert!(!child.is_draining());
     }
 }


### PR DESCRIPTION
## Summary

Second slice of the **#100 cancel-cascade redesign** multi-PR plan. Pure refactor — no external behavior change. PR 100.1's `cancel_cascade_flows` integration tests are the regression net.

Pulls the eager-propagation logic out of the inline blocks at `mcp/tools.rs:506-521` (worker registration) and `dispatch/sublead.rs:340-383` (sub-lead spawn) into four LayerState / DispatchState helpers backed by a new `pitboss-core` primitive.

## API additions

| Symbol | Where | Purpose |
|---|---|---|
| `CancelToken::cascade_to(&CancelToken)` | `pitboss-core::session::cancel` | terminate-dominates-drain propagation primitive |
| `LayerState::register_worker_cancel` | `pitboss-cli::dispatch::layer` | insert into `worker_cancels` + eager cascade in one call |
| `LayerState::cascade_to_workers` | `pitboss-cli::dispatch::layer` | watcher uses this to fan out to all registered workers |
| `DispatchState::register_sublead` | `pitboss-cli::dispatch::state` | insert into `subleads` + install watcher + eager cascade in one call |
| `DispatchState::cascade_to_subleads` | `pitboss-cli::dispatch::state` | root-cascade watcher uses this to fan out |

The fire-once watcher tasks in `dispatch/signals.rs` (per-sublead and root-cascade) now both funnel through `cascade_to_workers` / `cascade_to_subleads` so the terminate-dominates-drain rule lives in exactly one place.

## Why

The audit's complaint about "ownership inversion" — `DispatchState` reaching directly into `sub_layer.worker_cancels` from the root cascade watcher — disappears as a side effect: the watchers now operate on their own layer's helpers, never crossing layer boundaries. The watcher fan-out and the registration eager-check were two copies of the same pattern; collapsing them sets up PR 100.3 (retire fire-once watchers; address `terminate()`/`drain()` symmetry) without surgery on the call sites.

## Test plan

- [x] `cargo test -p pitboss-cli --test cancel_cascade_flows` — 4/4 (PR 100.1 contract preserved)
- [x] `cargo test -p pitboss-cli --lib dispatch::signals::tests` — 5/5
- [x] `cargo test -p pitboss-core session::cancel` — 8/8 (4 new `cascade_to` tests)
- [x] `cargo test --workspace --features pitboss-core/test-support` — full green
- [x] `cargo lint` — clean
- [x] `cargo tidy` — clean

## Multi-PR plan

- ✅ **PR 100.1** (#196) — test contract.
- ✅ **PR 100.2 (this PR)** — centralize cancel-cascade primitive; no behavior change.
- ⏳ PR 100.3 — retire fire-once watcher pattern; revisit `terminate()`/`drain()` symmetry now that the cascade rule has one home.
- ⏳ PR 100.4 — doc + state-access audit (sweep `state.rs:288-317`'s lock-discipline doc to reflect post-refactor reality).

🤖 Generated with [Claude Code](https://claude.com/claude-code)