### PR TITLE
feat(core): persist per-task cost_usd on TaskRecord at finalize time

### DIFF
--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -2436,6 +2436,7 @@ mod tests {
                 approvals_rejected: 0,
                 model: None,
                 failure_reason: None,
+                cost_usd: None,
             }),
         );
         state

--- a/crates/pitboss-cli/src/diff.rs
+++ b/crates/pitboss-cli/src/diff.rs
@@ -537,6 +537,7 @@ mod tests {
             approvals_rejected: 0,
             model: None,
             failure_reason: None,
+            cost_usd: None,
         }
     }
 

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -389,6 +389,7 @@ pub async fn run_hierarchical(
             lead_status = pitboss_core::store::TaskStatus::ApprovalRejected;
         }
     }
+    let lead_cost_usd = pitboss_core::prices::cost_usd(&lead.model, &total_token_usage);
     let lead_record = pitboss_core::store::TaskRecord {
         task_id: lead.id.clone(),
         status: lead_status,
@@ -431,6 +432,7 @@ pub async fn run_hierarchical(
                 r
             }
         }),
+        cost_usd: lead_cost_usd,
     };
 
     // Cleanup worktree per policy. Surface the result via tracing
@@ -584,8 +586,10 @@ pub async fn run_hierarchical(
     // would still see the worker as Running).
     let now = Utc::now();
     let mut cancelled_records: Vec<pitboss_core::store::TaskRecord> = Vec::new();
-    let make_cancelled =
-        |id: &str, parent_id: &str, model: Option<String>| pitboss_core::store::TaskRecord {
+    let make_cancelled = |id: &str, parent_id: &str, model: Option<String>| {
+        let token_usage = pitboss_core::parser::TokenUsage::default();
+        let cost_usd = pitboss_core::prices::cost_usd(model.as_deref().unwrap_or(""), &token_usage);
+        pitboss_core::store::TaskRecord {
             task_id: id.to_string(),
             status: pitboss_core::store::TaskStatus::Cancelled,
             exit_code: None,
@@ -594,7 +598,7 @@ pub async fn run_hierarchical(
             duration_ms: 0,
             worktree_path: None,
             log_path: run_subdir.join("tasks").join(id).join("stdout.log"),
-            token_usage: Default::default(),
+            token_usage,
             claude_session_id: None,
             final_message_preview: Some("cancelled when lead exited".into()),
             final_message: None,
@@ -606,7 +610,9 @@ pub async fn run_hierarchical(
             approvals_rejected: 0,
             model,
             failure_reason: None,
-        };
+            cost_usd,
+        }
+    };
     {
         let workers = state.root.workers.read().await;
         let worker_models = state.root.worker_models.read().await;
@@ -1215,6 +1221,7 @@ mod await_drained_tests {
                     approvals_rejected: 0,
                     model: None,
                     failure_reason: None,
+                    cost_usd: None,
                 }),
             );
             workers.insert("running-root".into(), WorkerState::Pending);
@@ -1267,6 +1274,7 @@ mod summary_jsonl_aggregation_tests {
             approvals_rejected: 0,
             model: None,
             failure_reason: None,
+            cost_usd: None,
         }
     }
 

--- a/crates/pitboss-cli/src/dispatch/resume.rs
+++ b/crates/pitboss-cli/src/dispatch/resume.rs
@@ -369,6 +369,7 @@ mod tests {
                 approvals_rejected: 0,
                 model: None,
                 failure_reason: None,
+                cost_usd: None,
             })
             .collect();
 
