### PR TITLE
fix(mcp): bump approval counters from every resolution path (#224)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Approval counters now bump for every resolution path, not just
+  operator responses** (#224). Pre-fix, `worker_counters.approvals_approved`
+  / `approvals_rejected` were only bumped inside `ApprovalBridge::respond`
+  and the operator-driven path in `control/server.rs`. Every other
+  resolution path — `default_approval_policy = auto_approve` /
+  `auto_reject` short-circuits, `[[approval_policy]]` rule
+  `auto_approve` / `auto_reject` short-circuits in
+  `mcp/tools/approval.rs::handle_request_approval` and
+  `handle_propose_plan`, TTL fallbacks fired by
+  `runner.rs::install_approval_ttl_watcher` (both queue and bridge
+  scans), and the queue-full safe-rejection path in
+  `ApprovalBridge::request` — synthesized the response inline without
+  touching the counters. After PR #220 made `auto_approve`
+  short-circuit unconditionally, every smoke run exhibited the
+  resulting off-by-one (1 requested, 0 approved/rejected) on the
+  lead's `TaskRecord`. The matcher-rule paths additionally never
+  bumped `approvals_requested` either, so policy-resolved approvals
+  showed `(0, 0, 0)` end-to-end.
+
+  **Fix:** lifted counter bookkeeping into two helpers in
+  `mcp/approval.rs` — `bump_approval_requested` and
+  `record_approval_outcome` — and called them from every resolution
+  path. The existing `respond()` and `control/server.rs` paths were
+  refactored to use the helper. Pinned by 4 new tests in
+  `mcp::approval::tests` (`auto_approve_bumps_requested_and_approved`,
+  `auto_reject_bumps_requested_and_rejected`,
+  `queue_full_safe_rejection_bumps_requested_and_rejected`,
+  `respond_path_bumps_approved`).
+
 - **Hierarchical run finalize: `summary.json` now includes every actor
   across all layers** (#221). Pre-fix, `dispatch/hierarchical.rs`'s
   finalize phase built `summary.json`'s `tasks` array by walking

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -1138,15 +1138,7 @@ async fn dispatch_op(
                     },
                 )
                 .await;
-                {
-                    let mut guard = state.root.worker_counters.write().await;
-                    let entry = guard.entry(caller_id).or_default();
-                    if approved {
-                        entry.approvals_approved += 1;
-                    } else {
-                        entry.approvals_rejected += 1;
-                    }
-                }
+                crate::mcp::approval::record_approval_outcome(state, &caller_id, approved).await;
                 ControlEvent::OpAcked {
                     op: "approve".into(),
                     task_id: None,

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -1134,6 +1134,7 @@ async fn expire_layer_approvals(
         state
             .record_last_approval_response(&entry.task_id, approved, true)
             .await;
+        crate::mcp::approval::record_approval_outcome(state, &entry.task_id, approved).await;
         let _ = entry.responder.send(response);
     }
 
@@ -1182,6 +1183,7 @@ async fn expire_layer_approvals(
             state
                 .record_last_approval_response(&entry.task_id, approved, true)
                 .await;
+            crate::mcp::approval::record_approval_outcome(state, &entry.task_id, approved).await;
             let _ = entry.responder.send(response);
         }
     }

--- a/crates/pitboss-cli/src/mcp/approval.rs
+++ b/crates/pitboss-cli/src/mcp/approval.rs
@@ -72,6 +72,38 @@ pub struct ApprovalBridge {
     state: Arc<DispatchState>,
 }
 
+/// Bump `approvals_requested` for the given caller. Called once per
+/// approval, regardless of which resolution path it takes.
+pub(crate) async fn bump_approval_requested(state: &Arc<DispatchState>, caller_id: &str) {
+    state
+        .root
+        .worker_counters
+        .write()
+        .await
+        .entry(caller_id.to_string())
+        .or_default()
+        .approvals_requested += 1;
+}
+
+/// Bump `approvals_approved` or `approvals_rejected` for the given caller
+/// based on outcome. Called from every resolution path so counter state
+/// stays consistent regardless of whether the response came from an
+/// operator, a policy short-circuit, a TTL fallback, or a queue-full
+/// safe rejection.
+pub(crate) async fn record_approval_outcome(
+    state: &Arc<DispatchState>,
+    caller_id: &str,
+    approved: bool,
+) {
+    let mut guard = state.root.worker_counters.write().await;
+    let entry = guard.entry(caller_id.to_string()).or_default();
+    if approved {
+        entry.approvals_approved += 1;
+    } else {
+        entry.approvals_rejected += 1;
+    }
+}
+
 /// Convert the MCP-tool-layer `ApprovalPlan` into the control-protocol
 /// wire shape. Field layout is identical; the duplication exists so
 /// `control::protocol` stays independent of `mcp::tools`.
@@ -166,14 +198,8 @@ impl ApprovalBridge {
                     reason: None,
                     from_ttl: false,
                 });
-                self.state
-                    .root
-                    .worker_counters
-                    .write()
-                    .await
-                    .entry(task_id_for_counter.clone())
-                    .or_default()
-                    .approvals_requested += 1;
+                bump_approval_requested(&self.state, &task_id_for_counter).await;
+                record_approval_outcome(&self.state, &task_id_for_counter, true).await;
                 return rx.await.map_err(|_| ApprovalError::Cancelled);
             }
             ApprovalPolicy::AutoReject => {
@@ -184,14 +210,8 @@ impl ApprovalBridge {
                     reason: None,
                     from_ttl: false,
                 });
