### PR TITLE
fix(approval): default_approval_policy now unconditional, regardless of TUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed (breaking, pre-v1)
+
+- **`default_approval_policy = "auto_approve"` / `"auto_reject"` is
+  now unconditional** — pre-fix it only fired when no TUI/web console
+  was attached. A connected console silently bypassed the policy and
+  routed every `request_approval` / `propose_plan` call to the
+  operator anyway. That made the field mean two different things
+  depending on whether someone happened to be watching, which was the
+  worst kind of bug class. Reported via the smoke-test post-run
+  zero-error scan: every sublead's auto-approved propose_plan call
+  popped up in the web console for manual click.
+
+  **New semantics:**
+  - `auto_approve` — short-circuits inside the dispatcher, regardless
+    of whether a TUI is attached. Operator UI is never paged.
+  - `auto_reject` — same, with rejection. Comment text is now
+    `"auto-rejected by default_approval_policy"` (was
+    `"no operator available"` on the no-TUI path).
+  - `block` (default) — unchanged: route to TUI if attached, else
+    queue for next connect.
+
+  **Migration:** operators who relied on the old "auto_approve only
+  when headless" behavior should leave `default_approval_policy` at
+  the default `block` and add an `[[approval_policy]]` rule like
+  `match.actor = "*"` / `action = "auto_approve"` to express the
+  fallback declaratively. (`[[approval_policy]]` rules already
+  short-circuit before the TUI hop, so this gives the same headless
+  behavior without the surprise when a console connects.)
+
+  Pinned by 2 new regression tests
+  (`auto_approve_short_circuits_with_tui_attached`,
+  `auto_reject_short_circuits_with_tui_attached`) that simulate a
+  connected control writer and verify no `ApprovalRequest` event is
+  ever sent. Schema field doc on `default_approval_policy` and the
+  module-level rustdoc on `mcp::approval` updated to spell out the
+  three resolution paths in order.
+
 ### Changed
 
 - **Failure classifier: schema-first matching against Anthropic API

--- a/crates/pitboss-cli/src/manifest/schema.rs
+++ b/crates/pitboss-cli/src/manifest/schema.rs
@@ -359,14 +359,31 @@ pub struct RunConfig {
         help = "Write a JSONL event stream alongside summary.jsonl."
     )]
     pub emit_event_stream: bool,
-    /// Default approval-policy action when no TUI is attached and no
-    /// `[[approval_policy]]` rule matches. Renamed from `approval_policy`
-    /// in v0.9 to disambiguate from the rules array. One of:
-    /// `"block"` (default), `"auto_approve"`, `"auto_reject"`.
+    /// Default approval-policy action applied to every approval request
+    /// that no `[[approval_policy]]` rule matches. Renamed from
+    /// `approval_policy` in v0.9 to disambiguate from the rules array.
+    /// One of:
+    /// - `"block"` (default): if a TUI/web console is attached, route
+    ///   the request to the operator; otherwise queue until one
+    ///   connects.
+    /// - `"auto_approve"`: unconditionally auto-approve. Operator UI is
+    ///   never paged; the response is synthesized inside the dispatcher.
+    /// - `"auto_reject"`: unconditionally auto-reject. Same UI behavior.
+    ///
+    /// Pre-v0.9.2 these only applied "when no TUI is attached" — a
+    /// connected console silently bypassed `auto_approve` /
+    /// `auto_reject` and routed to the operator anyway. That meant the
+    /// field's effective behavior depended on whether someone happened
+    /// to be watching, which was the worst kind of bug class. Now both
+    /// `auto_*` actions short-circuit unconditionally; only `block`
+    /// routes through the TUI. Operators who want manual review with a
+    /// "headless = approve" fallback should leave this at `block` and
+    /// add a `[[approval_policy]]` rule for the auto-approve case
+    /// (rules already short-circuit before the TUI hop).
     #[serde(default)]
     #[field(
         label = "Default approval policy",
-        help = "Default action for request_approval / propose_plan when no TUI is attached and no rule matches.",
+        help = "Default action for request_approval / propose_plan when no rule matches. `auto_approve`/`auto_reject` are unconditional; `block` routes to the operator if attached, else queues.",
         enum_values = ["block", "auto_approve", "auto_reject"]
     )]
     pub default_approval_policy: Option<crate::dispatch::state::ApprovalPolicy>,

--- a/crates/pitboss-cli/src/mcp/approval.rs
+++ b/crates/pitboss-cli/src/mcp/approval.rs
@@ -1,6 +1,20 @@
 //! Approval bridge: wires an in-dispatcher MCP `request_approval` call to
