### PR TITLE
feat(container): warn when extra_apt-only manifest's derived image is missing

### DIFF
--- a/crates/pitboss-cli/src/dispatch/container.rs
+++ b/crates/pitboss-cli/src/dispatch/container.rs
@@ -51,6 +51,19 @@ pub fn run_container_dispatch(
             manifest_path.display()
         );
     }
+    // #266: surface the silent slow-path fallback. When extra_apt is
+    // declared but no derived image exists, dispatch is correct but
+    // slower than the operator likely intends. A single stderr warning
+    // points at the fix (`pitboss container-build`) without changing
+    // behavior.
+    if let Some(msg) = super::container_build::derived_fallback_warning(
+        container,
+        derived.as_deref(),
+        use_derived,
+        manifest_path,
+    ) {
+        eprintln!("{msg}");
+    }
     let derived_image_override = if use_derived {
         derived.as_deref()
     } else {

--- a/crates/pitboss-cli/src/dispatch/container_build.rs
+++ b/crates/pitboss-cli/src/dispatch/container_build.rs
@@ -281,6 +281,43 @@ fn expand_tilde(p: &Path) -> PathBuf {
     }
 }
 
+/// Decide whether to surface a "derived image not built; using
+/// slow-path apt install" warning to the operator.
+///
+/// Returns `Some(message)` when the operator declared `extra_apt`
+/// inputs that warrant a derived image (so a `container-build` would
+/// have helped) but no such image exists locally — `container-dispatch`
+/// will fall through to the Phase 1 apt-at-spin-up path. The
+/// `[[container.copy]]` case is excluded because the dispatcher already
+/// hard-errors there (the COPY contents would be missing — see
+/// `dispatch/container.rs:run_container_dispatch`).
+///
+/// Returns `None` when no warning is needed: the derived image is
+/// already in use, no derived inputs were declared, or the copy-set
+/// hard-error path will fire instead.
+pub(crate) fn derived_fallback_warning(
+    container: &ContainerConfig,
+    derived_tag: Option<&str>,
+    use_derived: bool,
+    manifest_path: &Path,
+) -> Option<String> {
+    if use_derived {
+        return None;
+    }
+    if container.extra_apt.is_empty() {
+        return None;
+    }
+    if !container.copy.is_empty() {
+        return None;
+    }
+    let tag = derived_tag?;
+    Some(format!(
+        "warning: derived image {tag} not found locally; falling back to apt-at-spin-up.\n\
+         Re-run `pitboss container-build {}` to restore the cached fast-path.",
+        manifest_path.display()
+    ))
+}
+
 /// Check whether `tag` exists in the runtime's local image store.
 /// Returns Ok(true) when the image is present, Ok(false) when absent,
 /// and Err only on runtime invocation failures.
@@ -518,6 +555,89 @@ mod tests {
             df.trim_end().ends_with("USER pitboss"),
             "must drop privs at end: {df}"
         );
