### PR TITLE
feat(container): bootstrap apt packages via [container].extra_apt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,7 +260,8 @@ The `[container]` section enables `pitboss container-dispatch`, which assembles 
 |---|---|---|---|
 | `image` | string | `ghcr.io/sds-mode/pitboss-with-claude:latest` | Container image to run. |
 | `runtime` | `"docker"` \| `"podman"` \| `"auto"` | `"auto"` | Runtime selector. `"auto"` prefers podman when available. |
-| `extra_args` | array of string | `[]` | Inserted verbatim before the image name in the assembled `run` invocation. |
+| `extra_args` | array of string | `[]` | Verbatim flags for `podman run` / `docker run`. The escape hatch for any container-runtime concern: networking (`--network=corp-fw`, `--dns=10.0.0.53`, `--add-host=svc:1.2.3.4`), capabilities (`--cap-add=NET_ADMIN`), security (`--security-opt=…`), resource limits (`--memory=4g`, `--cpus=2`). |
+| `extra_apt` | array of string | `[]` | Debian/Ubuntu packages installed inside the container before `pitboss dispatch` starts. Adds 30–90 s spin-up per dispatch (no caching yet — see roadmap). Each entry must match `[a-zA-Z0-9][a-zA-Z0-9.+-]*`; rejected at validate time otherwise. |
 | `workdir` | string | first mount's container path, else `/home/pitboss` | Working directory inside the container. |
 
 #### `[[container.mount]]`

--- a/crates/pitboss-cli/src/dispatch/container.rs
+++ b/crates/pitboss-cli/src/dispatch/container.rs
@@ -161,17 +161,71 @@ fn build_run_args(
     // ── Extra operator args ───────────────────────────────────────────────────
     args.extend(container.extra_args.clone());
 
+    // ── extra_apt: validate + override user to root for the apt step ─────────
+    // apt-get needs root. When `extra_apt` is non-empty we override `-u` to
+    // 0:0 here (last `-u` wins) and rewrite the entrypoint below into a
+    // shell that installs the packages, then `exec runuser -u pitboss --
+    // pitboss dispatch …` so the long-lived process drops to UID 1000
+    // before workers spawn. Tini stays as PID 1, so signal forwarding to
+    // the post-exec pitboss is preserved.
+    //
+    // Package names are joined verbatim into a shell command, so we
+    // require each entry to match `[a-zA-Z0-9][a-zA-Z0-9.+-]*` and reject
+    // anything else at dispatch time.
+    let bootstrap_apt = !container.extra_apt.is_empty();
+    if bootstrap_apt {
+        for pkg in &container.extra_apt {
+            if !is_valid_apt_pkg(pkg) {
+                bail!(
+                    "[container].extra_apt: invalid package name {pkg:?} \
+                     (allowed: ASCII alphanumeric, `.`, `+`, `-`; must start \
+                     with alphanumeric)"
+                );
+            }
+        }
+        args.push("-u".into());
+        args.push("0:0".into());
+    }
+
     // ── Image + pitboss command ───────────────────────────────────────────────
     let image = container
         .image
         .clone()
         .unwrap_or_else(|| DEFAULT_IMAGE.to_string());
     args.push(image);
-    args.push("pitboss".into());
-    args.push("dispatch".into());
-    args.push("/run/pitboss.toml".into());
+
+    if bootstrap_apt {
+        let pkg_list = container.extra_apt.join(" ");
+        let cmd = format!(
+            "apt-get update && \
+             apt-get install -y --no-install-recommends {pkg_list} && \
+             exec runuser -u pitboss -- pitboss dispatch /run/pitboss.toml"
+        );
+        args.push("sh".into());
+        args.push("-c".into());
+        args.push(cmd);
+    } else {
+        args.push("pitboss".into());
+        args.push("dispatch".into());
+        args.push("/run/pitboss.toml".into());
+    }
 
     Ok(args)
+}
+
+/// Validate a debian/ubuntu package name for shell-safe interpolation
+/// into `apt-get install -y …`. Restrictive on purpose: must begin with
+/// an ASCII alphanumeric and contain only `[a-zA-Z0-9.+-]` thereafter.
+///
+/// Re-used by `manifest::validate` so `pitboss validate` rejects bad names
+/// in the same shape as dispatch.
+pub(crate) fn is_valid_apt_pkg(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphanumeric() => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '+' | '-'))
 }
 
 /// Detect the container runtime to use, in priority order:
@@ -330,6 +384,7 @@ mod tests {
             image: None,
             runtime: None,
             extra_args: vec![],
+            extra_apt: vec![],
             mounts,
             workdir: None,
         }
