### PR TITLE
fix(web): auto-refresh runs list, re-fetch run record in detail tick

### DIFF
--- a/crates/pitboss-web/spa/src/routes/+page.svelte
+++ b/crates/pitboss-web/spa/src/routes/+page.svelte
@@ -51,7 +51,25 @@
     }
   }
 
-  onMount(load);
+  // Poll every 5 s, but only when the tab is visible — keeps a tab
+  // left open all day from burning cycles. visibilitychange fires
+  // an immediate refresh when the operator comes back to the tab so
+  // they don't see stale data while the next interval lands.
+  onMount(() => {
+    void load();
+    const POLL_MS = 5000;
+    const handle = setInterval(() => {
+      if (document.visibilityState === 'visible') void load();
+    }, POLL_MS);
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') void load();
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      clearInterval(handle);
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+  });
 
   // Facet counts derived from the filtered run set so the operator
   // sees how their filter narrows things.

--- a/crates/pitboss-web/spa/src/routes/+page.svelte
+++ b/crates/pitboss-web/spa/src/routes/+page.svelte
@@ -51,13 +51,14 @@
     }
   }
 
-  // Poll every 5 s, but only when the tab is visible — keeps a tab
-  // left open all day from burning cycles. visibilitychange fires
-  // an immediate refresh when the operator comes back to the tab so
-  // they don't see stale data while the next interval lands.
+  // Poll every 3 s, but only when the tab is visible — keeps a tab
+  // left open all day from burning cycles. Matches the run-detail
+  // page's polling cadence. visibilitychange fires an immediate
+  // refresh when the operator comes back to the tab so they don't
+  // see stale data while the next interval lands.
   onMount(() => {
     void load();
-    const POLL_MS = 5000;
+    const POLL_MS = 3000;
     const handle = setInterval(() => {
       if (document.visibilityState === 'visible') void load();
     }, POLL_MS);

--- a/crates/pitboss-web/spa/src/routes/runs/[id]/+page.svelte
+++ b/crates/pitboss-web/spa/src/routes/runs/[id]/+page.svelte
@@ -502,6 +502,17 @@
       } catch {
         /* run may have just finalized — next render uses summary.json */
       }
+      // Re-fetch the top-level run record so the page transitions
+      // gracefully when the dispatcher writes the finalised summary:
+      // `r.in_progress` flips false, `inProgress` flips, and the UI
+      // swaps from the Live view to the Tasks/Manifest/etc. view
+      // without a manual reload. Without this, the page sits stuck
+      // in the Live view with frozen data after finalization.
+      try {
+        detail = await getRun(runId);
+      } catch {
+        /* network blip — keep the last good record */
+      }
       // Fire-and-forget; the WorkersSnapshot reply lands via SSE.
       void postControlOp(runId, { op: 'list_workers' }).catch(() => {});
     };
@@ -727,6 +738,16 @@
       <TabsTrigger value="summary">Summary JSON</TabsTrigger>
     </TabsList>
 
+    <!--
+      The Live tab (event stream + Filter UI + Workers card) is
+      gated on inProgress on purpose: SSE closes when the
+      dispatcher exits and there's no static event-log surface
+      yet, so a finalised run has nothing live to show. The 3-s
+      polling tick re-fetches the run record (see effect above),
+      so this gate flips at finalize without a manual reload.
+      Don't remove the gate — fix the post-finalise event view
+      instead if operators want to filter historical events.
+    -->
     {#if inProgress}
       <TabsContent value="live" class="mt-4 space-y-4">
         {#if superseded}


### PR DESCRIPTION
## Summary

- Run list (`spa/src/routes/+page.svelte`) now polls every 5 s while the tab is visible, with a `visibilitychange` listener for immediate refresh on focus. New runs and in-flight status changes appear without a manual click.
- Run-detail (`spa/src/routes/runs/[id]/+page.svelte`) tick now also re-fetches the top-level run record via `getRun(runId)`, so `inProgress` flips when the dispatcher writes the finalised summary and the page transitions gracefully from Live → Tasks/Manifest/etc. without a manual reload.
- Adds a comment near the Live tab gate explaining the gating is intentional. The "SSE filter UI disappears at finalize" symptom from #246 was downstream of (2) — it resolves once the page transitions correctly.

Closes #246.

## Notes

- Pure SPA change. No Rust changes; the binary just needs a rebuild to pick up the embedded SPA assets.
- Polling on the run list runs every 5 s only when `document.visibilityState === 'visible'`, so a tab left open in the background stays quiet.
- The run-detail tick adds a second `try { } catch { }` for `getRun` so a transient network blip during polling doesn't surface to the user — it just keeps the last good record until the next tick.
- The Live tab gating comment explicitly tells future readers not to strip the `{#if inProgress}`. If operators want to filter historical events post-finalize, that's a separate feature (mentioned in #246's out-of-scope section).

## Test plan

- [x] `cd crates/pitboss-web/spa && npm run check` — 0 errors / 0 warnings
- [x] `npm run build` — clean build, assets in `spa/build/`
- [x] `cargo lint` — workspace clean
- [x] `cargo build -p pitboss-web --release` — binary picked up new SPA via rust-embed
- [ ] Manual: relaunch web console, open a run, dispatch a small flat manifest, confirm the run list ticks new runs in within 5 s and the run-detail page transitions to the finalised view automatically when the run ends
- [ ] Manual: leave a tab in the background for 30+ s, confirm no extra polling fires, then return to the tab and confirm an immediate refresh