### PR TITLE
refactor(dispatch): collapse cancel-cascade watcher tasks; close #100 (PR 100.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **Collapse cancel-cascade watcher tasks; close #100** (#100, PR 100.3).
+  `install_sublead_cancel_watcher` and `install_cascade_cancel_watcher`
+  used to spawn two tasks each (one for drain, one for terminate); now
+  a single `tokio::select!`-based task per watcher waits for the first
+  signal, cascades, and — if the first signal was drain — waits for the
+  follow-up terminate to upgrade drained actors to terminated. Halves
+  the watcher task count and makes the lifecycle visible in one place.
+  New `sublead_watcher_upgrades_drained_workers_to_terminated` unit
+  test pins the upgrade path. ROADMAP entry for #100 updated to
+  reflect that all four audit concerns landed across 100.1–100.3.
+
 - **Centralize cancel-cascade primitive** (#100, PR 100.2). Adds
   `CancelToken::cascade_to(&CancelToken)` in `pitboss-core` (terminate
   dominates drain) and threads it through four new methods —

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -445,17 +445,26 @@ gates it with a validation error. Three tracked bugs block stabilization:
 **Status:** work-in-progress on `feat/path-b-permission-routing`.
 Landing all three unblocks removal of the validate-time gate.
 
-### Phase 4 per-sub-tree runners (#100)
+### Phase 4 per-sub-tree runners (#100) — closed
 
-The watcher cascades cancel tokens directly across sub-tree boundaries
-rather than going through a per-sub-tree runner that owns its workers'
-cancellation. Watchers are fire-once, so workers registered after the
-cascade fires can be orphaned. Also: `terminate()` does not cascade to
-sub-tree workers (only `drain()` does).
+Originally tracked four concerns: (1) fire-once watchers miss
+late-registered actors; (2) the root watcher reaches into sub-tree
+`worker_cancels` directly (ownership inversion); (3) `terminate()` does
+not cascade symmetrically with `drain()`; (4) the spawn-time mitigation
+is a band-aid on (1).
 
-**Status:** tracked in #100 with a detailed architecture memo. Tactical
-mitigation (post-register cascade check at worker-registration time) was
-already applied (#99, closed).
+**Status:** closed across PRs 100.1–100.3. (1) and (4) are fixed by
+making the eager registration cascade a documented part of the
+contract, not a band-aid (`LayerState::register_worker_cancel`,
+`DispatchState::register_sublead`, pinned by
+`tests/cancel_cascade_flows.rs`). (2) is fixed because the watchers now
+fan out via `LayerState::cascade_to_workers` /
+`DispatchState::cascade_to_subleads` — no watcher reaches across layer
+boundaries. (3) is fixed because both watchers funnel through
+`CancelToken::cascade_to`, which encodes terminate-dominates-drain in
+one place. The "per-sub-tree runner" abstraction itself was not built;
+the audit's correctness goals were met without introducing a new
+runner type.
 
 ### TUI approval replay on run-switch (#95)
 

--- a/crates/pitboss-cli/src/dispatch/signals.rs
+++ b/crates/pitboss-cli/src/dispatch/signals.rs
@@ -193,60 +193,68 @@ async fn cancel_and_find_parent(
 
 /// Install a per-sub-tree cancel-cascade watcher on `sub_layer`.
 ///
-/// Spawns two background tasks that mirror the per-layer variant of the root
-/// cascade watcher:
+/// Spawns one background task that:
 ///
-/// * **drain watcher**: fires when `sub_layer.cancel` is drained →
-///   `cascade_to_workers` walks `worker_cancels` and propagates this layer's
-///   current cancel state to each.
-/// * **terminate watcher**: fires when `sub_layer.cancel` is terminated →
-///   same `cascade_to_workers` call.
+/// 1. Waits for the first cancel signal (drain or terminate, whichever
+///    arrives first) on `sub_layer.cancel`.
+/// 2. Calls `cascade_to_workers` to fan the current cancel state out
+///    to every worker registered on this layer at that moment.
+/// 3. If the first signal was drain, waits for the (eventual) terminate
+///    and fans out again — the second cascade upgrades drained workers
+///    to terminated. If the first signal was terminate, exits.
 ///
-/// Both watchers funnel through `LayerState::cascade_to_workers` so the
-/// terminate-dominates-drain rule lives in exactly one place
-/// (`CancelToken::cascade_to`).  Call exactly once at sub-lead spawn time
-/// (see `DispatchState::register_sublead`).  The root cascade watcher
-/// (`install_cascade_cancel_watcher`) only needs to signal `sub_layer.cancel`;
-/// this function handles the worker cascade so `DispatchState` never touches
-/// `sub_layer.worker_cancels` directly.
+/// Funnelling through `LayerState::cascade_to_workers` keeps the
+/// terminate-dominates-drain rule in exactly one place
+/// (`CancelToken::cascade_to`).
+///
+/// **Pre- vs. post-registration coverage:** the watcher only fans out
+/// to actors registered *before* the signal arrives. Workers registered
+/// *after* the signal are covered by the eager cascade in
+/// `LayerState::register_worker_cancel` — these two paths together form
+/// the full timeline. Pinned by `tests/cancel_cascade_flows.rs`.
+///
+/// Call exactly once at sub-lead spawn time
+/// (see `DispatchState::register_sublead`).
 pub fn install_sublead_cancel_watcher(sub_layer: Arc<crate::dispatch::layer::LayerState>) {
-    let layer_drain = sub_layer.clone();
     tokio::spawn(async move {
-        layer_drain.cancel.await_drain().await;
-        layer_drain.cascade_to_workers().await;
-    });
-
-    let layer_term = sub_layer;
-    tokio::spawn(async move {
-        layer_term.cancel.await_terminate().await;
-        layer_term.cascade_to_workers().await;
+        tokio::select! {
+            () = sub_layer.cancel.await_drain() => {}
+            () = sub_layer.cancel.await_terminate() => {}
+        }
+        sub_layer.cascade_to_workers().await;
+        if !sub_layer.cancel.is_terminated() {
+            sub_layer.cancel.await_terminate().await;
+            sub_layer.cascade_to_workers().await;
+        }
     });
 }
 
 /// Spawn a background task that listens for root cancellation and
-/// cascades the signal into every registered sub-tree `LayerState` by
-/// tripping each sub-tree's own cancel token.  Each sub-tree's per-layer
-/// watcher (installed via `install_sublead_cancel_watcher` at spawn time)
-/// then cascades to the sub-tree's workers — `DispatchState` never
-/// reaches into `sub_layer.worker_cancels` directly.
+/// cascades the signal into every registered sub-tree's `LayerState`.
+/// Each sub-tree's per-layer watcher (installed via
+/// `install_sublead_cancel_watcher` at spawn time) then cascades to the
+/// sub-tree's workers — `DispatchState` never reaches into
+/// `sub_layer.worker_cancels` directly.
 ///
-/// **Idempotency:** Call exactly once per dispatch run. Subsequent calls spawn
-/// additional watcher tasks; the result is benign (drain is idempotent on the
-/// watch::Sender) but creates duplicate tracing output.
+/// Same shape as `install_sublead_cancel_watcher` (one task,
+/// drain-then-terminate-aware) — see that function's doc-comment for
+/// the lifecycle and pre/post-registration semantics.
 ///
-/// **Post-drain registration:** The watcher self-terminates after one cascade
-/// fire — re-installing after the cascade has fired will not catch sub-trees
-/// registered post-cascade. For that, see the spawn-time check in `spawn_sublead`.
+/// **Idempotency:** Call exactly once per dispatch run. Subsequent calls
+/// spawn additional watcher tasks; the result is benign (drain/terminate
+/// are idempotent on the watch::Sender) but creates duplicate tracing
+/// output.
 pub fn install_cascade_cancel_watcher(state: Arc<DispatchState>) {
-    let state_drain = state.clone();
     tokio::spawn(async move {
-        state_drain.root.cancel.await_drain().await;
-        state_drain.cascade_to_subleads().await;
-    });
-
-    tokio::spawn(async move {
-        state.root.cancel.await_terminate().await;
+        tokio::select! {
+            () = state.root.cancel.await_drain() => {}
+            () = state.root.cancel.await_terminate() => {}
+        }
         state.cascade_to_subleads().await;
+        if !state.root.cancel.is_terminated() {
+            state.root.cancel.await_terminate().await;
+            state.cascade_to_subleads().await;
+        }
     });
 }
 
@@ -480,6 +488,107 @@ mod tests {
         })
         .await
         .expect("worker terminate should have cascaded within 200ms");
+    }
+
+    /// `install_sublead_cancel_watcher` upgrades drained workers to
+    /// terminated when terminate fires after drain. Pins the
+    /// drain-then-terminate path through the unified watcher task
+    /// (drain wakes the select, cascade applies drain, watcher then
+    /// awaits terminate, second cascade upgrades the worker).
+    #[tokio::test]
+    async fn sublead_watcher_upgrades_drained_workers_to_terminated() {
+        use crate::dispatch::layer::LayerState;
+        use crate::dispatch::state::ApprovalPolicy;
+        use crate::manifest::resolve::ResolvedManifest;
+        use crate::manifest::schema::WorktreeCleanup;
+        use pitboss_core::process::{ProcessSpawner, TokioSpawner};
+        use pitboss_core::session::CancelToken;
+        use pitboss_core::store::{JsonFileStore, SessionStore};
+        use pitboss_core::worktree::{CleanupPolicy, WorktreeManager};
+        use std::path::PathBuf;
+        use std::sync::Arc;
+        use tempfile::TempDir;
+        use uuid::Uuid;
+
+        let dir = TempDir::new().unwrap();
+        let manifest = ResolvedManifest {
+            manifest_schema_version: 0,
+            name: None,
+            max_parallel_tasks: 1,
+            halt_on_failure: false,
+            run_dir: dir.path().to_path_buf(),
+            worktree_cleanup: WorktreeCleanup::OnSuccess,
+            emit_event_stream: false,
+            tasks: vec![],
+            lead: None,
+            max_workers: Some(1),
+            budget_usd: None,
+            lead_timeout_secs: None,
+            default_approval_policy: None,
+            notifications: vec![],
+            dump_shared_store: false,
+            require_plan_approval: false,
+            approval_rules: vec![],
+            container: None,
+            mcp_servers: vec![],
+            lifecycle: None,
+        };
+        let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
+        let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
+        let wt_mgr = Arc::new(WorktreeManager::new());
+        let shared = Arc::new(crate::shared_store::SharedStore::new());
+
+        let sub_layer = Arc::new(LayerState::new(
+            Uuid::now_v7(),
+            manifest,
+            store,
+            CancelToken::new(),
+            "sublead-1".into(),
+            spawner,
+            PathBuf::from("/bin/true"),
+            wt_mgr,
+            CleanupPolicy::Never,
+            dir.path().to_path_buf(),
+            ApprovalPolicy::AutoApprove,
+            None,
+            shared,
+            None,
+        ));
+
+        let w1 = CancelToken::new();
+        {
+            let mut cancels = sub_layer.worker_cancels.write().await;
+            cancels.insert("w1".into(), w1.clone());
+        }
+
+        install_sublead_cancel_watcher(sub_layer.clone());
+
+        // First, drain. Watcher should fan out drain to the worker.
+        sub_layer.cancel.drain();
+        tokio::time::timeout(std::time::Duration::from_millis(200), async {
+            loop {
+                if w1.is_draining() {
+                    return;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("drain cascade should reach worker within 200ms");
+
+        // Now terminate. The watcher's second await should fire and
+        // upgrade the worker from drained to terminated.
+        sub_layer.cancel.terminate();
+        tokio::time::timeout(std::time::Duration::from_millis(200), async {
+            loop {
+                if w1.is_terminated() {
+                    return;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("terminate cascade should reach drained worker within 200ms");
     }
 
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Summary

Final slice of the **#100 cancel-cascade redesign** multi-PR plan. Closes #100.

### Three coupled changes

1. **Collapse watchers from 2 tasks → 1 task per layer.** `install_sublead_cancel_watcher` and `install_cascade_cancel_watcher` used to spawn one task each for drain and terminate. The new shape uses a single `tokio::select!`-based task per watcher: wait for the first signal, cascade, then — if the first signal was drain — wait for the follow-up terminate to upgrade drained actors to terminated. Halves the watcher task count and makes the lifecycle explicit (one task, two states, known exit conditions).

2. **Refresh signals.rs doc-comments** to drop the stale "post-drain registration" reference. The eager-cascade in `LayerState::register_worker_cancel` / `DispatchState::register_sublead` is now the canonical post-signal path; spelling that out belongs on the registration helpers, not the watcher.

3. **Update ROADMAP entry for #100** to closed, summarizing which audit concerns were addressed by which slice. The "per-sub-tree runner" abstraction itself was not built — the audit's correctness goals were met without introducing a new runner type.

### Audit concerns — final disposition

| Audit concern | Closed by |
|---|---|
| (1) Fire-once watchers miss late actors | 100.1 (test contract) + 100.2 (eager cascade is documented part of the contract) |
| (2) Ownership inversion (root reaches into `worker_cancels`) | 100.2 (watchers funnel through layer-owned methods) |
| (3) `terminate()` cascade asymmetry | 100.2 (single `cascade_to` rule) |
| (4) Spawn-time mitigation is a band-aid | 100.2 (eager cascade is canonical, not a band-aid) |
| watcher task count | 100.3 (collapsed) |
| stale doc comments | 100.3 (refreshed) |

## Test plan

- [x] `cargo test -p pitboss-cli --lib dispatch::signals::tests` — 6/6 (new `sublead_watcher_upgrades_drained_workers_to_terminated` test pins the drain → terminate upgrade)
- [x] `cargo test -p pitboss-cli --test cancel_cascade_flows` — 4/4 (PR 100.1 contract preserved)
- [x] `cargo test --workspace --features pitboss-core/test-support` — all green
- [x] `cargo lint` — clean
- [x] `cargo tidy` — clean

## Multi-PR plan

- ✅ **PR 100.1** (#196) — test contract.
- ✅ **PR 100.2** (#199) — centralize cancel-cascade primitive.
- ✅ **PR 100.3 (this PR)** — collapse watcher tasks; doc sweep; close #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)