### PR TITLE
feat(container): pitboss container-build subcommand + [[container.copy]]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,7 +261,7 @@ The `[container]` section enables `pitboss container-dispatch`, which assembles 
 | `image` | string | `ghcr.io/sds-mode/pitboss-with-claude:latest` | Container image to run. |
 | `runtime` | `"docker"` \| `"podman"` \| `"auto"` | `"auto"` | Runtime selector. `"auto"` prefers podman when available. |
 | `extra_args` | array of string | `[]` | Verbatim flags for `podman run` / `docker run`. The escape hatch for any container-runtime concern: networking (`--network=corp-fw`, `--dns=10.0.0.53`, `--add-host=svc:1.2.3.4`), capabilities (`--cap-add=NET_ADMIN`), security (`--security-opt=…`), resource limits (`--memory=4g`, `--cpus=2`). |
-| `extra_apt` | array of string | `[]` | Debian/Ubuntu packages installed inside the container before `pitboss dispatch` starts. Adds 30–90 s spin-up per dispatch (no caching yet — see roadmap). Each entry must match `[a-zA-Z0-9][a-zA-Z0-9.+-]*`; rejected at validate time otherwise. |
+| `extra_apt` | array of string | `[]` | Debian/Ubuntu packages installed inside the container. Two paths: by default they are installed at dispatch start (~30–90 s per run); after `pitboss container-build`, they are baked into a derived image and dispatch picks up the cached tag automatically. Each entry must match `[a-zA-Z0-9][a-zA-Z0-9.+-]*`; rejected at validate time otherwise. |
 | `workdir` | string | first mount's container path, else `/home/pitboss` | Working directory inside the container. |
 
 #### `[[container.mount]]`
@@ -273,6 +273,30 @@ The `[container]` section enables `pitboss container-dispatch`, which assembles 
 | `readonly` | no | Default `false`. |
 
 Two mounts are always auto-injected: `~/.claude → /home/pitboss/.claude` (OAuth) and the run artifact directory; the manifest itself is injected at `/run/pitboss.toml` read-only.
+
+#### `[[container.copy]]`
+
+Files baked into a derived image at `pitboss container-build` time. Unlike `[[container.mount]]`, these are layered into the image — they're available even when no host bind mount is in place, and they require a build step before `container-dispatch` will run.
+
+| Key | Required? | Notes |
+|---|---|---|
+| `host` | yes | Absolute host path or tilde-prefixed (`~/...`). May be a file or directory. Read at build time only — edits to the host file invalidate the derived tag and force a rebuild. |
+| `container` | yes | Absolute path inside the container. |
+
+Declaring `[[container.copy]]` makes a `pitboss container-build <manifest>` call **mandatory** before `pitboss container-dispatch` will run — the dispatcher refuses to fall back to the stock image because the COPY contents would be missing.
+
+#### `pitboss container-build` (v0.9.2+)
+
+Synthesizes a thin Dockerfile from `[container]` and builds a derived image tagged deterministically as `pitboss-derived-<sha>:local`. The `<sha>` hashes the base image, sorted `extra_apt`, and sorted `[[container.copy]]` entries (host file CONTENTS, not paths). Idempotent: re-running with the same inputs is a no-op once the tag exists. `--no-cache` forces a rebuild.
+
+```bash
+pitboss container-build pitboss.toml             # build (or skip if cached)
+pitboss container-build pitboss.toml --no-cache  # force rebuild
+pitboss container-build pitboss.toml --print-dockerfile  # preview
+pitboss container-build pitboss.toml --dry-run   # print podman/docker invocation
+```
+
+`pitboss container-dispatch` automatically picks up the derived tag when `extra_apt` or `copy` is non-empty and the tag exists locally — no explicit wiring needed in the manifest. Stale derived tags from prior builds remain in the local image store; prune them with the runtime's standard tooling (`podman image prune`, etc.) — a pitboss-aware sweeper is tracked in the roadmap.
 
 ### `[[mcp_server]]` (v0.9+)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1903,6 +1903,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "sha2",
  "shellexpand",
  "tempfile",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ mime_guess         = "2"
 futures-util       = "0.3"
 notify             = "6"
 dirs               = "5"
+sha2               = "0.10"
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/crates/pitboss-cli/Cargo.toml
+++ b/crates/pitboss-cli/Cargo.toml
@@ -54,6 +54,8 @@ glob               = { workspace = true }
 dirs               = { workspace = true }
 base64             = { workspace = true }
 libc               = { workspace = true }
+sha2               = { workspace = true }
+tempfile           = { workspace = true }
 
 [dev-dependencies]
 # Note: pitboss-core's test-support feature is pulled in directly here so

--- a/crates/pitboss-cli/src/cli.rs
+++ b/crates/pitboss-cli/src/cli.rs
@@ -173,6 +173,29 @@ pub enum Command {
         #[arg(long)]
         runtime: Option<String>,
     },
