### PR TITLE
fix(core): return retained Worktree from cleanup (#149 L9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **`WorktreeManager::cleanup` now returns `Option<Worktree>`** (#149 L9).
+  Previously the method consumed `Worktree` by value and returned
+  `Result<(), WorktreeError>`, so callers using `CleanupPolicy::Never`
+  (or `OnSuccess` with `succeeded == false`) lost the path after the
+  call. The signature is now `Result<Option<Worktree>, WorktreeError>`:
+  `Some(wt)` when the worktree was retained on disk, `None` when it
+  was removed. All in-tree callers (`runner.rs`, `hierarchical.rs`,
+  `mcp/tools.rs`) already discarded the return value via `let _` /
+  `if let Err`, so they continue to compile unchanged. Worktree tests
+  now assert the retained-handle path and that the returned `Worktree`
+  exposes the same `path` and `name` as the input.
+
 ### Fixed
 
 - **TUI: async git-diff summary on detail-view open** (#154 M3).

--- a/crates/pitboss-core/src/worktree/manager.rs
+++ b/crates/pitboss-core/src/worktree/manager.rs
@@ -103,20 +103,23 @@ impl WorktreeManager {
         })
     }
 
-    #[allow(clippy::needless_pass_by_value)] // Worktree is consumed intentionally: taking ownership signals the caller has relinquished it.
+    /// Apply `policy` to `wt`. Returns `Ok(Some(wt))` when the worktree was
+    /// retained on disk (so the caller can keep working with the path —
+    /// `CleanupPolicy::Never`, or `CleanupPolicy::OnSuccess` with
+    /// `succeeded == false`); `Ok(None)` when it was removed.
     pub fn cleanup(
         &self,
         wt: Worktree,
         policy: CleanupPolicy,
         succeeded: bool,
-    ) -> Result<(), WorktreeError> {
+    ) -> Result<Option<Worktree>, WorktreeError> {
         let should_remove = match policy {
             CleanupPolicy::Always => true,
             CleanupPolicy::OnSuccess => succeeded,
             CleanupPolicy::Never => false,
         };
         if !should_remove {
-            return Ok(());
+            return Ok(Some(wt));
         }
 
         let repo = Repository::open(&wt.repo_root)?;
@@ -141,7 +144,7 @@ impl WorktreeManager {
         if wt.path.exists() {
             std::fs::remove_dir_all(&wt.path)?;
         }
-        Ok(())
+        Ok(None)
     }
 }
 

--- a/crates/pitboss-core/src/worktree/mod.rs
+++ b/crates/pitboss-core/src/worktree/mod.rs
@@ -126,7 +126,8 @@ mod tests {
         let mgr = WorktreeManager::new();
         let wt = mgr.prepare(repo_dir.path(), "wt-ca", None).unwrap();
         let path = wt.path.clone();
-        mgr.cleanup(wt, CleanupPolicy::Always, true).unwrap();
+        let retained = mgr.cleanup(wt, CleanupPolicy::Always, true).unwrap();
+        assert!(retained.is_none(), "removed worktree returns None");
         assert!(!path.exists());
     }
 
@@ -137,7 +138,8 @@ mod tests {
         let mgr = WorktreeManager::new();
         let wt = mgr.prepare(repo_dir.path(), "wt-cf", None).unwrap();
         let path = wt.path.clone();
-        mgr.cleanup(wt, CleanupPolicy::Always, false).unwrap();
+        let retained = mgr.cleanup(wt, CleanupPolicy::Always, false).unwrap();
+        assert!(retained.is_none());
         assert!(!path.exists());
     }
 
@@ -148,7 +150,12 @@ mod tests {
         let mgr = WorktreeManager::new();
         let wt = mgr.prepare(repo_dir.path(), "wt-os", None).unwrap();
         let path = wt.path.clone();
-        mgr.cleanup(wt, CleanupPolicy::OnSuccess, false).unwrap();
+        let retained = mgr
+            .cleanup(wt, CleanupPolicy::OnSuccess, false)
+            .unwrap()
+            .expect("retained worktree on failure");
+        assert_eq!(retained.path, path, "retained handle exposes the path");
+        assert_eq!(retained.name(), "wt-os");
         assert!(path.exists(), "failed worktree preserved for forensics");
     }
 
@@ -159,7 +166,11 @@ mod tests {
         let mgr = WorktreeManager::new();
         let wt = mgr.prepare(repo_dir.path(), "wt-nev", None).unwrap();
         let path = wt.path.clone();
-        mgr.cleanup(wt, CleanupPolicy::Never, true).unwrap();
+        let retained = mgr
+            .cleanup(wt, CleanupPolicy::Never, true)
+            .unwrap()
+            .expect("Never policy returns the worktree");
+        assert_eq!(retained.path, path);
         assert!(path.exists());
     }
 }


### PR DESCRIPTION
## Summary
- `WorktreeManager::cleanup` now returns `Result<Option<Worktree>, WorktreeError>` — `Some(wt)` when the worktree was retained on disk (`CleanupPolicy::Never`, or `OnSuccess` with `succeeded == false`), `None` when removed.
- All three in-tree production callers (`runner.rs`, `hierarchical.rs`, `mcp/tools.rs`) already discard the return value via `let _` / `if let Err`, so they continue to compile unchanged.
- Worktree tests now assert the retained-handle path: the returned `Worktree` exposes the same `path` and `name` as the input.

Closes the last open `#149` L9 audit item.

## Why
The audit flagged `cleanup` as a limitation: under `CleanupPolicy::Never` the caller silently lost ownership of the worktree handle — the only way back to the retained directory was to clone `wt.path` before the call. With this change a caller can do `let retained = wt_mgr.cleanup(wt, policy, succeeded)?;` and keep working with the handle when the policy retained it.

## Test plan
- [x] `cargo test -p pitboss-core --features test-support worktree::` — 11/11 pass, including the two updated retain-policy tests.
- [x] `cargo test --workspace --features pitboss-core/test-support` — workspace green.
- [x] `cargo lint` clean.
- [x] `cargo tidy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)