### PR TITLE
ci(container): roll :main on every main push + add :main-<sha> tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,20 @@
 #
 #   test ──────────────────────────────────────────────── always
 #   check-paths ────────────────────────────────────────── always
-#   build (matrix x4) ── needs [test, check-paths] ─────── code changed + test passed
+#   build (matrix x4) ── needs [test, check-paths] ─────── push always; PRs only when code changed
 #   merge (matrix x2) ── needs [build] ─────────────────── push/tag only
 #   smoke-test ───────── needs [merge] ──────────────────── push/tag only
 #
 # Triggers:
-#   push to main   -> test + (if code changed) build -> merge -> smoke-test
-#   push tag v*    -> test + build -> merge -> smoke-test
-#   pull_request   -> test + (if code changed AND test passed) build
+#   push to main   -> test + build -> merge -> smoke-test (always; rolls :main + :latest + :main-<sha>)
+#   push tag v*    -> test + build -> merge -> smoke-test (release tags: :0.9.1, :0.9, :0)
+#   pull_request   -> test + (if code changed AND test passed) build (no push)
+#
+# Note on docs-only commits: pushes to main always rebuild the image so
+# the rolling :main tag stays current with HEAD. README/CHANGELOG-only
+# *PRs* still skip CI via the pull_request paths-ignore, but the squash
+# commit on main rebuilds the image regardless. See #258 for the
+# motivation (avoid stealth-staleness in published images).
 
 name: CI
 
@@ -25,9 +31,6 @@ on:
   push:
     branches: [main]
     tags: ['v*']
-    paths-ignore:
-      - 'CHANGELOG.md'
-      - 'README.md'
   pull_request:
     branches: [main]
     paths-ignore:
@@ -267,14 +270,22 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ steps.image.outputs.name }}
+          # Tag scheme (#258):
+          #   release tag push v0.9.1   → :0.9.1, :0.9, :0
+          #   main push                 → :main, :main-<short-sha>, :latest
+          #   PR (no push happens here, but if it did) → :pr-<n>
+          # `:latest` strictly tracks main HEAD; release-tag pushes do not
+          # set it, so operators wanting fixes-since-last-release use :main
+          # or :latest. Operators wanting a fixed snapshot pin :0.9.1 or
+          # :main-<sha>.
           tags: |
             type=ref,event=branch
             type=ref,event=pr
+            type=sha,prefix=main-,format=short,enable={{is_default_branch}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Create manifest list and push
         working-directory: /tmp/digests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,6 +298,18 @@ pitboss container-build pitboss.toml --dry-run   # print podman/docker invocatio
 
 `pitboss container-dispatch` automatically picks up the derived tag when `extra_apt` or `copy` is non-empty and the tag exists locally — no explicit wiring needed in the manifest. Stale derived tags from prior builds remain in the local image store; prune them with the runtime's standard tooling (`podman image prune`, etc.) — a pitboss-aware sweeper is tracked in the roadmap.
 
+#### Image tag cadence (`ghcr.io/sds-mode/pitboss-with-claude`)
+
+Three tag families are published:
+
+| Tag family | Mutability | When it moves | Use when |
+|---|---|---|---|
+| `:0.9.1`, `:0.9`, `:0` | **Immutable snapshot** | Never (released) | You want a fixed, auditable point release. These tags do **not** receive backports — fixes that land after a release tag are only available via `:main` or `:latest`. |
+| `:main`, `:latest` | **Rolling** | Every push to main | You want the latest fixes since the most recent release. Both move together; `:latest` is a convenience alias for `:main`. |
+| `:main-<short-sha>` | Per-commit immutable | One per main commit | You need to pin a `container-dispatch` to a specific main-HEAD commit for reproducibility (debugging, soak tests). |
+
+Pushes to main rebuild the image regardless of whether the commit touched code paths — including README/CHANGELOG-only commits. This is deliberate: the cost of a stale published image (operators hitting "already-fixed" bugs in their containers) is higher than the runner-minute cost of always rebuilding. PRs that touch only README/CHANGELOG still skip CI; the rebuild fires when the squash commit lands on main.
+
 ### `[[mcp_server]]` (v0.9+)
 
 Declare external MCP servers to inject into **every actor's** `--mcp-config` (lead, sub-leads, and workers). This is the native alternative to the KV-bridge workaround for giving all actors access to tools like context7.


### PR DESCRIPTION
## Summary

- Drop `paths-ignore` from the `push:` trigger so every commit landing on main rebuilds the image, including README/CHANGELOG-only squash merges. PRs with only README/CHANGELOG changes continue to skip CI via the `pull_request:` paths-ignore.
- Add a `:main-<short-sha>` rolling tag on main pushes for SHA-pinned reproducibility (`type=sha,prefix=main-,format=short,enable={{is_default_branch}}`).
- Drop the redundant `type=raw,value=latest,enable=tag` rule. `:latest` now strictly tracks main HEAD via the `is_default_branch` rule.
- Document the three tag families in AGENTS.md `[container]` ("Image tag cadence" subsection).

## Why

The 0.9.1 image (tagged 2026-04-27) shipped without two fixes that landed on main shortly after the release: PR #245 (cost_usd persistence) and PR #220 (default_approval_policy unconditional). Container-dispatch users hit those as "already-fixed" regressions because there was no rolling tag to pull from. This is the stealth-staleness mode #258 calls out.

Cost of always rebuilding on main pushes: ~15-20 min of runner time per push. Cost of NOT always rebuilding: operators chase phantom bugs in stale images. The latter is worse.

## ⚠️ Behavior change for `:latest`

Old: `:latest` was set on both main pushes AND tag pushes (last writer wins).
New: `:latest` is set only on main pushes.

**Operators who pinned `:latest` expecting "most recent release" semantics will now get rolling main builds.** This is intentional and was the explicit ask in #258. To pin a release, use a version tag (`:0.9.1`, `:0.9`, `:0`).

## Files changed

- `.github/workflows/ci.yml` — trigger config + metadata-action tags + header comment.
- `AGENTS.md` — new "Image tag cadence" subsection under `[container]`.

## Test plan

- [x] YAML parses (`python3 -c 'import yaml; yaml.safe_load(...)'`)
- [ ] **This PR's own merge is the primary smoke**: verify `:main`, `:main-<short-sha>`, and `:latest` all land on `ghcr.io/sds-mode/pitboss-with-claude` after merge. (Secondary: confirm `pitboss-with-claude:main-<sha>` matches the merge SHA.)
- [ ] Follow-up smoke (issue acceptance criterion): open a PR touching only `README.md`, merge, confirm `:main` rolls forward.

## Out of scope

- Backporting fixes to the 0.9.1 image (#258 explicitly notes patch tags are heavyweight and unnecessary — operators wanting fixes-since-release use `:main` or `:latest`).
- pr-gate.yml or release.yml changes — separate concerns.

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)