### PR TITLE
feat(core, dispatch): SessionHandle builder overrides + resume-failure hint (#149, #184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,38 @@ This project uses [Semantic Versioning](https://semver.org/).
   Existing integration coverage in `tests/sublead_flows.rs` and
   `tests/hierarchical_flows.rs` is the regression net.
 
+- **Builder overrides for `TERMINATE_GRACE` / `STREAM_DRAIN_TIMEOUT`**
+  (#149). `SessionHandle` gains `with_terminate_grace(Duration)` and
+  `with_stream_drain_timeout(Duration)` builders. Defaults unchanged
+  (10 s / 30 s, exposed as `pitboss_core::session::TERMINATE_GRACE`
+  and `DEFAULT_STREAM_DRAIN_TIMEOUT`). Tests can drive the cancel /
+  drain windows quickly without monkey-patching globals; future
+  manifest fields could plumb operator-supplied values through the
+  same builders without touching `run_to_completion`.
+
+### Added
+
+- **Resume-failure hint on `FailureReason::Unknown`** (#184). New
+  `pitboss_core::failure_classify::enrich_with_resume_hint(reason,
+  session_id)` augments unhelpful `Unknown` failures from a
+  `--resume`-driven dispatch with an actionable message — names a
+  truncated session id prefix (8 chars, never the full id) and
+  points the operator at "re-run without `--resume` to start fresh,
+  or `pitboss resume <run-id>` against a more recent run." Specific
+  classified reasons (`RateLimit` / `AuthFailure` / `NetworkError` /
+  `ContextExceeded` / `InvalidArgument`) pass through unchanged
+  because their cause is unrelated to the resume. Wired at the three
+  dispatch failure-classification call sites that have a
+  `resume_session_id` in scope: root lead (`hierarchical.rs`), sub-
+  leads (`sublead.rs`), and flat-mode tasks (`runner.rs`). The audit
+  asked for a design call between active validation (ping the API at
+  startup) vs. lazy fail-with-hint; lazy was chosen because pitboss
+  otherwise doesn't talk to the API directly — adding auth plumbing
+  to duplicate what the subprocess already does for a single hint is
+  a poor trade.
+
+### Changed
+
 - **Collapse cancel-cascade watcher tasks; close #100** (#100, PR 100.3).
   `install_sublead_cancel_watcher` and `install_cascade_cancel_watcher`
   used to spawn two tasks each (one for drain, one for terminate); now

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -378,7 +378,18 @@ pub async fn run_hierarchical(
             final_outcome.exit_code,
             Some(&lead_log_path),
             Some(&lead_stderr_path),
-        ),
+        )
+        .map(|r| {
+            // #184: when --resume was used and we got an unhelpful
+            // Unknown classification, surface a hint about the session
+            // id potentially being invalid. Specific markers
+            // (RateLimit / AuthFailure / etc.) pass through unchanged.
+            if let Some(sid) = lead.resume_session_id.as_deref() {
+                pitboss_core::failure_classify::enrich_with_resume_hint(r, sid)
+            } else {
+                r
+            }
+        }),
     };
 
     // Cleanup worktree per policy. Surface the result via tracing

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -738,7 +738,17 @@ async fn execute_task(
         outcome.exit_code,
         Some(&log_path),
         Some(&stderr_log_path),
-    );
+    )
+    .map(|r| {
+        // #184: enrich Unknown failures with a --resume hint when the
+        // task was started with a resume_session_id. Specific markers
+        // pass through unchanged (their cause is unrelated to resume).
+        if let Some(sid) = task.resume_session_id.as_deref() {
+            pitboss_core::failure_classify::enrich_with_resume_hint(r, sid)
+        } else {
+            r
+        }
+    });
     TaskRecord {
         task_id: task.id.clone(),
         status,

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -610,6 +610,11 @@ async fn spawn_sublead_session(
     let mcp_config_path_bg = mcp_config_path.clone();
     let operator_env_bg = operator_env;
     let tools_override_bg = tools_override;
+    // Captured for the post-loop failure-reason enrichment (#184): when a
+    // sub-lead is spawned with --resume and exits with an unhelpful
+    // Unknown failure, the operator gets a hint pointing at the session
+    // id rather than a bare excerpt.
+    let resume_session_id_bg = resume_session_id.clone();
 
     tokio::spawn(async move {
         // Run the kill+resume loop via the shared helper. The closure
@@ -765,7 +770,14 @@ async fn spawn_sublead_session(
                 final_outcome.exit_code,
                 Some(&log_path),
                 Some(&stderr_path),
-            ),
+            )
+            .map(|r| {
+                if let Some(sid) = resume_session_id_bg.as_deref() {
+                    pitboss_core::failure_classify::enrich_with_resume_hint(r, sid)
+                } else {
+                    r
+                }
+            }),
         };
         if let Err(e) = sub_layer_bg
             .store

--- a/crates/pitboss-core/src/failure_classify.rs
+++ b/crates/pitboss-core/src/failure_classify.rs
@@ -173,6 +173,58 @@ fn match_network(blob: &str) -> Option<FailureReason> {
     }
 }
 
+/// Number of leading characters of a `claude_session_id` to surface in
+/// resume-hint diagnostic messages. Real Claude session ids are UUID-ish
+/// (~36 chars); 8 is enough for an operator to disambiguate which session
+/// failed without leaking the full id into log scrapers / chat dumps.
+pub const RESUME_HINT_SESSION_PREFIX_CHARS: usize = 8;
+
+/// Augment a [`FailureReason`] with a hint about a `--resume`-driven
+/// dispatch when the classification is otherwise unhelpful. Pure
+/// function — caller provides the `resume_session_id` from the spawn
+/// args; `enrich_with_resume_hint` only modifies `Unknown` reasons,
+/// since the specific markers (`RateLimit` / `AuthFailure` / `NetworkError`
+/// / `ContextExceeded` / `InvalidArgument`) are authoritative explanations
+/// that don't get clearer with a resume note.
+///
+/// **Why lazy fail-with-hint, not active validation:** validating the
+/// session id at dispatch start would mean pitboss itself talks to the
+/// Anthropic API (auth plumbing, rate-limit awareness, retry loop), all
+/// duplicating what the claude subprocess does. The subprocess is the
+/// authoritative source for "this session is invalid" — so we wait for
+/// it to fail, then surface a hint that points the operator at the
+/// actionable next step.
+///
+/// Issue #184. Pinned by the `enrich_with_resume_hint_*` tests below.
+#[must_use]
+pub fn enrich_with_resume_hint(
+    reason: crate::store::FailureReason,
+    resume_session_id: &str,
+) -> crate::store::FailureReason {
+    use crate::store::FailureReason;
+    match reason {
+        FailureReason::Unknown { message } => {
+            let prefix: String = resume_session_id
+                .chars()
+                .take(RESUME_HINT_SESSION_PREFIX_CHARS)
+                .collect();
+            FailureReason::Unknown {
+                message: format!(
+                    "subprocess was started with --resume {prefix}…; the \
+                     session id may be invalid (expired, revoked, or never \
+                     existed). Re-run without --resume to start fresh, or \
+                     run `pitboss resume <run-id>` against a more recent \
+                     run. Original excerpt: {message}"
+                ),
+            }
+        }
+        // Specific classified reasons are authoritative — don't second-
+        // guess them. A 401 / rate-limit / network error has the same
+        // diagnosis whether or not --resume was used.
+        other => other,
+    }
+}
+
 #[must_use]
 pub fn excerpt(blob: &str) -> String {
     let trimmed = blob.trim();
@@ -446,5 +498,88 @@ mod tests {
         let ctx = reset_context(blob);
         assert!(ctx.contains("no `resets ` marker"));
         assert!(ctx.contains("rate_limit_exceeded"));
+    }
+
+    // ── enrich_with_resume_hint (#184) ──────────────────────────────────
+
+    #[test]
+    fn enrich_with_resume_hint_augments_unknown() {
+        let r = FailureReason::Unknown {
+            message: "exit 1; <subprocess wrote nothing useful>".into(),
+        };
+        let r = enrich_with_resume_hint(r, "abc12345-deadbeef-cafe-1234-567890abcdef");
+        match r {
+            FailureReason::Unknown { message } => {
+                assert!(
+                    message.contains("--resume abc12345"),
+                    "should mention truncated session id; got: {message}"
+                );
+                assert!(
+                    !message.contains("deadbeef"),
+                    "should NOT leak full session id; got: {message}"
+                );
+                assert!(
+                    message.contains("Re-run without --resume"),
+                    "should give actionable guidance; got: {message}"
+                );
+                assert!(
+                    message.contains("Original excerpt:"),
+                    "should preserve the original message for triage; got: {message}"
+                );
+                assert!(
+                    message.contains("subprocess wrote nothing useful"),
+                    "original excerpt must survive enrichment; got: {message}"
+                );
+            }
+            other => panic!("expected Unknown, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn enrich_with_resume_hint_passes_through_auth_failure() {
+        // Auth failures have an authoritative explanation; the resume
+        // hint would be a distraction. Pass through unchanged.
+        let r = FailureReason::AuthFailure;
+        assert_eq!(
+            enrich_with_resume_hint(r, "sess_123"),
+            FailureReason::AuthFailure
+        );
+    }
+
+    #[test]
+    fn enrich_with_resume_hint_passes_through_rate_limit() {
+        let r = FailureReason::RateLimit { resets_at: None };
+        assert!(matches!(
+            enrich_with_resume_hint(r, "sess_123"),
+            FailureReason::RateLimit { resets_at: None }
+        ));
+    }
+
+    #[test]
+    fn enrich_with_resume_hint_passes_through_network_error() {
+        let r = FailureReason::NetworkError {
+            message: "connection refused".into(),
+        };
+        match enrich_with_resume_hint(r, "sess_123") {
+            FailureReason::NetworkError { message } => {
+                assert_eq!(message, "connection refused");
+            }
+            other => panic!("expected unchanged NetworkError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn enrich_with_resume_hint_handles_short_session_id() {
+        // Shorter than RESUME_HINT_SESSION_PREFIX_CHARS — take the whole id.
+        let r = FailureReason::Unknown {
+            message: "x".into(),
+        };
+        let r = enrich_with_resume_hint(r, "abc");
+        match r {
+            FailureReason::Unknown { message } => {
+                assert!(message.contains("--resume abc…"), "got: {message}");
+            }
+            other => panic!("expected Unknown, got {other:?}"),
+        }
     }
 }

--- a/crates/pitboss-core/src/session/handle.rs
+++ b/crates/pitboss-core/src/session/handle.rs
@@ -20,6 +20,8 @@ pub struct SessionHandle {
     stderr_log_path: Option<PathBuf>,
     session_id_tx: Option<tokio::sync::mpsc::Sender<String>>,
     pid_slot: Option<Arc<std::sync::atomic::AtomicU32>>,
+    terminate_grace: Duration,
+    stream_drain_timeout: Duration,
 }
 
 impl SessionHandle {
@@ -36,6 +38,8 @@ impl SessionHandle {
             stderr_log_path: None,
             session_id_tx: None,
             pid_slot: None,
+            terminate_grace: super::TERMINATE_GRACE,
+            stream_drain_timeout: super::DEFAULT_STREAM_DRAIN_TIMEOUT,
         }
     }
 
@@ -70,6 +74,31 @@ impl SessionHandle {
         self
     }
 
+    /// Override the SIGTERM-to-SIGKILL grace window. The default is
+    /// `super::TERMINATE_GRACE` (10 s). A non-zero value gives the
+    /// child a chance to flush logs and shutdown cleanly before the
+    /// kernel-enforced kill; zero means kill immediately.
+    ///
+    /// Tests use this to drive the cancel path quickly without
+    /// monkey-patching the global constant.
+    #[must_use]
+    pub fn with_terminate_grace(mut self, d: Duration) -> Self {
+        self.terminate_grace = d;
+        self
+    }
+
+    /// Override the post-exit stdout/stderr drain timeout. The default
+    /// is 30 s. After the child exits, `run_to_completion` waits up to
+    /// this long for the stream-reader task to consume any tail bytes
+    /// the kernel still has buffered. A non-zero value avoids losing
+    /// the final assistant message on slow stdout flushes; zero means
+    /// drop the tail immediately.
+    #[must_use]
+    pub fn with_stream_drain_timeout(mut self, d: Duration) -> Self {
+        self.stream_drain_timeout = d;
+        self
+    }
+
     /// # Panics
     ///
     /// Panics if the spawner does not attach stdout to the child process. This
@@ -77,7 +106,8 @@ impl SessionHandle {
     /// stdout.
     #[allow(clippy::too_many_lines)]
     pub async fn run_to_completion(self, cancel: CancelToken, timeout: Duration) -> SessionOutcome {
-        const STREAM_DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
+        let stream_drain_timeout = self.stream_drain_timeout;
+        let terminate_grace = self.terminate_grace;
         let _ = self.task_id; // kept for future logging
         let started_at = Utc::now();
 
@@ -190,13 +220,14 @@ impl SessionHandle {
             }
         };
 
-        // If we need to stop the child, send SIGTERM and wait up to TERMINATE_GRACE.
-        // After grace, send SIGKILL. This wait also serves as the SIGTERM → exit window.
+        // If we need to stop the child, send SIGTERM and wait up to the
+        // builder-configurable terminate grace. After grace, send SIGKILL.
+        // This wait also serves as the SIGTERM → exit window.
         let exit_status = match end_reason {
             EndReason::Exited(s) => s,
             EndReason::Terminated | EndReason::TimedOut => {
                 let _ = child.terminate();
-                match tokio::time::timeout(super::TERMINATE_GRACE, child.wait()).await {
+                match tokio::time::timeout(terminate_grace, child.wait()).await {
                     Ok(Ok(s)) => Some(s),
                     Ok(Err(_)) => None,
                     Err(_) => {
@@ -229,18 +260,18 @@ impl SessionHandle {
         // session id) and misclassify the task as `Failed { "no result
         // event" }`. A multi-second ceiling is kept as a safety net so a
         // hung log writer can't wedge the dispatcher indefinitely.
-        if tokio::time::timeout(STREAM_DRAIN_TIMEOUT, stream_task)
+        if tokio::time::timeout(stream_drain_timeout, stream_task)
             .await
             .is_err()
         {
             tracing::warn!(
                 "stream drain exceeded {}s after child exit; final Event::Result \
                  may be lost",
-                STREAM_DRAIN_TIMEOUT.as_secs()
+                stream_drain_timeout.as_secs()
             );
         }
         if let Some(t) = stderr_task {
-            let _ = tokio::time::timeout(STREAM_DRAIN_TIMEOUT, t).await;
+            let _ = tokio::time::timeout(stream_drain_timeout, t).await;
         }
 
         let exit_code = exit_status

--- a/crates/pitboss-core/src/session/mod.rs
+++ b/crates/pitboss-core/src/session/mod.rs
@@ -12,8 +12,19 @@ pub use handle::SessionHandle;
 pub use outcome::SessionOutcome;
 pub use state::SessionState;
 
-/// Grace window between SIGTERM and SIGKILL during terminate-phase cancellation.
+/// Default grace window between SIGTERM and SIGKILL during terminate-phase
+/// cancellation. Builders can override per-`SessionHandle` via
+/// `SessionHandle::with_terminate_grace`. The constant is the operational
+/// default; tests and tight-loop scenarios typically pass a smaller value.
 pub const TERMINATE_GRACE: Duration = Duration::from_secs(10);
+
+/// Default ceiling on the post-exit stdout/stderr drain in
+/// `run_to_completion`. Builders can override per-`SessionHandle` via
+/// `SessionHandle::with_stream_drain_timeout`. After the child exits, the
+/// stream-reader task drains buffered tail bytes; without this ceiling a
+/// hung log writer could wedge the dispatcher indefinitely. 30 seconds is
+/// generous for kernel-buffered stdout, tight for genuine wedges.
+pub const DEFAULT_STREAM_DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[cfg(all(test, feature = "test-support"))]
 mod happy_path_tests {
@@ -153,6 +164,62 @@ mod cancel_tests {
             .run_to_completion(CancelToken::new(), Duration::from_millis(100))
             .await;
         assert!(matches!(outcome.final_state, SessionState::TimedOut));
+    }
+
+    /// `with_terminate_grace` overrides the SIGTERM→SIGKILL window.
+    /// With a 50 ms grace, a hold-until-signal child that ignores
+    /// SIGTERM (`FakeSpawner` doesn't, but the assertion is on wall-clock
+    /// bound: the whole flow must finish within 1 s, which is well
+    /// under the 10 s default).
+    #[tokio::test]
+    async fn with_terminate_grace_overrides_default() {
+        let script = FakeScript::new()
+            .stdout_line(r#"{"type":"system","subtype":"init"}"#)
+            .hold_until_signal();
+        let spawner: Arc<dyn ProcessSpawner> = Arc::new(FakeSpawner::new(script));
+        let cancel = CancelToken::new();
+        let c2 = cancel.clone();
+        let started = std::time::Instant::now();
+        let handle_fut = tokio::spawn(async move {
+            SessionHandle::new("t", spawner, cmd())
+                .with_terminate_grace(Duration::from_millis(50))
+                .run_to_completion(c2, Duration::from_secs(60))
+                .await
+        });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        cancel.terminate();
+        let outcome = tokio::time::timeout(Duration::from_secs(2), handle_fut)
+            .await
+            .expect("finishes well under default 10s grace + 1s kill")
+            .unwrap();
+        assert!(matches!(outcome.final_state, SessionState::Cancelled));
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "with_terminate_grace(50ms) should bound the whole flow under 2s; \
+             elapsed = {:?}",
+            started.elapsed()
+        );
+    }
+
+    /// `with_stream_drain_timeout` is wired through. Verified by setting
+    /// a tiny drain ceiling and confirming the run still completes
+    /// (no hangs) when stdout has nothing more to deliver. This is a
+    /// smoke check — the real protection is against a hung log writer,
+    /// which is hard to simulate without a hostile `FakeSpawner`.
+    #[tokio::test]
+    async fn with_stream_drain_timeout_is_threaded_through() {
+        let script = FakeScript::new()
+            .stdout_line(r#"{"type":"system","subtype":"init"}"#)
+            .stdout_line(
+                r#"{"type":"result","duration_ms":1,"duration_api_ms":1,"is_error":false,"num_turns":1,"result":"done","session_id":"s","total_cost_usd":0.0,"usage":{"input_tokens":0,"output_tokens":0}}"#,
+            )
+            .exit_code(0);
+        let spawner: Arc<dyn ProcessSpawner> = Arc::new(FakeSpawner::new(script));
+        let outcome = SessionHandle::new("t", spawner, cmd())
+            .with_stream_drain_timeout(Duration::from_millis(100))
+            .run_to_completion(CancelToken::new(), Duration::from_secs(5))
+            .await;
+        assert!(matches!(outcome.final_state, SessionState::Completed));
     }
 }
 


### PR DESCRIPTION
## Summary

Two Tier-1 audit items in one PR. Both are additive and ship behavior unchanged for non-resume / non-tested code paths.

### `#149` — `TERMINATE_GRACE` / `STREAM_DRAIN_TIMEOUT` builder overrides

`SessionHandle` gains:

- \`with_terminate_grace(Duration)\` — overrides the SIGTERM→SIGKILL window (default 10 s).
- \`with_stream_drain_timeout(Duration)\` — overrides the post-exit stdout/stderr drain ceiling (default 30 s).

The previously-function-local \`STREAM_DRAIN_TIMEOUT\` constant is promoted to \`pitboss_core::session::DEFAULT_STREAM_DRAIN_TIMEOUT\` so callers / future manifest fields can reach for it explicitly. \`TERMINATE_GRACE\` stays as-is.

### `#184` — Resume-failure hint on `FailureReason::Unknown`

New \`pitboss_core::failure_classify::enrich_with_resume_hint(reason, session_id)\` augments \`Unknown\` failures from a \`--resume\`-driven dispatch with an actionable message:

\`\`\`text
subprocess was started with --resume abc12345…; the session id may
be invalid (expired, revoked, or never existed). Re-run without
--resume to start fresh, or run \`pitboss resume <run-id>\` against
a more recent run. Original excerpt: <orig>
\`\`\`

The session id is truncated to 8 chars (never leaks the full id). Specific classified reasons (\`RateLimit\` / \`AuthFailure\` / \`NetworkError\` / \`ContextExceeded\` / \`InvalidArgument\`) pass through unchanged because their cause is unrelated to the resume.

Wired at three dispatch failure-classification call sites that have \`resume_session_id\` in scope:

| File | Actor |
|---|---|
| \`dispatch/hierarchical.rs\` | root lead |
| \`dispatch/sublead.rs\` | sub-lead (captured into \`resume_session_id_bg\` for the post-loop classification) |
| \`dispatch/runner.rs\` | flat-mode task |

Workers spawned via the \`spawn_worker\` MCP tool don't accept a resume id, so those sites stay unchanged.

## Design call: lazy fail-with-hint, not active validation

The audit asked for a design call between (a) active validation — ping the API at dispatch start to verify the session id is live — and (b) lazy fail-with-hint — let the subprocess fail, parse the error, surface a clearer diagnostic.

**Chose (b).** Pitboss otherwise doesn't talk to the Anthropic API directly. Adding auth plumbing, retry logic, and rate-limit awareness to ping a session id at dispatch start would duplicate what the claude subprocess already does, and the subprocess is the authoritative source for "this session is invalid". The lazy path waits for the failure, then surfaces a hint that points the operator at the actionable next step.

## Test plan

- [x] \`cargo test -p pitboss-core --features test-support\` — 133 passed (2 new \`SessionHandle\` builder tests + 5 new \`enrich_with_resume_hint\` tests)
- [x] \`cargo test --workspace --features pitboss-core/test-support\` — full green
- [x] \`cargo lint\` — clean
- [x] \`cargo tidy\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)