@@ -562,6 +617,128 @@ prompt = "hi"
         assert!(
             joined.contains("/tmp/my-runs"),
             "run_dir override in mounts: {joined}"
+        );
+    }
+
+    #[test]
+    fn empty_extra_apt_keeps_direct_pitboss_entrypoint() {
+        // Sanity: with no extra_apt the entrypoint args are still the bare
+        // `pitboss dispatch /run/pitboss.toml` triplet — no shell wrap.
+        let cfg = make_config(vec![]);
+        let args = build_run_args("podman", &cfg, &temp_manifest(), None).unwrap();
+        assert!(
+            !args.iter().any(|a| a == "sh"),
+            "no sh wrapper expected: {args:?}"
+        );
+        assert!(
+            !args.iter().any(|a| a == "0:0"),
+            "no root override expected: {args:?}"
+        );
+        let dispatch_pos = args
+            .iter()
+            .position(|a| a == "dispatch")
+            .expect("dispatch present");
+        assert_eq!(args[dispatch_pos - 1], "pitboss", "args: {args:?}");
+        assert_eq!(
+            args[dispatch_pos + 1],
+            "/run/pitboss.toml",
+            "args: {args:?}"
+        );
+    }
+
+    #[test]
+    fn extra_apt_wraps_entrypoint_with_apt_install_and_runuser() {
+        let cfg = ContainerConfig {
+            extra_apt: vec!["mdbook".into(), "jq".into()],
+            ..ContainerConfig::default()
+        };
+        let args = build_run_args("podman", &cfg, &temp_manifest(), None).unwrap();
+
+        // -u 0:0 must appear (so apt-get can run as root).
+        let u_pos = args
+            .windows(2)
+            .position(|w| w[0] == "-u" && w[1] == "0:0")
+            .expect("expected -u 0:0 override: {args:?}");
+
+        // …and must come AFTER any earlier -u from the existing user-alignment
+        // logic, so it wins as the last -u in argv.
+        let last_u = args
+            .iter()
+            .enumerate()
+            .filter(|(_, a)| *a == "-u")
+            .map(|(i, _)| i)
+            .next_back()
+            .expect("at least one -u");
+        assert_eq!(last_u, u_pos, "extra_apt -u 0:0 must be the last -u");
+
+        // The image should be followed by `sh -c <cmd>`, not pitboss directly.
+        let img_pos = args.iter().position(|a| a == DEFAULT_IMAGE).expect("image");
+        assert_eq!(args[img_pos + 1], "sh", "wrapped entrypoint: {args:?}");
+        assert_eq!(args[img_pos + 2], "-c", "wrapped entrypoint: {args:?}");
+
+        let cmd = &args[img_pos + 3];
+        assert!(
+            cmd.contains("apt-get update"),
+            "apt-get update missing: {cmd}"
+        );
+        assert!(
+            cmd.contains("apt-get install -y --no-install-recommends mdbook jq"),
+            "apt install line missing or mis-shaped: {cmd}"
+        );
+        assert!(
+            cmd.contains("exec runuser -u pitboss -- pitboss dispatch /run/pitboss.toml"),
+            "runuser drop missing: {cmd}"
+        );
+    }
+
+    #[test]
+    fn extra_apt_rejects_shell_metacharacters() {
+        // Anything outside [a-zA-Z0-9][a-zA-Z0-9.+-]* must fail validation
+        // before any shell command is constructed.
+        for bad in [
+            "mdbook;rm -rf /",
+            "$(curl evil)",
+            "pkg name",
+            "--flag",
+            ".bad",
+        ] {
+            let cfg = ContainerConfig {
+                extra_apt: vec![bad.into()],
+                ..ContainerConfig::default()
+            };
+            let result = build_run_args("podman", &cfg, &temp_manifest(), None);
+            assert!(
+                result.is_err(),
+                "expected rejection for {bad:?}, got: {result:?}"
+            );
+            let msg = result.unwrap_err().to_string();
+            assert!(
+                msg.contains("extra_apt"),
+                "error should mention extra_apt: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn extra_apt_accepts_realistic_package_names() {
+        // Names with `.`, `+`, `-` and digits are common in the apt index
+        // (libssl3, g++-12, python3.11) — make sure validation lets them through.
+        let cfg = ContainerConfig {
+            extra_apt: vec![
+                "libssl3".into(),
+                "g++-12".into(),
+                "python3.11".into(),
+                "pandoc".into(),
+            ],
+            ..ContainerConfig::default()
+        };
+        let args = build_run_args("podman", &cfg, &temp_manifest(), None)
+            .expect("realistic package names should validate");
+        let img_pos = args.iter().position(|a| a == DEFAULT_IMAGE).expect("image");
+        let cmd = &args[img_pos + 3];
+        assert!(
+            cmd.contains("libssl3 g++-12 python3.11 pandoc"),
+            "expected joined package list, got: {cmd}"
         );
     }
 }

--- a/crates/pitboss-cli/src/manifest/schema.rs
+++ b/crates/pitboss-cli/src/manifest/schema.rs
@@ -83,12 +83,31 @@ pub struct ContainerConfig {
     )]
     pub runtime: Option<String>,
     /// Extra args inserted verbatim before the image name in the `run` call.
+    /// This is the escape hatch for any `podman run` / `docker run` flag —
+    /// networking (`--network=...`, `--dns=...`, `--add-host=...`),
+    /// capabilities (`--cap-add=NET_ADMIN`), security (`--security-opt=...`),
+    /// resources (`--memory=4g`, `--cpus=2`), and so on.
     #[serde(default)]
     #[field(
         label = "Extra args",
-        help = "Args inserted verbatim before the image name in the run invocation."
+        help = "Verbatim podman/docker run flags. Use for networking, capabilities, DNS, resources, etc. Example: [\"--network=corp-fw\", \"--dns=10.0.0.53\", \"--cap-add=NET_ADMIN\"]."
     )]
     pub extra_args: Vec<String>,
+    /// Apt packages installed inside the container at run start, before
+    /// `pitboss dispatch` runs. Useful for adding small tools (mdbook, jq,
+    /// pandoc) without rebuilding the base image. Each dispatch pays the
+    /// install cost; for a faster cached path see the future
+    /// `pitboss container-build` subcommand.
+    ///
+    /// Names are passed verbatim to `apt-get install -y --no-install-recommends`,
+    /// so each entry must match `[a-zA-Z0-9][a-zA-Z0-9.+-]*` — anything else
+    /// is rejected at dispatch time to keep the joined command shell-safe.
+    #[serde(default)]
+    #[field(
+        label = "Extra apt packages",
+        help = "Debian/Ubuntu packages installed inside the container before pitboss dispatch starts. Adds 30–90s spin-up per dispatch. Example: [\"mdbook\", \"jq\"]."
+    )]
+    pub extra_apt: Vec<String>,
     /// Host→container bind mounts (besides the auto-injected `~/.claude` and run_dir).
     #[serde(default, rename = "mount")]
     #[field(skip)]

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -25,6 +25,7 @@ fn validate_inner(resolved: &ResolvedManifest, skip_dir_check: bool) -> Result<(
         crate::notify::config::validate(cfg)?;
     }
     validate_lifecycle(resolved)?;
