### PR TITLE
docs(roadmap): track #266 + #267 in scoped & ready

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -126,6 +126,22 @@ abstract is the spec.
   shipped) — `Stale` is what `prune` matches on by default.
   **Status:** scoped. **Tracking:** none yet.
 
+- **Warn when `extra_apt`-only manifest's derived image is missing.**
+  Today `container-dispatch` silently falls through to the Phase 1
+  apt-at-spin-up path when the derived tag was deleted. Emit a single
+  stderr warning so the operator knows the cached fast-path was
+  bypassed and can re-run `container-build`.
+  **Status:** scoped. **Tracking:** #266.
+
+- **`pitboss container-prune` for stale derived images.** Clean up
+  `pitboss-derived-<sha>:local` tags that no in-use manifest still
+  references. Mirrors the existing `pitboss prune` shape for run
+  dirs; helps active operators iterating on `[[container.copy]]`
+  contents avoid linear image-list growth.
+  **Status:** scoped — open question on reference-set policy
+  (manifest list vs. glob vs. keep-recent-N).
+  **Tracking:** #267.
+
 - **systemd unit for long-lived dispatcher mode.** Run `pitboss
   dispatch` as a service rather than a one-shot, with restart
   semantics and journaled logs. **Status:** scoped. **Tracking:**


### PR DESCRIPTION
## Summary

Two follow-ups filed during the #258 image-cadence work get inline abstracts under \"Scoped & ready\":

- **#266** — warn when \`extra_apt\`-only manifest's derived image is missing. Advisor-flagged UX nit deferred from #264.
- **#267** — \`pitboss container-prune\` for stale derived images. AGENTS.md already referenced this as \"tracked in roadmap\" but the issue itself didn't exist until now.

Both labeled \`roadmap\` so the existing label filter picks them up.

## Why

Keeps ROADMAP.md a faithful index of the open scoped work — neither item is large enough to warrant a tracking issue all of its own without inline context, and neither was previously surfaced in the roadmap file.

## Test plan

- [x] Pure docs change; no code, tests, or generated artifacts.
- [x] cliff.toml \`^docs\` skip rule excludes this from CHANGELOG (verified against cliff.toml:96; same handling as #254 \`docs(roadmap):\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)