### PR TITLE
fix(web): poll summary.jsonl + list_workers while run is in-progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Run-detail view now updates task counts, costs, tokens, and worker
+  list while a run is in progress.** Pre-fix, the page fetched
+  `summary.jsonl` once at mount and never re-read it, so the per-task
+  metrics derived from it (count, cost, token totals, durations, failure
+  reasons) froze at whatever happened to be on disk when the operator
+  navigated to the page. The Workers card had a related but separate
+  bug: the dispatcher emits `WorkersSnapshot` only in response to a
+  `list_workers` op, never proactively, and the SPA never sent that op
+  — so the panel sat at "Waiting for first snapshot…" for the entire
+  run.
+
+  **Fix:** added a 3 s polling effect on the run-detail page that
+  re-fetches `summary.jsonl` and POSTs `list_workers` while the run is
+  in-progress. Also fires `list_workers` once on initial SSE connect
+  so the first paint has worker tiles instead of a placeholder. Tears
+  down as soon as `inProgress` flips false (run finalized — page swaps
+  to the static `summary.json` view), so completed runs don't burn
+  cycles.
+
 ### Added
 
 - **`pitboss-web stop` subcommand** for graceful shutdown of the web

--- a/crates/pitboss-web/spa/src/routes/runs/[id]/+page.svelte
+++ b/crates/pitboss-web/spa/src/routes/runs/[id]/+page.svelte
@@ -269,7 +269,15 @@
     activeApproval = null;
     superseded = false;
     const teardown = subscribeRunEvents(runId, {
-      onOpen: () => (sseStatus = 'open'),
+      onOpen: () => {
+        sseStatus = 'open';
+        // The dispatcher emits WorkersSnapshot only in response to
+        // ListWorkers, not proactively. Without this the Workers card
+        // sits at "Waiting for first snapshot…" for the whole run.
+        // Same for store_activity — fire once on connect so the panel
+        // has something before the first heartbeat.
+        void postControlOp(runId, { op: 'list_workers' }).catch(() => {});
+      },
       onError: () => (sseStatus = 'error'),
       onEvent: (envelope) => {
         ingest(envelope);
@@ -286,6 +294,39 @@
       teardown();
       sseStatus = 'closed';
     };
+  });
+
+  // ---- In-progress polling ---------------------------------------------
+  // Two pieces of UI state that DON'T derive from the SSE event stream:
+  //
+  //   1. summary.jsonl on disk — the per-task TaskRecord append log. Task
+  //      counts, costs, tokens, exit codes, durations all read from here.
+  //      The dispatcher appends as each actor finishes; without polling
+  //      the page only ever sees what was on disk at mount time.
+  //
+  //   2. WorkersSnapshot — emitted on demand in response to a list_workers
+  //      op, never proactively. New workers added/removed mid-run aren't
+  //      visible until we ask.
+  //
+  // Poll every 3 s while the run is in-progress. 3 s is a tradeoff: fast
+  // enough that the operator sees workers appearing within a refresh
+  // tick, slow enough that a tab left open all day doesn't burn cycles.
+  // The interval clears as soon as inProgress flips false (run finalized
+  // and the page swaps over to the static summary.json view).
+  const POLL_INTERVAL_MS = 3000;
+  $effect(() => {
+    if (!runId || !inProgress) return;
+    const tick = async () => {
+      try {
+        summaryJsonl = await getSummaryJsonl(runId);
+      } catch {
+        /* run may have just finalized — next render uses summary.json */
+      }
+      // Fire-and-forget; the WorkersSnapshot reply lands via SSE.
+      void postControlOp(runId, { op: 'list_workers' }).catch(() => {});
+    };
+    const handle = setInterval(tick, POLL_INTERVAL_MS);
+    return () => clearInterval(handle);
   });
 
   async function sendOp(opPromise: Promise<void>, label: string) {


### PR DESCRIPTION
## Summary

Two stale-state bugs on the run-detail page during in-progress runs, both reproduced live in tonight's depth-2 smoke test.

## Bug 1: \`summary.jsonl\` fetched once at mount

The page-load effect calls \`getSummaryJsonl(runId)\` exactly once. Every metric the page renders for in-progress runs flows through that response:

- \`tasksToRender.length\` (task count card)
- \`totalCost\` (cost card)
- \`totalTokens\` (token card)
- per-row durations / status / failure reasons in the Tasks tab

The dispatcher appends to \`summary.jsonl\` as each actor finishes, but the page never re-reads it — so the totals freeze the moment the operator navigates in.

## Bug 2: \`WorkersSnapshot\` only emitted on demand

\`crates/pitboss-cli/src/control/server.rs:1088\` — the dispatcher emits \`WorkersSnapshot\` only as a reply to \`ControlOp::ListWorkers\`. The SPA's \`subscribeRunEvents\` flow never sends that op, so the Workers card sits at \"Waiting for first snapshot…\" for the entire run.

## Fix

A 3 s polling effect on the run-detail page that, while \`inProgress\` is true:

1. Re-fetches \`summary.jsonl\` (drives all the per-task derived state)
2. POSTs \`{ op: 'list_workers' }\` (the snapshot reply lands via the existing SSE stream and \`ingest()\` updates \`workers\`)

Also fires \`list_workers\` once on initial SSE connect so the first paint has worker tiles instead of a placeholder. Tears down as soon as \`inProgress\` flips false (run finalized, page swaps to the static \`summary.json\` view) — completed runs don't burn cycles.

3 s is a tradeoff: fast enough that workers appear within a refresh tick, slow enough that an idle tab left open all day doesn't hammer the server.

## Test plan

- [x] \`npm run check\` clean
- [x] \`npm run build\` succeeds
- [x] Reinstalled \`pitboss-web\` locally to verify the SPA bundle ships with the fix
- [ ] After merge: dispatch the smoke manifest with the run-detail page open, confirm task count climbs from 0 → 5 over the run, worker tiles appear, cost / token totals update with each finalize

🤖 Generated with [Claude Code](https://claude.com/claude-code)