+    /// Build a derived container image from the manifest's `[container]`
+    /// section. Synthesizes a thin Dockerfile (`extra_apt` + `[[container.copy]]`),
+    /// builds it with `--layers`, and tags the result deterministically as
+    /// `pitboss-derived-<sha>:local`. Idempotent: skips the build when the
+    /// derived tag already exists locally (use `--no-cache` to force).
+    /// Pairs with `pitboss container-dispatch`, which picks up the same
+    /// derived tag automatically when `extra_apt`/`copy` are non-empty.
+    ContainerBuild {
+        manifest: PathBuf,
+        /// Override container runtime detection ("docker" or "podman").
+        #[arg(long)]
+        runtime: Option<String>,
+        /// Force a rebuild even when the derived tag is already present.
+        #[arg(long)]
+        no_cache: bool,
+        /// Print the synthesized Dockerfile to stdout and exit. Useful
+        /// for previewing the build before committing to it.
+        #[arg(long)]
+        print_dockerfile: bool,
+        /// Print the assembled `<runtime> build …` command and exit.
+        #[arg(long)]
+        dry_run: bool,
+    },
     /// Print a snapshot of all task records for a prior run.
     /// Reads summary.jsonl (in-flight) or summary.json (finalized).
     Status {

--- a/crates/pitboss-cli/src/dispatch/container.rs
+++ b/crates/pitboss-cli/src/dispatch/container.rs
@@ -33,7 +33,37 @@ pub fn run_container_dispatch(
         .canonicalize()
         .with_context(|| format!("canonicalizing manifest path {}", manifest_path.display()))?;
 
-    let args = build_run_args(&runtime, container, &manifest_abs, run_dir_override)?;
+    // Phase 2: when the manifest declares derived-image inputs, prefer
+    // the locally-built derived tag if it exists. `[[container.copy]]`
+    // is hard-required (the COPY contents only exist in the baked
+    // image) — error loudly when it's missing rather than silently
+    // falling back to a stock-image dispatch.
+    let derived = super::container_build::derived_image_tag(container)?;
+    let use_derived = match derived.as_ref() {
+        Some(tag) => super::container_build::image_exists(&runtime, tag)?,
+        None => false,
+    };
+    if !container.copy.is_empty() && !use_derived {
+        bail!(
+            "[[container.copy]] requires a built derived image. Run \
+             `pitboss container-build {}` first to bake the COPY contents \
+             into pitboss-derived-…:local.",
+            manifest_path.display()
+        );
+    }
+    let derived_image_override = if use_derived {
+        derived.as_deref()
+    } else {
+        None
+    };
+
+    let args = build_run_args(
+        &runtime,
+        container,
+        &manifest_abs,
+        run_dir_override,
+        derived_image_override,
+    )?;
 
     if dry_run {
         // Print the full command the operator would run so they can inspect it.
@@ -51,11 +81,17 @@ pub fn run_container_dispatch(
 }
 
 /// Build the full argument list for `<runtime> run …`.
+///
+/// `derived_image_override` is `Some(tag)` when `container-dispatch`
+/// resolved a built derived image (apt + COPY already baked in). When
+/// set, the Phase-1 apt-at-spin-up wrap is skipped — the work is
+/// already in the image.
 fn build_run_args(
     runtime: &str,
     container: &ContainerConfig,
     manifest_abs: &Path,
     run_dir_override: Option<PathBuf>,
+    derived_image_override: Option<&str>,
 ) -> Result<Vec<String>> {
     let mut args: Vec<String> = vec!["run".into(), "--rm".into()];
 
@@ -162,17 +198,22 @@ fn build_run_args(
     args.extend(container.extra_args.clone());
 
     // ── extra_apt: validate + override user to root for the apt step ─────────
-    // apt-get needs root. When `extra_apt` is non-empty we override `-u` to
-    // 0:0 here (last `-u` wins) and rewrite the entrypoint below into a
-    // shell that installs the packages, then `exec runuser -u pitboss --
-    // pitboss dispatch …` so the long-lived process drops to UID 1000
-    // before workers spawn. Tini stays as PID 1, so signal forwarding to
-    // the post-exec pitboss is preserved.
+    // apt-get needs root. When `extra_apt` is non-empty AND no derived
+    // image is available, we override `-u` to 0:0 here (last `-u` wins)
+    // and rewrite the entrypoint below into a shell that installs the
+    // packages, then `exec runuser -u pitboss -- pitboss dispatch …` so
+    // the long-lived process drops to UID 1000 before workers spawn.
+    // Tini stays as PID 1, so signal forwarding to the post-exec pitboss
+    // is preserved.
+    //
+    // When a derived image is in play (Phase 2 / `pitboss container-build`),
+    // apt is already baked into the image and this whole wrap is skipped —
+    // dispatch runs as the canonical pitboss user from the start.
     //
     // Package names are joined verbatim into a shell command, so we
     // require each entry to match `[a-zA-Z0-9][a-zA-Z0-9.+-]*` and reject
     // anything else at dispatch time.
-    let bootstrap_apt = !container.extra_apt.is_empty();
+    let bootstrap_apt = !container.extra_apt.is_empty() && derived_image_override.is_none();
     if bootstrap_apt {
         for pkg in &container.extra_apt {
             if !is_valid_apt_pkg(pkg) {
@@ -188,9 +229,12 @@ fn build_run_args(
     }
 
     // ── Image + pitboss command ───────────────────────────────────────────────
-    let image = container
-        .image
-        .clone()
+    // Derived image (built by `container-build`) wins over manifest
+    // `image` when present — the manifest's `image` field is the BASE
+    // for derivation, not the runtime image.
+    let image = derived_image_override
+        .map(String::from)
+        .or_else(|| container.image.clone())
         .unwrap_or_else(|| DEFAULT_IMAGE.to_string());
     args.push(image);
 
@@ -233,7 +277,10 @@ pub(crate) fn is_valid_apt_pkg(s: &str) -> bool {
 ///   2. `container.runtime` from the manifest
 ///   3. `PITBOSS_CONTAINER_RUNTIME` env var
 ///   4. Auto-detect: prefer `podman`, fall back to `docker`
-fn detect_runtime(
+///
+/// Re-used by `dispatch/container_build` so both subcommands see the
+/// same runtime selection rules.
+pub(crate) fn detect_runtime(
     runtime_override: Option<&str>,
     manifest_runtime: Option<&str>,
 ) -> Result<String> {
@@ -386,6 +433,7 @@ mod tests {
             extra_args: vec![],
             extra_apt: vec![],
             mounts,
+            copy: vec![],
             workdir: None,
         }
     }
@@ -417,7 +465,7 @@ prompt = "hi"
         let cfg = make_config(vec![]);
         let manifest = temp_manifest();
         // Build args without calling exec.
-        let args = build_run_args("podman", &cfg, &manifest, None).unwrap();
+        let args = build_run_args("podman", &cfg, &manifest, None, None).unwrap();
         let joined = args.join(" ");
         assert!(joined.contains("pitboss"), "should call pitboss: {joined}");
         assert!(
@@ -433,7 +481,7 @@ prompt = "hi"
     #[test]
     fn default_image_used_when_none_specified() {
         let cfg = make_config(vec![]);
-        let args = build_run_args("docker", &cfg, &temp_manifest(), None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None).unwrap();
         let joined = args.join(" ");
         assert!(
             joined.contains(DEFAULT_IMAGE),
@@ -447,7 +495,7 @@ prompt = "hi"
             image: Some("my-org/pitboss:latest".into()),
             ..ContainerConfig::default()
         };
-        let args = build_run_args("docker", &cfg, &temp_manifest(), None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None).unwrap();
         let joined = args.join(" ");
         assert!(
             joined.contains("my-org/pitboss:latest"),
@@ -469,7 +517,7 @@ prompt = "hi"
             }],
             ..ContainerConfig::default()
         };
-        let args = build_run_args("docker", &cfg, &temp_manifest(), None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None).unwrap();
         let joined = args.join(" ");
         assert!(
             joined.contains("/home/alice/project:/project:rw,z"),
@@ -487,7 +535,7 @@ prompt = "hi"
             }],
             ..ContainerConfig::default()
         };
-        let args = build_run_args("podman", &cfg, &temp_manifest(), None).unwrap();
+        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None).unwrap();
         let joined = args.join(" ");
         assert!(joined.contains("/ref:/ref:ro,z"), "readonly flag: {joined}");
     }
@@ -495,7 +543,7 @@ prompt = "hi"
     #[test]
     fn auto_inject_claude_when_not_in_mounts() {
         let cfg = make_config(vec![]);
-        let args = build_run_args("docker", &cfg, &temp_manifest(), None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None).unwrap();
         let joined = args.join(" ");
         assert!(
             joined.contains("/home/pitboss/.claude"),
@@ -513,7 +561,7 @@ prompt = "hi"
             }],
             ..ContainerConfig::default()
         };
-        let args = build_run_args("docker", &cfg, &temp_manifest(), None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None).unwrap();
         // Count -v args that mount to /home/pitboss/.claude — should be exactly 1
         // (the declared mount). The -w workdir may also reference the path but is
         // not a duplicate mount injection.
@@ -537,7 +585,7 @@ prompt = "hi"
             }],
             ..ContainerConfig::default()
         };
-        let args = build_run_args("docker", &cfg, &temp_manifest(), None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None).unwrap();
         // -w should be followed by /project
         let w_pos = args.iter().position(|a| a == "-w").expect("-w flag");
         assert_eq!(args[w_pos + 1], "/project", "workdir: {args:?}");
@@ -546,7 +594,7 @@ prompt = "hi"
     #[test]
     fn workdir_falls_back_to_home_pitboss_when_no_mounts() {
         let cfg = make_config(vec![]);
-        let args = build_run_args("docker", &cfg, &temp_manifest(), None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None).unwrap();
         let w_pos = args.iter().position(|a| a == "-w").expect("-w flag");
         assert_eq!(
             args[w_pos + 1],
@@ -566,7 +614,7 @@ prompt = "hi"
             workdir: Some(PathBuf::from("/project/sub")),
             ..ContainerConfig::default()
         };
-        let args = build_run_args("docker", &cfg, &temp_manifest(), None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None).unwrap();
         let w_pos = args.iter().position(|a| a == "-w").expect("-w flag");
         assert_eq!(
             args[w_pos + 1],
@@ -581,7 +629,7 @@ prompt = "hi"
             extra_args: vec!["--network=host".into(), "--cap-drop=ALL".into()],
             ..ContainerConfig::default()
         };
-        let args = build_run_args("docker", &cfg, &temp_manifest(), None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None).unwrap();
         let net_pos = args
             .iter()
             .position(|a| a == "--network=host")
@@ -612,7 +660,8 @@ prompt = "hi"
     fn run_dir_mount_uses_override() {
         let custom = PathBuf::from("/tmp/my-runs");
         let cfg = make_config(vec![]);
-        let args = build_run_args("docker", &cfg, &temp_manifest(), Some(custom.clone())).unwrap();
+        let args =
+            build_run_args("docker", &cfg, &temp_manifest(), Some(custom.clone()), None).unwrap();
         let joined = args.join(" ");
         assert!(
             joined.contains("/tmp/my-runs"),
@@ -625,7 +674,7 @@ prompt = "hi"
         // Sanity: with no extra_apt the entrypoint args are still the bare
         // `pitboss dispatch /run/pitboss.toml` triplet — no shell wrap.
         let cfg = make_config(vec![]);
-        let args = build_run_args("podman", &cfg, &temp_manifest(), None).unwrap();
+        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None).unwrap();
         assert!(
             !args.iter().any(|a| a == "sh"),
             "no sh wrapper expected: {args:?}"
@@ -652,7 +701,7 @@ prompt = "hi"
             extra_apt: vec!["mdbook".into(), "jq".into()],
             ..ContainerConfig::default()
         };
-        let args = build_run_args("podman", &cfg, &temp_manifest(), None).unwrap();
+        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None).unwrap();
 
         // -u 0:0 must appear (so apt-get can run as root).
         let u_pos = args
@@ -706,7 +755,7 @@ prompt = "hi"
                 extra_apt: vec![bad.into()],
                 ..ContainerConfig::default()
             };
-            let result = build_run_args("podman", &cfg, &temp_manifest(), None);
+            let result = build_run_args("podman", &cfg, &temp_manifest(), None, None);
             assert!(
                 result.is_err(),
                 "expected rejection for {bad:?}, got: {result:?}"
@@ -717,6 +766,68 @@ prompt = "hi"
                 "error should mention extra_apt: {msg}"
             );
         }
+    }
+
+    #[test]
+    fn derived_image_override_wins_over_manifest_image() {
+        // When `container-dispatch` resolves a built derived tag, it
+        // takes precedence over the operator's [container].image — the
+        // manifest image is the base for derivation, not the runtime.
+        let cfg = ContainerConfig {
+            image: Some("base/image:1".into()),
+            extra_apt: vec!["mdbook".into()],
+            ..ContainerConfig::default()
+        };
+        let args = build_run_args(
+            "podman",
+            &cfg,
+            &temp_manifest(),
+            None,
+            Some("pitboss-derived-abc123:local"),
+        )
+        .unwrap();
+        assert!(
+            args.iter().any(|a| a == "pitboss-derived-abc123:local"),
+            "derived tag must appear: {args:?}"
+        );
+        assert!(
+            !args.iter().any(|a| a == "base/image:1"),
+            "base image must NOT appear at runtime: {args:?}"
+        );
+    }
+
+    #[test]
+    fn derived_image_override_skips_entrypoint_apt_wrap() {
+        // With a derived image, apt is already installed at build time —
+        // the spin-up shell wrap and -u 0:0 root override should both be
+        // suppressed so dispatch runs as pitboss with bare entrypoint.
+        let cfg = ContainerConfig {
+            extra_apt: vec!["mdbook".into(), "jq".into()],
+            ..ContainerConfig::default()
+        };
+        let args = build_run_args(
+            "podman",
+            &cfg,
+            &temp_manifest(),
+            None,
+            Some("pitboss-derived-deadbeef:local"),
+        )
+        .unwrap();
+        assert!(
+            !args.iter().any(|a| a == "0:0"),
+            "no root override expected when derived image is used: {args:?}"
+        );
+        assert!(
+            !args.iter().any(|a| a == "sh"),
+            "no shell wrap expected when derived image is used: {args:?}"
+        );
+        // Bare pitboss/dispatch entrypoint should be present instead.
+        let dispatch_pos = args
+            .iter()
+            .position(|a| a == "dispatch")
+            .expect("dispatch arg present");
+        assert_eq!(args[dispatch_pos - 1], "pitboss");
+        assert_eq!(args[dispatch_pos + 1], "/run/pitboss.toml");
     }
 
     #[test]
@@ -732,7 +843,7 @@ prompt = "hi"
             ],
             ..ContainerConfig::default()
         };
-        let args = build_run_args("podman", &cfg, &temp_manifest(), None)
+        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None)
             .expect("realistic package names should validate");
         let img_pos = args.iter().position(|a| a == DEFAULT_IMAGE).expect("image");
         let cmd = &args[img_pos + 3];