@@ -638,6 +639,7 @@ mod tests {
             approvals_rejected: 0,
             model: None,
             failure_reason: None,
+            cost_usd: None,
         };
         let summary = RunSummary {
             run_id: Uuid::now_v7(),
@@ -752,6 +754,7 @@ mod tests {
             approvals_rejected: 0,
             model: None,
             failure_reason: None,
+            cost_usd: None,
         };
         let summary = RunSummary {
             run_id: Uuid::now_v7(),
@@ -862,6 +865,7 @@ mod tests {
             approvals_rejected: 0,
             model: None,
             failure_reason: None,
+            cost_usd: None,
         };
         let summary = RunSummary {
             run_id: Uuid::now_v7(),

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -615,6 +615,8 @@ async fn execute_task(
                 p
             }
             Err(e) => {
+                let token_usage = pitboss_core::parser::TokenUsage::default();
+                let cost_usd = pitboss_core::prices::cost_usd(&task.model, &token_usage);
                 return TaskRecord {
                     task_id: task.id.clone(),
                     status: TaskStatus::SpawnFailed,
@@ -624,7 +626,7 @@ async fn execute_task(
                     duration_ms: 0,
                     worktree_path: None,
                     log_path,
-                    token_usage: Default::default(),
+                    token_usage,
                     claude_session_id: None,
                     final_message_preview: Some(format!("worktree error: {e}")),
                     final_message: None,
@@ -636,6 +638,7 @@ async fn execute_task(
                     approvals_rejected: 0,
                     model: Some(task.model.clone()),
                     failure_reason: None,
+                    cost_usd,
                 };
             }
         }
@@ -691,6 +694,7 @@ async fn execute_task(
             r
         }
     });
+    let cost_usd = pitboss_core::prices::cost_usd(&task.model, &outcome.token_usage);
     TaskRecord {
         task_id: task.id.clone(),
         status,
@@ -712,6 +716,7 @@ async fn execute_task(
         approvals_rejected: 0,
         model: Some(task.model.clone()),
         failure_reason,
+        cost_usd,
     }
 }
 

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -744,6 +744,7 @@ async fn spawn_sublead_session(
 
         // 9. Build and persist a TaskRecord for the sub-lead's compound session.
         //    Uses total_token_usage across all subprocess iterations.
+        let cost_usd = pitboss_core::prices::cost_usd(&model_bg, &total_token_usage);
         let rec = pitboss_core::store::TaskRecord {
             task_id: sublead_id_bg.clone(),
             status,
@@ -778,6 +779,7 @@ async fn spawn_sublead_session(
                     r
                 }
             }),
+            cost_usd,
         };
         if let Err(e) = sub_layer_bg
             .store

--- a/crates/pitboss-cli/src/mcp/tools/spawn.rs
+++ b/crates/pitboss-cli/src/mcp/tools/spawn.rs
@@ -373,6 +373,8 @@ async fn run_worker(
                 release_reservation_for_layer(&layer, &task_id).await;
                 // Record a SpawnFailed TaskRecord and broadcast done.
                 let now = Utc::now();
+                let token_usage = pitboss_core::parser::TokenUsage::default();
+                let cost_usd = pitboss_core::prices::cost_usd(&model, &token_usage);
                 let rec = TaskRecord {
                     task_id: task_id.clone(),
                     status: TaskStatus::SpawnFailed,
@@ -382,7 +384,7 @@ async fn run_worker(
                     duration_ms: 0,
                     worktree_path: None,
                     log_path: log_path.clone(),
-                    token_usage: Default::default(),
+                    token_usage,
                     claude_session_id: None,
                     final_message_preview: Some(format!("worktree error: {e}")),
                     final_message: None,
@@ -394,6 +396,7 @@ async fn run_worker(
                     approvals_rejected: 0,
                     model: Some(model.clone()),
                     failure_reason: None,
+                    cost_usd,
                 };
                 let _ = layer.store.append_record(layer.run_id, &rec).await;
                 layer
@@ -605,6 +608,7 @@ async fn run_worker(
         Some(&log_path),
         Some(&stderr_path),
     );
+    let cost_usd = pitboss_core::prices::cost_usd(&model, &outcome.token_usage);
     let rec = TaskRecord {
         task_id: task_id.clone(),
         status,
@@ -626,6 +630,7 @@ async fn run_worker(
         approvals_rejected: counters.approvals_rejected,
         model: Some(model.clone()),
         failure_reason,
+        cost_usd,
     };
 
     // Persist record.
@@ -999,6 +1004,7 @@ pub async fn spawn_resume_worker(
             .get(&task_id_bg)
             .cloned()
             .unwrap_or_default();
+        let cost_usd = pitboss_core::prices::cost_usd(&resume_model, &outcome.token_usage);
         let rec = TaskRecord {
             task_id: task_id_bg.clone(),
             status,
@@ -1024,6 +1030,7 @@ pub async fn spawn_resume_worker(
                 Some(&log_path),
                 Some(&stderr_path),
             ),
+            cost_usd,
         };
         let _ = layer_bg.store.append_record(layer_bg.run_id, &rec).await;
         if let Some(reason) = rec.failure_reason.clone() {

--- a/crates/pitboss-cli/src/mcp/tools/tests.rs
+++ b/crates/pitboss-cli/src/mcp/tools/tests.rs
@@ -421,6 +421,7 @@ async fn wait_for_worker_returns_outcome_on_completion() {
             approvals_rejected: 0,
             model: None,
             failure_reason: None,
+            cost_usd: None,
         };
         let mut w = state_clone.root.workers.write().await;
         w.insert(task_id_clone.clone(), WorkerState::Done(rec));
@@ -495,6 +496,7 @@ async fn wait_for_any_returns_first_completed() {
             approvals_rejected: 0,
             model: None,
             failure_reason: None,
+            cost_usd: None,
         };
         let mut w = state_clone.root.workers.write().await;
         w.insert("w-b".into(), WorkerState::Done(rec));
@@ -1111,6 +1113,7 @@ async fn handle_reprompt_worker_from_done_errors() {
         approvals_rejected: 0,
         model: None,
         failure_reason: None,
+        cost_usd: None,
     };
     state
         .root

--- a/crates/pitboss-cli/src/status.rs
+++ b/crates/pitboss-cli/src/status.rs
@@ -175,6 +175,7 @@ mod tests {
             approvals_rejected: 0,
             model: None,
             failure_reason: None,
+            cost_usd: None,
         }
     }
 

--- a/crates/pitboss-cli/src/tui_table.rs
+++ b/crates/pitboss-cli/src/tui_table.rs
@@ -176,6 +176,7 @@ mod tests {
             approvals_rejected: 0,
             model: None,
             failure_reason: None,
+            cost_usd: None,
         }
     }
 

--- a/crates/pitboss-cli/tests/hierarchical_flows.rs
+++ b/crates/pitboss-cli/tests/hierarchical_flows.rs
@@ -286,6 +286,7 @@ async fn wait_actor_alias_resolves_worker_id() {
             approvals_rejected: 0,
             model: None,
             failure_reason: None,
+            cost_usd: None,
         };
         let mut w = state_clone.root.workers.write().await;
         w.insert(worker_id_clone.clone(), WorkerState::Done(rec));

--- a/crates/pitboss-cli/tests/sublead_flows.rs
+++ b/crates/pitboss-cli/tests/sublead_flows.rs
@@ -1267,6 +1267,7 @@ async fn wait_actor_still_handles_worker_back_compat() {
             approvals_rejected: 0,
             model: None,
             failure_reason: None,
+            cost_usd: None,
         };
         let mut w = state_clone.root.workers.write().await;
         w.insert(worker_id_clone.clone(), WorkerState::Done(rec));
@@ -1615,6 +1616,7 @@ async fn kill_with_reason_skips_delivery_when_lead_already_terminated() {
             approvals_rejected: 0,
             model: Some("claude-haiku-4-5".into()),
             failure_reason: None,
+            cost_usd: None,
         };
         sub.workers.write().await.insert(
             s1.clone(),

--- a/crates/pitboss-core/src/store/mod.rs
+++ b/crates/pitboss-core/src/store/mod.rs
@@ -55,6 +55,7 @@ mod integration_tests {
             approvals_rejected: 0,
             model: None,
             failure_reason: None,
+            cost_usd: None,
         }
     }
 

--- a/crates/pitboss-core/src/store/record.rs
+++ b/crates/pitboss-core/src/store/record.rs
@@ -100,6 +100,13 @@ pub struct TaskRecord {
     /// successful tasks, cancelled tasks, and pre-v0.7.1 records.
     #[serde(default)]
     pub failure_reason: Option<FailureReason>,
+    /// Estimated USD cost computed from `token_usage` + `model` at finalize
+    /// time via `pitboss_core::prices::cost_usd`. `None` for tasks whose
+    /// model isn't in the price table (renderer shows "—") and for pre-v0.11
+    /// records. Set once and never updated; pricing changes don't
+    /// retroactively rewrite historical records.
+    #[serde(default)]
+    pub cost_usd: Option<f64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -166,11 +173,13 @@ mod tests {
             approvals_rejected: 0,
             model: None,
             failure_reason: None,
+            cost_usd: Some(0.0234),
         };
         let json = serde_json::to_string(&rec).unwrap();
         let back: TaskRecord = serde_json::from_str(&json).unwrap();
         assert_eq!(back.task_id, "t1");
         assert!(matches!(back.status, TaskStatus::Success));
+        assert_eq!(back.cost_usd, Some(0.0234));
     }
 
     #[test]
@@ -196,6 +205,7 @@ mod tests {
             approvals_rejected: 0,
             model: None,
             failure_reason: None,
+            cost_usd: None,
         };
         let json = serde_json::to_string(&rec).unwrap();
         assert!(json.contains("parent_task_id"));
@@ -258,6 +268,7 @@ mod tests {
             approvals_rejected: 0,
             model: Some("claude-opus-4-7".into()),
             failure_reason: None,
+            cost_usd: None,
         };
         let json = serde_json::to_string(&rec).unwrap();
         assert!(json.contains("claude-opus-4-7"));
@@ -283,6 +294,26 @@ mod tests {
         }"#;
         let rec: TaskRecord = serde_json::from_str(old_json).unwrap();
         assert!(rec.model.is_none());
+    }
+
+    #[test]
+    fn task_record_missing_cost_usd_deserializes_as_none() {
+        // Pre-v0.11 records didn't have a `cost_usd` field; must still parse.
+        let old_json = r#"{
+            "task_id": "t1",
+            "status": "Success",
+            "exit_code": 0,
+            "started_at": "2026-04-17T00:00:00Z",
+            "ended_at":   "2026-04-17T00:00:30Z",
+            "duration_ms": 30000,
+            "worktree_path": null,
+            "log_path": "/dev/null",
+            "token_usage": {"input":0,"output":0,"cache_read":0,"cache_creation":0},
+            "claude_session_id": null,
+            "final_message_preview": null
+        }"#;
+        let rec: TaskRecord = serde_json::from_str(old_json).unwrap();
+        assert!(rec.cost_usd.is_none());
     }
 
     #[test]
@@ -355,6 +386,7 @@ mod tests {
             approvals_rejected: 0,
             model: None,
             failure_reason: None,
+            cost_usd: None,
         };
         let s = serde_json::to_string(&rec).unwrap();
         let back: TaskRecord = serde_json::from_str(&s).unwrap();
@@ -430,6 +462,7 @@ mod tests {
             approvals_rejected: 1,
             model: None,
             failure_reason: None,
+            cost_usd: None,
         };
         let s = serde_json::to_string(&rec).unwrap();
         let back: TaskRecord = serde_json::from_str(&s).unwrap();

--- a/crates/pitboss-core/src/store/sqlite.rs
+++ b/crates/pitboss-core/src/store/sqlite.rs
@@ -155,6 +155,11 @@ const MIGRATIONS: &[Migration] = &[
         name: "runs_env_json",
         apply: migrate_runs_env,
     },
+    Migration {
+        version: 9,
+        name: "cost_usd",
+        apply: migrate_cost_usd,
+    },
 ];
 
 /// Apply every entry in [`MIGRATIONS`] whose version is not yet
@@ -295,6 +300,14 @@ fn migrate_final_message(conn: &rusqlite::Connection) -> Result<(), StoreError> 
         .map_err(|e| StoreError::Incomplete(format!("migrate final_message alter: {e}")))?;
     }
     Ok(())
+}
+
+/// Idempotent migration: add the v0.11 `cost_usd` column (estimated USD cost
+/// computed from `model + token_usage` at finalize time). Stored as `REAL
+/// NULL` so older records and tasks whose model isn't in the price table
+/// keep `NULL` and consumers render "—".
+fn migrate_cost_usd(conn: &rusqlite::Connection) -> Result<(), StoreError> {
+    add_column_if_missing(conn, "task_records", "cost_usd", "REAL NULL")
 }
 
 /// Idempotent migration: add v0.4 counter columns to `task_records` if missing.
