### PR TITLE
fix(tui): don't strand approvals when no control client is attached (#154 L2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **TUI: don't strand approvals when no control client is attached**
+  (#154 L2). `send_approve` previously called `spawn_control_op`
+  (which silently no-op'd when the client or runtime was missing —
+  observe-only mode, or post-disconnect) and then unconditionally
+  removed the approval from the queue. The operator pressed approve,
+  the actor never received the response, and the request was
+  unreachable from the TUI. The function now gates list mutation on
+  `state.control_client.is_some() && state.runtime_handle.is_some()`
+  (matching the conditions `spawn_control_op` already checks
+  internally) — when those aren't satisfied, the queue is left intact
+  so the operator can retry once a client is attached or dismiss
+  intentionally with Esc. The list-mutation logic is split out as
+  `apply_approve_to_list` so it can be unit-tested without standing
+  up a tokio runtime.
+
 ### Changed
 
 - **`cancel_actor_with_reason` O(N) → O(1) sub-tree-worker routing**

--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -1301,6 +1301,18 @@ fn send_approve(
     comment: Option<String>,
     edited_summary: Option<String>,
 ) {
+    // #154 L2: gate on dispatch capability BEFORE mutating the list.
+    // Pre-fix, `spawn_control_op` silently no-op'd when the client or
+    // runtime was missing (observe-only mode, or post-disconnect), but
+    // we still removed the approval from the queue. The operator
+    // pressed approve, the actor never received the response, and the
+    // request was unreachable from the TUI — pure data loss. Now we
+    // leave the queue intact in that case so the operator can retry
+    // when the client recovers, or dismiss the modal intentionally
+    // with Esc.
+    if state.control_client.is_none() || state.runtime_handle.is_none() {
+        return;
+    }
     // When rejecting, forward the comment text also via the `reason` field
     // introduced in Task 4.3 so the requesting actor receives the rejection
     // rationale in `ApprovalResponse.reason`.
@@ -1315,11 +1327,19 @@ fn send_approve(
             reason,
         },
     );
-    // Drop from the approval-list queue optimistically — the server will
-    // ack the op before any subsequent ApprovalRequest with the same id
-    // could arrive, so a race that re-inserts a stale entry isn't
-    // reachable. Clamp `selected_idx` so an out-of-range index can't
-    // persist past the removal.
+    apply_approve_to_list(state, request_id);
+}
+
+/// Drop the approval matching `request_id` from the queue and clamp
+/// `selected_idx` to remain in-bounds.
+///
+/// Optimistic — the server acks before any subsequent
+/// `ApprovalRequest` with the same id could arrive, so a race that
+/// re-inserts a stale entry isn't reachable. Split out from
+/// `send_approve` so the list-mutation logic can be unit-tested
+/// directly without needing to stand up a tokio runtime / mock
+/// control client (#154 L2).
+fn apply_approve_to_list(state: &mut AppState, request_id: &str) {
     if let Some(pos) = state
         .approval_list
         .items
@@ -1410,11 +1430,11 @@ mod approval_queue_tests {
     }
 
     #[test]
-    fn send_approve_removes_matching_item_from_list() {
+    fn apply_approve_to_list_removes_matching_item() {
         let mut state = fresh_state();
         apply_control_event(&mut state, mk_approval_event("req-A", "root"));
         apply_control_event(&mut state, mk_approval_event("req-B", "sublead-1"));
-        send_approve(&mut state, "req-A", true, None, None);
+        apply_approve_to_list(&mut state, "req-A");
         assert_eq!(state.approval_list.items.len(), 1);
         assert_eq!(state.approval_list.items[0].id, "req-B");
         // selected_idx must stay in bounds after a removal.
@@ -1422,14 +1442,38 @@ mod approval_queue_tests {
     }
 
     #[test]
-    fn send_approve_clamps_selected_idx_when_last_item_removed() {
+    fn apply_approve_to_list_clamps_selected_idx_when_last_item_removed() {
         let mut state = fresh_state();
         apply_control_event(&mut state, mk_approval_event("req-A", "root"));
         apply_control_event(&mut state, mk_approval_event("req-B", "sublead-1"));
         state.approval_list.selected_idx = 1;
-        send_approve(&mut state, "req-B", false, None, None);
+        apply_approve_to_list(&mut state, "req-B");
         assert_eq!(state.approval_list.items.len(), 1);
         assert_eq!(state.approval_list.selected_idx, 0);
+    }
+
+    #[test]
+    fn send_approve_does_not_mutate_list_without_active_client() {
+        // #154 L2 regression: pre-fix, `send_approve` removed the approval
+        // from the queue even when no control client / runtime was
+        // attached, stranding the request — the operator pressed approve,
+        // the actor never received a response, and the modal was gone
+        // from the TUI. The fix gates list mutation on dispatch
+        // capability so the operator can retry once the client recovers.
+        let mut state = fresh_state();
+        apply_control_event(&mut state, mk_approval_event("req-A", "root"));
+        apply_control_event(&mut state, mk_approval_event("req-B", "sublead-1"));
+        // fresh_state() has no control_client / runtime_handle, matching
+        // the observe-only / disconnected mode this test pins.
+        assert!(state.control_client.is_none());
+        assert!(state.runtime_handle.is_none());
+
+        send_approve(&mut state, "req-A", true, None, None);
+
+        // Both items remain — nothing was stranded.
+        assert_eq!(state.approval_list.items.len(), 2);
+        assert_eq!(state.approval_list.items[0].id, "req-A");
+        assert_eq!(state.approval_list.items[1].id, "req-B");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Pre-fix bug: `send_approve` called `spawn_control_op` (which silently no-op'd when the client or runtime handle was missing) and *then* unconditionally removed the approval from the queue. The operator pressed approve, the actor never received the response, and the request was unreachable from the TUI — pure data loss in observe-only mode and post-disconnect.

## Fix

`send_approve` now gates list mutation on the same conditions `spawn_control_op` already checks internally (`state.control_client.is_some() && state.runtime_handle.is_some()`). When the gate fails, the queue is left intact so the operator can:

- Retry the approval once the client recovers, or
- Dismiss the modal intentionally with Esc.

The list-mutation logic is split out as `apply_approve_to_list` so the existing unit tests can keep their assertions about removal / `selected_idx` clamping without needing to stand up a tokio runtime or mock control client.

## Tests

- The two existing tests are renamed to call `apply_approve_to_list` directly (they were testing the list-mutation logic, not the dispatch gate, and pre-fix only passed because `spawn_control_op` silently no-op'd in `fresh_state()`).
- New regression test `send_approve_does_not_mutate_list_without_active_client` pins the fix: after calling `send_approve` on a state without a control client / runtime handle, the queue is unchanged.

## Closes

Closes L2 in #154. After this lands plus #207 (also #154), the issue has 4 of 9 items left — the major remaining one being M3 async `compute_git_diff_summary`.

## Test plan

- [x] `cargo build -p pitboss-tui` — clean
- [x] `cargo lint` — clean
- [x] `cargo tidy` — clean
- [x] `cargo test -p pitboss-tui --features pitboss-core/test-support --lib` — 108 tests pass (+1 vs main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)