### PR TITLE
docs(dispatch): document four #150 low-sev contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **Document four dispatch low-severity contracts** (#150 L11/L12/L15
+  + lifecycle composition). Comment-only changes that close out the
+  docs-shaped tail of the #150 audit: (1) `dispatch/background.rs`
+  now spells out that `--background` and `[lifecycle].survive_parent`
+  are orthogonal mechanisms (operational vs declarative), not
+  alternatives, and can compose; (2) the `current_exe()` call in
+  background dispatch now carries a TOCTOU note explaining why
+  pitboss does not `open()`-then-fexecve the binary; (3) `drop(child)`
+  after the detached spawn is annotated to make explicit that the
+  call uses `std::process::Child` (true no-op drop) rather than
+  `tokio::process::Child` (which has `kill_on_drop` semantics);
+  (4) `dispatch/runner.rs` now documents the cancel-honor contract
+  on `execute_task` and the rationale for the post-semaphore re-check
+  in `spawn_task_loop`. No behavioral changes.
+
 - **`cancel_actor_with_reason` O(N) → O(1) sub-tree-worker routing**
   (#150). The cancel-with-reason path used to walk every sub-tree's
   `worker_cancels` map under a held `state.subleads` read lock to

--- a/crates/pitboss-cli/src/dispatch/background.rs
+++ b/crates/pitboss-cli/src/dispatch/background.rs
@@ -38,13 +38,34 @@
 //!
 //! ## Composes with PR #137 lifecycle
 //!
-//! Background dispatch pairs naturally with `[lifecycle].notify` and
-//! `[lifecycle].survive_parent`: orchestrators that detach via
-//! `--background` and want completion notifications declare a webhook in
-//! the manifest, then `RunFinished` lands at the orchestrator's URL when
-//! the detached run finishes. Run-id correlation is automatic — the
-//! orchestrator stored the `run_id` it got back from the parent, and the
-//! webhook payload carries the same id.
+//! `--background` and `[lifecycle].survive_parent` are orthogonal
+//! mechanisms, not alternatives:
+//!
+//! - `--background` is *operational*: a CLI flag the operator sets at
+//!   dispatch time. It actually detaches the process via `setsid()` so
+//!   the dispatcher runs in a new session, decoupled from the parent's
+//!   controlling terminal.
+//! - `[lifecycle].survive_parent` is *declarative*: a manifest field
+//!   that advertises intent to orchestrators via the `RunDispatched`
+//!   event payload, telling them to exclude the run from any
+//!   cancel-tree-walk they perform on shutdown. It does not itself
+//!   detach the process.
+//!
+//! They can be combined: an orchestrator using `--background` with a
+//! manifest that sets `survive_parent = true` gets both — the dispatch
+//! is process-detached AND the orchestrator knows to leave it alone.
+//! Either alone is also valid: `--background` without `survive_parent`
+//! works for orchestrators that don't tree-walk; `survive_parent`
+//! without `--background` works for foreground dispatches whose parent
+//! plans to die voluntarily.
+//!
+//! Background dispatch also pairs naturally with `[lifecycle].notify`:
+//! orchestrators that detach via `--background` and want completion
+//! notifications declare a webhook in the manifest, then `RunFinished`
+//! lands at the orchestrator's URL when the detached run finishes.
+//! Run-id correlation is automatic — the orchestrator stored the
+//! `run_id` it got back from the parent, and the webhook payload
+//! carries the same id.
 //!
 //! ## Why not double-fork
 //!
@@ -100,6 +121,16 @@ pub fn run_background(manifest_path: &Path, run_dir_override: Option<PathBuf>) -
         std::fs::canonicalize(d).unwrap_or_else(|_| d.clone())
     });
 
+    // TOCTOU window (#150 L11): if pitboss is upgraded between this
+    // `current_exe()` read and the child's exec(), the child runs the
+    // NEW binary. In practice the new binary still recognizes
+    // `--internal-run-id` (it's a stable contract) and the older
+    // version's pre-minted run_id format (UUID v7) won't change across
+    // versions, so the worst case is that the child rejects an arg we
+    // added in the meantime — a bounded, recoverable failure logged to
+    // `<run_id>.bg-stderr.log`. Not worth `open()`-then-fexecve to
+    // close because the parent process is also the one that just
+    // started; the binary on disk almost certainly matches.
     let exe = std::env::current_exe().context("locate current pitboss binary")?;
 
     let mut cmd = std::process::Command::new(&exe);
@@ -150,6 +181,16 @@ pub fn run_background(manifest_path: &Path, run_dir_override: Option<PathBuf>) -
     // Drop the Child handle without waiting. On parent exit the child is
     // reparented to PID 1 which auto-reaps it. We keep no reference so
     // the parent can exit immediately after printing the announcement.