@@ -512,6 +525,7 @@ fn init_schema(conn: &rusqlite::Connection) -> Result<(), StoreError> {
             model                 TEXT NULL,
             failure_reason        TEXT NULL,
             final_message         TEXT NULL,
+            cost_usd              REAL NULL,
             PRIMARY KEY (run_id, task_id)
         );
         ",
@@ -617,6 +631,7 @@ struct TaskRow {
     model: Option<String>,
     failure_reason: Option<String>,
     final_message: Option<String>,
+    cost_usd: Option<f64>,
 }
 
 impl TaskRow {
@@ -645,6 +660,7 @@ impl TaskRow {
             model: row.get("model").unwrap_or(None),
             failure_reason: row.get("failure_reason").unwrap_or(None),
             final_message: row.get("final_message").unwrap_or(None),
+            cost_usd: row.get("cost_usd").unwrap_or(None),
         })
     }
 
@@ -682,6 +698,7 @@ impl TaskRow {
                 .failure_reason
                 .as_deref()
                 .and_then(|s| serde_json::from_str(s).ok()),
+            cost_usd: self.cost_usd,
         })
     }
 }
@@ -720,7 +737,7 @@ fn fetch_task_records(
                   claude_session_id, final_message_preview, parent_task_id, \
                   pause_count, reprompt_count, approvals_requested, \
                   approvals_approved, approvals_rejected, model, failure_reason, \
-                  final_message \
+                  final_message, cost_usd \
              FROM task_records WHERE run_id = ?1 ORDER BY rowid",
         )
         .map_err(|e| StoreError::Incomplete(format!("task query prepare: {e}")))?;
