### PR TITLE
fix(web,cli): manifest_name fallback + dim aborted rows (#227, #229)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **`manifest_name` in `summary.json` falls back to the manifest filename
+  stem when `[run].name` is omitted** (#227). Pre-fix, `manifest_name`
+  was set directly from `resolved.name` in both finalize paths;
+  manifests without an explicit `[run].name` landed `null` in the
+  finalized summary, which in turn split the UI: the runs list
+  synthesized `<unnamed>`, the insights aggregator independently
+  re-derived from the manifest filename, and the run-detail card
+  (`GET /api/runs/{id}`) showed `null`. Three different surfaces would
+  show three different names for the same run.
+
+  **Fix:** new `dispatch::summary::resolve_manifest_display_name`
+  helper that prefers the declared name, falls back to the filename
+  stem, and trims whitespace either way. Both `runner.rs::finalize_run`
+  and `hierarchical.rs`'s finalize phase route through it so all
+  surfaces agree. Pinned by 6 unit tests covering the declared/empty/
+  filename/no-stem/no-extension/whitespace cases.
+
+- **Aborted runs in the runs list are dimmed (italic + 60% opacity)**
+  (#229). Pre-fix, an aborted run with `tasks_total: 0` was visually
+  indistinguishable from a completed run except for the small status
+  pill, making the list noisy when scanning. Both the flat and the
+  manifest-grouped views in `routes/+page.svelte` now apply
+  `opacity-60 italic` to rows where `status === 'aborted'`. Default
+  visible (no filter), so the operator still sees them — they just
+  don't compete visually with completed runs.
+
 ### Fixed
 
 - **Run-detail Tokens card and Workers panel now show real data

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -671,10 +671,14 @@ pub async fn run_hierarchical(
         .count();
 
     let ended_at = Utc::now();
+    let manifest_name = crate::dispatch::summary::resolve_manifest_display_name(
+        resolved.name.as_deref(),
+        &manifest_path,
+    );
     let summary = RunSummary {
         run_id,
         manifest_path,
-        manifest_name: resolved.name.clone(),
+        manifest_name,
         pitboss_version: env!("CARGO_PKG_VERSION").to_string(),
         claude_version,
         started_at: init.started_at,

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -448,7 +448,10 @@ async fn finalize_run(
     let summary = RunSummary {
         run_id: init.run_id,
         manifest_path: manifest_path.to_path_buf(),
-        manifest_name: resolved.name.clone(),
+        manifest_name: crate::dispatch::summary::resolve_manifest_display_name(
+            resolved.name.as_deref(),
+            manifest_path,
+        ),
         pitboss_version: env!("CARGO_PKG_VERSION").to_string(),
         claude_version,
         started_at: init.started_at,

--- a/crates/pitboss-cli/src/dispatch/summary.rs
+++ b/crates/pitboss-cli/src/dispatch/summary.rs
@@ -1,1 +1,82 @@
-// Populated in Task 33.
+//! Helpers for shaping the finalize-time `RunSummary`. Lives outside
+//! `runner.rs` and `hierarchical.rs` so both finalize paths agree on
+//! the same logic — historical drift between them is what created
+//! #221, and #227 is a smaller version of the same problem (each
+//! finalize path independently set `manifest_name = resolved.name`,
+//! which left consumers split when no `[run].name` was declared).
+
+use std::path::Path;
+
+/// Resolve the run's display name. Prefers the operator-declared
+/// `[run].name`; falls back to the manifest filename's stem when that
+/// field is omitted, so the runs index, the run-detail card, and
+/// `/api/insights/runs` all show the same string for the same run.
+///
+/// Pre-fix (#227), `manifest_name` was set to `resolved.name.clone()`
+/// directly; without `[run].name` the field landed in `summary.json`
+/// as `null`, the runs list synthesized `<unnamed>`, and the insights
+/// aggregator independently re-derived from the manifest filename.
+/// Three different surfaces showed three different names for the same
+/// run.
+///
+/// `manifest_path` is the absolute (or run-relative) path that the
+/// dispatcher was invoked with; we only use its filename stem.
+#[must_use]
+pub fn resolve_manifest_display_name(
+    declared: Option<&str>,
+    manifest_path: &Path,
+) -> Option<String> {
+    if let Some(name) = declared {
+        let trimmed = name.trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_string());
+        }
+    }
+    manifest_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn declared_name_wins_over_filename() {
+        let n = resolve_manifest_display_name(Some("nightly"), Path::new("/x/something.toml"));
+        assert_eq!(n.as_deref(), Some("nightly"));
+    }
+
+    #[test]
+    fn falls_back_to_filename_stem_when_declared_is_none() {
+        let n = resolve_manifest_display_name(None, Path::new("/runs/smoke-test.toml"));
+        assert_eq!(n.as_deref(), Some("smoke-test"));
+    }
+
+    #[test]
+    fn falls_back_to_filename_stem_when_declared_is_empty() {
+        let n = resolve_manifest_display_name(Some("   "), Path::new("/runs/nightly.toml"));
+        assert_eq!(n.as_deref(), Some("nightly"));
+    }
+
+    #[test]
+    fn returns_none_when_path_has_no_stem() {
+        // `/`'s file_stem is None.
+        assert_eq!(resolve_manifest_display_name(None, Path::new("/")), None);
+    }
+
+    #[test]
+    fn handles_path_without_extension() {
+        let n = resolve_manifest_display_name(None, Path::new("Pitboss"));
+        assert_eq!(n.as_deref(), Some("Pitboss"));
+    }
+
+    #[test]
+    fn trims_whitespace_around_declared_name() {
+        let n = resolve_manifest_display_name(Some("  named  "), Path::new("/x.toml"));
+        assert_eq!(n.as_deref(), Some("named"));
+    }
+}

--- a/crates/pitboss-web/spa/src/routes/+page.svelte
+++ b/crates/pitboss-web/spa/src/routes/+page.svelte
@@ -245,7 +245,9 @@
             </TableRow>
             {#if expanded[g.manifest_name]}
               {#each g.runs as r (r.run_id)}
-                <TableRow class="bg-muted/20">
+                <TableRow
+                  class="bg-muted/20 {r.status === 'aborted' ? 'opacity-60 italic' : ''}"
+                >
                   <TableCell class="pl-10">
                     <a href="/runs/{r.run_id}" class="block">
                       <code class="text-xs">{r.run_id.slice(0, 18)}…</code>
@@ -295,7 +297,11 @@
           </TableRow>
         {:else}
           {#each runs as r (r.run_id)}
-            <TableRow class="hover:bg-muted/50 cursor-pointer">
+            <TableRow
+              class="hover:bg-muted/50 cursor-pointer {r.status === 'aborted'
+                ? 'opacity-60 italic'
+                : ''}"
+            >
               <TableCell>
                 <a href="/runs/{r.run_id}" class="block">
                   <code class="text-xs font-medium tracking-tight">{r.run_id.slice(0, 18)}…</code>


### PR DESCRIPTION
## Summary

Closes #227 and #229. Filing a separate comment on #228 noting the symptom doesn't reproduce — see "On #228" below.

## #227 — manifest_name fallback at finalize time

Pre-fix: \`manifest_name\` in \`summary.json\` was set directly from \`resolved.name\`. A manifest without \`[run].name\` produced \`null\` in the finalized summary, which then forked across UI surfaces:

- Runs list synthesized \`<unnamed>\`
- Insights aggregator re-derived from filename basename
- Run-detail card (\`GET /api/runs/{id}\`) returned \`null\`

Three surfaces showed three different names for the same run.

**Fix:** new \`dispatch::summary::resolve_manifest_display_name\` helper:

1. Prefers \`[run].name\` (trimmed) when non-empty
2. Falls back to \`manifest_path.file_stem()\`
3. Returns \`None\` only when neither yields a non-empty value

Both \`runner.rs::finalize_run\` and \`hierarchical.rs\`'s finalize phase now route through it, so the three surfaces agree on a single string per run.

## #229 — dim aborted rows in runs list

Pre-fix: a run with \`status: \"aborted\"\` and \`tasks_total: 0\` rendered with the same visual weight as a completed multi-task run. The status pill was the only differentiator.

**Fix:** \`opacity-60 italic\` applied to \`<TableRow>\` when \`r.status === 'aborted'\`, in both the flat list and the manifest-grouped expanded rows. Default visible — no filter, no localStorage state, no new UI controls. The operator can still scan and click through; the rows just don't compete visually with completed runs.

## On #228

Issue #228 says \"The frontend run-detail surface renders this on every run\" but \`grep -rin 'interrupt' crates/pitboss-web/spa/src/\` returns no matches. The \`was_interrupted\` field exists in the data model and is set at finalize time, but no SPA surface displays it today. The symptom in the issue doesn't reproduce — closing as not-applicable in a follow-up comment rather than touching unrelated code.

## Tests

6 new unit tests in \`dispatch::summary::tests\` covering the declared / empty / filename / no-stem / no-extension / whitespace cases. Full workspace + SPA \`npm run check\` + \`npm run build\` all green.

## Test plan

- [x] \`cargo test --workspace --features pitboss-core/test-support\` — 571+ tests pass
- [x] \`cargo lint\` clean
- [x] \`cargo tidy\` clean
- [x] SPA \`npm run check\` clean
- [x] SPA \`npm run build\` succeeds
- [ ] After merge: dispatch a manifest without \`[run].name\`, confirm runs list / insights / run-detail all show the filename stem
- [ ] After merge: dispatch a manifest, kill before any task spawns, confirm the row in the runs list shows dimmed/italic

🤖 Generated with [Claude Code](https://claude.com/claude-code)