### PR TITLE
feat(web): pitboss-web stop subcommand + graceful shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`pitboss-web stop` subcommand** for graceful shutdown of the web
+  console. The `serve` path now writes a PID file at
+  `$XDG_RUNTIME_DIR/pitboss/pitboss-web.pid` (falls back to
+  `dirs::cache_dir()` then `/tmp`); `stop` reads it, sends SIGTERM,
+  and polls until the process exits (default 10s timeout, override
+  with `--timeout-secs`). The serve path also installs a graceful-
+  shutdown future so SIGTERM / Ctrl-C drain in-flight requests
+  before returning.
+
+  Backward-compatible CLI: `pitboss-web --port 7077 …` still works
+  without the explicit `serve` subcommand. New `pitboss-web serve`
+  is an alias for callers that prefer explicit subcommands.
+
+  Side benefits: a second `pitboss-web` against a live PID file is
+  rejected with a friendly `pitboss-web already running with pid …`
+  error instead of port-bind racing; stale PID files (process gone
+  but file remained) are auto-cleaned on next start. Pinned by 5
+  unit tests in `pidfile::tests` covering self-PID liveness,
+  garbage-PID handling, and the EPERM-classifies-as-alive branch.
+
 - **`GET /api/runs/{run_id}/tasks/{task_id}` — single-task metadata
   endpoint** (#225). Returns the full `TaskRecord` JSON for one actor
   by reading `summary.jsonl` line-by-line, so leads / sub-leads / sub-tree

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1985,6 +1985,7 @@ dependencies = [
  "clap",
  "dirs 5.0.1",
  "futures-util",
+ "libc",
  "lru 0.16.4",
  "mime_guess",
  "pitboss-cli",

--- a/crates/pitboss-web/Cargo.toml
+++ b/crates/pitboss-web/Cargo.toml
@@ -32,6 +32,7 @@ mime_guess         = { workspace = true }
 futures-util       = { workspace = true }
 tokio-stream       = { workspace = true }
 dirs               = { workspace = true }
+libc               = { workspace = true }
 chrono             = { workspace = true }
 uuid               = { workspace = true }
 lru                = { workspace = true }

--- a/crates/pitboss-web/src/main.rs
+++ b/crates/pitboss-web/src/main.rs
@@ -4,12 +4,25 @@
 //! port and exposes a JSON API over the run filesystem (and, in
 //! later phases, the per-run control socket). Bind to `127.0.0.1`
 //! by default; remote-binding requires an explicit bearer token.
+//!
+//! Usage:
+//!
+//! ```text
+//! pitboss-web                   # serve (default), listen on 127.0.0.1:7077
+//! pitboss-web serve --port 8080 # serve, explicit subcommand
+//! pitboss-web stop              # graceful SIGTERM to the running instance
+//! ```
+//!
+//! The default-no-subcommand path is preserved verbatim from earlier
+//! versions for backward compatibility — `--port`, `--bind`, `--token`,
+//! `--runs-dir`, `--manifests-dir` continue to work without `serve`.
 
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
-use clap::Parser;
+use clap::{Args, Parser, Subcommand};
 use tracing_subscriber::EnvFilter;
 
 mod api;
@@ -17,6 +30,7 @@ mod assets;
 mod control_bridge;
 mod error;
 mod insights;
+mod pidfile;
 mod runs_index;
 mod state;
 
@@ -31,6 +45,30 @@ use state::AppState;
                   embedded SvelteKit SPA over a single port."
 )]
 struct Cli {
+    /// Subcommand. Omit to run the server in the foreground (the
+    /// pre-subcommand default).
+    #[command(subcommand)]
+    cmd: Option<Cmd>,
+
+    /// Serve flags also accepted at the top level so existing
+    /// invocations like `pitboss-web --port 8080` continue to work
+    /// without the explicit `serve` subcommand.
+    #[command(flatten)]
+    serve_args: ServeArgs,
+}
+
+#[derive(Subcommand, Debug)]
+enum Cmd {
+    /// Run the HTTP server in the foreground (the default action).
+    Serve(ServeArgs),
+    /// Send SIGTERM to the running pitboss-web instance, identified
+    /// by the PID file at `$XDG_RUNTIME_DIR/pitboss/pitboss-web.pid`.
+    /// Waits up to `--timeout-secs` for graceful shutdown.
+    Stop(StopArgs),
+}
+
+#[derive(Args, Debug, Default, Clone)]
+struct ServeArgs {
     /// Listen port. Default 7077.
     #[arg(long, default_value_t = 7077)]
     port: u16,
@@ -60,6 +98,15 @@ struct Cli {
     manifests_dir: Option<PathBuf>,
 }
 
+#[derive(Args, Debug)]
+struct StopArgs {
+    /// How long to wait for graceful shutdown before reporting failure.
+    /// SIGTERM is non-blocking; this controls how long we poll for the
+    /// PID to disappear.
+    #[arg(long, default_value_t = 10)]
+    timeout_secs: u64,
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
@@ -69,19 +116,26 @@ async fn main() -> Result<()> {
         .init();
 
     let cli = Cli::parse();
+    match cli.cmd {
+        None => run_serve(cli.serve_args).await,
+        Some(Cmd::Serve(args)) => run_serve(args).await,
+        Some(Cmd::Stop(args)) => run_stop(args).await,
+    }
+}
 
-    if !is_loopback(&cli.bind) && cli.token.is_none() {
+async fn run_serve(args: ServeArgs) -> Result<()> {
+    if !is_loopback(&args.bind) && args.token.is_none() {
         anyhow::bail!(
             "binding to non-loopback address {} requires --token (or PITBOSS_WEB_TOKEN)",
-            cli.bind
+            args.bind
         );
     }
 
-    let runs_dir = cli
+    let runs_dir = args
         .runs_dir
         .clone()
         .unwrap_or_else(pitboss_cli::runs::runs_base_dir);
-    let manifests_dir = cli
+    let manifests_dir = args
         .manifests_dir
         .clone()
         .unwrap_or_else(default_manifests_dir);
@@ -92,26 +146,121 @@ async fn main() -> Result<()> {
         "pitboss-web starting"
     );
 
-    let state = AppState::new(runs_dir, manifests_dir, cli.token.clone());
+    let state = AppState::new(runs_dir, manifests_dir, args.token.clone());
     let app = api::router(state);
 
-    let addr: SocketAddr = format!("{}:{}", cli.bind, cli.port)
+    let addr: SocketAddr = format!("{}:{}", args.bind, args.port)
         .parse()
-        .with_context(|| format!("invalid bind address {}:{}", cli.bind, cli.port))?;
+        .with_context(|| format!("invalid bind address {}:{}", args.bind, args.port))?;
 
     let listener = tokio::net::TcpListener::bind(addr)
         .await
         .with_context(|| format!("failed to bind {}", addr))?;
 
+    // Write PID file *after* the bind succeeds so a failed start
+    // doesn't leave a stale PID pointing at us behind. Surface a
+    // friendly error if another live pitboss-web is already running.
+    let pid_path = match pidfile::write_self() {
+        Ok(p) => p,
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            anyhow::bail!("{e}; run `pitboss-web stop` first or use a different port");
+        }
+        Err(e) => {
+            // Non-fatal: a missing /run dir, read-only filesystem,
+            // or container without writable runtime dir shouldn't
+            // block the server from starting. `stop` will report
+            // "no pidfile" in that case.
+            tracing::warn!(error = %e, "failed to write pidfile; `pitboss-web stop` will not work");
+            PathBuf::new()
+        }
+    };
+
     eprintln!("pitboss-web listening on http://{}/", addr);
-    if let Some(t) = &cli.token {
+    if !pid_path.as_os_str().is_empty() {
+        eprintln!("pidfile: {}", pid_path.display());
+    }
+    if let Some(t) = &args.token {
         eprintln!("auth required: Authorization: Bearer {}", t);
     } else {
         eprintln!("no auth (loopback only)");
     }
 
-    axum::serve(listener, app).await?;
+    let serve_result = axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await;
+
+    pidfile::remove_if_self();
+    serve_result?;
     Ok(())
+}
+
+async fn run_stop(args: StopArgs) -> Result<()> {
+    let path = pidfile::pidfile_path();
+    let pid = pidfile::read_pid(&path).with_context(|| {
+        format!(
+            "no pitboss-web pidfile at {} — is it running?",
+            path.display()
+        )
+    })?;
+
+    if !pidfile::pid_alive(pid) {
+        eprintln!(
+            "pitboss-web pidfile points at pid {pid} which is no longer alive; cleaning up {}",
+            path.display()
+        );
+        let _ = std::fs::remove_file(&path);
+        return Ok(());
+    }
+
+    pidfile::send_sigterm(pid)
+        .with_context(|| format!("failed to send SIGTERM to pitboss-web pid {pid}"))?;
+    eprintln!("sent SIGTERM to pitboss-web (pid {pid})");
+
+    // Poll for the process to exit. Each iteration is short so we
+    // observe shutdown promptly when it happens; the outer timeout
+    // bounds the total wait.
+    let deadline = std::time::Instant::now() + Duration::from_secs(args.timeout_secs);
+    while std::time::Instant::now() < deadline {
+        if !pidfile::pid_alive(pid) {
+            eprintln!("pitboss-web (pid {pid}) exited");
+            // The serving process should have removed its pidfile in
+            // its shutdown branch; clean up here as a safety net.
+            let _ = std::fs::remove_file(&path);
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    anyhow::bail!(
+        "pitboss-web (pid {pid}) did not exit within {}s; check logs or rerun with --timeout-secs",
+        args.timeout_secs
+    )
+}
+
+/// Block until SIGTERM or SIGINT (Ctrl-C). Used as the
+/// `with_graceful_shutdown` future so axum drains in-flight requests
+/// before returning.
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        let mut term = match signal(SignalKind::terminate()) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to install SIGTERM handler");
+                return;
+            }
+        };
+        let ctrl_c = tokio::signal::ctrl_c();
+        tokio::select! {
+            _ = term.recv() => tracing::info!("SIGTERM received; draining"),
+            _ = ctrl_c => tracing::info!("SIGINT received; draining"),
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+        tracing::info!("Ctrl-C received; draining");
+    }
 }
 
 fn is_loopback(addr: &str) -> bool {

--- a/crates/pitboss-web/src/pidfile.rs
+++ b/crates/pitboss-web/src/pidfile.rs
@@ -1,0 +1,176 @@
+//! PID-file lifecycle for the web server. The `serve` path writes one
+//! at startup; the `stop` subcommand reads it to send SIGTERM. Lives
+//! in `$XDG_RUNTIME_DIR/pitboss/pitboss-web.pid` when that's available
+//! (Linux with logind), otherwise falls back to `dirs::cache_dir()`,
+//! then `/tmp` as a last resort.
+//!
+//! Stale-PID detection: if the file points at a process that's no longer
+//! alive (or was reused by an unrelated PID), we treat the file as
+//! orphaned and overwrite it. This is a best-effort check via `kill(0)`
+//! — race-free against another live `pitboss-web` of the same user is
+//! good enough; we don't need full cgroup-level identity verification.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Resolve the PID-file path. Pure — does not create the parent dir.
+#[must_use]
+pub fn pidfile_path() -> PathBuf {
+    let dir = dirs::runtime_dir()
+        .or_else(dirs::cache_dir)
+        .unwrap_or_else(|| PathBuf::from("/tmp"));
+    dir.join("pitboss").join("pitboss-web.pid")
+}
+
+/// Write the current process's PID to the canonical pidfile path.
+/// Creates parent directories as needed. If a stale PID file is
+/// already present, overwrites it; if a *live* PID is present,
+/// returns `Err(io::ErrorKind::AlreadyExists)` so the caller can
+/// surface a friendly "another instance is running" message instead
+/// of clobbering it.
+pub fn write_self() -> io::Result<PathBuf> {
+    let path = pidfile_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    if let Ok(existing) = read_pid(&path) {
+        if pid_alive(existing) {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                format!(
+                    "pitboss-web already running with pid {existing} (pidfile: {})",
+                    path.display()
+                ),
+            ));
+        }
+    }
+    let pid = std::process::id();
+    fs::write(&path, format!("{pid}\n"))?;
+    Ok(path)
+}
+
+/// Remove the pidfile if it exists and points at us. No-op when the
+/// file is gone. Logs (not errors) on mismatch to avoid spurious
+/// failures during shutdown.
+pub fn remove_if_self() {
+    let path = pidfile_path();
+    let Ok(existing) = read_pid(&path) else {
+        return;
+    };
+    if existing == std::process::id() {
+        let _ = fs::remove_file(&path);
+    } else {
+        tracing::warn!(
+            existing,
+            our_pid = std::process::id(),
+            "pidfile points at another process; leaving it alone"
+        );
+    }
+}
+
+/// Read the PID from a file. Trims surrounding whitespace; returns
+/// `InvalidData` on parse failure.
+pub fn read_pid(path: &Path) -> io::Result<u32> {
+    let s = fs::read_to_string(path)?;
+    s.trim()
+        .parse::<u32>()
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
+}
+
+/// Best-effort liveness check via `kill(pid, 0)`. Returns `false` for
+/// PID 0 (would broadcast to the whole process group), and for any
+/// non-Unix target.
+#[cfg(unix)]
+pub fn pid_alive(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    // SAFETY: kill(pid, 0) is a pure liveness check; no signal is
+    // delivered. The pid is converted to i32; on platforms where
+    // pid_t is wider this is still fine because process IDs fit
+    // comfortably in u32.
+    let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    if rc == 0 {
+        return true;
+    }
+    // EPERM means the process exists but we lack permission to
+    // signal it — still alive from our perspective.
+    let err = io::Error::last_os_error();
+    err.raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(not(unix))]
+pub fn pid_alive(_pid: u32) -> bool {
+    false
+}
+
+/// Send SIGTERM to a PID. Returns `Ok(())` on successful signal,
+/// `Err` with the OS error on failure.
+#[cfg(unix)]
+pub fn send_sigterm(pid: u32) -> io::Result<()> {
+    // SAFETY: kill is safe for any pid; the kernel rejects invalid
+    // ones with ESRCH. We translate the C-style return into a Rust
+    // io::Error.
+    let rc = unsafe { libc::kill(pid as libc::pid_t, libc::SIGTERM) };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(unix))]
+pub fn send_sigterm(_pid: u32) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "pitboss-web stop is only implemented on Unix",
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn read_pid_parses_trailing_newline() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("p");
+        fs::write(&path, "12345\n").unwrap();
+        assert_eq!(read_pid(&path).unwrap(), 12345);
+    }
+
+    #[test]
+    fn read_pid_rejects_garbage() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("p");
+        fs::write(&path, "not-a-pid").unwrap();
+        let err = read_pid(&path).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pid_alive_reports_self() {
+        assert!(pid_alive(std::process::id()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pid_alive_rejects_pid_zero() {
+        assert!(!pid_alive(0));
+    }
+
+    /// PID 1 (init / systemd) almost always exists on a real Linux box.
+    /// We expect EPERM, which the helper translates to "alive" — covers
+    /// the EPERM branch that is otherwise unreachable from a unit test.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn pid_alive_reports_pid_one_via_eperm_branch() {
+        // If the test harness happens to run as root this still passes
+        // (kill(1, 0) returns 0 instead of EPERM); both paths classify
+        // pid 1 as alive.
+        assert!(pid_alive(1));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a \`stop\` subcommand for graceful shutdown of a running \`pitboss-web\` instance. The serve path writes a PID file at \`\$XDG_RUNTIME_DIR/pitboss/pitboss-web.pid\` (falls back to \`dirs::cache_dir()\` then \`/tmp\`); \`stop\` reads it, sends SIGTERM, polls until the process exits.

This was the last item from the cross-#221-#229 console-quality triage.

## CLI shape (backward-compatible)

\`\`\`text
pitboss-web                    # serve (no subcommand, pre-existing CLI)
pitboss-web --port 8080        # serve, existing flags still work
pitboss-web serve --port 8080  # serve, explicit subcommand alias
pitboss-web stop               # SIGTERM + poll
pitboss-web stop --timeout-secs 30
\`\`\`

The \`Cli\` struct uses \`#[command(flatten)]\` over \`ServeArgs\` so all the existing top-level flags (\`--port\` / \`--bind\` / \`--token\` / \`--runs-dir\` / \`--manifests-dir\`) continue to work without the explicit \`serve\` keyword.

## Behaviors landed alongside

- \`axum::serve\` now uses \`with_graceful_shutdown\` to drain in-flight requests on SIGTERM/SIGINT.
- Pidfile written **after** bind succeeds — a failed start can't leave a stale PID pointing at us.
- Stale-PID detection via \`kill(pid, 0)\` — orphan files (process gone but file remained) are auto-cleaned on next start.
- Double-start against a live PID is rejected with \`pitboss-web already running with pid <N>; run \`pitboss-web stop\` first or use a different port\` instead of port-bind racing.
- Pidfile write failure (read-only fs, missing /run dir, container without writable runtime dir) is non-fatal — server still starts, but \`stop\` will report \"no pidfile\" and the operator can use \`pkill\` directly.

## End-to-end smoke

\`\`\`
$ pitboss-web --port 7078 &
pitboss-web listening on http://127.0.0.1:7078/
pidfile: /run/user/1000/pitboss/pitboss-web.pid
no auth (loopback only)

$ pitboss-web --port 7079
Error: pitboss-web already running with pid 237918 (pidfile: /run/user/1000/pitboss/pitboss-web.pid); run \`pitboss-web stop\` first or use a different port

$ pitboss-web stop
sent SIGTERM to pitboss-web (pid 237918)
pitboss-web (pid 237918) exited

$ ls /run/user/1000/pitboss/pitboss-web.pid
ls: cannot access ...: No such file or directory
\`\`\`

## Tests

5 unit tests in \`pidfile::tests\`:
- \`read_pid_parses_trailing_newline\`
- \`read_pid_rejects_garbage\` — invalid utf-8 / non-numeric → \`InvalidData\`
- \`pid_alive_reports_self\` — \`kill(self_pid, 0) == 0\` → alive
- \`pid_alive_rejects_pid_zero\` — never broadcast to process group
- \`pid_alive_reports_pid_one_via_eperm_branch\` (Linux only) — covers the EPERM-classifies-as-alive branch using init/systemd-owned PID 1

## Test plan

- [x] \`cargo test --workspace --features pitboss-core/test-support\` — green
- [x] \`cargo lint\` clean
- [x] \`cargo tidy\` clean
- [x] End-to-end smoke (start, double-start rejection, stop) — see output above
- [ ] After merge: \`cargo install --path crates/pitboss-web\` then run the same smoke against the installed binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)