+    }
+
+    #[test]
+    fn fallback_warning_emits_when_extra_apt_set_and_image_missing() {
+        let c = ContainerConfig {
+            extra_apt: vec!["mdbook".into()],
+            ..cfg()
+        };
+        let manifest = PathBuf::from("/tmp/manifest.toml");
+        let out =
+            derived_fallback_warning(&c, Some("pitboss-derived-abc123:local"), false, &manifest);
+        let msg = out.expect("warning should fire");
+        assert!(
+            msg.contains("pitboss-derived-abc123:local"),
+            "missing tag: {msg}"
+        );
+        assert!(
+            msg.contains("apt-at-spin-up"),
+            "missing fallback hint: {msg}"
+        );
+        assert!(
+            msg.contains("pitboss container-build /tmp/manifest.toml"),
+            "missing rebuild hint with manifest path: {msg}"
+        );
+    }
+
+    #[test]
+    fn fallback_warning_suppressed_when_derived_image_in_use() {
+        let c = ContainerConfig {
+            extra_apt: vec!["mdbook".into()],
+            ..cfg()
+        };
+        let out = derived_fallback_warning(
+            &c,
+            Some("pitboss-derived-abc123:local"),
+            true, // built image is in use; no fallback in effect
+            &PathBuf::from("/tmp/manifest.toml"),
+        );
+        assert!(out.is_none(), "no warning when derived image is used");
+    }
+
+    #[test]
+    fn fallback_warning_suppressed_when_no_extra_apt() {
+        // Operator declared no derived inputs — there's no slow-path
+        // they're missing out on. Stay quiet.
+        let c = ContainerConfig::default();
+        let out = derived_fallback_warning(&c, None, false, &PathBuf::from("/tmp/manifest.toml"));
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn fallback_warning_suppressed_when_copy_set() {
+        // The dispatcher already hard-errors when copy is set without
+        // a built image — we'd be redundantly warning about a path
+        // that's about to bail.
+        let c = ContainerConfig {
+            extra_apt: vec!["mdbook".into()],
+            copy: vec![CopySpec {
+                host: PathBuf::from("/host/x"),
+                container: PathBuf::from("/opt/x"),
+            }],
+            ..cfg()
+        };
+        let out = derived_fallback_warning(
+            &c,
+            Some("pitboss-derived-abc123:local"),
+            false,
+            &PathBuf::from("/tmp/manifest.toml"),
+        );
+        assert!(out.is_none(), "copy-set is the hard-error path, not warn");
+    }
+
+    #[test]
+    fn fallback_warning_suppressed_when_derived_tag_is_none() {
+        // Defensive: if no tag was computed (shouldn't happen given
+        // extra_apt is non-empty, but the type permits it), stay quiet
+        // rather than emit an empty-tag warning.
+        let c = ContainerConfig {
+            extra_apt: vec!["mdbook".into()],
+            ..cfg()
+        };
+        let out = derived_fallback_warning(&c, None, false, &PathBuf::from("/tmp/manifest.toml"));
+        assert!(out.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Surface the silent slow-path fallback when `pitboss container-dispatch` runs against a manifest with `extra_apt` declared but no built derived image. Previously the dispatcher quietly fell through to Phase 1's apt-at-spin-up path — functionally correct but invisibly slow. Now a single stderr warning points at the fix.

## Behavior

For a manifest like:

```toml
[container]
extra_apt = ["mdbook"]
```

after the derived image has been pruned (`podman image prune -a`, system migration, etc.), `pitboss container-dispatch` emits:

```
warning: derived image pitboss-derived-465c3910a5c2:local not found locally; falling back to apt-at-spin-up.
Re-run `pitboss container-build /path/to/manifest.toml` to restore the cached fast-path.
```

stdout (assembled run command in `--dry-run`, or actual exec otherwise) is unchanged.

## Suppression conditions

The warning is suppressed in all of these cases:
- `derived_image_tag` returns `None` (no derived inputs declared — legitimate stock-image dispatch).
- The derived image **is** present locally (`use_derived = true`).
- `extra_apt` is empty (no install latency to flag).
- `[[container.copy]]` is non-empty (the dispatcher already hard-errors there per #264 — a warning would just duplicate the bail's message).

## Implementation

- **`derived_fallback_warning(container, derived_tag, use_derived, manifest_path) -> Option<String>`** — pure helper in `container_build.rs`, returns `Some(msg)` when the warning should fire, `None` otherwise. Unit-testable without touching dispatch.
- **`run_container_dispatch` in `container.rs`** — calls the helper, `eprintln!`s the result. Single one-shot, no other behavior change.

## Files changed

- `crates/pitboss-cli/src/dispatch/container_build.rs` — `derived_fallback_warning` helper + 5 unit tests.
- `crates/pitboss-cli/src/dispatch/container.rs` — wire the helper into `run_container_dispatch`.

## Test plan

- [x] `cargo test -p pitboss-cli --lib` (599 / 0 — 5 new unit tests for the helper)
- [x] `cargo lint` + `cargo tidy` clean
- [x] End-to-end smoke: manifest with `extra_apt = [\"mdbook\"]`, derived tag absent → warning on stderr, dry-run command on stdout (clean separation)
- [x] Suppression smoke: same manifest after `pitboss container-build` had run → no warning, dispatch uses derived tag

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)