### PR TITLE
fix(tui): drop dead viewport constant + cancel old bridge-forwarder on SwitchRun (#154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **TUI detail-view scroll: drop dead `DETAIL_VISIBLE_ROWS` constant**
+  (#154 L4). The hard-coded `DETAIL_VISIBLE_ROWS = 40` was passed
+  through to `detail_scroll_down` / `detail_jump_bottom` /
+  `detail_auto_scroll` but those callees already discarded it as
+  `_visible_rows` — the real viewport height comes from
+  `state.detail_log_viewport`, an atomic the renderer publishes from
+  the actual layout-derived inner height each frame. Removing the
+  constant and the unused parameters makes the dynamic source of
+  truth explicit. Operator-visible: jump-to-bottom and auto-follow
+  now lands at the right row regardless of terminal height —
+  pre-fix they appeared correct because the dynamic viewport was
+  always consulted in practice, but the dead `40` literal in the
+  call chain made it look like a sizing bug.
+
+- **TUI: cancel previous bridge-forwarder on SwitchRun** (#154 L1+L3).
+  Each call to `connect_control` previously spawned a tokio task that
+  forwarded events from the per-run `bridge_rx` onto the shared
+  `ctrl_events_tx`, but the OLD task kept running until its read_loop
+  socket closed naturally. Stale events from the prior run could
+  arrive on `ctrl_events_tx` after the explicit drain that follows
+  `reset_state_for_switch`, including ApprovalRequest events that
+  would open a modal whose request_id the new dispatcher cannot ack
+  (#104). The closure now returns the spawned forwarder's
+  `AbortHandle`; SwitchRun aborts the previous one before
+  reconnecting, which closes the bridge channel, causes the
+  read_loop's `events_tx.send()` to fail, and releases the old
+  socket. The drain remains as a backstop for events queued before
+  the abort takes effect.
+
 - **Document four dispatch low-severity contracts** (#150 L11/L12/L15
   + lifecycle composition). Comment-only changes that close out the
   docs-shaped tail of the #150 audit: (1) `dispatch/background.rs`

--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -46,20 +46,32 @@ pub fn run(run_dir: PathBuf, run_id: String) -> anyhow::Result<()> {
     // same path can be used on both initial startup and when the user
     // switches runs — without a fresh client, control ops after SwitchRun
     // would still target the old run's socket.
-    let connect_control = |state: &mut AppState| {
+    //
+    // Returns the `AbortHandle` of the bridge-forwarder task this call
+    // spawned. The caller stores it in `forwarder_abort` and aborts the
+    // *previous* one before re-calling on SwitchRun. Without that abort,
+    // the prior run's read_loop kept its `bridge_tx` alive (the read_loop
+    // owns a clone), the prior forwarder kept reading the prior
+    // `bridge_rx`, and stale events from the old socket continued
+    // arriving on the shared `ctrl_events_tx` — including ApprovalRequest
+    // events that would open a modal whose request_id the new
+    // dispatcher cannot ack (#104, #154 L1+L3).
+    let connect_control = |state: &mut AppState| -> Option<tokio::task::AbortHandle> {
+        let mut forwarder_abort: Option<tokio::task::AbortHandle> = None;
         let client = match uuid::Uuid::parse_str(&state.run_id) {
             Ok(uuid) => {
                 let socket_path = pitboss_cli::control::control_socket_path(uuid, &state.run_dir);
                 let (bridge_tx, mut bridge_rx) =
                     tokio::sync::mpsc::channel::<pitboss_cli::control::protocol::ControlEvent>(64);
                 let forward_tx = ctrl_events_tx.clone();
-                runtime.spawn(async move {
+                let handle = runtime.spawn(async move {
                     while let Some(ev) = bridge_rx.recv().await {
                         if forward_tx.send(ev).is_err() {
                             break;
                         }
                     }
                 });
+                forwarder_abort = Some(handle.abort_handle());
                 // #154 M1: bound the connect by a short timeout so a
                 // slow dispatcher accept doesn't stall the 50ms input
                 // loop for hundreds of milliseconds. The connect path
@@ -84,9 +96,10 @@ pub fn run(run_dir: PathBuf, run_id: String) -> anyhow::Result<()> {
         state.control_connected = client.as_ref().is_some_and(|c| c.is_connected());
         state.control_client = client;
         state.runtime_handle = Some(runtime.handle().clone());
+        forwarder_abort
     };
 
-    connect_control(&mut state);
+    let mut forwarder_abort = connect_control(&mut state);
     // `ctrl_events_tx` and `runtime` are both held by `connect_control`
     // (the closure clones the sender and spawns tasks on the runtime). They
     // have to stay alive for the full event loop so a SwitchRun can rebuild
@@ -131,22 +144,31 @@ pub fn run(run_dir: PathBuf, run_id: String) -> anyhow::Result<()> {
                             snapshot_rx = new_rx;
                             focus_tx = new_tx;
                             reset_state_for_switch(&mut state, run_dir, run_id);
-                            // Drain in-flight events from the old run's socket
-                            // reader before connecting to the new run. The old
-                            // read_loop keeps running until its Unix socket
-                            // closes and still forwards through the shared
-                            // ctrl_events_tx. Without this drain, stale events
-                            // (including ApprovalRequest) can arrive after
-                            // reset_state_for_switch cleared the approval list,
-                            // pass the de-dup guard as "new", and open a modal
-                            // whose request_id the new dispatcher cannot ack
-                            // (#104).
+                            // Cancel the previous run's bridge-forwarder
+                            // task (#154 L1+L3). Aborting drops its
+                            // `bridge_rx`; the dispatcher-side read_loop
+                            // then sees its `events_tx.send()` fail and
+                            // exits, releasing the old socket. After this
+                            // abort, no further old-run events can reach
+                            // `ctrl_events_tx`. The drain below still
+                            // catches anything already queued.
+                            if let Some(h) = forwarder_abort.take() {
+                                h.abort();
+                            }
+                            // Drain in-flight events from the old run's
+                            // socket reader. Pre-#154 fix this drain was
+                            // the *only* defense; stale events arriving
+                            // after the drain (and before the old socket
+                            // closed naturally) could still open modals
+                            // whose request_id the new dispatcher cannot
+                            // ack (#104). Combined with the abort above
+                            // it is now a belt-and-suspenders backstop.
                             while ctrl_events_rx.try_recv().is_ok() {}
                             // Rebuild the control client against the new run's
                             // socket; without this, post-switch control ops
                             // (cancel/pause/approve/reprompt) keep targeting
                             // the previous run.
-                            connect_control(&mut state);
+                            forwarder_abort = connect_control(&mut state);
                             let _ = focus_tx.send(String::new());
                             dirty = true;
                             continue;
@@ -184,8 +206,11 @@ pub fn run(run_dir: PathBuf, run_id: String) -> anyhow::Result<()> {
                             snapshot_rx = new_rx;
                             focus_tx = new_tx;
                             reset_state_for_switch(&mut state, run_dir, run_id);
+                            if let Some(h) = forwarder_abort.take() {
+                                h.abort(); // #154 L1+L3
+                            }
                             while ctrl_events_rx.try_recv().is_ok() {} // #104
-                            connect_control(&mut state);
+                            forwarder_abort = connect_control(&mut state);
                             let _ = focus_tx.send(String::new());
                             dirty = true;
                             continue;
@@ -225,7 +250,7 @@ pub fn run(run_dir: PathBuf, run_id: String) -> anyhow::Result<()> {
             // If we're in snap-in mode and at the bottom, keep the view
             // scrolled to the last line as new log lines arrive.
             if matches!(state.mode, Mode::Detail { .. }) {
-                state.detail_auto_scroll(DETAIL_VISIBLE_ROWS);
+                state.detail_auto_scroll();
             }
             // Notify watcher of current focus after snapshot (may have changed
             // via ensure_active_focus or Completed→Normal fallback).
@@ -295,15 +320,6 @@ fn reset_state_for_switch(state: &mut AppState, run_dir: PathBuf, run_id: String
     }
 }
 
-/// The visible height used for snap-in scroll calculations.
-///
-/// We can't query the terminal size from the key handler, so we use a
-/// representative constant. The real render uses `area.height`, but
-/// scroll clamping is soft (extra scroll just shows blank) so this is fine
-/// for the handler. The render pass also calls `detail_auto_scroll` with the
-/// real `visible_rows`.
-const DETAIL_VISIBLE_ROWS: usize = 40;
-
 /// Handle a single mouse event. Returns the same [`Action`] type as
 /// `handle_key` so the event-loop's existing `SwitchRun` dispatch can
 /// handle picker-click → open-run in one place.
@@ -318,7 +334,7 @@ fn handle_mouse(state: &mut AppState, mouse: crossterm::event::MouseEvent) -> Ac
             state.detail_scroll_up(5);
         }
         (Mode::Detail { .. }, MouseEventKind::ScrollDown) => {
-            state.detail_scroll_down(5, DETAIL_VISIBLE_ROWS);
+            state.detail_scroll_down(5);
         }
         // Right-click inside Detail view exits to the return_to mode.
         (Mode::Detail { .. }, MouseEventKind::Down(MouseButton::Right)) => {
@@ -623,7 +639,7 @@ fn handle_detail(state: &mut AppState, code: KeyCode, modifiers: KeyModifiers) -
         KeyCode::Char('q') => return Action::Quit,
 
         // Scroll down one line.
-        KeyCode::Char('j') | KeyCode::Down => state.detail_scroll_down(1, DETAIL_VISIBLE_ROWS),
+        KeyCode::Char('j') | KeyCode::Down => state.detail_scroll_down(1),
 
         // Scroll up one line.
         KeyCode::Char('k') | KeyCode::Up => state.detail_scroll_up(1),
@@ -631,14 +647,14 @@ fn handle_detail(state: &mut AppState, code: KeyCode, modifiers: KeyModifiers) -
         // Medium-speed scroll: 5 lines. Sits between single-line j/k and
         // half-page Ctrl-D/U. Shift-variants of the vim keys keep muscle
         // memory intact for users who live on j/k=1.
-        KeyCode::Char('J') => state.detail_scroll_down(5, DETAIL_VISIBLE_ROWS),
+        KeyCode::Char('J') => state.detail_scroll_down(5),
         KeyCode::Char('K') => state.detail_scroll_up(5),
 
         // Page down (Ctrl-D or PageDown).
         KeyCode::Char('d') if modifiers.contains(KeyModifiers::CONTROL) => {
-            state.detail_scroll_down(10, DETAIL_VISIBLE_ROWS);
+            state.detail_scroll_down(10);
         }
-        KeyCode::PageDown => state.detail_scroll_down(10, DETAIL_VISIBLE_ROWS),
+        KeyCode::PageDown => state.detail_scroll_down(10),
 
         // Page up (Ctrl-U or PageUp).
         KeyCode::Char('u') if modifiers.contains(KeyModifiers::CONTROL) => {
@@ -647,7 +663,7 @@ fn handle_detail(state: &mut AppState, code: KeyCode, modifiers: KeyModifiers) -
         KeyCode::PageUp => state.detail_scroll_up(10),
 
         // Jump to bottom, re-enable auto-scroll.
-        KeyCode::Char('G') => state.detail_jump_bottom(DETAIL_VISIBLE_ROWS),
+        KeyCode::Char('G') => state.detail_jump_bottom(),
 
         // Jump to top, disable auto-scroll.
         KeyCode::Char('g') => state.detail_jump_top(),

--- a/crates/pitboss-tui/src/state.rs
+++ b/crates/pitboss-tui/src/state.rs
@@ -581,7 +581,11 @@ impl AppState {
     /// valid row offset for the current wrapped log and viewport height.
     ///
     /// Disables auto-scroll if the new position is not at the bottom.
-    pub fn detail_scroll_down(&mut self, delta: usize, _visible_rows: usize) {
+    /// The viewport height is read from `detail_log_viewport`, an atomic
+    /// the renderer publishes each frame from the actual layout-derived
+    /// inner height (`render_detail_log` in `tui.rs`). This is the only
+    /// truthful source for "how many rows are visible right now."
+    pub fn detail_scroll_down(&mut self, delta: usize) {
         let total_rows = self
             .detail_log_total_rows
             .load(std::sync::atomic::Ordering::Relaxed);
@@ -661,7 +665,9 @@ impl AppState {
     }
 
     /// Jump to the bottom of the log in `Detail` mode; re-enables auto-scroll.
-    pub fn detail_jump_bottom(&mut self, _visible_rows: usize) {
+    /// Viewport height comes from `detail_log_viewport` — same dynamic
+    /// source as `detail_scroll_down`.
+    pub fn detail_jump_bottom(&mut self) {
         let total_rows = self
             .detail_log_total_rows
             .load(std::sync::atomic::Ordering::Relaxed);
@@ -689,7 +695,7 @@ impl AppState {
     ///
     /// If `at_bottom` is true, advances `scroll` so the last line stays
     /// visible. Does nothing if the user has scrolled up.
-    pub fn detail_auto_scroll(&mut self, _visible_rows: usize) {
+    pub fn detail_auto_scroll(&mut self) {
         let total_rows = self
             .detail_log_total_rows
             .load(std::sync::atomic::Ordering::Relaxed);
@@ -1195,7 +1201,7 @@ mod tests {
             return_to: Box::new(Mode::Normal),
         };
 
-        state.detail_scroll_down(1, 10);
+        state.detail_scroll_down(1);
 
         assert!(
             matches!(&state.mode, Mode::Detail { scroll: 1, .. }),
@@ -1220,7 +1226,7 @@ mod tests {
             return_to: Box::new(Mode::Normal),
         };
 
-        state.detail_scroll_down(5, 10);
+        state.detail_scroll_down(5);
 
         assert!(
             matches!(
@@ -1324,7 +1330,7 @@ mod tests {
             return_to: Box::new(Mode::Normal),
         };
 
-        state.detail_jump_bottom(10);
+        state.detail_jump_bottom();
 
         assert!(
             matches!(
@@ -1366,7 +1372,7 @@ mod tests {
         state
             .detail_log_total_rows
             .store(35, std::sync::atomic::Ordering::Relaxed);
-        state.detail_auto_scroll(10);
+        state.detail_auto_scroll();
 
         if let Mode::Detail { scroll, .. } = &state.mode {
             // scroll == max_scroll = total(35) - viewport(10) = 25.
@@ -1388,7 +1394,7 @@ mod tests {
         };
 
         state.focus_log = (0..35).map(|i| format!("line {i}")).collect();
-        state.detail_auto_scroll(10);
+        state.detail_auto_scroll();
 
         // scroll unchanged
         assert!(


### PR DESCRIPTION
## Summary

Two TUI-local items from #154 in one bundled PR:

### L4 — \`DETAIL_VISIBLE_ROWS\` dead-code removal

The hard-coded \`DETAIL_VISIBLE_ROWS = 40\` constant in \`app.rs\` was passed through to \`detail_scroll_down\`, \`detail_jump_bottom\`, and \`detail_auto_scroll\`, but those callees already discarded it as \`_visible_rows\` and read the actual viewport height from \`state.detail_log_viewport\` (an \`AtomicUsize\` the renderer publishes from the layout-derived inner height each frame, in \`render_detail_log\`). The dynamic source was always the truth; the literal \`40\` in the call chain was just misleading dead code.

This PR drops the constant, drops the unused parameter from all three methods, and updates call sites and unit tests.

**Operator-visible:** none — the dynamic viewport was always consulted in practice. The audit flagged this as a bug because of the dead literal in the call chain; closing it tightens the contract.

### L1+L3 — SwitchRun bridge-forwarder cancellation

Each \`connect_control\` call previously spawned a tokio task that forwarded events from a per-run \`bridge_rx\` onto the shared \`ctrl_events_tx\`, but the OLD task kept running until the dispatcher-side read_loop socket closed naturally. Stale events from the prior run could arrive on \`ctrl_events_tx\` after the explicit drain that follows \`reset_state_for_switch\` — including \`ApprovalRequest\` events that would open a modal whose \`request_id\` the new dispatcher cannot ack (#104).

\`connect_control\` now returns the spawned forwarder's \`AbortHandle\`. SwitchRun (both keyboard and mouse paths) aborts the previous one before reconnecting. That drops the old \`bridge_rx\`, which causes read_loop's \`events_tx.send()\` to fail, which exits read_loop and releases the old socket. The drain remains as a backstop for events queued in \`ctrl_events_tx\` before the abort takes effect.

**Operator-visible:** post-SwitchRun stale modal events stop appearing. The pre-fix race window was narrow but real on long-running prior dispatches whose socket stayed open after switch.

## Closes

Closes 2 of 5 remaining open items in #154:
- L4 \`DETAIL_VISIBLE_ROWS\` hardcoded → dynamic
- L1+L3 SwitchRun forwarder cancellation

After this PR: #154 has 3 items left (M3 async git-diff, L2 send_approve reorder, and one improvement item).

## Test plan

- [x] \`cargo build -p pitboss-tui\` — clean
- [x] \`cargo lint\` — clean
- [x] \`cargo tidy\` — clean
- [x] \`cargo test -p pitboss-tui --features pitboss-core/test-support\` — 107 lib tests + 7 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)