+    validate_container(resolved)?;
     if resolved.lead.is_some() {
         validate_lead(resolved, skip_dir_check)?;
         validate_hierarchical_ranges(resolved)?;
@@ -36,6 +37,26 @@ fn validate_inner(resolved: &ResolvedManifest, skip_dir_check: bool) -> Result<(
         }
         validate_branch_conflicts(resolved)?;
         validate_ranges(resolved)?;
+    }
+    Ok(())
+}
+
+/// Reject manifest-level container misconfigurations that would otherwise
+/// only surface at dispatch time. Today this is just the shell-safety check
+/// on `[container].extra_apt` package names — kept here so `pitboss validate`
+/// catches bad names symmetrically with `pitboss container-dispatch`.
+fn validate_container(r: &ResolvedManifest) -> Result<()> {
+    let Some(container) = &r.container else {
+        return Ok(());
+    };
+    for pkg in &container.extra_apt {
+        if !crate::dispatch::container::is_valid_apt_pkg(pkg) {
+            bail!(
+                "[container].extra_apt: invalid package name {pkg:?} \
+                 (allowed: ASCII alphanumeric, `.`, `+`, `-`; must start \
+                 with alphanumeric)"
+            );
+        }
     }
     Ok(())
 }
@@ -1199,5 +1220,37 @@ mod tests {
         let src = r#"catagory = "tool_use""#;
         let err: Result<super::super::schema::ApprovalMatchSpec, _> = toml::from_str(src);
         assert!(err.is_err(), "unknown field 'catagory' must be rejected");
+    }
+
+    #[test]
+    fn extra_apt_invalid_package_name_fails_validate() {
+        // pitboss validate must reject the same names that build_run_args
+        // rejects — operators expect schema-level validation to be
+        // authoritative, not deferred to dispatch.
+        use super::super::schema::ContainerConfig;
+        let d = with_tmp_repo(true);
+        let mut m = rm(vec![rt("t", d.path().to_path_buf(), false, None)]);
+        m.container = Some(ContainerConfig {
+            extra_apt: vec!["mdbook;rm -rf /".into()],
+            ..ContainerConfig::default()
+        });
+        let err = validate(&m).expect_err("invalid extra_apt name must fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("extra_apt"),
+            "error must reference extra_apt: {msg}"
+        );
+    }
+
+    #[test]
+    fn extra_apt_valid_package_names_pass_validate() {
+        use super::super::schema::ContainerConfig;
+        let d = with_tmp_repo(true);
+        let mut m = rm(vec![rt("t", d.path().to_path_buf(), false, None)]);
+        m.container = Some(ContainerConfig {
+            extra_apt: vec!["mdbook".into(), "g++-12".into(), "python3.11".into()],
+            ..ContainerConfig::default()
+        });
+        validate(&m).expect("realistic apt package names must validate");
     }
 }

--- a/docs/manifest-map.md
+++ b/docs/manifest-map.md
@@ -14,32 +14,32 @@ The annotated example lives at [`pitboss.example.toml`](../pitboss.example.toml)
 
 ## `[run]` — `RunConfig`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:313`](../crates/pitboss-cli/src/manifest/schema.rs#L313).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:332`](../crates/pitboss-cli/src/manifest/schema.rs#L332).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `name` | text | no | Human-readable label used to group related runs in the console (e.g. "build-db", "nightly-sync"). When unset, the manifest filename is used as fallback. | [`../crates/pitboss-cli/src/manifest/schema.rs#L324`](../crates/pitboss-cli/src/manifest/schema.rs#L324) |