-//! either (a) a connected TUI via the control socket, or (b) an auto-resolve
-//! per `ApprovalPolicy` when no TUI is attached.
+//! one of three resolution paths, in order:
+//!
+//!   1. **Operator-declared `[[approval_policy]]` rule match** —
+//!      handled by callers (`handle_request_approval` etc.) before
+//!      they reach the bridge; rules with `auto_approve` / `auto_reject`
+//!      / `block` actions short-circuit unconditionally.
+//!   2. **Manifest `default_approval_policy`** (`ApprovalPolicy`) —
+//!      `AutoApprove` and `AutoReject` short-circuit unconditionally
+//!      from inside `request()` regardless of whether a TUI/web
+//!      console is attached. Pre-v0.9.2 these only fired when no TUI
+//!      was connected; a connected console silently bypassed the
+//!      policy. The current behavior matches what the field name
+//!      implies — a *policy*, not a headless fallback.
+//!   3. **`Block` policy** (the default) — if a TUI is attached the
+//!      request is routed to it via the control socket; if no TUI
+//!      is attached the request is queued for the next connect.
 
 #![allow(dead_code)]
 
@@ -133,6 +147,58 @@ impl ApprovalBridge {
 
         let (tx, rx) = oneshot::channel::<ApprovalResponse>();
 
+        // Unconditional policy short-circuit. Pre-fix `default_approval_policy`
+        // only applied when no TUI was attached: a connected web console or
+        // pitboss-tui silently bypassed `auto_approve` / `auto_reject` and
+        // routed every approval to the operator. That made the field mean
+        // two different things depending on whether someone happened to be
+        // watching. Now `auto_approve` / `auto_reject` are always honored;
+        // `block` retains the legacy "ask operator if attached, else queue"
+        // path. Operators who want manual review with a fallback should use
+        // `[[approval_policy]]` rules (which already short-circuit) and
+        // leave `default_approval_policy` at its default of `block`.
+        match self.state.root.approval_policy {
+            ApprovalPolicy::AutoApprove => {
+                let _ = tx.send(ApprovalResponse {
+                    approved: true,
+                    comment: None,
+                    edited_summary: None,
+                    reason: None,
+                    from_ttl: false,
+                });
+                self.state
+                    .root
+                    .worker_counters
+                    .write()
+                    .await
+                    .entry(task_id_for_counter.clone())
+                    .or_default()
+                    .approvals_requested += 1;
+                return rx.await.map_err(|_| ApprovalError::Cancelled);
+            }
+            ApprovalPolicy::AutoReject => {
+                let _ = tx.send(ApprovalResponse {
+                    approved: false,
+                    comment: Some("auto-rejected by default_approval_policy".into()),
+                    edited_summary: None,
+                    reason: None,
+                    from_ttl: false,
+                });
+                self.state
+                    .root
+                    .worker_counters
+                    .write()
+                    .await
+                    .entry(task_id_for_counter.clone())
+                    .or_default()
+                    .approvals_requested += 1;
+                return rx.await.map_err(|_| ApprovalError::Cancelled);
+            }
+            ApprovalPolicy::Block => {
+                // Fall through to TUI/queue routing below.
+            }
+        }
+
         // Hold the control_writer lock across the `bridge.insert` and the
         // `w.send(ev)`. A previous version released the writer lock between
         // the "is it present?" check and the insert, so a TUI that
@@ -185,104 +251,60 @@ impl ApprovalBridge {
                     .await
                     .remove(&request_id);
                 drop(writer_guard);
-                // Apply the same fallback that fires on bridge timeout
-                // or no-TUI-attached. We swap to the no-TUI handling
-                // path by returning early through the policy block
-                // below — but `tx` was moved into the bridge entry,
-                // so we need to fabricate a synchronous reply here.
-                return Ok(match self.state.root.approval_policy {
-                    ApprovalPolicy::AutoApprove => ApprovalResponse {
-                        approved: true,
-                        comment: None,
-                        edited_summary: None,
-                        reason: None,
-                        from_ttl: false,
-                    },
-                    ApprovalPolicy::AutoReject => ApprovalResponse {
-                        approved: false,
-                        comment: None,
-                        edited_summary: None,
-                        reason: Some("control writer queue full; auto-rejected".into()),
-                        from_ttl: false,
-                    },
-                    ApprovalPolicy::Block => ApprovalResponse {
-                        // Match block-policy semantics: with no TUI to
-                        // make a decision and the queue full, the only
-                        // safe outcome is rejection. Pre-fix the caller
-                        // would block until bridge timeout for the same
-                        // result.
-                        approved: false,
-                        comment: None,
-                        edited_summary: None,
-                        reason: Some(
-                            "control writer queue full and approval_policy=block — no TUI \
-                             can decide; auto-rejected"
-                                .into(),
-                        ),
-                        from_ttl: false,
-                    },
+                // Block policy + queue full + no TUI can decide → safe
+                // rejection. (AutoApprove / AutoReject already
+                // short-circuited at the top of `request`, so policy is
+                // guaranteed to be Block here.) Pre-fix the caller would
+                // block until bridge timeout for the same outcome.
+                return Ok(ApprovalResponse {
+                    approved: false,
+                    comment: None,
+                    edited_summary: None,
+                    reason: Some(
+                        "control writer queue full and approval_policy=block — no TUI \
+                         can decide; auto-rejected"
+                            .into(),
+                    ),
+                    from_ttl: false,
                 });
             }
             drop(writer_guard);
         } else {
             drop(writer_guard);
-            // No TUI attached: policy decides.
-            match self.state.root.approval_policy {
-                ApprovalPolicy::AutoApprove => {
-                    let _ = tx.send(ApprovalResponse {
-                        approved: true,
-                        comment: None,
-                        edited_summary: None,
-                        reason: None,
-                        from_ttl: false,
-                    });
-                }
-                ApprovalPolicy::AutoReject => {
-                    let _ = tx.send(ApprovalResponse {
-                        approved: false,
-                        comment: Some("no operator available".into()),
-                        edited_summary: None,
-                        reason: None,
-                        from_ttl: false,
-                    });
-                }
-                ApprovalPolicy::Block => {
-                    // Queue; drain when a TUI connects (see control/server.rs).
-                    // Pass ttl_secs + fallback from the request so the TTL watcher
-                    // can expire and fire a from_ttl=true response before the
-                    // bridge timeout fires (which would return a generic error).
-                    self.state
-                        .root
-                        .approval_queue
-                        .lock()
-                        .await
-                        .push_back(QueuedApproval {
-                            request_id: request_id.clone(),
-                            task_id: task_id.clone(),
-                            summary: summary.clone(),
-                            plan,
-                            kind,
-                            responder: tx,
-                            ttl_secs,
-                            fallback,
-                            created_at: chrono::Utc::now(),
-                        });
+            // No TUI attached and policy is `Block`: queue the request and
+            // drain when a TUI connects (see control/server.rs). AutoApprove
+            // / AutoReject already short-circuited above, so this branch is
+            // reachable only under `block`.
+            self.state
+                .root
+                .approval_queue
+                .lock()
+                .await
+                .push_back(QueuedApproval {
+                    request_id: request_id.clone(),
+                    task_id: task_id.clone(),
+                    summary: summary.clone(),
+                    plan,
+                    kind,
+                    responder: tx,
+                    ttl_secs,
+                    fallback,
+                    created_at: chrono::Utc::now(),
+                });
 
-                    // Fire approval_pending notification
-                    if let Some(router) = self.state.root.notification_router.clone() {
-                        let envelope = crate::notify::NotificationEnvelope::new(
-                            &self.state.root.run_id.to_string(),
-                            crate::notify::Severity::Warning,
-                            crate::notify::PitbossEvent::ApprovalPending {
-                                request_id: request_id.clone(),
-                                task_id: task_id.clone(),
-                                summary: summary.clone(),
-                            },
-                            chrono::Utc::now(),
-                        );
-                        let _ = router.dispatch(envelope).await;
-                    }
-                }
+            // Fire approval_pending notification.
+            if let Some(router) = self.state.root.notification_router.clone() {
+                let envelope = crate::notify::NotificationEnvelope::new(
+                    &self.state.root.run_id.to_string(),
+                    crate::notify::Severity::Warning,
+                    crate::notify::PitbossEvent::ApprovalPending {
+                        request_id: request_id.clone(),
+                        task_id: task_id.clone(),
+                        summary: summary.clone(),
+                    },
+                    chrono::Utc::now(),
+                );
+                let _ = router.dispatch(envelope).await;
             }
         }
 
@@ -474,7 +496,90 @@ mod tests {
             .await
             .unwrap();
         assert!(!resp.approved);
-        assert_eq!(resp.comment.as_deref(), Some("no operator available"));
+        assert_eq!(
+            resp.comment.as_deref(),
+            Some("auto-rejected by default_approval_policy")
+        );
+    }
+
+    /// Regression for the v0.9.2 semantic change: `auto_approve` MUST
+    /// short-circuit even when a TUI/web console is attached. Pre-fix
+    /// the bridge routed every approval to the operator whenever the
+    /// control writer was connected, silently bypassing the policy.
+    #[tokio::test]
+    async fn auto_approve_short_circuits_with_tui_attached() {
+        use crate::control::protocol::ControlEvent;
+        use tokio::sync::mpsc;
+
+        let state = mk_state(ApprovalPolicy::AutoApprove).await;
+        // Simulate a connected TUI by registering a control writer.
+        let (tx, mut rx) = mpsc::channel::<ControlEvent>(8);
+        *state.root.control_writer.lock().await = Some(crate::dispatch::layer::ControlWriterSlot {
+            id: Uuid::now_v7(),
+            sender: tx,
+        });
+
+        let bridge = ApprovalBridge::new(state);
+        let resp = bridge
+            .request(
+                "lead".into(),
+                "spawn 2".into(),
+                None,
+                crate::control::protocol::ApprovalKind::Action,
+                Duration::from_secs(1),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        assert!(
+            resp.approved,
+            "auto_approve must short-circuit unconditionally"
+        );
+        // The TUI must NOT have received an ApprovalRequest event — that
+        // was the pre-fix bug, where a connected console silently overrode
+        // the policy.
+        assert!(
+            rx.try_recv().is_err(),
+            "auto_approve must not route the request to the TUI"
+        );
+    }
+
+    /// Regression for the v0.9.2 semantic change: `auto_reject` MUST
+    /// short-circuit even when a TUI/web console is attached.
+    #[tokio::test]
+    async fn auto_reject_short_circuits_with_tui_attached() {
+        use crate::control::protocol::ControlEvent;
+        use tokio::sync::mpsc;
+
+        let state = mk_state(ApprovalPolicy::AutoReject).await;
+        let (tx, mut rx) = mpsc::channel::<ControlEvent>(8);
+        *state.root.control_writer.lock().await = Some(crate::dispatch::layer::ControlWriterSlot {
+            id: Uuid::now_v7(),
+            sender: tx,
+        });
+
+        let bridge = ApprovalBridge::new(state);
+        let resp = bridge
+            .request(
+                "lead".into(),
+                "spawn 2".into(),
+                None,
+                crate::control::protocol::ApprovalKind::Action,
+                Duration::from_secs(1),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        assert!(
+            !resp.approved,
+            "auto_reject must short-circuit unconditionally"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "auto_reject must not route the request to the TUI"
+        );
     }
 
     #[tokio::test]

--- a/crates/pitboss-cli/tests/control_flows.rs
+++ b/crates/pitboss-cli/tests/control_flows.rs
@@ -476,7 +476,10 @@ async fn auto_reject_policy_responds_without_tui() {
         .await
         .unwrap();
     assert!(!resp.approved);
-    assert_eq!(resp.comment.as_deref(), Some("no operator available"));
+    assert_eq!(
+        resp.comment.as_deref(),
+        Some("auto-rejected by default_approval_policy")
+    );
 }
 
 #[tokio::test]

--- a/docs/manifest-map.md
+++ b/docs/manifest-map.md
@@ -24,22 +24,22 @@ Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:313`](../crates/pitbos
 | `run_dir` | path | no | Where per-run artifacts land. Default ~/.local/share/pitboss/runs. | [`../crates/pitboss-cli/src/manifest/schema.rs#L346`](../crates/pitboss-cli/src/manifest/schema.rs#L346) |
 | `worktree_cleanup` | enum (`always` \| `on_success` \| `never`) | no | What to do with each worker's git worktree after it finishes. | [`../crates/pitboss-cli/src/manifest/schema.rs#L354`](../crates/pitboss-cli/src/manifest/schema.rs#L354) |
 | `emit_event_stream` | boolean | no | Write a JSONL event stream alongside summary.jsonl. | [`../crates/pitboss-cli/src/manifest/schema.rs#L361`](../crates/pitboss-cli/src/manifest/schema.rs#L361) |
-| `default_approval_policy` | enum (`block` \| `auto_approve` \| `auto_reject`) | no | Default action for request_approval / propose_plan when no TUI is attached and no rule matches. | [`../crates/pitboss-cli/src/manifest/schema.rs#L372`](../crates/pitboss-cli/src/manifest/schema.rs#L372) |
-| `dump_shared_store` | boolean | no | Write shared-store.json into the run directory on finalize. | [`../crates/pitboss-cli/src/manifest/schema.rs#L380`](../crates/pitboss-cli/src/manifest/schema.rs#L380) |
-| `require_plan_approval` | boolean | no | When true, spawn_worker is blocked until propose_plan has been approved. | [`../crates/pitboss-cli/src/manifest/schema.rs#L388`](../crates/pitboss-cli/src/manifest/schema.rs#L388) |
+| `default_approval_policy` | enum (`block` \| `auto_approve` \| `auto_reject`) | no | Default action for request_approval / propose_plan when no rule matches. `auto_approve`/`auto_reject` are unconditional; `block` routes to the operator if attached, else queues. | [`../crates/pitboss-cli/src/manifest/schema.rs#L389`](../crates/pitboss-cli/src/manifest/schema.rs#L389) |
+| `dump_shared_store` | boolean | no | Write shared-store.json into the run directory on finalize. | [`../crates/pitboss-cli/src/manifest/schema.rs#L397`](../crates/pitboss-cli/src/manifest/schema.rs#L397) |
+| `require_plan_approval` | boolean | no | When true, spawn_worker is blocked until propose_plan has been approved. | [`../crates/pitboss-cli/src/manifest/schema.rs#L405`](../crates/pitboss-cli/src/manifest/schema.rs#L405) |
 
 ## `[defaults]` — `Defaults`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:421`](../crates/pitboss-cli/src/manifest/schema.rs#L421).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:438`](../crates/pitboss-cli/src/manifest/schema.rs#L438).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `model` | text | no | Claude model id (e.g. claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-7). | [`../crates/pitboss-cli/src/manifest/schema.rs#L426`](../crates/pitboss-cli/src/manifest/schema.rs#L426) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Maps to the claude --effort flag. | [`../crates/pitboss-cli/src/manifest/schema.rs#L432`](../crates/pitboss-cli/src/manifest/schema.rs#L432) |
-| `tools` | string list | no | Allowed tool surface. Pitboss auto-appends its MCP tools for leads and workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L437`](../crates/pitboss-cli/src/manifest/schema.rs#L437) |
-| `timeout_secs` | integer | no | Per-task wall-clock cap. No default (no cap). | [`../crates/pitboss-cli/src/manifest/schema.rs#L442`](../crates/pitboss-cli/src/manifest/schema.rs#L442) |
-| `use_worktree` | boolean | no | Isolate each worker in a git worktree. Default true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L447`](../crates/pitboss-cli/src/manifest/schema.rs#L447) |
-| `env` | key-value map | no | Environment variables passed to the claude subprocess. | [`../crates/pitboss-cli/src/manifest/schema.rs#L453`](../crates/pitboss-cli/src/manifest/schema.rs#L453) |
+| `model` | text | no | Claude model id (e.g. claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-7). | [`../crates/pitboss-cli/src/manifest/schema.rs#L443`](../crates/pitboss-cli/src/manifest/schema.rs#L443) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Maps to the claude --effort flag. | [`../crates/pitboss-cli/src/manifest/schema.rs#L449`](../crates/pitboss-cli/src/manifest/schema.rs#L449) |
+| `tools` | string list | no | Allowed tool surface. Pitboss auto-appends its MCP tools for leads and workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L454`](../crates/pitboss-cli/src/manifest/schema.rs#L454) |
+| `timeout_secs` | integer | no | Per-task wall-clock cap. No default (no cap). | [`../crates/pitboss-cli/src/manifest/schema.rs#L459`](../crates/pitboss-cli/src/manifest/schema.rs#L459) |
+| `use_worktree` | boolean | no | Isolate each worker in a git worktree. Default true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L464`](../crates/pitboss-cli/src/manifest/schema.rs#L464) |
+| `env` | key-value map | no | Environment variables passed to the claude subprocess. | [`../crates/pitboss-cli/src/manifest/schema.rs#L470`](../crates/pitboss-cli/src/manifest/schema.rs#L470) |
 
 ## `[container]` — `ContainerConfig`
 
@@ -64,58 +64,58 @@ Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:109`](../crates/pitbos
 
 ## `[[task]]` — `Task`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:484`](../crates/pitboss-cli/src/manifest/schema.rs#L484).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:501`](../crates/pitboss-cli/src/manifest/schema.rs#L501).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique slug. Alphanumeric + _ + -. Used in logs and worktree names. | [`../crates/pitboss-cli/src/manifest/schema.rs#L489`](../crates/pitboss-cli/src/manifest/schema.rs#L489) |
-| `directory` | path | **yes** | Working directory. Must be inside a git repo if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L494`](../crates/pitboss-cli/src/manifest/schema.rs#L494) |
-| `prompt` | text (multi-line) | no | Prompt body sent to claude via -p. Mutually exclusive with `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L500`](../crates/pitboss-cli/src/manifest/schema.rs#L500) |
-| `template` | text | no | Reference to a [[template]] entry. Mutually exclusive with `prompt`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L505`](../crates/pitboss-cli/src/manifest/schema.rs#L505) |
-| `vars` | key-value map | no | Substitutions for {placeholders} when using `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L511`](../crates/pitboss-cli/src/manifest/schema.rs#L511) |
-| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L516`](../crates/pitboss-cli/src/manifest/schema.rs#L516) |
-| `model` | text | no | Per-task override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L518`](../crates/pitboss-cli/src/manifest/schema.rs#L518) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-task override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L524`](../crates/pitboss-cli/src/manifest/schema.rs#L524) |
-| `tools` | string list | no | Per-task override of [defaults].tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L526`](../crates/pitboss-cli/src/manifest/schema.rs#L526) |
-| `timeout_secs` | integer | no | Per-task wall-clock cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L528`](../crates/pitboss-cli/src/manifest/schema.rs#L528) |
-| `use_worktree` | boolean | no | Per-task override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L533`](../crates/pitboss-cli/src/manifest/schema.rs#L533) |
-| `env` | key-value map | no | Per-task env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L539`](../crates/pitboss-cli/src/manifest/schema.rs#L539) |
+| `id` | text | **yes** | Unique slug. Alphanumeric + _ + -. Used in logs and worktree names. | [`../crates/pitboss-cli/src/manifest/schema.rs#L506`](../crates/pitboss-cli/src/manifest/schema.rs#L506) |
+| `directory` | path | **yes** | Working directory. Must be inside a git repo if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L511`](../crates/pitboss-cli/src/manifest/schema.rs#L511) |
+| `prompt` | text (multi-line) | no | Prompt body sent to claude via -p. Mutually exclusive with `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L517`](../crates/pitboss-cli/src/manifest/schema.rs#L517) |
+| `template` | text | no | Reference to a [[template]] entry. Mutually exclusive with `prompt`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L522`](../crates/pitboss-cli/src/manifest/schema.rs#L522) |
+| `vars` | key-value map | no | Substitutions for {placeholders} when using `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L528`](../crates/pitboss-cli/src/manifest/schema.rs#L528) |
+| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L533`](../crates/pitboss-cli/src/manifest/schema.rs#L533) |
+| `model` | text | no | Per-task override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L535`](../crates/pitboss-cli/src/manifest/schema.rs#L535) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-task override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L541`](../crates/pitboss-cli/src/manifest/schema.rs#L541) |
+| `tools` | string list | no | Per-task override of [defaults].tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L543`](../crates/pitboss-cli/src/manifest/schema.rs#L543) |
+| `timeout_secs` | integer | no | Per-task wall-clock cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L545`](../crates/pitboss-cli/src/manifest/schema.rs#L545) |
+| `use_worktree` | boolean | no | Per-task override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L550`](../crates/pitboss-cli/src/manifest/schema.rs#L550) |
+| `env` | key-value map | no | Per-task env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L556`](../crates/pitboss-cli/src/manifest/schema.rs#L556) |
 
 ## `[lead]` — `Lead`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:549`](../crates/pitboss-cli/src/manifest/schema.rs#L549).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:566`](../crates/pitboss-cli/src/manifest/schema.rs#L566).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique slug used as the TUI tile label and in run artifact paths. | [`../crates/pitboss-cli/src/manifest/schema.rs#L556`](../crates/pitboss-cli/src/manifest/schema.rs#L556) |
-| `directory` | path | **yes** | Working directory for the lead's claude subprocess. Must be a git work-tree if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L563`](../crates/pitboss-cli/src/manifest/schema.rs#L563) |
-| `prompt` | text (multi-line) | **yes** | Operator instructions passed to claude via -p. Must appear before any [lead.X] subtable in the source. | [`../crates/pitboss-cli/src/manifest/schema.rs#L575`](../crates/pitboss-cli/src/manifest/schema.rs#L575) |
-| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L583`](../crates/pitboss-cli/src/manifest/schema.rs#L583) |
-| `model` | text | no | Per-lead override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L586`](../crates/pitboss-cli/src/manifest/schema.rs#L586) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-lead override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L593`](../crates/pitboss-cli/src/manifest/schema.rs#L593) |
-| `tools` | string list | no | Per-lead override of [defaults].tools. Pitboss auto-appends its MCP tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L599`](../crates/pitboss-cli/src/manifest/schema.rs#L599) |
-| `timeout_secs` | integer | no | Per-actor subprocess wall-clock cap (claude --timeout). | [`../crates/pitboss-cli/src/manifest/schema.rs#L605`](../crates/pitboss-cli/src/manifest/schema.rs#L605) |
-| `use_worktree` | boolean | no | Per-lead override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L611`](../crates/pitboss-cli/src/manifest/schema.rs#L611) |
-| `env` | key-value map | no | Per-lead env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L617`](../crates/pitboss-cli/src/manifest/schema.rs#L617) |
-| `max_workers` | integer | no | Hard cap on the lead's concurrent + queued worker pool (1–16). Required when the lead spawns workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L626`](../crates/pitboss-cli/src/manifest/schema.rs#L626) |
-| `budget_usd` | float | no | Soft cap on lead spend with reservation accounting. spawn_worker fails once spent + reserved + next_estimate > budget. | [`../crates/pitboss-cli/src/manifest/schema.rs#L635`](../crates/pitboss-cli/src/manifest/schema.rs#L635) |
-| `lead_timeout_secs` | integer | no | Wall-clock cap on the lead session. Default 3600. | [`../crates/pitboss-cli/src/manifest/schema.rs#L644`](../crates/pitboss-cli/src/manifest/schema.rs#L644) |
-| `permission_routing` | enum (`path_a` \| `path_b`) | no | path_a (default) makes pitboss the sole permission authority. path_b routes claude's gate through pitboss (rejected at validate time pending stabilization). | [`../crates/pitboss-cli/src/manifest/schema.rs#L657`](../crates/pitboss-cli/src/manifest/schema.rs#L657) |
-| `allow_subleads` | boolean | no | Expose spawn_sublead to the root lead. | [`../crates/pitboss-cli/src/manifest/schema.rs#L666`](../crates/pitboss-cli/src/manifest/schema.rs#L666) |
-| `max_subleads` | integer | no | Hard cap on total live sub-leads under this root. | [`../crates/pitboss-cli/src/manifest/schema.rs#L673`](../crates/pitboss-cli/src/manifest/schema.rs#L673) |
-| `max_sublead_budget_usd` | float | no | Cap on the per-sub-lead budget envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L680`](../crates/pitboss-cli/src/manifest/schema.rs#L680) |
-| `max_total_workers` | integer | no | Cap on total live workers across the entire tree (root + sub-trees). | [`../crates/pitboss-cli/src/manifest/schema.rs#L688`](../crates/pitboss-cli/src/manifest/schema.rs#L688) |
+| `id` | text | **yes** | Unique slug used as the TUI tile label and in run artifact paths. | [`../crates/pitboss-cli/src/manifest/schema.rs#L573`](../crates/pitboss-cli/src/manifest/schema.rs#L573) |
+| `directory` | path | **yes** | Working directory for the lead's claude subprocess. Must be a git work-tree if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L580`](../crates/pitboss-cli/src/manifest/schema.rs#L580) |
+| `prompt` | text (multi-line) | **yes** | Operator instructions passed to claude via -p. Must appear before any [lead.X] subtable in the source. | [`../crates/pitboss-cli/src/manifest/schema.rs#L592`](../crates/pitboss-cli/src/manifest/schema.rs#L592) |
+| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L600`](../crates/pitboss-cli/src/manifest/schema.rs#L600) |
+| `model` | text | no | Per-lead override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L603`](../crates/pitboss-cli/src/manifest/schema.rs#L603) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-lead override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L610`](../crates/pitboss-cli/src/manifest/schema.rs#L610) |
+| `tools` | string list | no | Per-lead override of [defaults].tools. Pitboss auto-appends its MCP tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L616`](../crates/pitboss-cli/src/manifest/schema.rs#L616) |
+| `timeout_secs` | integer | no | Per-actor subprocess wall-clock cap (claude --timeout). | [`../crates/pitboss-cli/src/manifest/schema.rs#L622`](../crates/pitboss-cli/src/manifest/schema.rs#L622) |
+| `use_worktree` | boolean | no | Per-lead override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L628`](../crates/pitboss-cli/src/manifest/schema.rs#L628) |
+| `env` | key-value map | no | Per-lead env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L634`](../crates/pitboss-cli/src/manifest/schema.rs#L634) |
+| `max_workers` | integer | no | Hard cap on the lead's concurrent + queued worker pool (1–16). Required when the lead spawns workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L643`](../crates/pitboss-cli/src/manifest/schema.rs#L643) |
+| `budget_usd` | float | no | Soft cap on lead spend with reservation accounting. spawn_worker fails once spent + reserved + next_estimate > budget. | [`../crates/pitboss-cli/src/manifest/schema.rs#L652`](../crates/pitboss-cli/src/manifest/schema.rs#L652) |
+| `lead_timeout_secs` | integer | no | Wall-clock cap on the lead session. Default 3600. | [`../crates/pitboss-cli/src/manifest/schema.rs#L661`](../crates/pitboss-cli/src/manifest/schema.rs#L661) |
+| `permission_routing` | enum (`path_a` \| `path_b`) | no | path_a (default) makes pitboss the sole permission authority. path_b routes claude's gate through pitboss (rejected at validate time pending stabilization). | [`../crates/pitboss-cli/src/manifest/schema.rs#L674`](../crates/pitboss-cli/src/manifest/schema.rs#L674) |
+| `allow_subleads` | boolean | no | Expose spawn_sublead to the root lead. | [`../crates/pitboss-cli/src/manifest/schema.rs#L683`](../crates/pitboss-cli/src/manifest/schema.rs#L683) |
+| `max_subleads` | integer | no | Hard cap on total live sub-leads under this root. | [`../crates/pitboss-cli/src/manifest/schema.rs#L690`](../crates/pitboss-cli/src/manifest/schema.rs#L690) |
+| `max_sublead_budget_usd` | float | no | Cap on the per-sub-lead budget envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L697`](../crates/pitboss-cli/src/manifest/schema.rs#L697) |
+| `max_total_workers` | integer | no | Cap on total live workers across the entire tree (root + sub-trees). | [`../crates/pitboss-cli/src/manifest/schema.rs#L705`](../crates/pitboss-cli/src/manifest/schema.rs#L705) |
 
 ## `[sublead_defaults]` — `SubleadDefaults`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:695`](../crates/pitboss-cli/src/manifest/schema.rs#L695).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:712`](../crates/pitboss-cli/src/manifest/schema.rs#L712).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `budget_usd` | float | no | Per-sub-lead envelope when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L700`](../crates/pitboss-cli/src/manifest/schema.rs#L700) |
-| `max_workers` | integer | no | Per-sub-lead worker pool when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L705`](../crates/pitboss-cli/src/manifest/schema.rs#L705) |
-| `lead_timeout_secs` | integer | no | Wall-clock cap for the sub-lead session. | [`../crates/pitboss-cli/src/manifest/schema.rs#L710`](../crates/pitboss-cli/src/manifest/schema.rs#L710) |
-| `read_down` | boolean | no | When true, sub-lead shares root's budget + worker pool instead of carving its own envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L716`](../crates/pitboss-cli/src/manifest/schema.rs#L716) |
+| `budget_usd` | float | no | Per-sub-lead envelope when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L717`](../crates/pitboss-cli/src/manifest/schema.rs#L717) |
+| `max_workers` | integer | no | Per-sub-lead worker pool when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L722`](../crates/pitboss-cli/src/manifest/schema.rs#L722) |
+| `lead_timeout_secs` | integer | no | Wall-clock cap for the sub-lead session. | [`../crates/pitboss-cli/src/manifest/schema.rs#L727`](../crates/pitboss-cli/src/manifest/schema.rs#L727) |
+| `read_down` | boolean | no | When true, sub-lead shares root's budget + worker pool instead of carving its own envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L733`](../crates/pitboss-cli/src/manifest/schema.rs#L733) |
 
 ## `[[approval_policy]]` — `ApprovalRuleSpec`
 
@@ -138,12 +138,12 @@ Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:137`](../crates/pitbos
 
 ## `[[template]]` — `Template`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:468`](../crates/pitboss-cli/src/manifest/schema.rs#L468).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:485`](../crates/pitboss-cli/src/manifest/schema.rs#L485).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Slug referenced from [[task]].template. | [`../crates/pitboss-cli/src/manifest/schema.rs#L473`](../crates/pitboss-cli/src/manifest/schema.rs#L473) |
-| `prompt` | text (multi-line) | **yes** | Prompt body. Supports {var} placeholders supplied by [[task]].vars. | [`../crates/pitboss-cli/src/manifest/schema.rs#L479`](../crates/pitboss-cli/src/manifest/schema.rs#L479) |
+| `id` | text | **yes** | Slug referenced from [[task]].template. | [`../crates/pitboss-cli/src/manifest/schema.rs#L490`](../crates/pitboss-cli/src/manifest/schema.rs#L490) |
+| `prompt` | text (multi-line) | **yes** | Prompt body. Supports {var} placeholders supplied by [[task]].vars. | [`../crates/pitboss-cli/src/manifest/schema.rs#L496`](../crates/pitboss-cli/src/manifest/schema.rs#L496) |
 
 ## `[lifecycle]` — `Lifecycle`
 


### PR DESCRIPTION
## Summary

Reported during depth-2 smoke test: every sublead's \`propose_plan\` call
popped up in the web console for manual click, despite the manifest
having \`default_approval_policy = \"auto_approve\"\`. The console was
overriding the policy.

## What was wrong

\`mcp::approval::ApprovalBridge::request\` consulted the policy ONLY in
the \`else\` arm of \`if let Some(w) = writer_guard.as_ref()\` — i.e. when
no TUI was attached. With a connected console it routed every approval
to the operator. The schema doc said \"when no TUI is attached and no
rule matches\", buried in the help text, but the field is named
\`default_approval_policy\`, not \`headless_approval_policy\` — the
effective behavior depending on whether someone happened to be watching
is the worst kind of bug class.

## New semantics (breaking, pre-v1)

- \`auto_approve\` — short-circuits inside the dispatcher, regardless of
  whether a TUI is attached. Operator UI is never paged.
- \`auto_reject\` — same, with rejection. Comment text now
  \`\"auto-rejected by default_approval_policy\"\`.
- \`block\` (default) — unchanged: route to TUI if attached, else queue
  for next connect.

## Migration

Operators relying on the old \"auto_approve only when headless\"
behavior should leave \`default_approval_policy\` at \`block\` and add an
\`[[approval_policy]]\` rule:

\`\`\`toml
[[approval_policy]]
match.actor = \"*\"
action = \"auto_approve\"
\`\`\`

Rules already short-circuit before the TUI hop, so this gives the same
headless behavior without the connected-console surprise.

## Test plan

- [x] 2 new regression tests register a control writer, fire
  \`ApprovalBridge::request\`, and assert (a) the policy applies, (b) NO
  \`ApprovalRequest\` event is sent to the writer's mpsc channel
- [x] Existing \`auto_reject_policy_responds_without_tui\` integration
  test updated for the new comment string
- [x] \`cargo test --workspace --features pitboss-core/test-support\` — all 35 sections green
- [x] \`cargo lint\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`docs/manifest-map.md\` regenerated against the new schema doc
- [x] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)