@@ -864,9 +881,9 @@ impl SessionStore for SqliteStore {
                       claude_session_id, final_message_preview, parent_task_id, \
                       pause_count, reprompt_count, approvals_requested, \
                       approvals_approved, approvals_rejected, model, failure_reason, \
-                      final_message) \
+                      final_message, cost_usd) \
                      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, \
-                             ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24)",
+                             ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25)",
                     rusqlite::params![
                         run_id_str,
                         record.task_id,
@@ -898,6 +915,7 @@ impl SessionStore for SqliteStore {
                             .as_ref()
                             .and_then(|fr| serde_json::to_string(fr).ok()),
                         record.final_message,
+                        record.cost_usd,
                     ],
                 )
                 .map_err(|e| StoreError::Incomplete(format!("append_record insert: {e}")))?;
@@ -1081,6 +1099,7 @@ mod sqlite_tests {
             approvals_rejected: 0,
             model: None,
             failure_reason: None,
+            cost_usd: None,
         }
     }
 

--- a/crates/pitboss-web/src/api/runs.rs
+++ b/crates/pitboss-web/src/api/runs.rs
@@ -327,6 +327,7 @@ mod tests {
             approvals_rejected: 0,
             model: Some("claude-haiku-4-5".to_string()),
             failure_reason: None,
+            cost_usd: None,
         };
         serde_json::to_string(&rec).unwrap()
     }

