### PR TITLE
fix(cli): correct parent_task_id + retain terminated subleads in WorkersSnapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **`WorkersSnapshot` now produces correct `parent_task_id` and keeps
+  every actor visible after sub-leads exit.** Two long-standing bugs
+  in `crates/pitboss-cli/src/control/server.rs::collect_layer_workers`
+  that the SPA's #238 patch papered over but the wire format still got
+  wrong (TUI / future consumers saw the same garbage):
+
+  - Every entry from a sub-lead's layer was tagged with
+    `parent_task_id = sublead_id`, *including* the sub-lead's own
+    row that `run_kill_resume_loop` inserts into `layer.workers`.
+    The sub-lead became its own parent on the wire. Fix: pass the
+    layer's `lead_id` and a separate `lead_parent` arg into
+    `collect_layer_workers`; entries whose id matches the layer's
+    own `lead_id` use `lead_parent` (root lead's id for sub-leads,
+    `None` for root), everything else parents to `layer.lead_id`.
+    Side-effect: root-spawned workers now correctly report
+    `parent_task_id = root_lead_id` instead of `None`, matching
+    what `spawn.rs` writes into their `TaskRecord`.
+
+  - `dispatch/sublead.rs::reconcile_terminated_sublead` removed the
+    sub-lead from `state.subleads` and let the `LayerState` drop, so
+    a `ListWorkers` taken late in a run with short-lived sub-trees
+    silently lost both the sub-lead row and every sub-tree worker —
+    the operator was left looking at just the root lead. Fix: new
+    `state.terminated_sublead_layers: RwLock<Vec<Arc<LayerState>>>`
+    that the reconcile path pushes into; `ListWorkers` now iterates
+    `subleads` ∪ `terminated_sublead_layers` (deduped by `lead_id`).
+
+  Pinned by 2 new tests in `control::server::tests`:
+  `list_workers_sublead_self_row_parents_to_root_lead` and
+  `list_workers_includes_terminated_subleads`. The existing
+  `list_workers_aggregates_root_and_sublead_workers` was asserting
+  the broken behavior (`root_entry.parent_task_id.is_none()`);
+  updated to assert `Some("lead")` to match the corrected wire.
+
 - **Run-detail Tokens card and Workers panel now show real data
   (and the broken Cost card is gone).** Three data-flow bugs that all
   surfaced together once the polling fix landed:

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -450,17 +450,31 @@ async fn thaw_if_frozen(layer: &Arc<crate::dispatch::layer::LayerState>, task_id
     }
 }
 