-| `max_parallel_tasks` | integer | no | Flat-mode concurrency cap for [[task]] runs. Default 4. Overridden by ANTHROPIC_MAX_CONCURRENT. | [`../crates/pitboss-cli/src/manifest/schema.rs#L333`](../crates/pitboss-cli/src/manifest/schema.rs#L333) |
-| `halt_on_failure` | boolean | no | Stop remaining flat-mode tasks on first failure. | [`../crates/pitboss-cli/src/manifest/schema.rs#L340`](../crates/pitboss-cli/src/manifest/schema.rs#L340) |
-| `run_dir` | path | no | Where per-run artifacts land. Default ~/.local/share/pitboss/runs. | [`../crates/pitboss-cli/src/manifest/schema.rs#L346`](../crates/pitboss-cli/src/manifest/schema.rs#L346) |
-| `worktree_cleanup` | enum (`always` \| `on_success` \| `never`) | no | What to do with each worker's git worktree after it finishes. | [`../crates/pitboss-cli/src/manifest/schema.rs#L354`](../crates/pitboss-cli/src/manifest/schema.rs#L354) |
-| `emit_event_stream` | boolean | no | Write a JSONL event stream alongside summary.jsonl. | [`../crates/pitboss-cli/src/manifest/schema.rs#L361`](../crates/pitboss-cli/src/manifest/schema.rs#L361) |
-| `default_approval_policy` | enum (`block` \| `auto_approve` \| `auto_reject`) | no | Default action for request_approval / propose_plan when no rule matches. `auto_approve`/`auto_reject` are unconditional; `block` routes to the operator if attached, else queues. | [`../crates/pitboss-cli/src/manifest/schema.rs#L389`](../crates/pitboss-cli/src/manifest/schema.rs#L389) |
-| `dump_shared_store` | boolean | no | Write shared-store.json into the run directory on finalize. | [`../crates/pitboss-cli/src/manifest/schema.rs#L397`](../crates/pitboss-cli/src/manifest/schema.rs#L397) |
-| `require_plan_approval` | boolean | no | When true, spawn_worker is blocked until propose_plan has been approved. | [`../crates/pitboss-cli/src/manifest/schema.rs#L405`](../crates/pitboss-cli/src/manifest/schema.rs#L405) |
+| `name` | text | no | Human-readable label used to group related runs in the console (e.g. "build-db", "nightly-sync"). When unset, the manifest filename is used as fallback. | [`../crates/pitboss-cli/src/manifest/schema.rs#L343`](../crates/pitboss-cli/src/manifest/schema.rs#L343) |
+| `max_parallel_tasks` | integer | no | Flat-mode concurrency cap for [[task]] runs. Default 4. Overridden by ANTHROPIC_MAX_CONCURRENT. | [`../crates/pitboss-cli/src/manifest/schema.rs#L352`](../crates/pitboss-cli/src/manifest/schema.rs#L352) |
+| `halt_on_failure` | boolean | no | Stop remaining flat-mode tasks on first failure. | [`../crates/pitboss-cli/src/manifest/schema.rs#L359`](../crates/pitboss-cli/src/manifest/schema.rs#L359) |
+| `run_dir` | path | no | Where per-run artifacts land. Default ~/.local/share/pitboss/runs. | [`../crates/pitboss-cli/src/manifest/schema.rs#L365`](../crates/pitboss-cli/src/manifest/schema.rs#L365) |
+| `worktree_cleanup` | enum (`always` \| `on_success` \| `never`) | no | What to do with each worker's git worktree after it finishes. | [`../crates/pitboss-cli/src/manifest/schema.rs#L373`](../crates/pitboss-cli/src/manifest/schema.rs#L373) |
+| `emit_event_stream` | boolean | no | Write a JSONL event stream alongside summary.jsonl. | [`../crates/pitboss-cli/src/manifest/schema.rs#L380`](../crates/pitboss-cli/src/manifest/schema.rs#L380) |
+| `default_approval_policy` | enum (`block` \| `auto_approve` \| `auto_reject`) | no | Default action for request_approval / propose_plan when no rule matches. `auto_approve`/`auto_reject` are unconditional; `block` routes to the operator if attached, else queues. | [`../crates/pitboss-cli/src/manifest/schema.rs#L408`](../crates/pitboss-cli/src/manifest/schema.rs#L408) |
+| `dump_shared_store` | boolean | no | Write shared-store.json into the run directory on finalize. | [`../crates/pitboss-cli/src/manifest/schema.rs#L416`](../crates/pitboss-cli/src/manifest/schema.rs#L416) |
+| `require_plan_approval` | boolean | no | When true, spawn_worker is blocked until propose_plan has been approved. | [`../crates/pitboss-cli/src/manifest/schema.rs#L424`](../crates/pitboss-cli/src/manifest/schema.rs#L424) |
 
 ## `[defaults]` — `Defaults`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:438`](../crates/pitboss-cli/src/manifest/schema.rs#L438).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:457`](../crates/pitboss-cli/src/manifest/schema.rs#L457).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `model` | text | no | Claude model id (e.g. claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-7). | [`../crates/pitboss-cli/src/manifest/schema.rs#L443`](../crates/pitboss-cli/src/manifest/schema.rs#L443) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Maps to the claude --effort flag. | [`../crates/pitboss-cli/src/manifest/schema.rs#L449`](../crates/pitboss-cli/src/manifest/schema.rs#L449) |
-| `tools` | string list | no | Allowed tool surface. Pitboss auto-appends its MCP tools for leads and workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L454`](../crates/pitboss-cli/src/manifest/schema.rs#L454) |
-| `timeout_secs` | integer | no | Per-task wall-clock cap. No default (no cap). | [`../crates/pitboss-cli/src/manifest/schema.rs#L459`](../crates/pitboss-cli/src/manifest/schema.rs#L459) |
-| `use_worktree` | boolean | no | Isolate each worker in a git worktree. Default true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L464`](../crates/pitboss-cli/src/manifest/schema.rs#L464) |
-| `env` | key-value map | no | Environment variables passed to the claude subprocess. | [`../crates/pitboss-cli/src/manifest/schema.rs#L470`](../crates/pitboss-cli/src/manifest/schema.rs#L470) |
+| `model` | text | no | Claude model id (e.g. claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-7). | [`../crates/pitboss-cli/src/manifest/schema.rs#L462`](../crates/pitboss-cli/src/manifest/schema.rs#L462) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Maps to the claude --effort flag. | [`../crates/pitboss-cli/src/manifest/schema.rs#L468`](../crates/pitboss-cli/src/manifest/schema.rs#L468) |
+| `tools` | string list | no | Allowed tool surface. Pitboss auto-appends its MCP tools for leads and workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L473`](../crates/pitboss-cli/src/manifest/schema.rs#L473) |
+| `timeout_secs` | integer | no | Per-task wall-clock cap. No default (no cap). | [`../crates/pitboss-cli/src/manifest/schema.rs#L478`](../crates/pitboss-cli/src/manifest/schema.rs#L478) |
+| `use_worktree` | boolean | no | Isolate each worker in a git worktree. Default true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L483`](../crates/pitboss-cli/src/manifest/schema.rs#L483) |
+| `env` | key-value map | no | Environment variables passed to the claude subprocess. | [`../crates/pitboss-cli/src/manifest/schema.rs#L489`](../crates/pitboss-cli/src/manifest/schema.rs#L489) |
 
 ## `[container]` — `ContainerConfig`
 
@@ -49,107 +49,108 @@ Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:71`](../crates/pitboss
 |---|---|---|---|---|
 | `image` | text | no | Container image reference. Defaults to ghcr.io/sds-mode/pitboss-with-claude:latest. | [`../crates/pitboss-cli/src/manifest/schema.rs#L77`](../crates/pitboss-cli/src/manifest/schema.rs#L77) |
 | `runtime` | enum (`docker` \| `podman` \| `auto`) | no | Container runtime to invoke. "auto" prefers podman. | [`../crates/pitboss-cli/src/manifest/schema.rs#L84`](../crates/pitboss-cli/src/manifest/schema.rs#L84) |
-| `extra_args` | string list | no | Args inserted verbatim before the image name in the run invocation. | [`../crates/pitboss-cli/src/manifest/schema.rs#L91`](../crates/pitboss-cli/src/manifest/schema.rs#L91) |
-| `workdir` | path | no | cwd inside the container; defaults to the first mount's container path. | [`../crates/pitboss-cli/src/manifest/schema.rs#L103`](../crates/pitboss-cli/src/manifest/schema.rs#L103) |
+| `extra_args` | string list | no | Verbatim podman/docker run flags. Use for networking, capabilities, DNS, resources, etc. Example: ["--network=corp-fw", "--dns=10.0.0.53", "--cap-add=NET_ADMIN"]. | [`../crates/pitboss-cli/src/manifest/schema.rs#L95`](../crates/pitboss-cli/src/manifest/schema.rs#L95) |
+| `extra_apt` | string list | no | Debian/Ubuntu packages installed inside the container before pitboss dispatch starts. Adds 30–90s spin-up per dispatch. Example: ["mdbook", "jq"]. | [`../crates/pitboss-cli/src/manifest/schema.rs#L110`](../crates/pitboss-cli/src/manifest/schema.rs#L110) |
+| `workdir` | path | no | cwd inside the container; defaults to the first mount's container path. | [`../crates/pitboss-cli/src/manifest/schema.rs#L122`](../crates/pitboss-cli/src/manifest/schema.rs#L122) |
 
 ## `[[container.mount]]` — `MountSpec`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:109`](../crates/pitboss-cli/src/manifest/schema.rs#L109).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:128`](../crates/pitboss-cli/src/manifest/schema.rs#L128).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `host` | path | **yes** | Absolute host path. ~ is expanded. | [`../crates/pitboss-cli/src/manifest/schema.rs#L112`](../crates/pitboss-cli/src/manifest/schema.rs#L112) |
-| `container` | path | **yes** | Absolute path inside the container. | [`../crates/pitboss-cli/src/manifest/schema.rs#L115`](../crates/pitboss-cli/src/manifest/schema.rs#L115) |
-| `readonly` | boolean | no | Mount read-only. | [`../crates/pitboss-cli/src/manifest/schema.rs#L119`](../crates/pitboss-cli/src/manifest/schema.rs#L119) |
+| `host` | path | **yes** | Absolute host path. ~ is expanded. | [`../crates/pitboss-cli/src/manifest/schema.rs#L131`](../crates/pitboss-cli/src/manifest/schema.rs#L131) |
+| `container` | path | **yes** | Absolute path inside the container. | [`../crates/pitboss-cli/src/manifest/schema.rs#L134`](../crates/pitboss-cli/src/manifest/schema.rs#L134) |
+| `readonly` | boolean | no | Mount read-only. | [`../crates/pitboss-cli/src/manifest/schema.rs#L138`](../crates/pitboss-cli/src/manifest/schema.rs#L138) |
 
 ## `[[task]]` — `Task`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:501`](../crates/pitboss-cli/src/manifest/schema.rs#L501).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:520`](../crates/pitboss-cli/src/manifest/schema.rs#L520).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique slug. Alphanumeric + _ + -. Used in logs and worktree names. | [`../crates/pitboss-cli/src/manifest/schema.rs#L506`](../crates/pitboss-cli/src/manifest/schema.rs#L506) |
-| `directory` | path | **yes** | Working directory. Must be inside a git repo if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L511`](../crates/pitboss-cli/src/manifest/schema.rs#L511) |
-| `prompt` | text (multi-line) | no | Prompt body sent to claude via -p. Mutually exclusive with `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L517`](../crates/pitboss-cli/src/manifest/schema.rs#L517) |
-| `template` | text | no | Reference to a [[template]] entry. Mutually exclusive with `prompt`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L522`](../crates/pitboss-cli/src/manifest/schema.rs#L522) |
-| `vars` | key-value map | no | Substitutions for {placeholders} when using `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L528`](../crates/pitboss-cli/src/manifest/schema.rs#L528) |
-| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L533`](../crates/pitboss-cli/src/manifest/schema.rs#L533) |
-| `model` | text | no | Per-task override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L535`](../crates/pitboss-cli/src/manifest/schema.rs#L535) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-task override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L541`](../crates/pitboss-cli/src/manifest/schema.rs#L541) |
-| `tools` | string list | no | Per-task override of [defaults].tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L543`](../crates/pitboss-cli/src/manifest/schema.rs#L543) |
-| `timeout_secs` | integer | no | Per-task wall-clock cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L545`](../crates/pitboss-cli/src/manifest/schema.rs#L545) |
-| `use_worktree` | boolean | no | Per-task override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L550`](../crates/pitboss-cli/src/manifest/schema.rs#L550) |
-| `env` | key-value map | no | Per-task env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L556`](../crates/pitboss-cli/src/manifest/schema.rs#L556) |
+| `id` | text | **yes** | Unique slug. Alphanumeric + _ + -. Used in logs and worktree names. | [`../crates/pitboss-cli/src/manifest/schema.rs#L525`](../crates/pitboss-cli/src/manifest/schema.rs#L525) |
+| `directory` | path | **yes** | Working directory. Must be inside a git repo if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L530`](../crates/pitboss-cli/src/manifest/schema.rs#L530) |
+| `prompt` | text (multi-line) | no | Prompt body sent to claude via -p. Mutually exclusive with `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L536`](../crates/pitboss-cli/src/manifest/schema.rs#L536) |
+| `template` | text | no | Reference to a [[template]] entry. Mutually exclusive with `prompt`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L541`](../crates/pitboss-cli/src/manifest/schema.rs#L541) |
+| `vars` | key-value map | no | Substitutions for {placeholders} when using `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L547`](../crates/pitboss-cli/src/manifest/schema.rs#L547) |
+| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L552`](../crates/pitboss-cli/src/manifest/schema.rs#L552) |
+| `model` | text | no | Per-task override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L554`](../crates/pitboss-cli/src/manifest/schema.rs#L554) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-task override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L560`](../crates/pitboss-cli/src/manifest/schema.rs#L560) |
+| `tools` | string list | no | Per-task override of [defaults].tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L562`](../crates/pitboss-cli/src/manifest/schema.rs#L562) |
+| `timeout_secs` | integer | no | Per-task wall-clock cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L564`](../crates/pitboss-cli/src/manifest/schema.rs#L564) |
+| `use_worktree` | boolean | no | Per-task override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L569`](../crates/pitboss-cli/src/manifest/schema.rs#L569) |
+| `env` | key-value map | no | Per-task env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L575`](../crates/pitboss-cli/src/manifest/schema.rs#L575) |
 
 ## `[lead]` — `Lead`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:566`](../crates/pitboss-cli/src/manifest/schema.rs#L566).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:585`](../crates/pitboss-cli/src/manifest/schema.rs#L585).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique slug used as the TUI tile label and in run artifact paths. | [`../crates/pitboss-cli/src/manifest/schema.rs#L573`](../crates/pitboss-cli/src/manifest/schema.rs#L573) |
-| `directory` | path | **yes** | Working directory for the lead's claude subprocess. Must be a git work-tree if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L580`](../crates/pitboss-cli/src/manifest/schema.rs#L580) |
-| `prompt` | text (multi-line) | **yes** | Operator instructions passed to claude via -p. Must appear before any [lead.X] subtable in the source. | [`../crates/pitboss-cli/src/manifest/schema.rs#L592`](../crates/pitboss-cli/src/manifest/schema.rs#L592) |
-| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L600`](../crates/pitboss-cli/src/manifest/schema.rs#L600) |
-| `model` | text | no | Per-lead override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L603`](../crates/pitboss-cli/src/manifest/schema.rs#L603) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-lead override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L610`](../crates/pitboss-cli/src/manifest/schema.rs#L610) |
-| `tools` | string list | no | Per-lead override of [defaults].tools. Pitboss auto-appends its MCP tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L616`](../crates/pitboss-cli/src/manifest/schema.rs#L616) |
-| `timeout_secs` | integer | no | Per-actor subprocess wall-clock cap (claude --timeout). | [`../crates/pitboss-cli/src/manifest/schema.rs#L622`](../crates/pitboss-cli/src/manifest/schema.rs#L622) |
-| `use_worktree` | boolean | no | Per-lead override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L628`](../crates/pitboss-cli/src/manifest/schema.rs#L628) |
-| `env` | key-value map | no | Per-lead env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L634`](../crates/pitboss-cli/src/manifest/schema.rs#L634) |
-| `max_workers` | integer | no | Hard cap on the lead's concurrent + queued worker pool (1–16). Required when the lead spawns workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L643`](../crates/pitboss-cli/src/manifest/schema.rs#L643) |
-| `budget_usd` | float | no | Soft cap on lead spend with reservation accounting. spawn_worker fails once spent + reserved + next_estimate > budget. | [`../crates/pitboss-cli/src/manifest/schema.rs#L652`](../crates/pitboss-cli/src/manifest/schema.rs#L652) |
-| `lead_timeout_secs` | integer | no | Wall-clock cap on the lead session. Default 3600. | [`../crates/pitboss-cli/src/manifest/schema.rs#L661`](../crates/pitboss-cli/src/manifest/schema.rs#L661) |
-| `permission_routing` | enum (`path_a` \| `path_b`) | no | path_a (default) makes pitboss the sole permission authority. path_b routes claude's gate through pitboss (rejected at validate time pending stabilization). | [`../crates/pitboss-cli/src/manifest/schema.rs#L674`](../crates/pitboss-cli/src/manifest/schema.rs#L674) |
-| `allow_subleads` | boolean | no | Expose spawn_sublead to the root lead. | [`../crates/pitboss-cli/src/manifest/schema.rs#L683`](../crates/pitboss-cli/src/manifest/schema.rs#L683) |
-| `max_subleads` | integer | no | Hard cap on total live sub-leads under this root. | [`../crates/pitboss-cli/src/manifest/schema.rs#L690`](../crates/pitboss-cli/src/manifest/schema.rs#L690) |
-| `max_sublead_budget_usd` | float | no | Cap on the per-sub-lead budget envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L697`](../crates/pitboss-cli/src/manifest/schema.rs#L697) |
-| `max_total_workers` | integer | no | Cap on total live workers across the entire tree (root + sub-trees). | [`../crates/pitboss-cli/src/manifest/schema.rs#L705`](../crates/pitboss-cli/src/manifest/schema.rs#L705) |
+| `id` | text | **yes** | Unique slug used as the TUI tile label and in run artifact paths. | [`../crates/pitboss-cli/src/manifest/schema.rs#L592`](../crates/pitboss-cli/src/manifest/schema.rs#L592) |
+| `directory` | path | **yes** | Working directory for the lead's claude subprocess. Must be a git work-tree if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L599`](../crates/pitboss-cli/src/manifest/schema.rs#L599) |
+| `prompt` | text (multi-line) | **yes** | Operator instructions passed to claude via -p. Must appear before any [lead.X] subtable in the source. | [`../crates/pitboss-cli/src/manifest/schema.rs#L611`](../crates/pitboss-cli/src/manifest/schema.rs#L611) |
+| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L619`](../crates/pitboss-cli/src/manifest/schema.rs#L619) |
+| `model` | text | no | Per-lead override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L622`](../crates/pitboss-cli/src/manifest/schema.rs#L622) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-lead override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L629`](../crates/pitboss-cli/src/manifest/schema.rs#L629) |
+| `tools` | string list | no | Per-lead override of [defaults].tools. Pitboss auto-appends its MCP tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L635`](../crates/pitboss-cli/src/manifest/schema.rs#L635) |
+| `timeout_secs` | integer | no | Per-actor subprocess wall-clock cap (claude --timeout). | [`../crates/pitboss-cli/src/manifest/schema.rs#L641`](../crates/pitboss-cli/src/manifest/schema.rs#L641) |
+| `use_worktree` | boolean | no | Per-lead override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L647`](../crates/pitboss-cli/src/manifest/schema.rs#L647) |
+| `env` | key-value map | no | Per-lead env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L653`](../crates/pitboss-cli/src/manifest/schema.rs#L653) |
+| `max_workers` | integer | no | Hard cap on the lead's concurrent + queued worker pool (1–16). Required when the lead spawns workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L662`](../crates/pitboss-cli/src/manifest/schema.rs#L662) |
+| `budget_usd` | float | no | Soft cap on lead spend with reservation accounting. spawn_worker fails once spent + reserved + next_estimate > budget. | [`../crates/pitboss-cli/src/manifest/schema.rs#L671`](../crates/pitboss-cli/src/manifest/schema.rs#L671) |
+| `lead_timeout_secs` | integer | no | Wall-clock cap on the lead session. Default 3600. | [`../crates/pitboss-cli/src/manifest/schema.rs#L680`](../crates/pitboss-cli/src/manifest/schema.rs#L680) |
+| `permission_routing` | enum (`path_a` \| `path_b`) | no | path_a (default) makes pitboss the sole permission authority. path_b routes claude's gate through pitboss (rejected at validate time pending stabilization). | [`../crates/pitboss-cli/src/manifest/schema.rs#L693`](../crates/pitboss-cli/src/manifest/schema.rs#L693) |
+| `allow_subleads` | boolean | no | Expose spawn_sublead to the root lead. | [`../crates/pitboss-cli/src/manifest/schema.rs#L702`](../crates/pitboss-cli/src/manifest/schema.rs#L702) |
+| `max_subleads` | integer | no | Hard cap on total live sub-leads under this root. | [`../crates/pitboss-cli/src/manifest/schema.rs#L709`](../crates/pitboss-cli/src/manifest/schema.rs#L709) |
+| `max_sublead_budget_usd` | float | no | Cap on the per-sub-lead budget envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L716`](../crates/pitboss-cli/src/manifest/schema.rs#L716) |
+| `max_total_workers` | integer | no | Cap on total live workers across the entire tree (root + sub-trees). | [`../crates/pitboss-cli/src/manifest/schema.rs#L724`](../crates/pitboss-cli/src/manifest/schema.rs#L724) |
 
 ## `[sublead_defaults]` — `SubleadDefaults`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:712`](../crates/pitboss-cli/src/manifest/schema.rs#L712).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:731`](../crates/pitboss-cli/src/manifest/schema.rs#L731).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `budget_usd` | float | no | Per-sub-lead envelope when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L717`](../crates/pitboss-cli/src/manifest/schema.rs#L717) |
-| `max_workers` | integer | no | Per-sub-lead worker pool when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L722`](../crates/pitboss-cli/src/manifest/schema.rs#L722) |
-| `lead_timeout_secs` | integer | no | Wall-clock cap for the sub-lead session. | [`../crates/pitboss-cli/src/manifest/schema.rs#L727`](../crates/pitboss-cli/src/manifest/schema.rs#L727) |
-| `read_down` | boolean | no | When true, sub-lead shares root's budget + worker pool instead of carving its own envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L733`](../crates/pitboss-cli/src/manifest/schema.rs#L733) |
+| `budget_usd` | float | no | Per-sub-lead envelope when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L736`](../crates/pitboss-cli/src/manifest/schema.rs#L736) |
+| `max_workers` | integer | no | Per-sub-lead worker pool when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L741`](../crates/pitboss-cli/src/manifest/schema.rs#L741) |
+| `lead_timeout_secs` | integer | no | Wall-clock cap for the sub-lead session. | [`../crates/pitboss-cli/src/manifest/schema.rs#L746`](../crates/pitboss-cli/src/manifest/schema.rs#L746) |
+| `read_down` | boolean | no | When true, sub-lead shares root's budget + worker pool instead of carving its own envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L752`](../crates/pitboss-cli/src/manifest/schema.rs#L752) |
 
 ## `[[approval_policy]]` — `ApprovalRuleSpec`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:263`](../crates/pitboss-cli/src/manifest/schema.rs#L263).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:282`](../crates/pitboss-cli/src/manifest/schema.rs#L282).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `action` | enum (`auto_approve` \| `auto_reject` \| `block`) | **yes** | Action when this rule matches. | [`../crates/pitboss-cli/src/manifest/schema.rs#L274`](../crates/pitboss-cli/src/manifest/schema.rs#L274) |
+| `action` | enum (`auto_approve` \| `auto_reject` \| `block`) | **yes** | Action when this rule matches. | [`../crates/pitboss-cli/src/manifest/schema.rs#L293`](../crates/pitboss-cli/src/manifest/schema.rs#L293) |
 
 ## `[[mcp_server]]` — `McpServerSpec`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:137`](../crates/pitboss-cli/src/manifest/schema.rs#L137).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:156`](../crates/pitboss-cli/src/manifest/schema.rs#L156).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Key under mcpServers in the generated config. | [`../crates/pitboss-cli/src/manifest/schema.rs#L143`](../crates/pitboss-cli/src/manifest/schema.rs#L143) |
-| `command` | text | **yes** | Executable to launch (e.g. npx, uvx, or an absolute path). | [`../crates/pitboss-cli/src/manifest/schema.rs#L149`](../crates/pitboss-cli/src/manifest/schema.rs#L149) |
-| `args` | string list | no | Arguments passed to the command. | [`../crates/pitboss-cli/src/manifest/schema.rs#L153`](../crates/pitboss-cli/src/manifest/schema.rs#L153) |
-| `env` | key-value map | no | Environment variables injected into the MCP server process. | [`../crates/pitboss-cli/src/manifest/schema.rs#L160`](../crates/pitboss-cli/src/manifest/schema.rs#L160) |
+| `id` | text | **yes** | Key under mcpServers in the generated config. | [`../crates/pitboss-cli/src/manifest/schema.rs#L162`](../crates/pitboss-cli/src/manifest/schema.rs#L162) |
+| `command` | text | **yes** | Executable to launch (e.g. npx, uvx, or an absolute path). | [`../crates/pitboss-cli/src/manifest/schema.rs#L168`](../crates/pitboss-cli/src/manifest/schema.rs#L168) |
+| `args` | string list | no | Arguments passed to the command. | [`../crates/pitboss-cli/src/manifest/schema.rs#L172`](../crates/pitboss-cli/src/manifest/schema.rs#L172) |
+| `env` | key-value map | no | Environment variables injected into the MCP server process. | [`../crates/pitboss-cli/src/manifest/schema.rs#L179`](../crates/pitboss-cli/src/manifest/schema.rs#L179) |
 
 ## `[[template]]` — `Template`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:485`](../crates/pitboss-cli/src/manifest/schema.rs#L485).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:504`](../crates/pitboss-cli/src/manifest/schema.rs#L504).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Slug referenced from [[task]].template. | [`../crates/pitboss-cli/src/manifest/schema.rs#L490`](../crates/pitboss-cli/src/manifest/schema.rs#L490) |
-| `prompt` | text (multi-line) | **yes** | Prompt body. Supports {var} placeholders supplied by [[task]].vars. | [`../crates/pitboss-cli/src/manifest/schema.rs#L496`](../crates/pitboss-cli/src/manifest/schema.rs#L496) |
+| `id` | text | **yes** | Slug referenced from [[task]].template. | [`../crates/pitboss-cli/src/manifest/schema.rs#L509`](../crates/pitboss-cli/src/manifest/schema.rs#L509) |
+| `prompt` | text (multi-line) | **yes** | Prompt body. Supports {var} placeholders supplied by [[task]].vars. | [`../crates/pitboss-cli/src/manifest/schema.rs#L515`](../crates/pitboss-cli/src/manifest/schema.rs#L515) |
 
 ## `[lifecycle]` — `Lifecycle`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:240`](../crates/pitboss-cli/src/manifest/schema.rs#L240).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:259`](../crates/pitboss-cli/src/manifest/schema.rs#L259).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `survive_parent` | boolean | no | Allow this dispatch to outlive its parent process. Requires a notify target. | [`../crates/pitboss-cli/src/manifest/schema.rs#L251`](../crates/pitboss-cli/src/manifest/schema.rs#L251) |
+| `survive_parent` | boolean | no | Allow this dispatch to outlive its parent process. Requires a notify target. | [`../crates/pitboss-cli/src/manifest/schema.rs#L270`](../crates/pitboss-cli/src/manifest/schema.rs#L270) |
 

--- a/docs/manifest-reference.toml
+++ b/docs/manifest-reference.toml
@@ -43,6 +43,7 @@ env = { EXAMPLE_KEY = "value" }
 image = "<value>"
 runtime = "docker"
 extra_args = []
+extra_apt = []
 workdir = "/path/to/value"
 
 [[container.mount]]


### PR DESCRIPTION
## Summary

- Adds optional `[container].extra_apt: Vec<String>` so operators can install Debian/Ubuntu packages inside the container at run start (e.g. `extra_apt = ["mdbook", "jq"]`), without rebuilding the base image.
- When set, `container-dispatch` overrides `-u 0:0` and wraps the entrypoint in a shell that does `apt-get update && apt-get install -y --no-install-recommends <pkgs> && exec runuser -u pitboss -- pitboss dispatch /run/pitboss.toml`. Tini stays as PID 1 so signal forwarding through the `runuser` exec is preserved.
- Package names are restricted to `[a-zA-Z0-9][a-zA-Z0-9.+-]*` for shell safety. Validation lives in both `build_run_args` and `pitboss validate`, so bad names are rejected at schema time — not deferred to dispatch.
- Tightens the existing `extra_args` help text to call out networking / capability / DNS / resource use cases. That field is the escape hatch for any `podman run` / `docker run` flag (`--network=...`, `--cap-add=NET_ADMIN`, `--dns=...`, `--memory=4g`) and was under-documented.

## Why

Phase 1 of the rollout planned in #256 — the smallest viable mechanism for "I forgot to bake X into the image." Trade is 30–90 s spin-up overhead per dispatch on cache miss; the fast cached path (`pitboss container-build` + derived-image layer cache) is tracked separately in #262.

Networking / capabilities / DNS / resource limits explicitly do not get structured TOML in this PR — they're already covered verbatim by `extra_args`, and adding a parallel typed schema would shadow it. Promote to first-class structure only when a specific pattern is provably common across many manifests.

## Files changed

- `crates/pitboss-cli/src/manifest/schema.rs` — new `extra_apt` field; tightened `extra_args` help.
- `crates/pitboss-cli/src/dispatch/container.rs` — entrypoint wrap + `is_valid_apt_pkg` (now `pub(crate)`); 4 unit tests.
- `crates/pitboss-cli/src/manifest/validate.rs` — `validate_container` runs the same predicate; 2 unit tests.
- `AGENTS.md` — `[container]` table row for `extra_apt`; expanded `extra_args` row.
- `docs/manifest-reference.toml` + `docs/manifest-map.md` — regenerated from schema.

## Test plan

- [x] `cargo test -p pitboss-cli --lib` (579 / 0)
- [x] `cargo test --workspace --features pitboss-core/test-support`
- [x] `cargo lint` + `cargo tidy` clean
- [x] `pitboss container-dispatch --dry-run` against a manifest with `extra_apt = ["mdbook", "jq"]` + `extra_args = ["--network=host", "--dns=1.1.1.1"]` — assembled argv has correct `-u 0:0` placement (last `-u` wins) + `sh -c '…apt-get…&& exec runuser -u pitboss -- pitboss dispatch /run/pitboss.toml'`
- [x] `pitboss validate` on `extra_apt = ["mdbook;rm -rf /"]` exits non-zero with a clear error
- [ ] Live container dispatch with `extra_apt = ["mdbook"]` (deferred — depends on container image rebuild on main; targeting next operator smoke run)

## Follow-ups

- (advisor item 3) The "last `-u` wins" assertion isn't exercised on the docker-with-non-1000-host-UID code path. Refactoring user alignment to take an injectable UID would close the testability gap; not blocking.

Refs #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)