--- a/crates/pitboss-cli/src/dispatch/container_build.rs
+++ b/crates/pitboss-cli/src/dispatch/container_build.rs
@@ -1,0 +1,536 @@
+//! `pitboss container-build` — synthesize a thin Dockerfile from the
+//! manifest's `[container]` section, build a derived image tagged
+//! deterministically, and skip the rebuild when the same tag already
+//! exists locally.
+//!
+//! The derived tag is `pitboss-derived-<sha>:local`, where `<sha>` is
+//! a SHA-256 over the build inputs that materially affect the image
+//! contents — base image, sorted `extra_apt`, sorted `[[container.copy]]`
+//! pairs (host bytes hashed in, not just the path). This means:
+//!
+//! - Re-running `container-build` with the same manifest is a no-op once
+//!   the tag exists (idempotent fast path).
+//! - `container-dispatch` can compute the same tag and pick it up
+//!   without state coordination — see `dispatch/container.rs`.
+//! - Mutating a copied host file rewrites the tag, so the rebuild is
+//!   automatic on next build.
+//!
+//! Caching strategy: we use `--layers` for local layer reuse. The
+//! `--cache-from` / `--cache-to` flags are remote-cache features (per
+//! podman docs) and explicitly out of scope for Phase 2. Their slot is
+//! reserved for a future remote-cache work item.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{bail, Context, Result};
+use sha2::{Digest, Sha256};
+
+use crate::manifest::schema::{ContainerConfig, CopySpec};
+
+/// Default base image when `[container].image` is unset. Mirrors the
+/// constant in `dispatch/container.rs`; kept duplicated rather than
+/// re-exported to keep the module-graph DAG simple.
+const DEFAULT_BASE_IMAGE: &str = "ghcr.io/sds-mode/pitboss-with-claude:latest";
+
+/// Options bag for `run_container_build` — separate from
+/// `ContainerConfig` because these are CLI-driven and don't belong in
+/// the manifest schema.
+#[derive(Debug, Clone, Default)]
+pub struct BuildOptions {
+    /// Force a rebuild even when the derived tag already exists.
+    pub no_cache: bool,
+    /// Print the synthesized Dockerfile to stdout and exit. Skips
+    /// staging and the actual build.
+    pub print_dockerfile: bool,
+    /// Print the assembled `<runtime> build …` command and exit.
+    pub dry_run: bool,
+    /// Override the auto-detected runtime ("docker" / "podman").
+    pub runtime_override: Option<String>,
+}
+
+/// Compute the deterministic derived-image tag for the given container
+/// configuration. Same inputs always yield the same tag; any change to
+/// the base image, `extra_apt`, or `[[container.copy]]` (including
+/// host-file contents) flips it.
+///
+/// Returns `None` when the configuration declares no derived-image
+/// inputs (no `extra_apt` and no `copy` entries). In that case the
+/// operator's stock `[container].image` is used directly and there's
+/// nothing to build.
+pub fn derived_image_tag(container: &ContainerConfig) -> Result<Option<String>> {
+    if container.extra_apt.is_empty() && container.copy.is_empty() {
+        return Ok(None);
+    }
+
+    let base = container.image.as_deref().unwrap_or(DEFAULT_BASE_IMAGE);
+
+    // Tag-scheme version. Bump to v2 when the set of hashed inputs
+    // changes (e.g. adding a new field that materially affects the
+    // derived image), so existing `pitboss-derived-…:local` tags get
+    // rebuilt rather than silently reused with stale content.
+    let mut hasher = Sha256::new();
+    hasher.update(b"pitboss-derived-tag-v1\n");
+    hasher.update(b"base=");
+    hasher.update(base.as_bytes());
+    hasher.update(b"\n");
+
+    // Sort apt packages so `["jq","mdbook"]` and `["mdbook","jq"]` hash
+    // identically — install order doesn't change the resulting layer.
+    let mut apt_sorted: Vec<&String> = container.extra_apt.iter().collect();
+    apt_sorted.sort();
+    for pkg in apt_sorted {
+        hasher.update(b"apt=");
+        hasher.update(pkg.as_bytes());
+        hasher.update(b"\n");
+    }
+
+    // Sort copy specs by container path (the deterministic key) so
+    // operators can shuffle the manifest order without invalidating the
+    // cache. Hash the host file's CONTENTS, not just the path — the
+    // operator may edit the file, and the rebuild needs to fire.
+    let mut copy_sorted: Vec<&CopySpec> = container.copy.iter().collect();
+    copy_sorted.sort_by(|a, b| a.container.cmp(&b.container));
+    for spec in copy_sorted {
+        let host = expand_tilde(&spec.host);
+        hasher.update(b"copy_container=");
+        hasher.update(spec.container.to_string_lossy().as_bytes());
+        hasher.update(b"\n");
+        hasher.update(b"copy_host_bytes=");
+        let mut file_hasher = Sha256::new();
+        hash_path_into(&host, &mut file_hasher).with_context(|| {
+            format!(
+                "hashing copy source {} for derived-image tag",
+                host.display()
+            )
+        })?;
+        let file_digest = file_hasher.finalize();
+        hasher.update(format!("{:x}", file_digest).as_bytes());
+        hasher.update(b"\n");
+    }
+
+    let digest = hasher.finalize();
+    // 12 hex chars = 48 bits — ~10^14 distinct tags. Plenty for a per-host
+    // local cache; the leading byte cluster reads cleanly in image lists.
+    let short = format!("{:x}", digest);
+    let tag = format!("pitboss-derived-{}:local", &short[..12]);
+    Ok(Some(tag))
+}
+
+/// Build a thin Dockerfile that derives a child image from
+/// `[container].image` (or the default), installs `[container].extra_apt`
+/// as a single layer, and `COPY`s `[[container.copy]]` entries. The
+/// host paths are written as numbered relative paths (`copy0`, `copy1`,
+/// …) so the staged build context layout is predictable.
+pub fn synthesize_dockerfile(container: &ContainerConfig) -> String {
+    let base = container.image.as_deref().unwrap_or(DEFAULT_BASE_IMAGE);
+    let mut out = String::new();
+    out.push_str("# Auto-generated by `pitboss container-build` — do not edit.\n");
+    out.push_str(&format!("FROM {base}\n"));
+
+    // Track the active USER so we don't emit redundant `USER root`
+    // directives when both extra_apt and copy are present (each one
+    // would otherwise stamp its own `USER root` line, layering a
+    // no-op).
+    let mut as_root = false;
+
+    if !container.extra_apt.is_empty() {
+        out.push_str("USER root\n");
+        as_root = true;
+        out.push_str("RUN apt-get update \\\n");
+        out.push_str(" && apt-get install -y --no-install-recommends");
+        for pkg in &container.extra_apt {
+            out.push(' ');
+            out.push_str(pkg);
+        }
+        out.push_str(" \\\n");
+        out.push_str(" && rm -rf /var/lib/apt/lists/*\n");
+    }
+
+    if !container.copy.is_empty() {
+        // COPY runs as root regardless of USER, but we want the file
+        // ownership to settle as `pitboss:pitboss` so the runtime user
+        // can write/exec it without surprise.
+        if !as_root {
+            out.push_str("USER root\n");
+            as_root = true;
+        }
+        for (i, spec) in container.copy.iter().enumerate() {
+            out.push_str(&format!(
+                "COPY --chown=pitboss:pitboss copy{i} {}\n",
+                spec.container.display()
+            ));
+        }
+    }
+
+    // Restore the canonical runtime user. Phase-1 dispatch logic
+    // assumes the image leaves the runtime as the `pitboss` user;
+    // re-asserting it here keeps the derived image consistent — but
+    // only when we strayed from it.
+    if as_root {
+        out.push_str("USER pitboss\n");
+    }
+    out
+}
+
+/// Top-level entry called from main.rs for `pitboss container-build`.
+pub fn run_container_build(container: &ContainerConfig, opts: &BuildOptions) -> Result<()> {
+    let dockerfile = synthesize_dockerfile(container);
+
+    if opts.print_dockerfile {
+        print!("{dockerfile}");
+        return Ok(());
+    }
+
+    let Some(tag) = derived_image_tag(container)? else {
+        bail!(
+            "[container] has no derived-image inputs (no extra_apt, no [[container.copy]]) — \
+             nothing to build. Use `pitboss container-dispatch` against the stock image instead."
+        );
+    };
+
+    let runtime = crate::dispatch::container::detect_runtime(
+        opts.runtime_override.as_deref(),
+        container.runtime.as_deref(),
+    )?;
+
+    // Idempotency: skip the build if the derived tag is already in the
+    // local image store, unless the operator forced --no-cache.
+    if !opts.no_cache && image_exists(&runtime, &tag)? {
+        if !opts.dry_run {
+            println!("derived image already exists: {tag} (--no-cache to force rebuild)");
+        }
+        return Ok(());
+    }
+
+    // Stage the build context: a temp dir holding the synthesized
+    // Dockerfile and the numbered COPY sources.
+    let context_dir = tempfile::Builder::new()
+        .prefix("pitboss-build-context-")
+        .tempdir()
+        .context("creating temp build context dir")?;
+
+    let dockerfile_path = context_dir.path().join("Dockerfile");
+    std::fs::write(&dockerfile_path, &dockerfile)
+        .with_context(|| format!("writing {}", dockerfile_path.display()))?;
+
+    for (i, spec) in container.copy.iter().enumerate() {
+        let host = expand_tilde(&spec.host);
+        if !host.exists() {
+            bail!(
+                "[[container.copy]] host path does not exist: {}",
+                host.display()
+            );
+        }
+        let dest = context_dir.path().join(format!("copy{i}"));
+        copy_path(&host, &dest).with_context(|| {
+            format!(
+                "staging copy source {} → {}",
+                host.display(),
+                dest.display()
+            )
+        })?;
+    }
+
+    let mut args: Vec<String> = vec![
+        "build".into(),
+        "--layers".into(),
+        "-t".into(),
+        tag.clone(),
+        "-f".into(),
+        dockerfile_path.display().to_string(),
+        context_dir.path().display().to_string(),
+    ];
+    if opts.no_cache {
+        // --no-cache implies "rebuild every layer" but is compatible
+        // with --layers (the layer cache is still populated for the
+        // *next* build). Without --layers, podman warns and downgrades.
+        args.push("--no-cache".into());
+    }
+
+    if opts.dry_run {
+        let cmd_str = std::iter::once(runtime.as_str())
+            .chain(args.iter().map(String::as_str))
+            .collect::<Vec<_>>()
+            .join(" ");
+        println!("{cmd_str}");
+        return Ok(());
+    }
+
+    let status = Command::new(&runtime)
+        .args(&args)
+        .status()
+        .with_context(|| format!("invoking {runtime} build"))?;
+    if !status.success() {
+        bail!("{runtime} build exited with {status}");
+    }
+
+    println!("built derived image: {tag}");
+    Ok(())
+}
+
+/// Best-effort tilde expansion. Mirrors the helper in
+/// `dispatch/container.rs`; kept here too rather than re-exported to
+/// keep the build module's import surface small.
+fn expand_tilde(p: &Path) -> PathBuf {
+    let s = p.to_string_lossy();
+    match shellexpand::tilde(s.as_ref()) {
+        std::borrow::Cow::Borrowed(_) => p.to_path_buf(),
+        std::borrow::Cow::Owned(expanded) => PathBuf::from(expanded),
+    }
+}
+
+/// Check whether `tag` exists in the runtime's local image store.
+/// Returns Ok(true) when the image is present, Ok(false) when absent,
+/// and Err only on runtime invocation failures.
+pub(crate) fn image_exists(runtime: &str, tag: &str) -> Result<bool> {
+    let status = Command::new(runtime)
+        .args(["image", "exists", tag])
+        .status()
+        .with_context(|| format!("invoking {runtime} image exists"))?;
+    Ok(status.success())
+}
+
+/// Recursively hash a path's contents into the supplied hasher. For
+/// directories we walk in sorted order so the hash is deterministic
+/// across filesystems with different `readdir` orderings.
+fn hash_path_into(path: &Path, hasher: &mut Sha256) -> std::io::Result<()> {
+    let meta = std::fs::metadata(path)?;
+    if meta.is_dir() {
+        hasher.update(b"D|");
+        hasher.update(path.file_name().unwrap_or_default().as_encoded_bytes());
+        hasher.update(b"\n");
+        let mut entries: BTreeMap<std::ffi::OsString, PathBuf> = BTreeMap::new();
+        for entry in std::fs::read_dir(path)? {
+            let entry = entry?;
+            entries.insert(entry.file_name(), entry.path());
+        }
+        for (_, child) in entries {
+            hash_path_into(&child, hasher)?;
+        }
+    } else if meta.is_file() {
+        hasher.update(b"F|");
+        hasher.update(path.file_name().unwrap_or_default().as_encoded_bytes());
+        hasher.update(b"|len=");
+        hasher.update(meta.len().to_le_bytes());
+        hasher.update(b"|bytes=");
+        let bytes = std::fs::read(path)?;
+        hasher.update(&bytes);
+        hasher.update(b"\n");
+    } else {
+        // Symlinks and other special files are unusual inputs for a
+        // build COPY. Hash a stable marker so the user gets a tag, but
+        // the build will likely fail at COPY time with a clearer error.
+        hasher.update(b"S|");
+        hasher.update(path.to_string_lossy().as_bytes());
+        hasher.update(b"\n");
+    }
+    Ok(())
+}
+
+/// Copy `src` into `dest`. For files this is a single std::fs::copy;
+/// for directories we recurse so the build context layout mirrors the
+/// host tree under the synthesized name (`copyN`).
+fn copy_path(src: &Path, dest: &Path) -> std::io::Result<()> {
+    let meta = std::fs::metadata(src)?;
+    if meta.is_dir() {
+        std::fs::create_dir_all(dest)?;
+        for entry in std::fs::read_dir(src)? {
+            let entry = entry?;
+            let from = entry.path();
+            let to = dest.join(entry.file_name());
+            copy_path(&from, &to)?;
+        }
+    } else if meta.is_file() {
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::copy(src, dest)?;
+    } else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            format!(
+                "[[container.copy]] sources must be regular files or directories: {}",
+                src.display()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn cfg() -> ContainerConfig {
+        ContainerConfig::default()
+    }
+
+    #[test]
+    fn no_inputs_yields_no_tag() {
+        let c = cfg();
+        assert_eq!(derived_image_tag(&c).unwrap(), None);
+    }
+
+    #[test]
+    fn extra_apt_alone_yields_a_tag() {
+        let c = ContainerConfig {
+            extra_apt: vec!["mdbook".into()],
+            ..cfg()
+        };
+        let tag = derived_image_tag(&c).unwrap().expect("tag for apt-only");
+        assert!(tag.starts_with("pitboss-derived-"));
+        assert!(tag.ends_with(":local"), "tag: {tag}");
+    }
+
+    #[test]
+    fn tag_is_stable_across_apt_ordering() {
+        let a = ContainerConfig {
+            extra_apt: vec!["jq".into(), "mdbook".into()],
+            ..cfg()
+        };
+        let b = ContainerConfig {
+            extra_apt: vec!["mdbook".into(), "jq".into()],
+            ..cfg()
+        };
+        assert_eq!(
+            derived_image_tag(&a).unwrap(),
+            derived_image_tag(&b).unwrap(),
+            "manifest apt order must not change the derived tag"
+        );
+    }
+
+    #[test]
+    fn tag_changes_when_apt_changes() {
+        let a = ContainerConfig {
+            extra_apt: vec!["mdbook".into()],
+            ..cfg()
+        };
+        let b = ContainerConfig {
+            extra_apt: vec!["mdbook".into(), "jq".into()],
+            ..cfg()
+        };
+        assert_ne!(
+            derived_image_tag(&a).unwrap(),
+            derived_image_tag(&b).unwrap()
+        );
+    }
+
+    #[test]
+    fn tag_changes_when_base_image_changes() {
+        let a = ContainerConfig {
+            extra_apt: vec!["mdbook".into()],
+            ..cfg()
+        };
+        let b = ContainerConfig {
+            image: Some("custom/image:1".into()),
+            extra_apt: vec!["mdbook".into()],
+            ..cfg()
+        };
+        assert_ne!(
+            derived_image_tag(&a).unwrap(),
+            derived_image_tag(&b).unwrap()
+        );
+    }
+
+    #[test]
+    fn tag_changes_when_copy_source_bytes_change() {
+        let dir = tempfile::tempdir().unwrap();
+        let host = dir.path().join("script.sh");
+        std::fs::write(&host, b"echo hello\n").unwrap();
+        let a = ContainerConfig {
+            copy: vec![CopySpec {
+                host: host.clone(),
+                container: PathBuf::from("/opt/script.sh"),
+            }],
+            ..cfg()
+        };
+        let tag_a = derived_image_tag(&a).unwrap().unwrap();
+
+        // Same path, different bytes — tag must flip so a rebuild fires.
+        std::fs::write(&host, b"echo goodbye\n").unwrap();
+        let tag_b = derived_image_tag(&a).unwrap().unwrap();
+        assert_ne!(
+            tag_a, tag_b,
+            "edits to a COPY source must invalidate the derived tag"
+        );
+    }
+
+    #[test]
+    fn dockerfile_contains_apt_install_when_extra_apt_set() {
+        let c = ContainerConfig {
+            extra_apt: vec!["mdbook".into(), "jq".into()],
+            ..cfg()
+        };
+        let df = synthesize_dockerfile(&c);
+        assert!(df.contains("FROM "), "FROM line: {df}");
+        assert!(
+            df.contains("apt-get install -y --no-install-recommends mdbook jq"),
+            "apt install line: {df}"
+        );
+        assert!(df.contains("USER root"), "needs root for apt: {df}");
+        assert!(
+            df.trim_end().ends_with("USER pitboss"),
+            "must drop privs at end: {df}"
+        );
+    }
+
+    #[test]
+    fn dockerfile_contains_copy_when_copy_set() {
+        let c = ContainerConfig {
+            copy: vec![CopySpec {
+                host: PathBuf::from("/host/script.sh"),
+                container: PathBuf::from("/opt/script.sh"),
+            }],
+            ..cfg()
+        };
+        let df = synthesize_dockerfile(&c);
+        assert!(
+            df.contains("COPY --chown=pitboss:pitboss copy0 /opt/script.sh"),
+            "copy line: {df}"
+        );
+    }
+
+    #[test]
+    fn dockerfile_emits_user_root_only_once_when_both_set() {
+        // With both `extra_apt` and `copy`, the Dockerfile previously
+        // emitted two adjacent `USER root` directives — one for the
+        // RUN apt-get block, another for the COPY block. The second is
+        // redundant (apt already left us as root) and produces a no-op
+        // image layer. Verify we collapse to a single `USER root`.
+        let c = ContainerConfig {
+            extra_apt: vec!["jq".into()],
+            copy: vec![CopySpec {
+                host: PathBuf::from("/host/x"),
+                container: PathBuf::from("/opt/x"),
+            }],
+            ..cfg()
+        };
+        let df = synthesize_dockerfile(&c);
+        let user_root_count = df.lines().filter(|l| l.trim() == "USER root").count();
+        assert_eq!(
+            user_root_count, 1,
+            "expected exactly one `USER root` directive, got {user_root_count}: {df}"
+        );
+        assert!(
+            df.trim_end().ends_with("USER pitboss"),
+            "must drop privs at end: {df}"
+        );
+    }
+
+    #[test]
+    fn dockerfile_skips_apt_block_when_only_copy_set() {
+        let c = ContainerConfig {
+            copy: vec![CopySpec {
+                host: PathBuf::from("/host/script.sh"),
+                container: PathBuf::from("/opt/script.sh"),
+            }],
+            ..cfg()
+        };
+        let df = synthesize_dockerfile(&c);
+        assert!(!df.contains("apt-get"), "no apt block expected: {df}");
+        assert!(df.contains("COPY"));
+    }
+}

--- a/crates/pitboss-cli/src/dispatch/mod.rs
+++ b/crates/pitboss-cli/src/dispatch/mod.rs
@@ -1,6 +1,7 @@
 pub mod actor;
 pub mod background;
 pub mod container;
+pub mod container_build;
 pub mod depth;
 pub mod entrypoint;
 pub mod events;

--- a/crates/pitboss-cli/src/main.rs
+++ b/crates/pitboss-cli/src/main.rs
@@ -105,6 +105,21 @@ fn main() -> Result<()> {
         } => {
             run_container_dispatch(&manifest, run_dir, dry_run, runtime.as_deref());
         }
+        Command::ContainerBuild {
+            manifest,
+            runtime,
+            no_cache,
+            print_dockerfile,
+            dry_run,
+        } => {
+            std::process::exit(run_container_build(
+                &manifest,
+                runtime,
+                no_cache,
+                print_dockerfile,
+                dry_run,
+            ));
+        }
         Command::Completions { shell } => {
             use clap::CommandFactory;
             let mut cmd = cli::Cli::command();
@@ -410,6 +425,47 @@ fn run_dispatch(
         }
     });
     std::process::exit(code);