-/// Append every worker in `layer` to `out` as a
-/// `WorkerSnapshotEntry`. Used by `ListWorkers` to aggregate root +
-/// sub-lead workers into a single snapshot. Pre-fix this lived inline
-/// in the handler and only ever ran against `state.root`. (#152 M2)
+/// Append every worker in `layer` to `out` as a `WorkerSnapshotEntry`.
+/// Used by `ListWorkers` to aggregate root + sub-lead workers into a
+/// single snapshot. Pre-fix this lived inline in the handler and only
+/// ever ran against `state.root`. (#152 M2)
+///
+/// `lead_parent` is the parent of the *layer's own lead actor* — the
+/// actor whose `task_id == layer.lead_id`. For the root layer that's
+/// `None` (the root lead has no parent); for a sub-lead's layer that's
+/// `Some(root_lead_id)`. `lead_parent` exists because
+/// `run_kill_resume_loop` inserts the layer's owning actor into
+/// `layer.workers` as a `Running` entry, and pre-fix every entry in a
+/// sub-lead's layer was tagged with `parent_task_id = sublead_id` —
+/// making the sub-lead its own parent on the wire.
+///
+/// Children of the layer's lead (workers spawned via `spawn_worker`)
+/// keep `parent_task_id = layer.lead_id`, which matches what the
+/// dispatcher writes into their `TaskRecord` at finalize.
 async fn collect_layer_workers(
     layer: &Arc<crate::dispatch::layer::LayerState>,
-    parent_task_id: Option<String>,
+    lead_parent: Option<String>,
     out: &mut Vec<crate::control::protocol::WorkerSnapshotEntry>,
 ) {
     let workers = layer.workers.read().await;
     let prompts = layer.worker_prompts.read().await;
+    let layer_lead_id = layer.lead_id.as_str();
     for (id, w) in workers.iter() {
         let (state_str, started_at, session_id) = match w {
             crate::dispatch::state::WorkerState::Pending => ("pending".to_string(), None, None),
@@ -505,12 +519,20 @@ async fn collect_layer_workers(
                 rec.claude_session_id.clone(),
             ),
         };
+        // Distinguish the layer's owning actor (its lead) from children
+        // spawned within the layer. The lead's parent is the layer's
+        // parent (caller-supplied); children's parent is the lead.
+        let entry_parent = if id == layer_lead_id {
+            lead_parent.clone()
+        } else {
+            Some(layer_lead_id.to_string())
+        };
         out.push(crate::control::protocol::WorkerSnapshotEntry {
             task_id: id.clone(),
             state: state_str,
             prompt_preview: prompts.get(id).cloned().unwrap_or_default(),
             started_at,
-            parent_task_id: parent_task_id.clone(),
+            parent_task_id: entry_parent,
             session_id,
         });
     }
@@ -1086,20 +1108,41 @@ async fn dispatch_op(
             }
         }
         ControlOp::ListWorkers => {
-            // #152 M2: aggregate root-layer workers AND each sub-lead's
-            // workers. Pre-fix only emitted root.workers, so a TUI
-            // attached to a hierarchical run with sub-leads saw an
-            // incomplete tree (sub-lead-owned workers were invisible).
+            // Aggregate every layer the run has touched: root + every
+            // currently-registered sub-lead + every sub-lead that has
+            // already terminated. Pre-fix this iterated only
+            // `state.subleads`, but `dispatch/sublead.rs` removes each
+            // sub-lead from that map when it exits — so a snapshot
+            // taken late in a run with short-lived sub-trees lost the
+            // entire sub-tree (sub-lead row + all sub-tree workers)
+            // before the operator could see it.
             //
-            // `parent_task_id` is set to the sub-lead's id for
-            // sub-lead-owned workers (and `None` for root-owned), so the
-            // TUI can render the tree shape correctly. Pre-fix it was
-            // hard-coded to `None` for everything.
+            // `parent_task_id` plumbing (collect_layer_workers's
+            // `lead_parent` arg) lets the layer's owning actor (the
+            // lead) carry the right parent — `None` for the root, the
+            // root lead's id for sub-leads — instead of being tagged
+            // with the same id as its children. Pre-fix the sub-lead
+            // showed itself as its own parent on the wire.
             let mut entries: Vec<crate::control::protocol::WorkerSnapshotEntry> = Vec::new();
             collect_layer_workers(&state.root, None, &mut entries).await;
-            let subleads = state.subleads.read().await;
-            for (sublead_id, layer) in subleads.iter() {
-                collect_layer_workers(layer, Some(sublead_id.clone()), &mut entries).await;
+            let root_lead_id = state.root.lead_id.clone();
+            let live_subleads = state.subleads.read().await;
+            let mut seen_layer_leads: std::collections::HashSet<String> =
+                std::collections::HashSet::new();
+            for (_sublead_id, layer) in live_subleads.iter() {
+                seen_layer_leads.insert(layer.lead_id.clone());
+                collect_layer_workers(layer, Some(root_lead_id.clone()), &mut entries).await;
+            }
+            drop(live_subleads);
+            // Layers held only via `terminated_subleads` survive sub-lead
+            // de-registration. Iterating them here keeps the snapshot
+            // covering every actor that's ever existed in this run.
+            let term_subleads = state.terminated_sublead_layers.read().await;
+            for layer in term_subleads.iter() {
+                if seen_layer_leads.contains(&layer.lead_id) {
+                    continue;
+                }
+                collect_layer_workers(layer, Some(root_lead_id.clone()), &mut entries).await;
             }
             ControlEvent::WorkersSnapshot { workers: entries }
         }
@@ -2168,10 +2211,277 @@ mod tests {
             ControlEvent::WorkersSnapshot { mut workers } => {
                 workers.sort_by(|a, b| a.task_id.cmp(&b.task_id));
                 assert_eq!(workers.len(), 2, "must include root + sub-lead workers");
+                // Root-spawned worker now reports `parent_task_id = "lead"`
+                // (the root lead's id) — matches what spawn.rs writes
+                // into the worker's TaskRecord. Pre-fix it was None,
+                // which is what `collect_layer_workers` had been
+                // hard-coding for every entry in the root layer
+                // regardless of whether the entry was the lead itself
+                // or a child.
                 let root_entry = workers.iter().find(|e| e.task_id == "root-w").unwrap();
-                assert!(root_entry.parent_task_id.is_none());
+                assert_eq!(root_entry.parent_task_id.as_deref(), Some("lead"));
                 let sub_entry = workers.iter().find(|e| e.task_id == "sub-w").unwrap();
                 assert_eq!(sub_entry.parent_task_id.as_deref(), Some("sublead-A"));
+            }
+            other => panic!("expected WorkersSnapshot, got {other:?}"),
+        }
+        drop(handle);
+    }
+
+    /// Regression: a sub-lead's own row in `WorkersSnapshot` must
+    /// carry `parent_task_id = root_lead_id`, not `parent_task_id =
+    /// sublead_id`. Pre-fix, `collect_layer_workers` tagged every
+    /// entry from a sub-lead's layer with the same id, so the
+    /// sub-lead became its own parent on the wire and the SPA tile
+    /// grid nested it under itself.
+    #[tokio::test]
+    async fn list_workers_sublead_self_row_parents_to_root_lead() {
+        let dir = TempDir::new().unwrap();
+        let run_id = Uuid::now_v7();
+        let state = mk_state(dir.path(), run_id);
+
+        let sub_manifest = ResolvedManifest {
+            manifest_schema_version: 0,
+            name: None,
+            max_parallel_tasks: 4,
+            halt_on_failure: false,
+            run_dir: dir.path().to_path_buf(),
+            worktree_cleanup: WorktreeCleanup::Never,
+            emit_event_stream: false,
+            tasks: vec![],
+            lead: None,
+            max_workers: Some(4),
+            budget_usd: Some(50.0),
+            lead_timeout_secs: None,
+            default_approval_policy: None,
+            notifications: vec![],
+            dump_shared_store: false,
+            require_plan_approval: false,
+            approval_rules: vec![],
+            container: None,
+            mcp_servers: vec![],
+            lifecycle: None,
+        };
+        let sub_layer = std::sync::Arc::new(LayerState::new(
+            run_id,
+            sub_manifest,
+            state.root.store.clone(),
+            CancelToken::new(),
+            "sublead-S".into(),
+            state.root.spawner.clone(),
+            PathBuf::from("/bin/true"),
+            state.root.wt_mgr.clone(),
+            CleanupPolicy::Never,
+            dir.path().join(run_id.to_string()),
+            ApprovalPolicy::Block,
+            None,
+            std::sync::Arc::new(crate::shared_store::SharedStore::new()),
+            None,
+        ));
+        // The sub-lead inserts itself into its own layer.workers via
+        // run_kill_resume_loop in production. Mirror that here.
+        sub_layer.workers.write().await.insert(
+            "sublead-S".into(),
+            crate::dispatch::state::WorkerState::Running {
+                started_at: chrono::Utc::now(),
+                session_id: Some("sub-sess".into()),
+            },
+        );
+        sub_layer.workers.write().await.insert(
+            "sub-tree-w".into(),
+            crate::dispatch::state::WorkerState::Running {
+                started_at: chrono::Utc::now(),
+                session_id: None,
+            },
+        );
+        state
+            .subleads
+            .write()
+            .await
+            .insert("sublead-S".into(), sub_layer);
+
+        let sock = dir.path().join("list-sublead-self.sock");
+        let handle = start_control_server(
+            sock.clone(),
+            "0.4.0".into(),
+            run_id.to_string(),
+            "hierarchical".into(),
+            state.clone(),
+        )
+        .await
+        .unwrap();
+        let mut stream = tokio::net::UnixStream::connect(&sock).await.unwrap();
+        stream
+            .write_all(b"{\"op\":\"hello\",\"client_version\":\"0.4.0\"}\n")
+            .await
+            .unwrap();
+        stream
+            .write_all(b"{\"op\":\"list_workers\"}\n")
+            .await
+            .unwrap();
+        let (r, _w) = stream.split();
+        let mut lines = BufReader::new(r).lines();
+        let _hello = lines.next_line().await.unwrap();
+        let reply_line = lines.next_line().await.unwrap().unwrap();
+        let reply: ControlEvent = serde_json::from_str(&reply_line).unwrap();
+        match reply {
+            ControlEvent::WorkersSnapshot { workers } => {
+                let sublead_row = workers
+                    .iter()
+                    .find(|e| e.task_id == "sublead-S")
+                    .expect("sublead row missing");
+                assert_eq!(
+                    sublead_row.parent_task_id.as_deref(),
+                    Some("lead"),
+                    "sublead's own row must parent to root lead, not itself"
+                );
+                let worker_row = workers
+                    .iter()
+                    .find(|e| e.task_id == "sub-tree-w")
+                    .expect("sub-tree worker row missing");
+                assert_eq!(
+                    worker_row.parent_task_id.as_deref(),
+                    Some("sublead-S"),
+                    "sub-tree worker still parents to its sublead"
+                );
+            }
+            other => panic!("expected WorkersSnapshot, got {other:?}"),
+        }
+        drop(handle);
+    }
+
+    /// Regression: a sub-tree's actors must remain visible in
+    /// `WorkersSnapshot` after the sub-lead has terminated and been
+    /// moved out of `state.subleads`. Pre-fix the layer was dropped
+    /// at `subleads.remove`, so a snapshot taken late in a run with
+    /// short-lived sub-trees lost both the sub-lead row and every
+    /// sub-tree worker — the operator was left looking at just the
+    /// root lead.
+    #[tokio::test]
+    async fn list_workers_includes_terminated_subleads() {
+        let dir = TempDir::new().unwrap();
+        let run_id = Uuid::now_v7();
+        let state = mk_state(dir.path(), run_id);
+
+        let sub_manifest = ResolvedManifest {
+            manifest_schema_version: 0,
+            name: None,
+            max_parallel_tasks: 4,
+            halt_on_failure: false,
+            run_dir: dir.path().to_path_buf(),
+            worktree_cleanup: WorktreeCleanup::Never,
+            emit_event_stream: false,
+            tasks: vec![],
+            lead: None,
+            max_workers: Some(4),
+            budget_usd: Some(50.0),
+            lead_timeout_secs: None,
+            default_approval_policy: None,
+            notifications: vec![],
+            dump_shared_store: false,
+            require_plan_approval: false,
+            approval_rules: vec![],
+            container: None,
+            mcp_servers: vec![],
+            lifecycle: None,
+        };
+        let sub_layer = std::sync::Arc::new(LayerState::new(
+            run_id,
+            sub_manifest,
+            state.root.store.clone(),
+            CancelToken::new(),
+            "sublead-T".into(),
+            state.root.spawner.clone(),
+            PathBuf::from("/bin/true"),
+            state.root.wt_mgr.clone(),
+            CleanupPolicy::Never,
+            dir.path().join(run_id.to_string()),
+            ApprovalPolicy::Block,
+            None,
+            std::sync::Arc::new(crate::shared_store::SharedStore::new()),
+            None,
+        ));
+        // Pretend this sub-tree already finished: a Done worker entry
+        // and a Running sublead-self entry. NOTE we put the layer
+        // directly into `terminated_sublead_layers` (skipping the live
+        // `subleads` map) to model post-`reconcile_terminated_sublead`
+        // state.
+        sub_layer.workers.write().await.insert(
+            "sublead-T".into(),
+            crate::dispatch::state::WorkerState::Running {
+                started_at: chrono::Utc::now(),
+                session_id: Some("sub-sess".into()),
+            },
+        );
+        sub_layer.workers.write().await.insert(
+            "sub-w".into(),
+            crate::dispatch::state::WorkerState::Done(pitboss_core::store::TaskRecord {
+                task_id: "sub-w".into(),
+                status: pitboss_core::store::TaskStatus::Success,
+                exit_code: Some(0),
+                started_at: chrono::Utc::now(),
+                ended_at: chrono::Utc::now(),
+                duration_ms: 1234,
+                worktree_path: None,
+                log_path: PathBuf::from("/dev/null"),
+                token_usage: Default::default(),
+                claude_session_id: None,
+                final_message_preview: None,
+                final_message: None,
+                parent_task_id: Some("sublead-T".into()),
+                pause_count: 0,
+                reprompt_count: 0,
+                approvals_requested: 0,
+                approvals_approved: 0,
+                approvals_rejected: 0,
+                model: None,
+                failure_reason: None,
+            }),
+        );
+        state
+            .terminated_sublead_layers
+            .write()
+            .await
+            .push(sub_layer);
+
+        let sock = dir.path().join("list-terminated.sock");
+        let handle = start_control_server(
+            sock.clone(),
+            "0.4.0".into(),
+            run_id.to_string(),
+            "hierarchical".into(),
+            state.clone(),
+        )
+        .await
+        .unwrap();
+        let mut stream = tokio::net::UnixStream::connect(&sock).await.unwrap();
+        stream
+            .write_all(b"{\"op\":\"hello\",\"client_version\":\"0.4.0\"}\n")
+            .await
+            .unwrap();
+        stream
+            .write_all(b"{\"op\":\"list_workers\"}\n")
+            .await
+            .unwrap();
+        let (r, _w) = stream.split();
+        let mut lines = BufReader::new(r).lines();
+        let _hello = lines.next_line().await.unwrap();
+        let reply_line = lines.next_line().await.unwrap().unwrap();
+        let reply: ControlEvent = serde_json::from_str(&reply_line).unwrap();
+        match reply {
+            ControlEvent::WorkersSnapshot { workers } => {
+                let ids: Vec<&str> = workers.iter().map(|e| e.task_id.as_str()).collect();
+                assert!(
+                    ids.contains(&"sublead-T"),
+                    "terminated sublead must still appear: {ids:?}"
+                );
+                assert!(
+                    ids.contains(&"sub-w"),
+                    "sub-tree worker of terminated sublead must still appear: {ids:?}"
+                );
+                let sub_w = workers.iter().find(|e| e.task_id == "sub-w").unwrap();
+                assert_eq!(sub_w.state, "done_success");
+                assert_eq!(sub_w.parent_task_id.as_deref(), Some("sublead-T"));
             }
             other => panic!("expected WorkersSnapshot, got {other:?}"),
         }

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -324,6 +324,14 @@ pub struct DispatchState {
     /// sublead_id. Populated by `reconcile_terminated_sublead`; consulted by
     /// `wait_for_actor_internal` to satisfy `wait_actor(sublead_id)` calls.
     pub sublead_results: RwLock<HashMap<String, SubleadTerminalRecord>>,
+    /// Layer handles for sub-leads that have terminated (and therefore
+    /// been removed from `subleads`). Kept alive for the duration of the
+    /// run so `ListWorkers` can still surface the sub-tree's actors —
+    /// otherwise a TUI/console attached late in a run with short-lived
+    /// sub-trees sees only the actors that happened to still be active
+    /// at the moment of the snapshot, with no way to inspect what came
+    /// before.
+    pub terminated_sublead_layers: RwLock<Vec<Arc<LayerState>>>,
     /// Worker-id → layer-id index for O(1) KV routing.
     ///
     /// - Root-layer workers map to `None`.
@@ -415,6 +423,7 @@ impl DispatchState {
             root,
             subleads: RwLock::new(HashMap::new()),
             sublead_results: RwLock::new(HashMap::new()),
+            terminated_sublead_layers: RwLock::new(Vec::new()),
             worker_layer_index: RwLock::new(HashMap::new()),
             run_leases: Arc::new(RunLeaseRegistry::new()),
             last_approval_response: RwLock::new(HashMap::new()),

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -886,6 +886,17 @@ pub async fn reconcile_terminated_sublead(
         // Already reconciled or never existed.
         return Ok(());
     };
+    // Keep the layer reachable for the rest of the run so `ListWorkers`
+    // can still surface the sub-tree's actors after the sub-lead exits.
+    // Pre-fix the layer was dropped here as soon as `subleads.remove`
+    // returned and the binding fell out of scope, so a TUI/console
+    // querying mid-run after the sub-tree finished saw an incomplete
+    // worker tree.
+    state
+        .terminated_sublead_layers
+        .write()
+        .await
+        .push(sub_layer.clone());
 
     let actual_spend = *sub_layer.spent_usd.lock().await;
     let original_reservation_usd = sub_layer.original_reservation_usd.unwrap_or(0.0);


### PR DESCRIPTION
## Summary

Two long-standing bugs in \`crates/pitboss-cli/src/control/server.rs::collect_layer_workers\` that #238 patched around in the SPA layer, but the wire format itself was still emitting garbage — the TUI and any future consumer would see the same thing.

This is the dispatcher-side cleanup I noted as a follow-up in #238.

## Bug 1: sublead is its own parent on the wire

\`collect_layer_workers\` tagged every entry from a sub-lead's layer with \`parent_task_id = sublead_id\`, including the sub-lead's *own* row that \`run_kill_resume_loop\` inserts into \`layer.workers\`. The sub-lead became its own parent.

Mid-run probe (pre-fix):

\`\`\`
{"workers":[
  {"task_id":"smoke-lead","state":"running"},
  {"task_id":"sublead-019dd7f0-...","parent_task_id":"sublead-019dd7f0-..."},  ← self
  {"task_id":"sublead-019dd7f0-...","parent_task_id":"sublead-019dd7f0-..."}
]}
\`\`\`

## Bug 2: sub-tree vanishes when sub-lead exits

\`dispatch/sublead.rs::reconcile_terminated_sublead\` removed the sub-lead from \`state.subleads\` and let the \`LayerState\` drop. A \`ListWorkers\` taken late in a run with short-lived sub-trees lost both the sub-lead row and every sub-tree worker — the operator was left looking at just the root lead.

Mid-run probe at t=45s after subleads exited (pre-fix):

\`\`\`
{"workers":[{"task_id":"smoke-lead","state":"running"}]}     ← lone lead
\`\`\`

## Fix

**collect_layer_workers** takes a new \`lead_parent: Option<String>\` arg in addition to the layer. Entries whose id matches \`layer.lead_id\` use \`lead_parent\` (root lead's id for sub-leads, \`None\` for the root); everything else parents to \`layer.lead_id\`. Side-effect cleanup: root-spawned workers now correctly report \`parent_task_id = root_lead_id\` instead of \`None\` — matches what \`spawn.rs\` writes into their \`TaskRecord\`.

**state.terminated_sublead_layers** — new \`RwLock<Vec<Arc<LayerState>>>\` that \`reconcile_terminated_sublead\` pushes into right after \`subleads.remove\`. \`ListWorkers\` now iterates \`subleads\` ∪ \`terminated_sublead_layers\` (deduped by \`layer.lead_id\` so a layer that's somehow in both maps doesn't double-emit).

## Tests

Two new tests in \`control::server::tests\`:

- \`list_workers_sublead_self_row_parents_to_root_lead\` — pins the sublead-is-its-own-parent fix.
- \`list_workers_includes_terminated_subleads\` — pins the layer-retention fix; constructs a layer, drops it into \`terminated_sublead_layers\` directly to model post-reconcile state, asserts both the sub-lead row and the Done sub-tree worker are still in the snapshot.

The existing \`list_workers_aggregates_root_and_sublead_workers\` was asserting the broken behavior (\`root_entry.parent_task_id.is_none()\`). Updated to \`Some(\"lead\")\` to match the corrected wire.

## Test plan

- [x] \`cargo test --workspace --features pitboss-core/test-support\` — 567+ green
- [x] \`cargo lint\` clean
- [x] \`cargo tidy\` clean
- [ ] After merge: rebuild local CLI + web, run smoke with the run-detail page open, confirm the workers panel shows correct hierarchy (smoke-lead → subleads → workers) throughout the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)