-                self.state
-                    .root
-                    .worker_counters
-                    .write()
-                    .await
-                    .entry(task_id_for_counter.clone())
-                    .or_default()
-                    .approvals_requested += 1;
+                bump_approval_requested(&self.state, &task_id_for_counter).await;
+                record_approval_outcome(&self.state, &task_id_for_counter, false).await;
                 return rx.await.map_err(|_| ApprovalError::Cancelled);
             }
             ApprovalPolicy::Block => {
@@ -256,6 +276,8 @@ impl ApprovalBridge {
                 // short-circuited at the top of `request`, so policy is
                 // guaranteed to be Block here.) Pre-fix the caller would
                 // block until bridge timeout for the same outcome.
+                bump_approval_requested(&self.state, &task_id_for_counter).await;
+                record_approval_outcome(&self.state, &task_id_for_counter, false).await;
                 return Ok(ApprovalResponse {
                     approved: false,
                     comment: None,
@@ -308,19 +330,11 @@ impl ApprovalBridge {
             }
         }
 
-        // task_id may have been moved into the ControlEvent or QueuedApproval
-        // above; use the request_id as the lookup key is not right — we need
-        // the caller id. Both branches clone task_id before consuming it, so
-        // we capture a clone here at the top of the function instead.
-        // (The clone is taken at function entry via task_id_for_counter below.)
-        self.state
-            .root
-            .worker_counters
-            .write()
-            .await
-            .entry(task_id_for_counter.clone())
-            .or_default()
-            .approvals_requested += 1;
+        // task_id was moved into the ControlEvent or QueuedApproval above;
+        // task_id_for_counter was cloned at function entry for this purpose.
+        // approved/rejected gets bumped later by either control/server.rs
+        // (operator response) or runner.rs (TTL fallback).
+        bump_approval_requested(&self.state, &task_id_for_counter).await;
 
         // When a per-request TTL is set, the TTL watcher fires the response
         // with from_ttl=true before the bridge timeout. Add 60 s of buffer so
@@ -387,15 +401,7 @@ impl ApprovalBridge {
             .responder
             .send(resp)
             .map_err(|_| ApprovalError::Cancelled)?;
-        {
-            let mut guard = self.state.root.worker_counters.write().await;
-            let entry = guard.entry(caller_id).or_default();
-            if approved {
-                entry.approvals_approved += 1;
-            } else {
-                entry.approvals_rejected += 1;
-            }
-        }
+        record_approval_outcome(&self.state, &caller_id, approved).await;
         Ok(())
     }
 }
@@ -580,6 +586,151 @@ mod tests {
             rx.try_recv().is_err(),
             "auto_reject must not route the request to the TUI"
         );
+    }
+
+    /// Regression for #224: every approval-resolution path must bump the
+    /// caller's approval counters consistently. Pre-fix, only the operator
+    /// response path bumped `approvals_approved`/`approvals_rejected`; every
+    /// short-circuit path silently left them at zero.
+    async fn counters_for(state: &Arc<DispatchState>, caller: &str) -> (u32, u32, u32) {
+        let guard = state.root.worker_counters.read().await;
+        let c = guard.get(caller).cloned().unwrap_or_default();
+        (
+            c.approvals_requested,
+            c.approvals_approved,
+            c.approvals_rejected,
+        )
+    }
+
+    #[tokio::test]
+    async fn auto_approve_bumps_requested_and_approved() {
+        let state = mk_state(ApprovalPolicy::AutoApprove).await;
+        let bridge = ApprovalBridge::new(Arc::clone(&state));
+        let _ = bridge
+            .request(
+                "lead".into(),
+                "summary".into(),
+                None,
+                crate::control::protocol::ApprovalKind::Action,
+                Duration::from_secs(1),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(counters_for(&state, "lead").await, (1, 1, 0));
+    }
+
+    #[tokio::test]
+    async fn auto_reject_bumps_requested_and_rejected() {
+        let state = mk_state(ApprovalPolicy::AutoReject).await;
+        let bridge = ApprovalBridge::new(Arc::clone(&state));
+        let _ = bridge
+            .request(
+                "lead".into(),
+                "summary".into(),
+                None,
+                crate::control::protocol::ApprovalKind::Action,
+                Duration::from_secs(1),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(counters_for(&state, "lead").await, (1, 0, 1));
+    }
+
+    /// Block policy + connected control writer with a full queue → bridge
+    /// auto-rejects. Both `requested` and `rejected` must bump.
+    #[tokio::test]
+    async fn queue_full_safe_rejection_bumps_requested_and_rejected() {
+        use crate::control::protocol::ControlEvent;
+        use tokio::sync::mpsc;
+
+        let state = mk_state(ApprovalPolicy::Block).await;
+        // Capacity-1 channel filled to force `try_send` to fail. We must not
+        // drain the receiver — the bridge's send needs to fail synchronously.
+        let (tx, _rx) = mpsc::channel::<ControlEvent>(1);
+        // Pre-fill with one event so the bridge's try_send is guaranteed to fail.
+        tx.try_send(ControlEvent::OpAcked {
+            op: "noop".into(),
+            task_id: None,
+        })
+        .unwrap();
+        *state.root.control_writer.lock().await = Some(crate::dispatch::layer::ControlWriterSlot {
+            id: Uuid::now_v7(),
+            sender: tx,
+        });
+
+        let bridge = ApprovalBridge::new(Arc::clone(&state));
+        let resp = bridge
+            .request(
+                "lead".into(),
+                "summary".into(),
+                None,
+                crate::control::protocol::ApprovalKind::Action,
+                Duration::from_secs(1),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        assert!(!resp.approved);
+        assert_eq!(counters_for(&state, "lead").await, (1, 0, 1));
+    }
+
+    /// Operator-driven respond path: `request` bumps `requested`, `respond`
+    /// bumps `approved` or `rejected`. Together they yield (1, 1, 0) or (1, 0, 1).
+    #[tokio::test]
+    async fn respond_path_bumps_approved() {
+        use crate::control::protocol::ControlEvent;
+        use tokio::sync::mpsc;
+
+        let state = mk_state(ApprovalPolicy::Block).await;
+        let (tx, mut rx) = mpsc::channel::<ControlEvent>(8);
+        *state.root.control_writer.lock().await = Some(crate::dispatch::layer::ControlWriterSlot {
+            id: Uuid::now_v7(),
+            sender: tx,
+        });
+
+        let bridge = Arc::new(ApprovalBridge::new(Arc::clone(&state)));
+        let bridge_for_request = Arc::clone(&bridge);
+        let request_handle = tokio::spawn(async move {
+            bridge_for_request
+                .request(
+                    "lead".into(),
+                    "summary".into(),
+                    None,
+                    crate::control::protocol::ApprovalKind::Action,
+                    Duration::from_secs(2),
+                    None,
+                    None,
+                )
+                .await
+        });
+
+        // Wait for the bridge to emit the ApprovalRequest event, capture the
+        // request_id, then call respond().
+        let request_id = match rx.recv().await.unwrap() {
+            ControlEvent::ApprovalRequest { request_id, .. } => request_id,
+            other => panic!("unexpected event: {other:?}"),
+        };
+        bridge
+            .respond(
+                &request_id,
+                ApprovalResponse {
+                    approved: true,
+                    comment: None,
+                    edited_summary: None,
+                    reason: None,
+                    from_ttl: false,
+                },
+            )
+            .await
+            .unwrap();
+        let resp = request_handle.await.unwrap().unwrap();
+        assert!(resp.approved);
+        assert_eq!(counters_for(&state, "lead").await, (1, 1, 0));
     }
 
     #[tokio::test]

--- a/crates/pitboss-cli/src/mcp/tools/approval.rs
+++ b/crates/pitboss-cli/src/mcp/tools/approval.rs
@@ -122,6 +122,17 @@ pub async fn handle_request_approval(
                     state
                         .record_last_approval_response(&pending.requesting_actor_id, true, false)
                         .await;
+                    crate::mcp::approval::bump_approval_requested(
+                        state,
+                        &pending.requesting_actor_id,
+                    )
+                    .await;
+                    crate::mcp::approval::record_approval_outcome(
+                        state,
+                        &pending.requesting_actor_id,
+                        true,
+                    )
+                    .await;
                     return Ok(ApprovalToolResponse {
                         approved: true,
                         comment: Some("auto-approved by policy".into()),
@@ -137,6 +148,17 @@ pub async fn handle_request_approval(
                     state
                         .record_last_approval_response(&pending.requesting_actor_id, false, false)
                         .await;
+                    crate::mcp::approval::bump_approval_requested(
+                        state,
+                        &pending.requesting_actor_id,
+                    )
+                    .await;
+                    crate::mcp::approval::record_approval_outcome(
+                        state,
+                        &pending.requesting_actor_id,
+                        false,
+                    )
+                    .await;
                     return Ok(ApprovalToolResponse {
                         approved: false,
                         comment: Some("auto-rejected by policy".into()),
@@ -277,6 +299,17 @@ pub async fn handle_propose_plan(
                     state
                         .record_last_approval_response(&pending.requesting_actor_id, true, false)
                         .await;
+                    crate::mcp::approval::bump_approval_requested(
+                        state,
+                        &pending.requesting_actor_id,
+                    )
+                    .await;
+                    crate::mcp::approval::record_approval_outcome(
+                        state,
+                        &pending.requesting_actor_id,
+                        true,
+                    )
+                    .await;
                     return Ok(ApprovalToolResponse {
                         approved: true,
                         comment: Some("auto-approved by policy".into()),
@@ -292,6 +325,17 @@ pub async fn handle_propose_plan(
                     state
                         .record_last_approval_response(&pending.requesting_actor_id, false, false)
                         .await;
+                    crate::mcp::approval::bump_approval_requested(
+                        state,
+                        &pending.requesting_actor_id,
+                    )
+                    .await;
+                    crate::mcp::approval::record_approval_outcome(
+                        state,
+                        &pending.requesting_actor_id,
+                        false,
+                    )
+                    .await;
                     return Ok(ApprovalToolResponse {
                         approved: false,
                         comment: Some("auto-rejected by policy".into()),


### PR DESCRIPTION
## Summary

Closes #224. Pre-fix, only the operator-driven response path bumped `approvals_approved` / `approvals_rejected`; every short-circuit path synthesized a response inline and left the counters stale. After #220 made `auto_approve` short-circuit unconditionally, every smoke run exhibited the resulting off-by-one on the lead's TaskRecord.

## What changed

Two new helpers in `crates/pitboss-cli/src/mcp/approval.rs`:

- `bump_approval_requested(state, caller_id)` — single-line writer-counters bump.
- `record_approval_outcome(state, caller_id, approved)` — bumps `approved` or `rejected` based on outcome.

Wired into every resolution path:

| Path | File | Pre-fix counters | Post-fix |
|---|---|---|---|
| `default_approval_policy = auto_approve` | `mcp/approval.rs::request` | requested only | requested + approved |
| `default_approval_policy = auto_reject` | `mcp/approval.rs::request` | requested only | requested + rejected |
| `[[approval_policy]]` rule auto_approve | `mcp/tools/approval.rs::handle_request_approval` + `handle_propose_plan` | none | requested + approved |
| `[[approval_policy]]` rule auto_reject | same | none | requested + rejected |
| Queue-full safe rejection | `mcp/approval.rs::request` | none | requested + rejected |
| TTL fallback (queue) | `dispatch/runner.rs::install_approval_ttl_watcher` | none (requested already bumped) | + approved/rejected |
| TTL fallback (bridge) | same | none | + approved/rejected |
| Operator respond | `mcp/approval.rs::respond` + `control/server.rs` | correct | refactored to helper |

## Tests

4 new tests in `mcp::approval::tests`:
- `auto_approve_bumps_requested_and_approved` — `(1, 1, 0)`
- `auto_reject_bumps_requested_and_rejected` — `(1, 0, 1)`
- `queue_full_safe_rejection_bumps_requested_and_rejected` — pre-fills capacity-1 channel to force `try_send` failure, asserts `(1, 0, 1)`
- `respond_path_bumps_approved` — exercises the operator-driven path end-to-end via `mpsc::channel<ControlEvent>` + `bridge.respond(...)`, asserts `(1, 1, 0)`

Full workspace test + clippy + fmt all green.

## Test plan

- [x] `cargo test --workspace --features pitboss-core/test-support` — all 565+ tests pass
- [x] `cargo lint` clean
- [x] `cargo tidy` clean
- [ ] After merge: rebuild local CLI, re-run depth-2 smoke test, verify lead's TaskRecord shows `approvals_approved == approvals_requested` for an `auto_approve` run

🤖 Generated with [Claude Code](https://claude.com/claude-code)