+}
+
+fn run_container_build(
+    manifest: &std::path::Path,
+    runtime: Option<String>,
+    no_cache: bool,
+    print_dockerfile: bool,
+    dry_run: bool,
+) -> i32 {
+    let env_mp = parse_env_max_parallel();
+    let resolved = match manifest::load_manifest_skip_dir_check(manifest, env_mp) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("validation failed: {e:#}");
+            return 2;
+        }
+    };
+    let container = match resolved.container {
+        Some(ref c) => c,
+        None => {
+            eprintln!(
+                "pitboss container-build: manifest has no [container] section.\n\
+                 Add a [container] block (with extra_apt and/or [[container.copy]]) \
+                 to use container-build."
+            );
+            return 2;
+        }
+    };
+    let opts = dispatch::container_build::BuildOptions {
+        no_cache,
+        print_dockerfile,
+        dry_run,
+        runtime_override: runtime,
+    };
+    match dispatch::container_build::run_container_build(container, &opts) {
+        Ok(()) => 0,
+        Err(e) => {
+            eprintln!("container-build: {e:#}");
+            1
+        }
+    }
 }
 
 fn run_container_dispatch(

--- a/crates/pitboss-cli/src/manifest/schema.rs
+++ b/crates/pitboss-cli/src/manifest/schema.rs
@@ -112,6 +112,15 @@ pub struct ContainerConfig {
     #[serde(default, rename = "mount")]
     #[field(skip)]
     pub mounts: Vec<MountSpec>,
+    /// Host→container file copies baked into a derived image at
+    /// `pitboss container-build` time. Unlike `mount`, these are not
+    /// runtime bind-mounts — the file contents are layered into the
+    /// container image, so they're available even when no host path is
+    /// mounted there. Use this for small build inputs (scripts,
+    /// configuration) that should travel with the image.
+    #[serde(default, rename = "copy")]
+    #[field(skip)]
+    pub copy: Vec<CopySpec>,
     /// Working directory inside the container.
     /// Defaults to the container path of the first `[[container.mount]]` entry,
     /// or `/home/pitboss` if no mounts are declared.
@@ -136,6 +145,23 @@ pub struct MountSpec {
     #[serde(default)]
     #[field(label = "Read-only", help = "Mount read-only.")]
     pub readonly: bool,
+}
+
+/// A single host→container `COPY` entry baked into the derived image
+/// by `pitboss container-build`. Unlike `MountSpec`, this is image
+/// content, not a runtime mount — the host file is read at build time
+/// and layered into the image.
+#[derive(Debug, Clone, Deserialize, Serialize, FieldMetadata)]
+#[serde(deny_unknown_fields)]
+pub struct CopySpec {
+    /// Absolute path on the host (tilde expansion is performed at build time).
+    /// Must be a regular file or a directory. Read at `container-build` time
+    /// only; subsequent host mutations require a rebuild.
+    #[field(label = "Host path", help = "Absolute host path. ~ is expanded.")]
+    pub host: PathBuf,
+    /// Absolute path inside the container.
+    #[field(label = "Container path", help = "Absolute path inside the container.")]
+    pub container: PathBuf,
 }
 
 /// An external MCP server to inject into every actor's `--mcp-config`.

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -42,9 +42,14 @@ fn validate_inner(resolved: &ResolvedManifest, skip_dir_check: bool) -> Result<(
 }
 
 /// Reject manifest-level container misconfigurations that would otherwise
-/// only surface at dispatch time. Today this is just the shell-safety check
-/// on `[container].extra_apt` package names — kept here so `pitboss validate`
-/// catches bad names symmetrically with `pitboss container-dispatch`.
+/// only surface at dispatch / build time. Covers:
+/// - `[container].extra_apt` package names must be shell-safe.
+/// - `[[container.copy]].container` must be an absolute path (Dockerfile
+///   `COPY <src> <dest>` rejects relative dests when WORKDIR is unset for
+///   the FROM line, and we want the schema to be unambiguous).
+/// - `[[container.copy]].host` should be an absolute path or a tilde-
+///   prefixed path; relative host paths can't be resolved without a
+///   manifest-relative anchor that pitboss doesn't currently track.
 fn validate_container(r: &ResolvedManifest) -> Result<()> {
     let Some(container) = &r.container else {
         return Ok(());
@@ -55,6 +60,25 @@ fn validate_container(r: &ResolvedManifest) -> Result<()> {
                 "[container].extra_apt: invalid package name {pkg:?} \
                  (allowed: ASCII alphanumeric, `.`, `+`, `-`; must start \
                  with alphanumeric)"
+            );
+        }
+    }
+    for spec in &container.copy {
+        if !spec.container.is_absolute() {
+            bail!(
+                "[[container.copy]].container must be an absolute path, got {:?}",
+                spec.container
+            );
+        }
+        // Host path: accept tilde-prefixed paths (expanded at build time)
+        // OR absolute paths. Reject relative paths since there is no
+        // canonical anchor (the manifest may live anywhere).
+        let host_str = spec.host.to_string_lossy();
+        let is_tilde = host_str.starts_with('~');
+        if !spec.host.is_absolute() && !is_tilde {
+            bail!(
+                "[[container.copy]].host must be an absolute or tilde-prefixed path, got {:?}",
+                spec.host
             );
         }
     }
@@ -1252,5 +1276,60 @@ mod tests {
             ..ContainerConfig::default()
         });
         validate(&m).expect("realistic apt package names must validate");
+    }
+
+    #[test]
+    fn copy_relative_container_path_fails_validate() {
+        use super::super::schema::{ContainerConfig, CopySpec};
+        let d = with_tmp_repo(true);
+        let mut m = rm(vec![rt("t", d.path().to_path_buf(), false, None)]);
+        m.container = Some(ContainerConfig {
+            copy: vec![CopySpec {
+                host: PathBuf::from("/abs/script.py"),
+                container: PathBuf::from("relative/path"),
+            }],
+            ..ContainerConfig::default()
+        });
+        let err = validate(&m).expect_err("relative container path must fail");
+        assert!(
+            err.to_string()
+                .contains("container must be an absolute path"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn copy_relative_host_path_fails_validate() {
+        use super::super::schema::{ContainerConfig, CopySpec};
+        let d = with_tmp_repo(true);
+        let mut m = rm(vec![rt("t", d.path().to_path_buf(), false, None)]);
+        m.container = Some(ContainerConfig {
+            copy: vec![CopySpec {
+                host: PathBuf::from("./script.py"),
+                container: PathBuf::from("/opt/script.py"),
+            }],
+            ..ContainerConfig::default()
+        });
+        let err = validate(&m).expect_err("relative host path must fail");
+        assert!(
+            err.to_string()
+                .contains("host must be an absolute or tilde-prefixed path"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn copy_tilde_host_and_absolute_container_pass_validate() {
+        use super::super::schema::{ContainerConfig, CopySpec};
+        let d = with_tmp_repo(true);
+        let mut m = rm(vec![rt("t", d.path().to_path_buf(), false, None)]);
+        m.container = Some(ContainerConfig {
+            copy: vec![CopySpec {
+                host: PathBuf::from("~/scripts/install.sh"),
+                container: PathBuf::from("/opt/install.sh"),
+            }],
+            ..ContainerConfig::default()
+        });
+        validate(&m).expect("tilde host + absolute container must validate");
     }
 }

--- a/docs/manifest-map.md
+++ b/docs/manifest-map.md
@@ -14,32 +14,32 @@ The annotated example lives at [`pitboss.example.toml`](../pitboss.example.toml)
 
 ## `[run]` — `RunConfig`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:332`](../crates/pitboss-cli/src/manifest/schema.rs#L332).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:358`](../crates/pitboss-cli/src/manifest/schema.rs#L358).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `name` | text | no | Human-readable label used to group related runs in the console (e.g. "build-db", "nightly-sync"). When unset, the manifest filename is used as fallback. | [`../crates/pitboss-cli/src/manifest/schema.rs#L343`](../crates/pitboss-cli/src/manifest/schema.rs#L343) |
-| `max_parallel_tasks` | integer | no | Flat-mode concurrency cap for [[task]] runs. Default 4. Overridden by ANTHROPIC_MAX_CONCURRENT. | [`../crates/pitboss-cli/src/manifest/schema.rs#L352`](../crates/pitboss-cli/src/manifest/schema.rs#L352) |
-| `halt_on_failure` | boolean | no | Stop remaining flat-mode tasks on first failure. | [`../crates/pitboss-cli/src/manifest/schema.rs#L359`](../crates/pitboss-cli/src/manifest/schema.rs#L359) |
-| `run_dir` | path | no | Where per-run artifacts land. Default ~/.local/share/pitboss/runs. | [`../crates/pitboss-cli/src/manifest/schema.rs#L365`](../crates/pitboss-cli/src/manifest/schema.rs#L365) |
-| `worktree_cleanup` | enum (`always` \| `on_success` \| `never`) | no | What to do with each worker's git worktree after it finishes. | [`../crates/pitboss-cli/src/manifest/schema.rs#L373`](../crates/pitboss-cli/src/manifest/schema.rs#L373) |
-| `emit_event_stream` | boolean | no | Write a JSONL event stream alongside summary.jsonl. | [`../crates/pitboss-cli/src/manifest/schema.rs#L380`](../crates/pitboss-cli/src/manifest/schema.rs#L380) |
-| `default_approval_policy` | enum (`block` \| `auto_approve` \| `auto_reject`) | no | Default action for request_approval / propose_plan when no rule matches. `auto_approve`/`auto_reject` are unconditional; `block` routes to the operator if attached, else queues. | [`../crates/pitboss-cli/src/manifest/schema.rs#L408`](../crates/pitboss-cli/src/manifest/schema.rs#L408) |
-| `dump_shared_store` | boolean | no | Write shared-store.json into the run directory on finalize. | [`../crates/pitboss-cli/src/manifest/schema.rs#L416`](../crates/pitboss-cli/src/manifest/schema.rs#L416) |
-| `require_plan_approval` | boolean | no | When true, spawn_worker is blocked until propose_plan has been approved. | [`../crates/pitboss-cli/src/manifest/schema.rs#L424`](../crates/pitboss-cli/src/manifest/schema.rs#L424) |
+| `name` | text | no | Human-readable label used to group related runs in the console (e.g. "build-db", "nightly-sync"). When unset, the manifest filename is used as fallback. | [`../crates/pitboss-cli/src/manifest/schema.rs#L369`](../crates/pitboss-cli/src/manifest/schema.rs#L369) |
+| `max_parallel_tasks` | integer | no | Flat-mode concurrency cap for [[task]] runs. Default 4. Overridden by ANTHROPIC_MAX_CONCURRENT. | [`../crates/pitboss-cli/src/manifest/schema.rs#L378`](../crates/pitboss-cli/src/manifest/schema.rs#L378) |
+| `halt_on_failure` | boolean | no | Stop remaining flat-mode tasks on first failure. | [`../crates/pitboss-cli/src/manifest/schema.rs#L385`](../crates/pitboss-cli/src/manifest/schema.rs#L385) |
+| `run_dir` | path | no | Where per-run artifacts land. Default ~/.local/share/pitboss/runs. | [`../crates/pitboss-cli/src/manifest/schema.rs#L391`](../crates/pitboss-cli/src/manifest/schema.rs#L391) |
+| `worktree_cleanup` | enum (`always` \| `on_success` \| `never`) | no | What to do with each worker's git worktree after it finishes. | [`../crates/pitboss-cli/src/manifest/schema.rs#L399`](../crates/pitboss-cli/src/manifest/schema.rs#L399) |
+| `emit_event_stream` | boolean | no | Write a JSONL event stream alongside summary.jsonl. | [`../crates/pitboss-cli/src/manifest/schema.rs#L406`](../crates/pitboss-cli/src/manifest/schema.rs#L406) |
+| `default_approval_policy` | enum (`block` \| `auto_approve` \| `auto_reject`) | no | Default action for request_approval / propose_plan when no rule matches. `auto_approve`/`auto_reject` are unconditional; `block` routes to the operator if attached, else queues. | [`../crates/pitboss-cli/src/manifest/schema.rs#L434`](../crates/pitboss-cli/src/manifest/schema.rs#L434) |
+| `dump_shared_store` | boolean | no | Write shared-store.json into the run directory on finalize. | [`../crates/pitboss-cli/src/manifest/schema.rs#L442`](../crates/pitboss-cli/src/manifest/schema.rs#L442) |
+| `require_plan_approval` | boolean | no | When true, spawn_worker is blocked until propose_plan has been approved. | [`../crates/pitboss-cli/src/manifest/schema.rs#L450`](../crates/pitboss-cli/src/manifest/schema.rs#L450) |
 
 ## `[defaults]` — `Defaults`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:457`](../crates/pitboss-cli/src/manifest/schema.rs#L457).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:483`](../crates/pitboss-cli/src/manifest/schema.rs#L483).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `model` | text | no | Claude model id (e.g. claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-7). | [`../crates/pitboss-cli/src/manifest/schema.rs#L462`](../crates/pitboss-cli/src/manifest/schema.rs#L462) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Maps to the claude --effort flag. | [`../crates/pitboss-cli/src/manifest/schema.rs#L468`](../crates/pitboss-cli/src/manifest/schema.rs#L468) |
-| `tools` | string list | no | Allowed tool surface. Pitboss auto-appends its MCP tools for leads and workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L473`](../crates/pitboss-cli/src/manifest/schema.rs#L473) |
-| `timeout_secs` | integer | no | Per-task wall-clock cap. No default (no cap). | [`../crates/pitboss-cli/src/manifest/schema.rs#L478`](../crates/pitboss-cli/src/manifest/schema.rs#L478) |
-| `use_worktree` | boolean | no | Isolate each worker in a git worktree. Default true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L483`](../crates/pitboss-cli/src/manifest/schema.rs#L483) |
-| `env` | key-value map | no | Environment variables passed to the claude subprocess. | [`../crates/pitboss-cli/src/manifest/schema.rs#L489`](../crates/pitboss-cli/src/manifest/schema.rs#L489) |
+| `model` | text | no | Claude model id (e.g. claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-7). | [`../crates/pitboss-cli/src/manifest/schema.rs#L488`](../crates/pitboss-cli/src/manifest/schema.rs#L488) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Maps to the claude --effort flag. | [`../crates/pitboss-cli/src/manifest/schema.rs#L494`](../crates/pitboss-cli/src/manifest/schema.rs#L494) |
+| `tools` | string list | no | Allowed tool surface. Pitboss auto-appends its MCP tools for leads and workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L499`](../crates/pitboss-cli/src/manifest/schema.rs#L499) |
+| `timeout_secs` | integer | no | Per-task wall-clock cap. No default (no cap). | [`../crates/pitboss-cli/src/manifest/schema.rs#L504`](../crates/pitboss-cli/src/manifest/schema.rs#L504) |
+| `use_worktree` | boolean | no | Isolate each worker in a git worktree. Default true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L509`](../crates/pitboss-cli/src/manifest/schema.rs#L509) |
+| `env` | key-value map | no | Environment variables passed to the claude subprocess. | [`../crates/pitboss-cli/src/manifest/schema.rs#L515`](../crates/pitboss-cli/src/manifest/schema.rs#L515) |
 
 ## `[container]` — `ContainerConfig`
 
@@ -51,106 +51,106 @@ Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:71`](../crates/pitboss
 | `runtime` | enum (`docker` \| `podman` \| `auto`) | no | Container runtime to invoke. "auto" prefers podman. | [`../crates/pitboss-cli/src/manifest/schema.rs#L84`](../crates/pitboss-cli/src/manifest/schema.rs#L84) |
 | `extra_args` | string list | no | Verbatim podman/docker run flags. Use for networking, capabilities, DNS, resources, etc. Example: ["--network=corp-fw", "--dns=10.0.0.53", "--cap-add=NET_ADMIN"]. | [`../crates/pitboss-cli/src/manifest/schema.rs#L95`](../crates/pitboss-cli/src/manifest/schema.rs#L95) |
 | `extra_apt` | string list | no | Debian/Ubuntu packages installed inside the container before pitboss dispatch starts. Adds 30–90s spin-up per dispatch. Example: ["mdbook", "jq"]. | [`../crates/pitboss-cli/src/manifest/schema.rs#L110`](../crates/pitboss-cli/src/manifest/schema.rs#L110) |
-| `workdir` | path | no | cwd inside the container; defaults to the first mount's container path. | [`../crates/pitboss-cli/src/manifest/schema.rs#L122`](../crates/pitboss-cli/src/manifest/schema.rs#L122) |
+| `workdir` | path | no | cwd inside the container; defaults to the first mount's container path. | [`../crates/pitboss-cli/src/manifest/schema.rs#L131`](../crates/pitboss-cli/src/manifest/schema.rs#L131) |
 
 ## `[[container.mount]]` — `MountSpec`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:128`](../crates/pitboss-cli/src/manifest/schema.rs#L128).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:137`](../crates/pitboss-cli/src/manifest/schema.rs#L137).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `host` | path | **yes** | Absolute host path. ~ is expanded. | [`../crates/pitboss-cli/src/manifest/schema.rs#L131`](../crates/pitboss-cli/src/manifest/schema.rs#L131) |
-| `container` | path | **yes** | Absolute path inside the container. | [`../crates/pitboss-cli/src/manifest/schema.rs#L134`](../crates/pitboss-cli/src/manifest/schema.rs#L134) |
-| `readonly` | boolean | no | Mount read-only. | [`../crates/pitboss-cli/src/manifest/schema.rs#L138`](../crates/pitboss-cli/src/manifest/schema.rs#L138) |
+| `host` | path | **yes** | Absolute host path. ~ is expanded. | [`../crates/pitboss-cli/src/manifest/schema.rs#L140`](../crates/pitboss-cli/src/manifest/schema.rs#L140) |
+| `container` | path | **yes** | Absolute path inside the container. | [`../crates/pitboss-cli/src/manifest/schema.rs#L143`](../crates/pitboss-cli/src/manifest/schema.rs#L143) |
+| `readonly` | boolean | no | Mount read-only. | [`../crates/pitboss-cli/src/manifest/schema.rs#L147`](../crates/pitboss-cli/src/manifest/schema.rs#L147) |
 
 ## `[[task]]` — `Task`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:520`](../crates/pitboss-cli/src/manifest/schema.rs#L520).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:546`](../crates/pitboss-cli/src/manifest/schema.rs#L546).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique slug. Alphanumeric + _ + -. Used in logs and worktree names. | [`../crates/pitboss-cli/src/manifest/schema.rs#L525`](../crates/pitboss-cli/src/manifest/schema.rs#L525) |
-| `directory` | path | **yes** | Working directory. Must be inside a git repo if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L530`](../crates/pitboss-cli/src/manifest/schema.rs#L530) |
-| `prompt` | text (multi-line) | no | Prompt body sent to claude via -p. Mutually exclusive with `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L536`](../crates/pitboss-cli/src/manifest/schema.rs#L536) |
-| `template` | text | no | Reference to a [[template]] entry. Mutually exclusive with `prompt`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L541`](../crates/pitboss-cli/src/manifest/schema.rs#L541) |
-| `vars` | key-value map | no | Substitutions for {placeholders} when using `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L547`](../crates/pitboss-cli/src/manifest/schema.rs#L547) |
-| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L552`](../crates/pitboss-cli/src/manifest/schema.rs#L552) |
-| `model` | text | no | Per-task override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L554`](../crates/pitboss-cli/src/manifest/schema.rs#L554) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-task override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L560`](../crates/pitboss-cli/src/manifest/schema.rs#L560) |
-| `tools` | string list | no | Per-task override of [defaults].tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L562`](../crates/pitboss-cli/src/manifest/schema.rs#L562) |
-| `timeout_secs` | integer | no | Per-task wall-clock cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L564`](../crates/pitboss-cli/src/manifest/schema.rs#L564) |
-| `use_worktree` | boolean | no | Per-task override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L569`](../crates/pitboss-cli/src/manifest/schema.rs#L569) |
-| `env` | key-value map | no | Per-task env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L575`](../crates/pitboss-cli/src/manifest/schema.rs#L575) |
+| `id` | text | **yes** | Unique slug. Alphanumeric + _ + -. Used in logs and worktree names. | [`../crates/pitboss-cli/src/manifest/schema.rs#L551`](../crates/pitboss-cli/src/manifest/schema.rs#L551) |
+| `directory` | path | **yes** | Working directory. Must be inside a git repo if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L556`](../crates/pitboss-cli/src/manifest/schema.rs#L556) |
+| `prompt` | text (multi-line) | no | Prompt body sent to claude via -p. Mutually exclusive with `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L562`](../crates/pitboss-cli/src/manifest/schema.rs#L562) |
+| `template` | text | no | Reference to a [[template]] entry. Mutually exclusive with `prompt`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L567`](../crates/pitboss-cli/src/manifest/schema.rs#L567) |
+| `vars` | key-value map | no | Substitutions for {placeholders} when using `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L573`](../crates/pitboss-cli/src/manifest/schema.rs#L573) |
+| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L578`](../crates/pitboss-cli/src/manifest/schema.rs#L578) |
+| `model` | text | no | Per-task override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L580`](../crates/pitboss-cli/src/manifest/schema.rs#L580) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-task override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L586`](../crates/pitboss-cli/src/manifest/schema.rs#L586) |
+| `tools` | string list | no | Per-task override of [defaults].tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L588`](../crates/pitboss-cli/src/manifest/schema.rs#L588) |
+| `timeout_secs` | integer | no | Per-task wall-clock cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L590`](../crates/pitboss-cli/src/manifest/schema.rs#L590) |
+| `use_worktree` | boolean | no | Per-task override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L595`](../crates/pitboss-cli/src/manifest/schema.rs#L595) |
+| `env` | key-value map | no | Per-task env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L601`](../crates/pitboss-cli/src/manifest/schema.rs#L601) |
 
 ## `[lead]` — `Lead`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:585`](../crates/pitboss-cli/src/manifest/schema.rs#L585).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:611`](../crates/pitboss-cli/src/manifest/schema.rs#L611).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique slug used as the TUI tile label and in run artifact paths. | [`../crates/pitboss-cli/src/manifest/schema.rs#L592`](../crates/pitboss-cli/src/manifest/schema.rs#L592) |
-| `directory` | path | **yes** | Working directory for the lead's claude subprocess. Must be a git work-tree if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L599`](../crates/pitboss-cli/src/manifest/schema.rs#L599) |
-| `prompt` | text (multi-line) | **yes** | Operator instructions passed to claude via -p. Must appear before any [lead.X] subtable in the source. | [`../crates/pitboss-cli/src/manifest/schema.rs#L611`](../crates/pitboss-cli/src/manifest/schema.rs#L611) |
-| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L619`](../crates/pitboss-cli/src/manifest/schema.rs#L619) |
-| `model` | text | no | Per-lead override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L622`](../crates/pitboss-cli/src/manifest/schema.rs#L622) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-lead override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L629`](../crates/pitboss-cli/src/manifest/schema.rs#L629) |
-| `tools` | string list | no | Per-lead override of [defaults].tools. Pitboss auto-appends its MCP tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L635`](../crates/pitboss-cli/src/manifest/schema.rs#L635) |
-| `timeout_secs` | integer | no | Per-actor subprocess wall-clock cap (claude --timeout). | [`../crates/pitboss-cli/src/manifest/schema.rs#L641`](../crates/pitboss-cli/src/manifest/schema.rs#L641) |
-| `use_worktree` | boolean | no | Per-lead override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L647`](../crates/pitboss-cli/src/manifest/schema.rs#L647) |
-| `env` | key-value map | no | Per-lead env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L653`](../crates/pitboss-cli/src/manifest/schema.rs#L653) |
-| `max_workers` | integer | no | Hard cap on the lead's concurrent + queued worker pool (1–16). Required when the lead spawns workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L662`](../crates/pitboss-cli/src/manifest/schema.rs#L662) |
-| `budget_usd` | float | no | Soft cap on lead spend with reservation accounting. spawn_worker fails once spent + reserved + next_estimate > budget. | [`../crates/pitboss-cli/src/manifest/schema.rs#L671`](../crates/pitboss-cli/src/manifest/schema.rs#L671) |
-| `lead_timeout_secs` | integer | no | Wall-clock cap on the lead session. Default 3600. | [`../crates/pitboss-cli/src/manifest/schema.rs#L680`](../crates/pitboss-cli/src/manifest/schema.rs#L680) |
-| `permission_routing` | enum (`path_a` \| `path_b`) | no | path_a (default) makes pitboss the sole permission authority. path_b routes claude's gate through pitboss (rejected at validate time pending stabilization). | [`../crates/pitboss-cli/src/manifest/schema.rs#L693`](../crates/pitboss-cli/src/manifest/schema.rs#L693) |
-| `allow_subleads` | boolean | no | Expose spawn_sublead to the root lead. | [`../crates/pitboss-cli/src/manifest/schema.rs#L702`](../crates/pitboss-cli/src/manifest/schema.rs#L702) |
-| `max_subleads` | integer | no | Hard cap on total live sub-leads under this root. | [`../crates/pitboss-cli/src/manifest/schema.rs#L709`](../crates/pitboss-cli/src/manifest/schema.rs#L709) |
-| `max_sublead_budget_usd` | float | no | Cap on the per-sub-lead budget envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L716`](../crates/pitboss-cli/src/manifest/schema.rs#L716) |
-| `max_total_workers` | integer | no | Cap on total live workers across the entire tree (root + sub-trees). | [`../crates/pitboss-cli/src/manifest/schema.rs#L724`](../crates/pitboss-cli/src/manifest/schema.rs#L724) |
+| `id` | text | **yes** | Unique slug used as the TUI tile label and in run artifact paths. | [`../crates/pitboss-cli/src/manifest/schema.rs#L618`](../crates/pitboss-cli/src/manifest/schema.rs#L618) |
+| `directory` | path | **yes** | Working directory for the lead's claude subprocess. Must be a git work-tree if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L625`](../crates/pitboss-cli/src/manifest/schema.rs#L625) |
+| `prompt` | text (multi-line) | **yes** | Operator instructions passed to claude via -p. Must appear before any [lead.X] subtable in the source. | [`../crates/pitboss-cli/src/manifest/schema.rs#L637`](../crates/pitboss-cli/src/manifest/schema.rs#L637) |
+| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L645`](../crates/pitboss-cli/src/manifest/schema.rs#L645) |
+| `model` | text | no | Per-lead override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L648`](../crates/pitboss-cli/src/manifest/schema.rs#L648) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-lead override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L655`](../crates/pitboss-cli/src/manifest/schema.rs#L655) |
+| `tools` | string list | no | Per-lead override of [defaults].tools. Pitboss auto-appends its MCP tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L661`](../crates/pitboss-cli/src/manifest/schema.rs#L661) |
+| `timeout_secs` | integer | no | Per-actor subprocess wall-clock cap (claude --timeout). | [`../crates/pitboss-cli/src/manifest/schema.rs#L667`](../crates/pitboss-cli/src/manifest/schema.rs#L667) |
+| `use_worktree` | boolean | no | Per-lead override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L673`](../crates/pitboss-cli/src/manifest/schema.rs#L673) |
+| `env` | key-value map | no | Per-lead env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L679`](../crates/pitboss-cli/src/manifest/schema.rs#L679) |
+| `max_workers` | integer | no | Hard cap on the lead's concurrent + queued worker pool (1–16). Required when the lead spawns workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L688`](../crates/pitboss-cli/src/manifest/schema.rs#L688) |
+| `budget_usd` | float | no | Soft cap on lead spend with reservation accounting. spawn_worker fails once spent + reserved + next_estimate > budget. | [`../crates/pitboss-cli/src/manifest/schema.rs#L697`](../crates/pitboss-cli/src/manifest/schema.rs#L697) |
+| `lead_timeout_secs` | integer | no | Wall-clock cap on the lead session. Default 3600. | [`../crates/pitboss-cli/src/manifest/schema.rs#L706`](../crates/pitboss-cli/src/manifest/schema.rs#L706) |
+| `permission_routing` | enum (`path_a` \| `path_b`) | no | path_a (default) makes pitboss the sole permission authority. path_b routes claude's gate through pitboss (rejected at validate time pending stabilization). | [`../crates/pitboss-cli/src/manifest/schema.rs#L719`](../crates/pitboss-cli/src/manifest/schema.rs#L719) |
+| `allow_subleads` | boolean | no | Expose spawn_sublead to the root lead. | [`../crates/pitboss-cli/src/manifest/schema.rs#L728`](../crates/pitboss-cli/src/manifest/schema.rs#L728) |
+| `max_subleads` | integer | no | Hard cap on total live sub-leads under this root. | [`../crates/pitboss-cli/src/manifest/schema.rs#L735`](../crates/pitboss-cli/src/manifest/schema.rs#L735) |
+| `max_sublead_budget_usd` | float | no | Cap on the per-sub-lead budget envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L742`](../crates/pitboss-cli/src/manifest/schema.rs#L742) |
+| `max_total_workers` | integer | no | Cap on total live workers across the entire tree (root + sub-trees). | [`../crates/pitboss-cli/src/manifest/schema.rs#L750`](../crates/pitboss-cli/src/manifest/schema.rs#L750) |
 
 ## `[sublead_defaults]` — `SubleadDefaults`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:731`](../crates/pitboss-cli/src/manifest/schema.rs#L731).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:757`](../crates/pitboss-cli/src/manifest/schema.rs#L757).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `budget_usd` | float | no | Per-sub-lead envelope when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L736`](../crates/pitboss-cli/src/manifest/schema.rs#L736) |
-| `max_workers` | integer | no | Per-sub-lead worker pool when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L741`](../crates/pitboss-cli/src/manifest/schema.rs#L741) |
-| `lead_timeout_secs` | integer | no | Wall-clock cap for the sub-lead session. | [`../crates/pitboss-cli/src/manifest/schema.rs#L746`](../crates/pitboss-cli/src/manifest/schema.rs#L746) |
-| `read_down` | boolean | no | When true, sub-lead shares root's budget + worker pool instead of carving its own envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L752`](../crates/pitboss-cli/src/manifest/schema.rs#L752) |
+| `budget_usd` | float | no | Per-sub-lead envelope when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L762`](../crates/pitboss-cli/src/manifest/schema.rs#L762) |
+| `max_workers` | integer | no | Per-sub-lead worker pool when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L767`](../crates/pitboss-cli/src/manifest/schema.rs#L767) |
+| `lead_timeout_secs` | integer | no | Wall-clock cap for the sub-lead session. | [`../crates/pitboss-cli/src/manifest/schema.rs#L772`](../crates/pitboss-cli/src/manifest/schema.rs#L772) |
+| `read_down` | boolean | no | When true, sub-lead shares root's budget + worker pool instead of carving its own envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L778`](../crates/pitboss-cli/src/manifest/schema.rs#L778) |
 
 ## `[[approval_policy]]` — `ApprovalRuleSpec`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:282`](../crates/pitboss-cli/src/manifest/schema.rs#L282).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:308`](../crates/pitboss-cli/src/manifest/schema.rs#L308).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `action` | enum (`auto_approve` \| `auto_reject` \| `block`) | **yes** | Action when this rule matches. | [`../crates/pitboss-cli/src/manifest/schema.rs#L293`](../crates/pitboss-cli/src/manifest/schema.rs#L293) |
+| `action` | enum (`auto_approve` \| `auto_reject` \| `block`) | **yes** | Action when this rule matches. | [`../crates/pitboss-cli/src/manifest/schema.rs#L319`](../crates/pitboss-cli/src/manifest/schema.rs#L319) |
 
 ## `[[mcp_server]]` — `McpServerSpec`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:156`](../crates/pitboss-cli/src/manifest/schema.rs#L156).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:182`](../crates/pitboss-cli/src/manifest/schema.rs#L182).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Key under mcpServers in the generated config. | [`../crates/pitboss-cli/src/manifest/schema.rs#L162`](../crates/pitboss-cli/src/manifest/schema.rs#L162) |
-| `command` | text | **yes** | Executable to launch (e.g. npx, uvx, or an absolute path). | [`../crates/pitboss-cli/src/manifest/schema.rs#L168`](../crates/pitboss-cli/src/manifest/schema.rs#L168) |
-| `args` | string list | no | Arguments passed to the command. | [`../crates/pitboss-cli/src/manifest/schema.rs#L172`](../crates/pitboss-cli/src/manifest/schema.rs#L172) |
-| `env` | key-value map | no | Environment variables injected into the MCP server process. | [`../crates/pitboss-cli/src/manifest/schema.rs#L179`](../crates/pitboss-cli/src/manifest/schema.rs#L179) |
+| `id` | text | **yes** | Key under mcpServers in the generated config. | [`../crates/pitboss-cli/src/manifest/schema.rs#L188`](../crates/pitboss-cli/src/manifest/schema.rs#L188) |
+| `command` | text | **yes** | Executable to launch (e.g. npx, uvx, or an absolute path). | [`../crates/pitboss-cli/src/manifest/schema.rs#L194`](../crates/pitboss-cli/src/manifest/schema.rs#L194) |
+| `args` | string list | no | Arguments passed to the command. | [`../crates/pitboss-cli/src/manifest/schema.rs#L198`](../crates/pitboss-cli/src/manifest/schema.rs#L198) |
+| `env` | key-value map | no | Environment variables injected into the MCP server process. | [`../crates/pitboss-cli/src/manifest/schema.rs#L205`](../crates/pitboss-cli/src/manifest/schema.rs#L205) |
 
 ## `[[template]]` — `Template`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:504`](../crates/pitboss-cli/src/manifest/schema.rs#L504).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:530`](../crates/pitboss-cli/src/manifest/schema.rs#L530).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Slug referenced from [[task]].template. | [`../crates/pitboss-cli/src/manifest/schema.rs#L509`](../crates/pitboss-cli/src/manifest/schema.rs#L509) |
-| `prompt` | text (multi-line) | **yes** | Prompt body. Supports {var} placeholders supplied by [[task]].vars. | [`../crates/pitboss-cli/src/manifest/schema.rs#L515`](../crates/pitboss-cli/src/manifest/schema.rs#L515) |
+| `id` | text | **yes** | Slug referenced from [[task]].template. | [`../crates/pitboss-cli/src/manifest/schema.rs#L535`](../crates/pitboss-cli/src/manifest/schema.rs#L535) |
+| `prompt` | text (multi-line) | **yes** | Prompt body. Supports {var} placeholders supplied by [[task]].vars. | [`../crates/pitboss-cli/src/manifest/schema.rs#L541`](../crates/pitboss-cli/src/manifest/schema.rs#L541) |
 
 ## `[lifecycle]` — `Lifecycle`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:259`](../crates/pitboss-cli/src/manifest/schema.rs#L259).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:285`](../crates/pitboss-cli/src/manifest/schema.rs#L285).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `survive_parent` | boolean | no | Allow this dispatch to outlive its parent process. Requires a notify target. | [`../crates/pitboss-cli/src/manifest/schema.rs#L270`](../crates/pitboss-cli/src/manifest/schema.rs#L270) |
+| `survive_parent` | boolean | no | Allow this dispatch to outlive its parent process. Requires a notify target. | [`../crates/pitboss-cli/src/manifest/schema.rs#L296`](../crates/pitboss-cli/src/manifest/schema.rs#L296) |
 


### PR DESCRIPTION
## Summary

- New `pitboss container-build <manifest>` subcommand: synthesizes a thin Dockerfile from `[container]`, builds with `--layers` for local layer reuse, tags deterministically as `pitboss-derived-<sha>:local`. Idempotent — re-runs with the same inputs are a no-op once the tag exists; `--no-cache` forces rebuild.
- New manifest field `[[container.copy]] { host, container }` — file content baked into the derived image at build time. Distinct from `[[container.mount]]` (which is a runtime bind). Supports files and directories. Editing a copied host file changes the SHA and auto-invalidates the cached tag.
- `pitboss container-dispatch` now picks up the derived tag automatically when `extra_apt` or `copy` is non-empty AND the tag exists locally; the Phase-1 apt-at-spin-up wrap is suppressed in that case (apt is already baked). When `[[container.copy]]` is declared but the derived image is missing, dispatch refuses with a pointer to `container-build` rather than silently using the stock image (the COPY contents would be missing).
- The 12-hex SHA hashes the base image, sorted `extra_apt`, and sorted `[[container.copy]]` host bytes (not just paths). Tag-scheme is versioned with a `pitboss-derived-tag-v1` prefix so future input additions can force rebuilds rather than silently reusing stale layers.
- Validate rejects relative `[[container.copy]].host` (no canonical anchor since manifests can live anywhere) and relative `.container` (Dockerfile `COPY` semantics).

## Why this and not just Phase 1

Phase 1's apt-at-spin-up costs 30–90 s every dispatch on cache miss. Phase 2 amortizes that cost: after one `container-build`, subsequent dispatches with the same inputs reuse the layered image in <1 s.

`[[container.copy]]` couldn't be done at run time (no entrypoint hook for COPY), so it always required a build pathway — Phase 2 brings that under the same caching umbrella.

Per the planning consult on #256, `--cache-from`/`--cache-to` are remote-cache features (per podman docs) and explicitly out of scope here. Reserved for a future remote-cache work item if cross-machine cache sharing becomes a real ask.

## Files changed

- `crates/pitboss-cli/src/dispatch/container_build.rs` (new) — `derived_image_tag`, `synthesize_dockerfile`, `run_container_build`, file-content hashing, build-context staging, idempotency check.
- `crates/pitboss-cli/src/manifest/schema.rs` — `CopySpec` + `[[container.copy]]` field.
- `crates/pitboss-cli/src/dispatch/container.rs` — `build_run_args` takes `derived_image_override: Option<&str>`; dispatch entry point computes derived tag, probes the runtime, gates on `[[container.copy]]` requiring a built image.
- `crates/pitboss-cli/src/cli.rs` + `main.rs` — wire `ContainerBuild` subcommand with `--runtime`, `--no-cache`, `--print-dockerfile`, `--dry-run`.
- `crates/pitboss-cli/src/manifest/validate.rs` — `[[container.copy]]` host/container path checks.
- `Cargo.toml` + `crates/pitboss-cli/Cargo.toml` — add `sha2` workspace dep; promote `tempfile` to runtime dep.
- `AGENTS.md` — `[[container.copy]]` table + `pitboss container-build` subsection.
- `docs/manifest-map.md` — regenerated from schema.

## Test plan

- [x] `cargo test -p pitboss-cli --lib` (594 / 0 — 15 new unit tests)
- [x] `cargo test --workspace --features pitboss-core/test-support` all green
- [x] `cargo lint` + `cargo tidy` clean
- [x] `pitboss container-build --print-dockerfile` round-trip on a manifest with `extra_apt = ["jq"]` + `[[container.copy]]`
- [x] `pitboss container-build` first run builds + tags; re-run is a no-op with "derived image already exists" message
- [x] `pitboss container-build --no-cache` forces rebuild, retains the same tag (since inputs unchanged)
- [x] Editing a copied host file flips the SHA — verified: `pitboss-derived-e6ef43f84b70:local` → `pitboss-derived-7d38bcf9ad17:local`
- [x] Built image carries the apt package (`jq --version` → `jq-1.7`) AND the COPY'd script with correct `pitboss:pitboss 755` ownership
- [x] `pitboss container-dispatch` against a manifest with `[[container.copy]]` but no built image errors with a clear pointer to `container-build`

## Follow-ups (not blocking)

- The "extra_apt-only manifest where the derived image was deleted" path silently falls back to Phase 1 spin-up. Counterintuitive for an operator who built specifically for the speedup — a single `eprintln!` warning would be a small UX win. Defer until a real operator hits it.
- Stale derived tags accumulate in the local image store. Pruning is currently manual (`podman image prune`). A pitboss-aware sweeper is worth tracking.
- The advisor flagged a testability gap on the docker-with-non-1000-host-UID path (existing from Phase 1) — not a regression here, but worth a follow-up once we touch user-alignment again.

Closes #262 — refs #263 (Phase 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)