--- a/crates/pitboss-web/tests/insights_aggregator_integration.rs
+++ b/crates/pitboss-web/tests/insights_aggregator_integration.rs
@@ -70,6 +70,7 @@ fn task(id: &str, status: TaskStatus, reason: Option<FailureReason>) -> TaskReco
         approvals_rejected: 0,
         model: None,
         failure_reason: reason,
+        cost_usd: None,
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds `Option<f64> cost_usd` to `TaskRecord`; computed via `pitboss_core::prices::cost_usd` at every production finalize site (flat lead, hierarchical lead, sublead, worker, sublead-worker — plus the synthetic spawn-failed / cancelled-pre-exec records).
- SQLite migration v9 adds the column via the existing `add_column_if_missing` helper; back-compat handled by `#[serde(default)]` for both the JSON files and SQL row reads.
- Centralises pricing on the producer side so downstream consumers (`pitboss status`, `pitboss-tui`, insights aggregator, external integrations) read a number rather than each maintaining their own rate table.

## Notes

- **SPA untouched.** `crates/pitboss-web/spa/src/lib/prices.ts` keeps working as the fallback. A follow-up will route the SPA fully through `task.cost_usd` and delete `prices.ts` once historical-run coverage isn't a concern. Splitting it that way avoids leaving the codebase in a hybrid "prefer server, fall back to client" middle state.
- **Borrow-after-move.** Three sites (`sublead.rs:768`, `spawn.rs:1021`, `hierarchical.rs:607`) needed the cost computed into a `let` binding *before* the struct literal opens, because `model` was being moved into `Some(model)` mid-literal. The same pattern is used at all production sites for uniformity.
- **Synthetic records.** Spawn-failure / cancelled-pre-exec records on a known model produce `Some(0.0)` rather than `None` — zero tokens really did cost zero dollars, and the SPA already renders `"$0.0000"` for these today, so no display regression.

Closes #241

## Test plan

- [x] `cargo build --workspace --tests --features pitboss-core/test-support` — clean
- [x] `cargo test --workspace --features pitboss-core/test-support` — all green (573 in pitboss-core alone, plus the new `task_record_missing_cost_usd_deserializes_as_none` and updated `task_record_round_trips_json` with `Some(0.0234)` round-trip)
- [x] `cargo lint && cargo tidy` — clean
- [x] `scripts/smoke-part1.sh` — 11/11 PASS
- [x] Depth-2 smoke (`pitboss_proj/smoke-test.toml`, real Haiku) — 5 actors all `Success`, zero `is_error: true` tool_results, `cost_usd` populated on every record, lead total $0.0927 / run total $0.2272