### PR TITLE
feat(web): GET /api/runs/{id}/tasks/{task_id} task-metadata endpoint (#225)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`GET /api/runs/{run_id}/tasks/{task_id}` — single-task metadata
+  endpoint** (#225). Returns the full `TaskRecord` JSON for one actor
+  by reading `summary.jsonl` line-by-line, so leads / sub-leads / sub-tree
+  workers are all directly addressable. Pre-fix, the SPA's per-task
+  page had to load the entire run summary just to render one row, and
+  hierarchical-run sub-tree records were unreachable because
+  `summary.json`'s `tasks[]` only carried the root layer (#221). The
+  per-task SPA page now fetches metadata and log in parallel
+  (`Promise.allSettled`); a 404 on metadata is non-fatal so the page
+  still renders the log for older runs that pre-date the endpoint.
+
 ### Fixed
 
 - **Approval counters now bump for every resolution path, not just

--- a/crates/pitboss-web/spa/src/lib/api.ts
+++ b/crates/pitboss-web/spa/src/lib/api.ts
@@ -126,6 +126,42 @@ export function getTaskLog(runId: string, taskId: string, opts: TaskLogOpts = {}
   return request<string>(path, { accept: 'text' });
 }
 
+/**
+ * Wire-format mirror of `pitboss_core::store::TaskRecord`. The SPA only
+ * names the fields it renders; backend additions land here as needed.
+ */
+export interface TaskRecord {
+  task_id: string;
+  status: string;
+  exit_code: number | null;
+  started_at: string;
+  ended_at: string;
+  duration_ms: number;
+  worktree_path: string | null;
+  log_path: string;
+  token_usage: {
+    input: number;
+    output: number;
+    cache_read?: number;
+    cache_creation?: number;
+  };
+  claude_session_id: string | null;
+  final_message_preview: string | null;
+  final_message: string | null;
+  parent_task_id: string | null;
+  pause_count: number;
+  reprompt_count: number;
+  approvals_requested: number;
+  approvals_approved: number;
+  approvals_rejected: number;
+  model: string | null;
+  failure_reason: unknown | null;
+}
+
+export function getTaskDetail(runId: string, taskId: string): Promise<TaskRecord> {
+  return request<TaskRecord>(`/api/runs/${enc(runId)}/tasks/${enc(taskId)}`);
+}
+
 // ---- Control writes (POST /api/runs/:id/control) ------------------------
 
 /**

--- a/crates/pitboss-web/spa/src/routes/runs/[id]/tasks/[task_id]/+page.svelte
+++ b/crates/pitboss-web/spa/src/routes/runs/[id]/tasks/[task_id]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { page } from '$app/state';
-  import { getTaskLog, ApiError } from '$lib/api';
+  import { getTaskLog, getTaskDetail, ApiError, type TaskRecord } from '$lib/api';
   import { Card, CardContent } from '$lib/components/ui/card';
   import { Button } from '$lib/components/ui/button';
   import { Badge } from '$lib/components/ui/badge';
@@ -13,16 +13,27 @@
   let error = $state<string | null>(null);
   let loading = $state(false);
   let tail = $state(true);
+  let detail = $state<TaskRecord | null>(null);
   const limit = 256 * 1024; // 256 KiB
 
   async function load() {
     loading = true;
     error = null;
     try {
-      log = await getTaskLog(runId, taskId, { limit, tail });
-    } catch (e) {
-      log = null;
-      error = e instanceof ApiError ? `${e.status}: ${e.body || e.message}` : String(e);
+      // Fetch metadata + log in parallel; metadata 404 is non-fatal
+      // (older runs may pre-date the endpoint, summary.jsonl missing).
+      const [logResult, detailResult] = await Promise.allSettled([
+        getTaskLog(runId, taskId, { limit, tail }),
+        getTaskDetail(runId, taskId),
+      ]);
+      if (logResult.status === 'fulfilled') {
+        log = logResult.value;
+      } else {
+        log = null;
+        const e = logResult.reason;
+        error = e instanceof ApiError ? `${e.status}: ${e.body || e.message}` : String(e);
+      }
+      detail = detailResult.status === 'fulfilled' ? detailResult.value : null;
     } finally {
       loading = false;
     }
@@ -31,6 +42,21 @@
   $effect(() => {
     if (runId && taskId) load();
   });
+
+  function fmtDuration(ms: number): string {
+    if (ms < 1000) return `${ms} ms`;
+    if (ms < 60_000) return `${(ms / 1000).toFixed(1)} s`;
+    const m = Math.floor(ms / 60_000);
+    const s = Math.floor((ms % 60_000) / 1000);
+    return `${m}m ${s}s`;
+  }
+
+  function statusVariant(s: string): 'default' | 'destructive' | 'secondary' | 'outline' {
+    if (s === 'Success') return 'default';
+    if (s === 'Failed' || s === 'SpawnFailed') return 'destructive';
+    if (s === 'Cancelled' || s === 'TimedOut') return 'secondary';
+    return 'outline';
+  }
 
   function downloadFull() {
     const url = `/api/runs/${encodeURIComponent(runId)}/tasks/${encodeURIComponent(taskId)}/log?limit=8388608`;
@@ -78,6 +104,73 @@
     </Button>
   </div>
 </div>
+
+{#if detail}
+  <Card class="mb-4">
+    <CardContent class="grid grid-cols-2 gap-x-6 gap-y-2 pt-4 text-sm md:grid-cols-4">
+      <div>
+        <div class="text-muted-foreground text-xs">Status</div>
+        <Badge variant={statusVariant(detail.status)}>{detail.status}</Badge>
+      </div>
+      <div>
+        <div class="text-muted-foreground text-xs">Duration</div>
+        <div>{fmtDuration(detail.duration_ms)}</div>
+      </div>
+      <div>
+        <div class="text-muted-foreground text-xs">Exit code</div>
+        <div><code class="text-xs">{detail.exit_code ?? '—'}</code></div>
+      </div>
+      <div>
+        <div class="text-muted-foreground text-xs">Model</div>
+        <div><code class="text-xs">{detail.model ?? '—'}</code></div>
+      </div>
+      <div>
+        <div class="text-muted-foreground text-xs">Tokens (in / out)</div>
+        <div>
+          <code class="text-xs"
+            >{detail.token_usage.input.toLocaleString()} / {detail.token_usage.output.toLocaleString()}</code
+          >
+        </div>
+      </div>
+      <div>
+        <div class="text-muted-foreground text-xs">Approvals (req / ok / rej)</div>
+        <div>
+          <code class="text-xs"
+            >{detail.approvals_requested} / {detail.approvals_approved} / {detail.approvals_rejected}</code
+          >
+        </div>
+      </div>
+      <div>
+        <div class="text-muted-foreground text-xs">Parent</div>
+        <div>
+          {#if detail.parent_task_id}
+            <code class="text-xs">{detail.parent_task_id}</code>
+          {:else}
+            <span class="text-muted-foreground text-xs">root</span>
+          {/if}
+        </div>
+      </div>
+      <div>
+        <div class="text-muted-foreground text-xs">Pause / reprompt</div>
+        <div><code class="text-xs">{detail.pause_count} / {detail.reprompt_count}</code></div>
+      </div>
+      {#if detail.failure_reason}
+        <div class="col-span-2 md:col-span-4">
+          <div class="text-muted-foreground text-xs">Failure</div>
+          <pre class="bg-muted/40 mt-1 max-h-32 overflow-auto rounded p-2 text-xs"><code
+              >{JSON.stringify(detail.failure_reason, null, 2)}</code
+            ></pre>
+        </div>
+      {/if}
+      {#if detail.final_message_preview}
+        <div class="col-span-2 md:col-span-4">
+          <div class="text-muted-foreground text-xs">Final message</div>
+          <p class="mt-1 text-sm">{detail.final_message_preview}</p>
+        </div>
+      {/if}
+    </CardContent>
+  </Card>
+{/if}
 
 {#if error}
   <Card class="border-destructive/50">

--- a/crates/pitboss-web/src/api/mod.rs
+++ b/crates/pitboss-web/src/api/mod.rs
@@ -25,6 +25,7 @@ pub fn router(state: AppState) -> Router {
         .route("/runs/{run_id}/manifest", get(runs::manifest))
         .route("/runs/{run_id}/resolved", get(runs::resolved))
         .route("/runs/{run_id}/summary-jsonl", get(runs::summary_jsonl))
+        .route("/runs/{run_id}/tasks/{task_id}", get(runs::task_detail))
         .route("/runs/{run_id}/tasks/{task_id}/log", get(runs::task_log))
         .route("/runs/{run_id}/events", get(events::events))
         .route("/runs/{run_id}/control", post(control::send))

--- a/crates/pitboss-web/src/api/runs.rs
+++ b/crates/pitboss-web/src/api/runs.rs
@@ -123,6 +123,54 @@ pub struct LogQuery {
     pub tail: Option<bool>,
 }
 
+/// `GET /api/runs/:run_id/tasks/:task_id` — single `TaskRecord` for one
+/// actor (lead, sub-lead, or worker). Reads `summary.jsonl` line by line
+/// and returns the first record whose `task_id` matches. `summary.jsonl`
+/// is the source of truth — it captures every actor across every layer
+/// (root + sub-leads + workers), unlike `summary.json` which is written
+/// once at finalize and aggregates only what the dispatcher had visible
+/// at that moment (#221).
+///
+/// 404 when the run dir exists but no record carries the given task_id.
+pub async fn task_detail(
+    State(state): State<AppState>,
+    AxPath((run_id, task_id)): AxPath<(String, String)>,
+) -> ApiResult<Response> {
+    let run_dir = run_dir(state.runs_dir(), &run_id)?;
+    // task_id is rendered into a JSON string match below, not into a
+    // path, so the path-segment sanitizer doesn't apply here. We still
+    // bound the length to keep the substring scan cheap.
+    if task_id.is_empty() || task_id.len() > 256 {
+        return Err(ApiError::BadRequest("invalid task_id length".into()));
+    }
+    let path = run_dir.join("summary.jsonl");
+    let bytes = match tokio::fs::read(&path).await {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Err(ApiError::NotFound),
+        Err(e) => return Err(e.into()),
+    };
+    // Lossy decode: a partial-write tail (the dispatcher appends as
+    // each actor finishes) shouldn't 500 the request — better to skip
+    // a malformed line than to fail a perfectly-readable lookup.
+    let text = String::from_utf8_lossy(&bytes);
+    let needle = format!("\"task_id\":\"{task_id}\"");
+    for line in text.lines() {
+        if !line.contains(&needle) {
+            continue;
+        }
+        // Substring match isn't authoritative (the task_id could appear
+        // inside another field — a parent_task_id reference, the log
+        // path, etc.). Confirm with a real parse.
+        let Ok(rec) = serde_json::from_str::<pitboss_core::store::TaskRecord>(line) else {
+            continue;
+        };
+        if rec.task_id == task_id {
+            return Ok(Json(rec).into_response());
+        }
+    }
+    Err(ApiError::NotFound)
+}
+
 /// `GET /api/runs/:id/tasks/:task_id/log` — task `stdout.log`.
 pub async fn task_log(
     State(state): State<AppState>,
@@ -224,5 +272,202 @@ mod tests {
     fn sanitize_rejects_overlong_ids() {
         let big = "a".repeat(129);
         assert!(sanitize_id(&big).is_err());
+    }
+
+    // ── #225: task_detail endpoint ─────────────────────────────────────────
+
+    use crate::state::AppState;
+    use axum::body::to_bytes;
+    use axum::http::StatusCode;
+    use tempfile::TempDir;
+
+    /// Lay down a run dir with a `summary.jsonl` containing the given
+    /// raw lines. Returns the AppState anchored at that dir's parent.
+    fn build_run_with_summary_jsonl(run_id: &str, lines: &[&str]) -> (TempDir, AppState) {
+        let tmp = TempDir::new().unwrap();
+        let runs_dir = tmp.path().to_path_buf();
+        let run_dir = runs_dir.join(run_id);
+        std::fs::create_dir_all(&run_dir).unwrap();
+        let mut content = String::new();
+        for l in lines {
+            content.push_str(l);
+            content.push('\n');
+        }
+        std::fs::write(run_dir.join("summary.jsonl"), content).unwrap();
+        let manifests_dir = tmp.path().join("manifests");
+        std::fs::create_dir_all(&manifests_dir).unwrap();
+        let state = AppState::new(runs_dir, manifests_dir, None);
+        (tmp, state)
+    }
+
+    /// Minimal valid `TaskRecord` JSON line. `pitboss-core` is allowed
+    /// to evolve the shape; we keep the fixture in sync with whatever
+    /// `serde_json::to_string(&TaskRecord)` currently emits to avoid
+    /// hand-rolled drift.
+    fn task_record_line(task_id: &str, status: &str, parent: Option<&str>) -> String {
+        use pitboss_core::store::TaskRecord;
+        let rec = TaskRecord {
+            task_id: task_id.to_string(),
+            status: serde_json::from_str(&format!("\"{status}\"")).unwrap(),
+            exit_code: Some(0),
+            started_at: chrono::Utc::now(),
+            ended_at: chrono::Utc::now(),
+            duration_ms: 1000,
+            worktree_path: None,
+            log_path: PathBuf::from(format!("/tmp/pitboss/{task_id}/stdout.log")),
+            token_usage: pitboss_core::parser::TokenUsage::default(),
+            claude_session_id: None,
+            final_message_preview: None,
+            final_message: None,
+            parent_task_id: parent.map(String::from),
+            pause_count: 0,
+            reprompt_count: 0,
+            approvals_requested: 0,
+            approvals_approved: 0,
+            approvals_rejected: 0,
+            model: Some("claude-haiku-4-5".to_string()),
+            failure_reason: None,
+        };
+        serde_json::to_string(&rec).unwrap()
+    }
+
+    async fn body_to_value(resp: Response) -> serde_json::Value {
+        let bytes = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    #[tokio::test]
+    async fn task_detail_returns_record_for_matching_id() {
+        let run_id = "01950000-0000-7000-8000-000000000001";
+        let (_tmp, state) = build_run_with_summary_jsonl(
+            run_id,
+            &[
+                &task_record_line("worker-A", "Success", Some("lead-1")),
+                &task_record_line("worker-B", "Failed", Some("lead-1")),
+            ],
+        );
+
+        let resp = task_detail(
+            State(state),
+            AxPath((run_id.to_string(), "worker-B".to_string())),
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_to_value(resp).await;
+        assert_eq!(v["task_id"], "worker-B");
+        assert_eq!(v["status"], "Failed");
+        assert_eq!(v["parent_task_id"], "lead-1");
+    }
+
+    /// Hierarchical-run regression: a sub-lead's record must be findable
+    /// via the same endpoint as a worker. summary.jsonl is the source of
+    /// truth across all layers (#221).
+    #[tokio::test]
+    async fn task_detail_finds_sublead_record() {
+        let run_id = "01950000-0000-7000-8000-000000000002";
+        let (_tmp, state) = build_run_with_summary_jsonl(
+            run_id,
+            &[
+                &task_record_line("worker-A", "Success", Some("sublead-1")),
+                &task_record_line("sublead-1", "Success", Some("lead-1")),
+                &task_record_line("lead-1", "Success", None),
+            ],
+        );
+
+        let resp = task_detail(
+            State(state),
+            AxPath((run_id.to_string(), "sublead-1".to_string())),
+        )
+        .await
+        .unwrap();
+        let v = body_to_value(resp).await;
+        assert_eq!(v["task_id"], "sublead-1");
+        assert_eq!(v["parent_task_id"], "lead-1");
+    }
+
+    /// The substring scan (`"task_id":"<X>"`) is only an optimization —
+    /// records that mention `<X>` in some other field (e.g.,
+    /// `parent_task_id`) must NOT be returned for that lookup.
+    #[tokio::test]
+    async fn task_detail_does_not_match_parent_task_id_substring() {
+        let run_id = "01950000-0000-7000-8000-000000000003";
+        let (_tmp, state) = build_run_with_summary_jsonl(
+            run_id,
+            // worker-X mentions "needle" only as parent_task_id.
+            &[&task_record_line("worker-X", "Success", Some("needle"))],
+        );
+
+        let resp = task_detail(
+            State(state),
+            AxPath((run_id.to_string(), "needle".to_string())),
+        )
+        .await;
+        assert!(matches!(resp, Err(ApiError::NotFound)));
+    }
+
+    #[tokio::test]
+    async fn task_detail_returns_404_when_summary_jsonl_missing() {
+        let run_id = "01950000-0000-7000-8000-000000000004";
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join(run_id)).unwrap();
+        let manifests_dir = tmp.path().join("manifests");
+        std::fs::create_dir_all(&manifests_dir).unwrap();
+        let state = AppState::new(tmp.path().to_path_buf(), manifests_dir, None);
+
+        let resp = task_detail(
+            State(state),
+            AxPath((run_id.to_string(), "worker-A".to_string())),
+        )
+        .await;
+        assert!(matches!(resp, Err(ApiError::NotFound)));
+    }
+
+    #[tokio::test]
+    async fn task_detail_rejects_overlong_task_id() {
+        let run_id = "01950000-0000-7000-8000-000000000005";
+        let (_tmp, state) = build_run_with_summary_jsonl(run_id, &[]);
+        let huge = "a".repeat(257);
+        let resp = task_detail(State(state), AxPath((run_id.to_string(), huge))).await;
+        assert!(matches!(resp, Err(ApiError::BadRequest(_))));
+    }
+
+    /// A run that exists but contains no record for the requested task
+    /// returns 404 (vs 200 with empty body or 500). Pre-fix the issue
+    /// suggested this case in the spec.
+    #[tokio::test]
+    async fn task_detail_returns_404_when_task_id_not_in_summary() {
+        let run_id = "01950000-0000-7000-8000-000000000006";
+        let (_tmp, state) =
+            build_run_with_summary_jsonl(run_id, &[&task_record_line("worker-A", "Success", None)]);
+        let resp = task_detail(
+            State(state),
+            AxPath((run_id.to_string(), "worker-Z".to_string())),
+        )
+        .await;
+        assert!(matches!(resp, Err(ApiError::NotFound)));
+    }
+
+    /// Malformed JSON lines (e.g., a partial-write tail caught mid-flush)
+    /// must not 500 the request — the scan skips and continues.
+    #[tokio::test]
+    async fn task_detail_skips_malformed_lines() {
+        let run_id = "01950000-0000-7000-8000-000000000007";
+        let lines = [
+            "{\"truncated\":".to_string(), // malformed
+            task_record_line("worker-good", "Success", None),
+        ];
+        let (_tmp, state) = build_run_with_summary_jsonl(
+            run_id,
+            &lines.iter().map(String::as_str).collect::<Vec<_>>(),
+        );
+
+        let resp = task_detail(
+            State(state),
+            AxPath((run_id.to_string(), "worker-good".to_string())),
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 }


### PR DESCRIPTION
## Summary

Closes #225. Adds a single-task metadata endpoint that reads from \`summary.jsonl\` (the only source of truth that covers every actor across every layer in hierarchical runs) and wires the SPA's per-task page to use it.

## What changed

**Backend:** \`crates/pitboss-web/src/api/runs.rs\` — new \`task_detail\` handler:
- Substring prefilter (\`\"task_id\":\"<X>\"\`) for cheap line scanning, then \`serde_json::from_str\` to confirm and return the parsed \`TaskRecord\`.
- Parent-reference / log-path substring collisions are rejected by the parsed comparison.
- Malformed lines (partial-write tail caught mid-flush) are skipped rather than 500ing the request.
- 404 on missing run dir, missing \`summary.jsonl\`, or no matching record.
- Bounded \`task_id\` length (256 codepoints) to keep the scan cheap.

\`crates/pitboss-web/src/api/mod.rs\` — route wired:

\`\`\`
GET /api/runs/{run_id}/tasks/{task_id}
\`\`\`

**SPA:** \`spa/src/lib/api.ts\` — \`TaskRecord\` interface + \`getTaskDetail()\`. \`spa/src/routes/runs/[id]/tasks/[task_id]/+page.svelte\` fetches metadata and log in parallel via \`Promise.allSettled\`; 404 on metadata is non-fatal so older runs that pre-date the endpoint still render the log. New metadata card shows status / duration / exit code / model / token usage / approval counters / parent / pause-reprompt / failure_reason / final_message_preview.

## Tests

7 unit tests in \`api::runs::tests\`:
- \`task_detail_returns_record_for_matching_id\` — happy path
- \`task_detail_finds_sublead_record\` — hierarchical-run regression (sub-lead in summary.jsonl is reachable)
- \`task_detail_does_not_match_parent_task_id_substring\` — substring prefilter is only an optimization
- \`task_detail_returns_404_when_summary_jsonl_missing\` — 404 not 500
- \`task_detail_rejects_overlong_task_id\` — 400 on > 256 codepoints
- \`task_detail_returns_404_when_task_id_not_in_summary\` — explicit miss
- \`task_detail_skips_malformed_lines\` — partial-write tail safety

## Test plan

- [x] \`cargo test --workspace --features pitboss-core/test-support\` — 565+ green
- [x] \`cargo lint\` clean
- [x] \`cargo tidy\` clean
- [x] \`npm run check\` (svelte-check) clean
- [x] \`npm run build\` succeeds
- [ ] After merge: rebuild local CLI, navigate to \`/runs/<id>/tasks/<task_id>\` for a hierarchical run and verify the sub-lead and sub-tree worker pages render their metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)