### PR TITLE
perf(dispatch): O(1) sub-tree-worker routing in cancel_actor_with_reason (#150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **`cancel_actor_with_reason` O(N) → O(1) sub-tree-worker routing**
+  (#150). The cancel-with-reason path used to walk every sub-tree's
+  `worker_cancels` map under a held `state.subleads` read lock to
+  find a worker's owning sub-lead — O(N) per cancel call, blocking
+  new sublead registration. Now routes through
+  `state.worker_layer_index` (already populated by
+  `handle_spawn_worker`, mirrors the existing routing in
+  `resolve_layer_for_caller` for KV ops). Same race window as before
+  on the index-set / worker_cancels-set ordering. Fixture-only
+  consequence: tests in `sublead_flows.rs` that bypass
+  `handle_spawn_worker` and inject workers directly into
+  `sub.worker_cancels` now also need to populate
+  `state.worker_layer_index` to match the production invariant —
+  three test cases updated to do so.
+
 - **Consolidate dispatch entry-point boilerplate** (#150 M9). Both
   `runner::execute` (flat) and `hierarchical::run_hierarchical`
   inlined ~50 lines each of identical run-id minting, manifest

--- a/crates/pitboss-cli/src/dispatch/signals.rs
+++ b/crates/pitboss-cli/src/dispatch/signals.rs
@@ -157,6 +157,17 @@ pub async fn cancel_actor_with_reason(
 /// root lead — in that case the function still returns `Some(root)`;
 /// `None` is reserved for the root itself, which cannot be cancel-with-
 /// reason'd because there is no parent to receive the reason).
+///
+/// Routing strategy is O(1) at every layer:
+/// 1. Root-layer worker → `state.root.worker_cancels` HashMap.
+/// 2. Sub-lead itself → `state.subleads` HashMap.
+/// 3. Sub-tree worker → `state.worker_layer_index` HashMap to resolve
+///    the owning sublead id, then the sub-tree's own `worker_cancels`.
+///
+/// The previous implementation walked every sub-tree's `worker_cancels`
+/// under a held `state.subleads` read lock — O(N) per cancel call,
+/// blocking new sublead registration. The `worker_layer_index` lookup
+/// mirrors `resolve_layer_for_caller`'s routing for KV ops (#150 audit).
 async fn cancel_and_find_parent(
     state: &Arc<DispatchState>,
     target: &str,
@@ -179,12 +190,22 @@ async fn cancel_and_find_parent(
         return Ok(Some(state.root.clone()));
     }
 
-    // Workers in a sub-tree: parent = that sub-tree's LayerState.
-    for (_sublead_id, sub_layer) in subleads.iter() {
-        let cancels = sub_layer.worker_cancels.read().await;
-        if let Some(tok) = cancels.get(target) {
-            tok.terminate();
-            return Ok(Some(sub_layer.clone()));
+    // Sub-tree workers: route via worker_layer_index for O(1) lookup
+    // instead of scanning every sub-tree's worker_cancels under the
+    // held subleads lock. `worker_layer_index` is populated by
+    // `handle_spawn_worker` immediately before the worker_cancel is
+    // registered, so a successful index hit guarantees the target is
+    // in the named sub-tree (modulo a brief intra-spawn window where
+    // the index is set but worker_cancels insertion hasn't completed —
+    // same race as the prior linear-scan implementation).
+    let layer_idx = state.worker_layer_index.read().await.get(target).cloned();
+    if let Some(Some(sublead_id)) = layer_idx {
+        if let Some(sub_layer) = subleads.get(&sublead_id) {
+            let cancels = sub_layer.worker_cancels.read().await;
+            if let Some(tok) = cancels.get(target) {
+                tok.terminate();
+                return Ok(Some(sub_layer.clone()));
+            }
         }
     }
 

--- a/crates/pitboss-cli/tests/sublead_flows.rs
+++ b/crates/pitboss-cli/tests/sublead_flows.rs
@@ -954,7 +954,10 @@ async fn kill_worker_with_reason_reprompts_parent_sublead() {
         .to_string();
 
     // Inject a worker into S1's layer (simulating what S1's Claude session
-    // would do in production via the sub-tree MCP socket).
+    // would do in production via the sub-tree MCP socket). Also populate
+    // `state.worker_layer_index` to match the invariant that
+    // `handle_spawn_worker` maintains — `cancel_actor_with_reason` routes
+    // through the index for O(1) sub-tree-worker lookup (#150 audit fix).
     {
         let subleads = state.subleads.read().await;
         let sub = subleads.get(s1.as_str()).unwrap();
@@ -967,6 +970,11 @@ async fn kill_worker_with_reason_reprompts_parent_sublead() {
             .await
             .insert("worker-A".into(), CancelToken::new());
     }
+    state
+        .worker_layer_index
+        .write()
+        .await
+        .insert("worker-A".into(), Some(s1.clone()));
 
     // Install a capture hook on S1's layer so we can assert on the reprompt.
     let s1_reprompts = std::sync::Arc::new(tokio::sync::Mutex::new(Vec::<String>::new()));
@@ -1461,7 +1469,10 @@ async fn kill_with_reason_delivers_synthetic_reprompt_to_running_lead() {
         .expect("response should have sublead_id field")
         .to_string();
 
-    // Inject a worker into S1's layer.
+    // Inject a worker into S1's layer. Also populate
+    // `state.worker_layer_index` to match the production invariant
+    // (`handle_spawn_worker` writes both); `cancel_actor_with_reason`
+    // routes through the index for O(1) sub-tree-worker lookup.
     {
         let subleads = state.subleads.read().await;
         let sub = subleads.get(s1.as_str()).unwrap();
@@ -1474,6 +1485,11 @@ async fn kill_with_reason_delivers_synthetic_reprompt_to_running_lead() {
             .await
             .insert("worker-B".into(), CancelToken::new());
     }
+    state
+        .worker_layer_index
+        .write()
+        .await
+        .insert("worker-B".into(), Some(s1.clone()));
 
     // Manually install a reprompt_tx channel on S1's layer, simulating what
     // spawn_sublead_session does. This exercises the real production path
@@ -1549,7 +1565,10 @@ async fn kill_with_reason_skips_delivery_when_lead_already_terminated() {
         .expect("response should have sublead_id field")
         .to_string();
 
-    // Inject a worker into S1's layer.
+    // Inject a worker into S1's layer. Also populate
+    // `state.worker_layer_index` to match the production invariant —
+    // `cancel_actor_with_reason` routes through the index for O(1)
+    // sub-tree-worker lookup (#150 audit).
     {
         let subleads = state.subleads.read().await;
         let sub = subleads.get(s1.as_str()).unwrap();
@@ -1562,6 +1581,11 @@ async fn kill_with_reason_skips_delivery_when_lead_already_terminated() {
             .await
             .insert("worker-C".into(), CancelToken::new());
     }
+    state
+        .worker_layer_index
+        .write()
+        .await
+        .insert("worker-C".into(), Some(s1.clone()));
 
     // Simulate S1's lead session having already terminated: set workers[s1] to Done
     // AND drop the reprompt_tx channel (simulating spawn_sublead_session cleanup).


### PR DESCRIPTION
## Summary

\`cancel_actor_with_reason::cancel_and_find_parent\` walked every sub-tree's \`worker_cancels\` map under a held \`state.subleads\` read lock — O(N) where N is the number of sub-leads. Audit (#150) flagged it because new sublead registration needs \`state.subleads.write()\`, which blocks behind any held read lock; with many sub-leads the held-read window extends enough to matter.

Replaced with an O(1) \`state.worker_layer_index\` lookup. Same pattern \`resolve_layer_for_caller\` already uses for KV ops.

## Routing — before vs. after

| Path | Before | After |
|---|---|---|
| Root-layer worker | O(1) HashMap | O(1) HashMap (unchanged) |
| Sub-lead itself | O(1) HashMap | O(1) HashMap (unchanged) |
| Sub-tree worker | **O(N) linear scan** of every sub-tree's \`worker_cancels\` | **O(1)** via \`worker_layer_index\` |

\`worker_layer_index\` is populated by \`handle_spawn_worker\` immediately before \`worker_cancels\` insertion. A successful index hit guarantees the target is in the named sub-tree, modulo the same brief intra-spawn window the prior linear-scan implementation also missed in.

## Test impact (fixture-only)

Three tests in \`sublead_flows.rs\` inject workers directly into \`sub.worker_cancels\` without going through \`handle_spawn_worker\`, so they were missing the \`worker_layer_index\` invariant the production spawn path maintains. Pre-fix the old O(N) scan still found these workers; the new index-based code correctly misses them. Updated each test to populate \`state.worker_layer_index\` alongside \`sub.worker_cancels\` — matches the production invariant.

| Test | Worker injected | Now populates index |
|---|---|---|
| \`kill_worker_with_reason_reprompts_parent_sublead\` | \`worker-A\` | ✓ |
| \`kill_with_reason_delivers_synthetic_reprompt_to_running_lead\` | \`worker-B\` | ✓ |
| \`kill_with_reason_skips_delivery_when_lead_already_terminated\` | \`worker-C\` | ✓ |

## Test plan

- [x] \`cargo test -p pitboss-cli --test sublead_flows --features pitboss-core/test-support\` — 29 passed (3 cancel-with-reason tests now pin the new routing)
- [x] \`cargo test --workspace --features pitboss-core/test-support\` — full green
- [x] \`cargo lint\` — clean
- [x] \`cargo tidy\` — clean

\`dogfood_real_flows.rs\` exercises \`cancel_actor_with_reason\` end-to-end through real claude subprocesses (the production path; populates \`worker_layer_index\` correctly via the spawn handler) — those tests pass without modification.

## Audit progress on #150

Closes the \`cancel_actor_with_reason\` O(N) lock-scan item. Other open #150 items: M6+M7 worker drain join-with-timeout (architectural — Tier 3), low-sev docs (current_exe TOCTOU comment, drop(child) comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)