+    //
+    // NB: this is `std::process::Child` (line 105 above), whose `Drop`
+    // is a true no-op aside from closing the child's stdio file
+    // descriptors. `tokio::process::Child` would behave differently —
+    // it has a `kill_on_drop` builder (default `false`, but the
+    // existence of the option matters) and runs reaping inside the
+    // tokio runtime's signal handler. We deliberately use the std
+    // variant here so dropping is unambiguously fire-and-forget; this
+    // path runs synchronously before the parent exits and there is no
+    // tokio runtime to coordinate with. (#150 L15)
     drop(child);
 
     let payload = json!({

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -351,7 +351,17 @@ async fn spawn_task_loop(
             Ok(p) => p,
             Err(_) => break,
         };
-        // Re-check after potentially blocking on the semaphore.
+        // Re-check after potentially blocking on the semaphore (#150 L12).
+        // The window between `acquire_owned().await` returning and this
+        // gate is microseconds, but a cancel that fires during the wait
+        // would otherwise still spawn one task per available permit
+        // before the next iteration's top-of-loop gate caught it. The
+        // re-check here closes that window for the loop driver. The
+        // task we're about to spawn (`execute_task` below) is also
+        // contractually required to honor cancel at entry — see the
+        // doc comment on `execute_task` for the in-task gate that
+        // covers any further cancel that fires after this re-check
+        // succeeds but before the spawned task begins running.
         if harness.cancel.is_draining() {
             break;
         }
@@ -555,6 +565,22 @@ pub async fn execute(
     .await
 }
 
+/// Run a single resolved task to completion or cancellation.
+///
+/// **Cancel contract (#150 L12):** the loop driver in `spawn_task_loop`
+/// re-checks `cancel.is_draining()` after the semaphore acquire but
+/// before calling this function, so by the time we enter we know the
+/// cancel was not tripped at the gate. After that, this function
+/// itself owns the obligation to honor cancel — specifically, the
+/// `spawner.run_to_completion(cancel, ...)` call below races the child
+/// process against `cancel.await_drain()` / `cancel.await_terminate()`,
+/// so a cancel that fires after we enter (but before / during the
+/// child's run) still terminates the task and produces a `Cancelled`
+/// `TaskRecord` rather than blocking on a hung child. Any future code
+/// added between this entry point and `run_to_completion` must NOT
+/// reach a blocking await without consulting `cancel.is_draining()` —
+/// that would re-introduce the gap the loop driver's re-check is
+/// closing on the spawn side.
 #[allow(clippy::too_many_arguments)]
 async fn execute_task(
     task: &ResolvedTask,


### PR DESCRIPTION
## Summary

Comment-only PR that closes out the docs-shaped tail of the #150 audit. Four low-severity items checked off in one bite:

- **`background.rs` module doc** — clarifies that `--background` (operational, sets `setsid()` to detach the dispatch process) and `[lifecycle].survive_parent` (declarative, advertises survive intent to orchestrators via `RunDispatched`) are *orthogonal* mechanisms. They can compose; they are not alternatives. The pre-fix wording (\"pairs naturally with `[lifecycle].survive_parent`\") implied dependency where there is none.
- **`background.rs` `current_exe()` (#150 L11)** — TOCTOU note explaining the failure mode if pitboss is upgraded between the parent's `current_exe()` read and the child's `exec()`, and why we don't fix it via `open()`-then-`fexecve` (bounded recoverable failure, logged to `<run_id>.bg-stderr.log`).
- **`background.rs` `drop(child)` (#150 L15)** — explicit comment that the spawn uses `std::process::Child` on purpose. `tokio::process::Child` has `kill_on_drop` semantics that would be wrong at the parent's synchronous exit path; we want fire-and-forget with PID-1 reaping.
- **`runner.rs` cancel-honor contract (#150 L12)** — doc comment on `execute_task` describing the in-task cancel gate (`run_to_completion(cancel, ...)` race against `await_drain` / `await_terminate`) plus an expanded inline comment on the post-semaphore re-check in `spawn_task_loop` explaining why the gate exists and how it composes with the in-task contract.

No code paths or behavior change.

## Closes

Closes 4 of 6 remaining open items in #150:
- L11 `current_exe()` TOCTOU comment
- L12 `runner.rs:338-342` cancel re-check documentation
- L15 `drop(child)` std vs tokio comment
- L16 `[lifecycle].survive_parent` vs `--background` docs

After this merges, #150 has only the M6+M7 architectural pair (worker drain join-with-timeout) and 0 docs-shaped items left.

## Test plan

- [x] `cargo lint` — clean
- [x] `cargo tidy` — clean
- [x] No source/test changes — no new test coverage required

🤖 Generated with [Claude Code](https://claude.com/claude-code)