### PR TITLE
refactor(dispatch): decompose runner::execute into per-phase functions (#185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **Decompose `runner::execute` into per-phase functions** (#185). The
+  263-line `dispatch/runner.rs::execute` now reads as five sequential
+  phases: `init_run_state` (mint run id, write manifest snapshots, init
+  `RunMeta`), `print_dry_run_plan` (early-return path), `setup_run_harness`
+  (progress table, semaphore, cancel + Ctrl-C watcher, worktree manager,
+  notification router, flat `DispatchState`, control server),
+  `spawn_task_loop` (per-task `tokio::spawn` + await all), and
+  `finalize_run` (build `RunSummary`, persist, fire `RunFinished`,
+  compute exit code). Bridge state lives on a new `RunHarness` struct
+  for the long-lived references (cancel, store, spawner, etc.); the
+  per-phase-only `records` / `halt_drained` Arcs stay outside the
+  harness so `spawn_task_loop` can `Arc::try_unwrap` the records vec
+  without contending with a harness-held strong ref. No external
+  behavior change: existing `dispatch_flows`, `e2e_flows`, and the
+  full workspace test suite stay green.
+
 - **Extract kill+resume helper** (#185). The kill+resume subprocess
   loop in `dispatch/hierarchical.rs` (root lead) and
   `dispatch/sublead.rs` (`spawn_sublead_session` background task) was

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -201,17 +201,53 @@ pub async fn run_dispatch_inner(
 
 /// Inner workhorse — takes its dependencies injected for testability.
 #[allow(clippy::too_many_arguments)]
-pub async fn execute(
-    resolved: ResolvedManifest,
-    manifest_text: String,
-    manifest_path: PathBuf,
-    claude_binary: PathBuf,
-    claude_version: Option<String>,
+/// Output of `init_run_state`: identifiers and paths shared across the
+/// remaining phases. Carries the `started_at` timestamp captured at the
+/// moment of `RunMeta` construction so the finalize phase can compute an
+/// authoritative `RunSummary.total_duration_ms`.
+struct RunInit {
+    run_id: Uuid,
+    run_subdir: PathBuf,
+    /// `PITBOSS_RUN_ID` from the inherited env at dispatch start, snapshotted
+    /// before we overwrite it. `None` when this dispatch isn't running under
+    /// a parent orchestrator. Surfaced on the `RunDispatched` notification.
+    parent_run_id: Option<String>,
+    started_at: chrono::DateTime<Utc>,
+}
+
+/// Run-level shared state assembled by `setup_run_harness` and consumed
+/// by `spawn_task_loop` + `finalize_run`. Holds the long-lived references
+/// (cancel, store, shared_store, etc.) — `records` and `halt_drained`
+/// are passed as standalone Arcs so `spawn_task_loop` can consume the
+/// records vector via `Arc::try_unwrap` without contending with a
+/// harness-held strong ref.
+struct RunHarness {
+    cancel: CancelToken,
+    semaphore: Arc<Semaphore>,
+    table: Arc<Mutex<crate::tui_table::ProgressTable>>,
+    wt_mgr: Arc<WorktreeManager>,
+    shared_store: Arc<crate::shared_store::SharedStore>,
+    /// Cloned snapshot of the notification router for the `RunFinished`
+    /// emit at finalize time. The original is moved into `flat_state` so
+    /// the MCP handlers can also reach the router; this clone keeps a
+    /// finalize-side handle alive after that move.
+    notification_router_for_emit: Option<Arc<crate::notify::NotificationRouter>>,
     spawner: Arc<dyn ProcessSpawner>,
     store: Arc<dyn SessionStore>,
-    dry_run: bool,
+}
+
+/// Mint / honor the run id, write the per-run subdir + snapshot files, and
+/// initialise `RunMeta` in the store. Also snapshots the parent run id
+/// from the inherited env BEFORE overwriting it for the lifetime of this
+/// dispatch (so `RunDispatched` can carry the parent context).
+async fn init_run_state(
+    resolved: &ResolvedManifest,
+    manifest_text: &str,
+    manifest_path: &Path,
+    claude_version: Option<String>,
+    store: &Arc<dyn SessionStore>,
     pre_minted_run_id: Option<Uuid>,
-) -> Result<i32> {
+) -> Result<RunInit> {
     // Snapshot any `PITBOSS_RUN_ID` already in our env BEFORE we overwrite it
     // with our own run_id. If we're running under a parent orchestrator (or as
     // a sub-dispatch the agent triggered from inside a worktree), the prior
@@ -227,33 +263,59 @@ pub async fn execute(
     let run_dir = resolved.run_dir.clone();
     let run_subdir = run_dir.join(run_id.to_string());
     tokio::fs::create_dir_all(&run_subdir).await.ok();
-    tokio::fs::write(run_subdir.join("manifest.snapshot.toml"), &manifest_text).await?;
-    if let Ok(b) = serde_json::to_vec_pretty(&resolved) {
+    tokio::fs::write(run_subdir.join("manifest.snapshot.toml"), manifest_text).await?;
+    if let Ok(b) = serde_json::to_vec_pretty(resolved) {
         tokio::fs::write(run_subdir.join("resolved.json"), b).await?;
     }
 
+    let started_at = Utc::now();
     let meta = RunMeta {
         run_id,
-        manifest_path: manifest_path.clone(),
+        manifest_path: manifest_path.to_path_buf(),
         pitboss_version: env!("CARGO_PKG_VERSION").to_string(),
-        claude_version: claude_version.clone(),
-        started_at: Utc::now(),
+        claude_version,
+        started_at,
         env: Default::default(),
     };
     store.init_run(&meta).await.context("init run")?;
 
-    if dry_run {
-        for t in &resolved.tasks {
-            println!(
-                "DRY-RUN {}: {} {}",
-                t.id,
-                claude_binary.display(),
-                spawn_args(t).join(" ")
-            );
-        }
-        return Ok(0);
-    }
+    Ok(RunInit {
+        run_id,
+        run_subdir,
+        parent_run_id,
+        started_at,
+    })
+}
 
+/// Print the dry-run plan to stdout. Caller checks the `dry_run` flag and
+/// returns `Ok(0)` after this — the caller still wants `init_run_state` to
+/// have written the manifest snapshot to the run subdir, so the dry-run
+/// check happens AFTER init. Pre-existing behavior.
+fn print_dry_run_plan(resolved: &ResolvedManifest, claude_binary: &Path) {
+    for t in &resolved.tasks {
+        println!(
+            "DRY-RUN {}: {} {}",
+            t.id,
+            claude_binary.display(),
+            spawn_args(t).join(" ")
+        );
+    }
+}
+
+/// Build the run-level shared state that `spawn_task_loop` and
+/// `finalize_run` consume: progress table, semaphore, cancel + Ctrl-C
+/// watcher, worktree manager, records collector, halt-drained flag,
+/// notification router, flat-mode `DispatchState`, and the control
+/// server. Also fires the `RunDispatched` notification before any
+/// tokens spend.
+async fn setup_run_harness(
+    resolved: &ResolvedManifest,
+    manifest_path: &Path,
+    init: &RunInit,
+    spawner: Arc<dyn ProcessSpawner>,
+    store: Arc<dyn SessionStore>,
+    claude_binary: PathBuf,
+) -> Result<RunHarness> {
     let is_tty = atty::is(atty::Stream::Stdout);
     let table = Arc::new(Mutex::new(crate::tui_table::ProgressTable::new(is_tty)));
     for t in &resolved.tasks {
@@ -264,10 +326,6 @@ pub async fn execute(
     let cancel = CancelToken::new();
     crate::dispatch::signals::install_ctrl_c_watcher(cancel.clone());
     let wt_mgr = Arc::new(WorktreeManager::new());
-    let records: Arc<Mutex<Vec<TaskRecord>>> = Arc::new(Mutex::new(Vec::new()));
-    // Tracks whether the cancel drain was triggered by halt_on_failure logic
-    // (not by a user signal), so was_interrupted is not set in that case.
-    let halt_drained: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
 
     // Build notification router from manifest [[notification]] sections AND
     // the optional `PITBOSS_PARENT_NOTIFY_URL` env var. Returns None when
@@ -278,7 +336,7 @@ pub async fn execute(
         // Bind the run subdir so terminal emit failures land in
         // <run_subdir>/notifications.jsonl as TaskEvent::NotificationFailed.
         // Issue #156 (M4).
-        router.set_run_subdir(run_subdir.clone());
+        router.set_run_subdir(init.run_subdir.clone());
     }
 
     // Fire RunDispatched immediately. The orchestrator wants to register
@@ -286,11 +344,11 @@ pub async fn execute(
     // (the prior behavior) defeats the point of the hook.
     if let Some(router) = &notification_router {
         let env = crate::notify::NotificationEnvelope::new(
-            &run_id.to_string(),
+            &init.run_id.to_string(),
             crate::notify::Severity::Info,
             crate::notify::PitbossEvent::RunDispatched {
-                run_id: run_id.to_string(),
-                parent_run_id: parent_run_id.clone(),
+                run_id: init.run_id.to_string(),
+                parent_run_id: init.parent_run_id.clone(),
                 manifest_path: manifest_path.display().to_string(),
                 mode: "flat".to_string(),
                 survive_parent: resolved
@@ -303,64 +361,102 @@ pub async fn execute(
         let _ = router.dispatch(env).await;
     }
 
-    // Build a minimal DispatchState so the control server has something to bind
-    // against. Flat mode has no lead and no spawn_worker path, but cancel and
-    // list_workers still apply.
+    // Build a minimal DispatchState so the control server has something to
+    // bind against. Flat mode has no lead and no spawn_worker path, but
+    // cancel and list_workers still apply. The router is cloned: the
+    // original is moved into `flat_state` so MCP handlers can use it; the
+    // clone (`notification_router_for_emit`) is kept on the harness so the
+    // finalize phase can fire `RunFinished` after `flat_state` is no longer
+    // reachable.
     let notification_router_for_emit = notification_router.clone();
     let shared_store = Arc::new(crate::shared_store::SharedStore::new());
     shared_store.start_lease_pruner();
     let flat_state = Arc::new(crate::dispatch::state::DispatchState::new(
-        run_id,
+        init.run_id,
         resolved.clone(),
         store.clone(),
         cancel.clone(),
         "".into(),
         spawner.clone(),
-        claude_binary.clone(),
+        claude_binary,
         wt_mgr.clone(),
         cleanup_policy_from(resolved.worktree_cleanup),
-        run_subdir.clone(),
+        init.run_subdir.clone(),
         resolved.default_approval_policy.unwrap_or_default(),
         notification_router,
         shared_store.clone(),
     ));
-    let control_sock = crate::control::control_socket_path(run_id, &run_dir);
+    let control_sock = crate::control::control_socket_path(init.run_id, &resolved.run_dir);
     let _control = crate::control::server::start_control_server(
         control_sock,
         env!("CARGO_PKG_VERSION").to_string(),
-        run_id.to_string(),
+        init.run_id.to_string(),
         "flat".into(),
         flat_state,
     )
     .await
     .context("start control server")?;
 
+    Ok(RunHarness {
+        cancel,
+        semaphore,
+        table,
+        wt_mgr,
+        shared_store,
+        notification_router_for_emit,
+        spawner,
+        store,
+    })
+}
+
+/// Per-task spawn loop. Acquires a permit, re-checks the cancel gate,
+/// then spawns `execute_task` on a tokio task. Awaits all spawned tasks
+/// before returning the collected `TaskRecord`s. `halt_on_failure` trips
+/// the cancel drain (and the `halt_drained` flag) so subsequent loop
+/// iterations short-circuit on the gate check at the top.
+///
+/// Takes `records` and `halt_drained` as explicit Arcs so this fn can
+/// consume the records vector via `Arc::try_unwrap` after all spawned
+/// tasks drop their clones — keeping these on `RunHarness` would leave a
+/// long-lived strong ref that defeats `try_unwrap`.
+async fn spawn_task_loop(
+    resolved: &ResolvedManifest,
+    claude_binary: &Path,
+    init: &RunInit,
+    harness: &RunHarness,
+    records: Arc<Mutex<Vec<TaskRecord>>>,
+    halt_drained: Arc<AtomicBool>,
+) -> Vec<TaskRecord> {
     let mut handles = Vec::new();
+    let cleanup_policy = match resolved.worktree_cleanup {
+        crate::manifest::schema::WorktreeCleanup::Always => CleanupPolicy::Always,
+        crate::manifest::schema::WorktreeCleanup::OnSuccess => CleanupPolicy::OnSuccess,
+        crate::manifest::schema::WorktreeCleanup::Never => CleanupPolicy::Never,
+    };
 
     for task in resolved.tasks.clone() {
-        if cancel.is_draining() {
+        if harness.cancel.is_draining() {
             break;
         }
-        let permit = semaphore.clone().acquire_owned().await?;
+        let permit = match harness.semaphore.clone().acquire_owned().await {
+            Ok(p) => p,
+            Err(_) => break,
+        };
         // Re-check after potentially blocking on the semaphore.
-        if cancel.is_draining() {
+        if harness.cancel.is_draining() {
             break;
         }
-        let spawner = spawner.clone();
-        let store = store.clone();
-        let cancel = cancel.clone();
-        let claude = claude_binary.clone();
+        let spawner = harness.spawner.clone();
+        let store = harness.store.clone();
+        let cancel = harness.cancel.clone();
+        let claude = claude_binary.to_path_buf();
         let records = records.clone();
-        let wt_mgr = wt_mgr.clone();
+        let wt_mgr = harness.wt_mgr.clone();
         let halt_on_failure = resolved.halt_on_failure;
         let run_dir = resolved.run_dir.clone();
-        let cleanup_policy = match resolved.worktree_cleanup {
-            crate::manifest::schema::WorktreeCleanup::Always => CleanupPolicy::Always,
-            crate::manifest::schema::WorktreeCleanup::OnSuccess => CleanupPolicy::OnSuccess,
-            crate::manifest::schema::WorktreeCleanup::Never => CleanupPolicy::Never,
-        };
-        let table = table.clone();
+        let table = harness.table.clone();
         let halt_drained = halt_drained.clone();
+        let run_id = init.run_id;
 
         handles.push(tokio::spawn(async move {
             let _permit = permit;
@@ -403,48 +499,65 @@ pub async fn execute(
         let _ = h.await;
     }
 
-    let records = Arc::try_unwrap(records)
-        .map_err(|_| anyhow::anyhow!("records locked"))?
-        .into_inner();
+    // After every spawned task has been awaited, the only remaining strong
+    // ref to `records` is the local Arc. `try_unwrap` succeeds and we move
+    // out the inner Vec without copying.
+    Arc::try_unwrap(records)
+        .map(tokio::sync::Mutex::into_inner)
+        .map_err(|_| anyhow::anyhow!("records arc still has multiple refs after task await"))
+        .expect("all spawned tasks have completed; records arc must be uniquely owned")
+}
+
+/// Build the `RunSummary`, persist it, dump shared-store contents if
+/// requested, fire `RunFinished`, and compute the dispatcher exit code.
+/// Consumes the harness because no further phase needs it.
+async fn finalize_run(
+    resolved: &ResolvedManifest,
+    manifest_path: &Path,
+    claude_version: Option<String>,
+    init: &RunInit,
+    records: Vec<TaskRecord>,
+    halt_drained: &AtomicBool,
+    harness: RunHarness,
+) -> Result<i32> {
     let tasks_failed = records
         .iter()
         .filter(|r| !matches!(r.status, TaskStatus::Success))
         .count();
 
-    let started_at = meta.started_at;
     let ended_at = Utc::now();
     let summary = RunSummary {
-        run_id,
-        manifest_path: manifest_path.clone(),
+        run_id: init.run_id,
+        manifest_path: manifest_path.to_path_buf(),
         manifest_name: resolved.name.clone(),
         pitboss_version: env!("CARGO_PKG_VERSION").to_string(),
-        claude_version: claude_version.clone(),
-        started_at,
+        claude_version,
+        started_at: init.started_at,
         ended_at,
-        total_duration_ms: (ended_at - started_at).num_milliseconds(),
+        total_duration_ms: (ended_at - init.started_at).num_milliseconds(),
         tasks_total: records.len(),
         tasks_failed,
-        was_interrupted: (cancel.is_draining() || cancel.is_terminated())
+        was_interrupted: (harness.cancel.is_draining() || harness.cancel.is_terminated())
             && !halt_drained.load(Ordering::Acquire),
         tasks: records,
     };
-    store.finalize_run(&summary).await?;
+    harness.store.finalize_run(&summary).await?;
 
     // Optional post-mortem dump of shared-store contents.
     if resolved.dump_shared_store {
-        let dump_path = run_subdir.join("shared-store.json");
-        if let Err(e) = shared_store.dump_to_path(&dump_path).await {
+        let dump_path = init.run_subdir.join("shared-store.json");
+        if let Err(e) = harness.shared_store.dump_to_path(&dump_path).await {
             tracing::warn!(?e, "shared-store dump failed");
         }
     }
 
     // Emit RunFinished event if notification router is configured.
-    if let Some(router) = notification_router_for_emit {
+    if let Some(router) = harness.notification_router_for_emit {
         let env = crate::notify::NotificationEnvelope::new(
-            &run_id.to_string(),
+            &init.run_id.to_string(),
             crate::notify::Severity::Info,
             crate::notify::PitbossEvent::RunFinished {
-                run_id: run_id.to_string(),
+                run_id: init.run_id.to_string(),
                 tasks_total: summary.tasks_total,
                 tasks_failed,
                 duration_ms: summary.total_duration_ms as u64,
@@ -455,7 +568,7 @@ pub async fn execute(
         let _ = router.dispatch(env).await;
     }
 
-    let rc = if cancel.is_terminated() {
+    let rc = if harness.cancel.is_terminated() {
         130
     } else if tasks_failed > 0 {
         1
@@ -463,6 +576,70 @@ pub async fn execute(
         0
     };
     Ok(rc)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn execute(
+    resolved: ResolvedManifest,
+    manifest_text: String,
+    manifest_path: PathBuf,
+    claude_binary: PathBuf,
+    claude_version: Option<String>,
+    spawner: Arc<dyn ProcessSpawner>,
+    store: Arc<dyn SessionStore>,
+    dry_run: bool,
+    pre_minted_run_id: Option<Uuid>,
+) -> Result<i32> {
+    let init = init_run_state(
+        &resolved,
+        &manifest_text,
+        &manifest_path,
+        claude_version.clone(),
+        &store,
+        pre_minted_run_id,
+    )
+    .await?;
+
+    if dry_run {
+        print_dry_run_plan(&resolved, &claude_binary);
+        return Ok(0);
+    }
+
+    let harness = setup_run_harness(
+        &resolved,
+        &manifest_path,
+        &init,
+        spawner,
+        store,
+        claude_binary.clone(),
+    )
+    .await?;
+
+    let records_arc: Arc<Mutex<Vec<TaskRecord>>> = Arc::new(Mutex::new(Vec::new()));
+    // Tracks whether the cancel drain was triggered by halt_on_failure logic
+    // (not by a user signal), so was_interrupted is not set in that case.
+    let halt_drained: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
+
+    let records = spawn_task_loop(
+        &resolved,
+        &claude_binary,
+        &init,
+        &harness,
+        records_arc,
+        halt_drained.clone(),
+    )
+    .await;
+
+    finalize_run(
+        &resolved,
+        &manifest_path,
+        claude_version,
+        &init,
+        records,
+        &halt_drained,
+        harness,
+    )
+    .await
 }
 
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
## Summary

The 263-line \`dispatch/runner::execute\` was a monolithic dispatch entry-point handling run-id minting, manifest snapshots, dry-run output, harness setup, per-task spawn loop, and finalize all in one body. Audit (#185) flagged it as a code-quality concern and suggested per-phase extraction. Decomposed into five named phases.

## New shape

\`\`\`rust
pub async fn execute(...) -> Result<i32> {
    let init = init_run_state(...).await?;       // ~40 lines
    if dry_run { print_dry_run_plan(...); return Ok(0); }
    let harness = setup_run_harness(...).await?; // ~70 lines
    let records = spawn_task_loop(...).await;    // ~70 lines
    finalize_run(...).await                      // ~50 lines
}
\`\`\`

| Phase | Function | Owns |
|---|---|---|
| init | \`init_run_state\` | run_id, run_subdir, RunMeta, parent_run_id |
| dry-run | \`print_dry_run_plan\` | spawn_args printing |
| harness | \`setup_run_harness\` | cancel, table, semaphore, wt_mgr, notify router, flat DispatchState, control server. Fires RunDispatched. |
| spawn | \`spawn_task_loop\` | per-task \`tokio::spawn\`, await-all, \`Arc::try_unwrap\` records |
| finalize | \`finalize_run\` | RunSummary, finalize_run, RunFinished, exit code |

The new \`RunHarness\` struct holds long-lived refs (cancel, store, spawner, table, wt_mgr, semaphore, shared_store, notification_router_for_emit). The per-phase-only \`records\` / \`halt_drained\` Arcs stay outside the harness — keeping \`records\` on the harness would leave a long-lived strong ref that defeats the \`Arc::try_unwrap\` that \`spawn_task_loop\` uses to move the \`Vec\` out without copying.

## Why now

- Audit-flagged code-quality item; mechanical extract, predictable scope.
- **Sets up #150 M9** (entry-point boilerplate consolidation between \`runner::execute\` and \`run_hierarchical\`). Now that flat mode's phases are visible as named functions, the cross-mode comparison is "do the same phases live on each path?" — a natural follow-up PR.

## Test plan

- [x] \`cargo test --workspace --features pitboss-core/test-support\` — all suites green
- [x] \`dispatch_flows\` / \`e2e_flows\` / \`hierarchical_flows\` integration tests are the regression net (they exercise \`execute\` end-to-end through the public CLI surface)
- [x] \`cargo lint\` — clean
- [x] \`cargo tidy\` — clean

## Diff

| File | Lines |
|---|---|
| \`dispatch/runner.rs\` | +247 / -70 |
| \`CHANGELOG.md\` | +16 |

The +247/-70 reflects the structural cost of named phases (struct definitions, doc-comments, parameter threading). The original 263-line \`execute\` body shrank to a 25-line orchestration sequence; the rest moved into five phase functions averaging ~50 lines each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)