### PR TITLE
feat(communication): parent-child mailbox + artifact MCP tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,6 +350,35 @@ All declared servers are injected into all actors (scope = all). Per-actor scopi
 
 **Tools from injected servers are available immediately** — no additional `--allowedTools` configuration is needed; claude's MCP client discovers the tools from the server at startup.
 
+### `[communication]` (v0.10+, opt-in)
+
+Declares the policy for the Pitboss-owned mailbox + artifact MCP tools.
+**Default `mode = "disabled"`** — KV remains the only inter-actor surface
+unless an operator opts in. The mailbox is for short coordination notes
+referencing artifact ids; the artifact store is for binary payloads
+(parents passing context to workers, workers handing back outputs)
+without forcing actors to base64-encode blobs into KV.
+
+```toml
+[communication]
+mode                    = "parent_child"   # "disabled" (default) | "parent_child"
+max_message_bytes       = 8192              # body cap on message_send
+max_artifact_bytes      = 10485760          # decoded payload cap on artifact_put
+max_artifacts_per_actor = 128               # per-actor publish ceiling per run
+```
+
+**`parent_child` semantics:**
+- Root lead reads / sends to every actor.
+- Sub-leads read / send within their own sub-tree; may also message `"root"` upward.
+- Workers may message only their direct parent (via the alias `"parent"`); they may read messages they sent or received.
+- Sibling-worker artifact transfer requires the parent (or root) to call `artifact_grant` — there is no peer-to-peer write channel.
+
+**Artifact storage** lands at `<run_dir>/communication/artifacts/<artifact_id>`. Auto-mounted under `pitboss container-dispatch`; cleaned with the run dir by `pitboss prune --remove`.
+
+**Disabled mode** (the default) hides the 8 tools from `list_tools` and rejects every handler call with `CommunicationError::Disabled`. Tool names still appear in the lead/sublead/worker `--allowedTools` argv (cosmetic only — Claude does not call tools missing from `list_tools`).
+
+See `examples/communication-parent-child-demo.toml` for a full walkthrough.
+
 ### Migration from v0.8 → v0.9
 
 Pre-v0.9 manifests are rejected. `pitboss validate` scans for the migration
@@ -762,6 +791,14 @@ populated with these. You (the operator) don't list them explicitly.
 | `mcp__pitboss__run_lease_release` | `{lease_id}` | `{ok: true}` |
 | `mcp__pitboss__analyze_run` | `{run_id}` | `RunAnalysis` — header (id / manifest / mode / status / duration / versions), `cost` rollup (per-model + lead-vs-worker), `failures` grouped by classified `FailureReason::kind`, `tasks` (workers grouped under their lead), `hotspots` (longest / costliest / most-tokens). Read-only triage over a prior run; resolves `run_id` against the canonical runs base directory. |
 | `mcp__pitboss__analyze_recent` | `{limit?, failed_only?}` | `RecentAnalysis { runs, aggregates }` — per-run analyses plus a cross-run aggregate (failure histogram, model usage, top-3 slowest / costliest / most-failed runs). `limit` defaults to 10 and is silently clamped to 50. `failed_only` skips runs with zero failed tasks. |
+| `mcp__pitboss__message_send` | `{to, subject, body, refs?}` | `{message_id}` — opt-in via `[communication] mode = "parent_child"` (default disabled). Workers may target `"parent"` or self; subleads may target `"root"` or workers in their own sub-tree; root may target any actor. Body capped by `max_message_bytes`. |
+| `mcp__pitboss__message_list` | `{scope?}` | `{messages: [...]}` — `scope` defaults to `inbox`. Other scopes: `sent`, `visible`, `all` (root only). |
+| `mcp__pitboss__message_read` | `{message_id}` | `{message}` — parents can read child messages; workers can read only messages they sent or received. |
+| `mcp__pitboss__message_ack` | `{message_id}` | `{ok: true}` |
+| `mcp__pitboss__artifact_put` | `{name, mime_type?, content_base64}` | `{artifact_id, uri, size_bytes, sha256}` — bytes land at `<run_dir>/communication/artifacts/<id>`. Subject to `max_artifact_bytes` and `max_artifacts_per_actor`. |
+| `mcp__pitboss__artifact_list` | `{scope?}` | `{artifacts: [...]}` — `scope` defaults to `visible`. Other scopes: `owned`, `granted`, `all` (root only). |
+| `mcp__pitboss__artifact_read` | `{artifact_id}` | `{artifact, content_base64}` |
+| `mcp__pitboss__artifact_grant` | `{artifact_id, to}` | `{ok: true}` — caller must already be allowed to read the artifact and address the recipient. Used by parents to enable sibling-worker handoffs. Read access only; ownership does not transfer. |
 
 All tool responses returning a collection are wrapped in a record
 (`{workers: [...]}`, `{entries: [...]}`, `{entry: ...}`) — MCP spec

--- a/crates/pitboss-cli/src/communication.rs
+++ b/crates/pitboss-cli/src/communication.rs
@@ -1,0 +1,1306 @@
+//! Pitboss-owned directional communication plane.
+//!
+//! KV remains the small metadata/coordination surface. This module owns
+//! mailbox messages and larger artifacts so actors transfer payloads by
+//! Pitboss-managed ids rather than by stuffing serialized blobs into KV.
+
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use base64::Engine;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tokio::sync::RwLock;
+use uuid::Uuid;
+
+use crate::dispatch::state::DispatchState;
+use crate::manifest::schema::{CommunicationConfig, CommunicationMode};
+use crate::shared_store::tools::MetaField;
+use crate::shared_store::ActorRole;
+
+#[derive(Debug, thiserror::Error)]
+pub enum CommunicationError {
+    #[error("communication tools are disabled by [communication].mode")]
+    Disabled,
+    #[error("caller identity required (missing _meta)")]
+    MissingIdentity,
+    #[error("unknown actor: {0}")]
+    UnknownActor(String),
+    #[error("not found: {0}")]
+    NotFound(String),
+    #[error("forbidden: {0}")]
+    Forbidden(String),
+    #[error("message body exceeds max_message_bytes ({actual} > {limit})")]
+    MessageTooLarge { actual: usize, limit: usize },
+    #[error("artifact payload exceeds max_artifact_bytes ({actual} > {limit})")]
+    ArtifactTooLarge { actual: usize, limit: usize },
+    #[error("artifact count limit exceeded for {actor_id} ({limit})")]
+    ArtifactCountExceeded { actor_id: String, limit: usize },
+    #[error("invalid base64 content: {0}")]
+    InvalidBase64(String),
+    #[error("artifact storage error: {0}")]
+    Storage(String),
+    #[error("invalid scope: {0}")]
+    InvalidScope(String),
+}
+
+#[derive(Debug, Clone)]
+struct Caller {
+    id: String,
+    role: ActorRole,
+}
+
+impl From<MetaField> for Caller {
+    fn from(meta: MetaField) -> Self {
+        Self {
+            id: meta.actor_id,
+            role: meta.actor_role,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Message {
+    pub message_id: String,
+    pub from: String,
+    pub to: String,
+    pub subject: String,
+    pub body: String,
+    pub refs: Vec<String>,
+    pub created_at: DateTime<Utc>,
+    pub acked_by: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MessageSummary {
+    pub message_id: String,
+    pub from: String,
+    pub to: String,
+    pub subject: String,
+    pub refs: Vec<String>,
+    pub created_at: DateTime<Utc>,
+    pub acked_by: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct StoredMessage {
+    message_id: String,
+    from: String,
+    to: String,
+    subject: String,
+    body: String,
+    refs: Vec<String>,
+    created_at: DateTime<Utc>,
+    acked_by: HashSet<String>,
+}
+
+impl StoredMessage {
+    fn summary(&self) -> MessageSummary {
+        let mut acked_by: Vec<String> = self.acked_by.iter().cloned().collect();
+        acked_by.sort();
+        MessageSummary {
+            message_id: self.message_id.clone(),
+            from: self.from.clone(),
+            to: self.to.clone(),
+            subject: self.subject.clone(),
+            refs: self.refs.clone(),
+            created_at: self.created_at,
+            acked_by,
+        }
+    }
+
+    fn full(&self) -> Message {
+        let mut acked_by: Vec<String> = self.acked_by.iter().cloned().collect();
+        acked_by.sort();
+        Message {
+            message_id: self.message_id.clone(),
+            from: self.from.clone(),
+            to: self.to.clone(),
+            subject: self.subject.clone(),
+            body: self.body.clone(),
+            refs: self.refs.clone(),
+            created_at: self.created_at,
+            acked_by,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ArtifactMetadata {
+    pub artifact_id: String,
+    pub uri: String,
+    pub owner: String,
+    pub name: String,
+    pub mime_type: Option<String>,
+    pub size_bytes: u64,
+    pub sha256: String,
+    pub created_at: DateTime<Utc>,
+    pub grants: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct StoredArtifact {
+    metadata: ArtifactMetadata,
+    path: PathBuf,
+    grants: HashSet<String>,
+}
+
+impl StoredArtifact {
+    fn metadata(&self) -> ArtifactMetadata {
+        let mut metadata = self.metadata.clone();
+        metadata.grants = self.grants.iter().cloned().collect();
+        metadata.grants.sort();
+        metadata
+    }
+}
+
+pub struct CommunicationStore {
+    config: CommunicationConfig,
+    artifact_dir: PathBuf,
+    messages: RwLock<HashMap<String, StoredMessage>>,
+    artifacts: RwLock<HashMap<String, StoredArtifact>>,
+    activity: RwLock<HashMap<String, CommunicationActivityCounters>>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CommunicationActivityCounters {
+    pub message_ops: u64,
+    pub artifact_ops: u64,
+}
+
+impl CommunicationStore {
+    pub fn new(config: CommunicationConfig, run_subdir: PathBuf) -> Self {
+        Self {
+            config,
+            artifact_dir: run_subdir.join("communication").join("artifacts"),
+            messages: RwLock::new(HashMap::new()),
+            artifacts: RwLock::new(HashMap::new()),
+            activity: RwLock::new(HashMap::new()),
+        }
+    }
+
+    pub fn config(&self) -> &CommunicationConfig {
+        &self.config
+    }
+
+    pub async fn note_message_op(&self, actor_id: &str) {
+        if actor_id.is_empty() {
+            return;
+        }
+        let mut activity = self.activity.write().await;
+        activity
+            .entry(actor_id.to_string())
+            .or_default()
+            .message_ops += 1;
+    }
+
+    pub async fn note_artifact_op(&self, actor_id: &str) {
+        if actor_id.is_empty() {
+            return;
+        }
+        let mut activity = self.activity.write().await;
+        activity
+            .entry(actor_id.to_string())
+            .or_default()
+            .artifact_ops += 1;
+    }
+
+    pub async fn activity_snapshot(&self) -> HashMap<String, CommunicationActivityCounters> {
+        self.activity.read().await.clone()
+    }
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct MessageSendArgs {
+    pub to: String,
+    pub subject: String,
+    pub body: String,
+    #[serde(default)]
+    pub refs: Vec<String>,
+    #[serde(rename = "_meta")]
+    #[schemars(skip)]
+    pub meta: MetaField,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MessageSendResult {
+    pub message_id: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct MessageListArgs {
+    #[serde(default)]
+    pub scope: Option<String>,
+    #[serde(rename = "_meta")]
+    #[schemars(skip)]
+    pub meta: MetaField,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MessageListResult {
+    pub messages: Vec<MessageSummary>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct MessageReadArgs {
+    pub message_id: String,
+    #[serde(rename = "_meta")]
+    #[schemars(skip)]
+    pub meta: MetaField,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MessageReadResult {
+    pub message: Message,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct MessageAckArgs {
+    pub message_id: String,
+    #[serde(rename = "_meta")]
+    #[schemars(skip)]
+    pub meta: MetaField,
+}
+
+#[derive(Debug, Serialize)]
+pub struct OkResult {
+    pub ok: bool,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ArtifactPutArgs {
+    pub name: String,
+    #[serde(default)]
+    pub mime_type: Option<String>,
+    pub content_base64: String,
+    #[serde(rename = "_meta")]
+    #[schemars(skip)]
+    pub meta: MetaField,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ArtifactPutResult {
+    pub artifact_id: String,
+    pub uri: String,
+    pub size_bytes: u64,
+    pub sha256: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ArtifactListArgs {
+    #[serde(default)]
+    pub scope: Option<String>,
+    #[serde(rename = "_meta")]
+    #[schemars(skip)]
+    pub meta: MetaField,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ArtifactListResult {
+    pub artifacts: Vec<ArtifactMetadata>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ArtifactReadArgs {
+    pub artifact_id: String,
+    #[serde(rename = "_meta")]
+    #[schemars(skip)]
+    pub meta: MetaField,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ArtifactReadResult {
+    pub artifact: ArtifactMetadata,
+    pub content_base64: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ArtifactGrantArgs {
+    pub artifact_id: String,
+    pub to: String,
+    #[serde(rename = "_meta")]
+    #[schemars(skip)]
+    pub meta: MetaField,
+}
+
+pub async fn handle_message_send(
+    state: &Arc<DispatchState>,
+    args: MessageSendArgs,
+) -> Result<MessageSendResult, CommunicationError> {
+    ensure_enabled(state)?;
+    let caller: Caller = args.meta.into();
+    state.communication.note_message_op(&caller.id).await;
+    let limit = state.root.manifest.communication.max_message_bytes as usize;
+    if args.body.len() > limit {
+        return Err(CommunicationError::MessageTooLarge {
+            actual: args.body.len(),
+            limit,
+        });
+    }
+    let to = resolve_recipient(state, &caller, &args.to).await?;
+    ensure_can_send(state, &caller, &to).await?;
+
+    let message_id = Uuid::now_v7().to_string();
+    let message = StoredMessage {
+        message_id: message_id.clone(),
+        from: caller.id,
+        to,
+        subject: args.subject,
+        body: args.body,
+        refs: args.refs,
+        created_at: Utc::now(),
+        acked_by: HashSet::new(),
+    };
+    state
+        .communication
+        .messages
+        .write()
+        .await
+        .insert(message_id.clone(), message);
+    Ok(MessageSendResult { message_id })
+}
+
+pub async fn handle_message_list(
+    state: &Arc<DispatchState>,
+    args: MessageListArgs,
+) -> Result<MessageListResult, CommunicationError> {
+    ensure_enabled(state)?;
+    let caller: Caller = args.meta.into();
+    state.communication.note_message_op(&caller.id).await;
+    let scope = args.scope.as_deref().unwrap_or("inbox");
+    let messages = state.communication.messages.read().await;
+    let mut out = Vec::new();
+    for message in messages.values() {
+        let visible = match scope {
+            "inbox" => message.to == caller.id,
+            "sent" => message.from == caller.id,
+            "visible" => can_read_message(state, &caller, message).await?,
+            "all" => {
+                if caller.role != ActorRole::Lead {
+                    return Err(CommunicationError::Forbidden(
+                        "message_list scope=all is root-lead only".into(),
+                    ));
+                }
+                true
+            }
+            other => return Err(CommunicationError::InvalidScope(other.into())),
+        };
+        if visible {
+            out.push(message.summary());
+        }
+    }
+    out.sort_by(|a, b| {
+        a.created_at
+            .cmp(&b.created_at)
+            .then(a.message_id.cmp(&b.message_id))
+    });
+    Ok(MessageListResult { messages: out })
+}
+
+pub async fn handle_message_read(
+    state: &Arc<DispatchState>,
+    args: MessageReadArgs,
+) -> Result<MessageReadResult, CommunicationError> {
+    ensure_enabled(state)?;
+    let caller: Caller = args.meta.into();
+    state.communication.note_message_op(&caller.id).await;
+    let messages = state.communication.messages.read().await;
+    let message = messages
+        .get(&args.message_id)
+        .ok_or_else(|| CommunicationError::NotFound(args.message_id.clone()))?;
+    if !can_read_message(state, &caller, message).await? {
+        return Err(CommunicationError::Forbidden(format!(
+            "{} cannot read message {}",
+            caller.id, args.message_id
+        )));
+    }
+    Ok(MessageReadResult {
+        message: message.full(),
+    })
+}
+
+pub async fn handle_message_ack(
+    state: &Arc<DispatchState>,
+    args: MessageAckArgs,
+) -> Result<OkResult, CommunicationError> {
+    ensure_enabled(state)?;
+    let caller: Caller = args.meta.into();
+    state.communication.note_message_op(&caller.id).await;
+    let mut messages = state.communication.messages.write().await;
+    let message = messages
+        .get_mut(&args.message_id)
+        .ok_or_else(|| CommunicationError::NotFound(args.message_id.clone()))?;
+    if !can_read_message(state, &caller, message).await? {
+        return Err(CommunicationError::Forbidden(format!(
+            "{} cannot ack message {}",
+            caller.id, args.message_id
+        )));
+    }
+    message.acked_by.insert(caller.id);
+    Ok(OkResult { ok: true })
+}
+
+pub async fn handle_artifact_put(
+    state: &Arc<DispatchState>,
+    args: ArtifactPutArgs,
+) -> Result<ArtifactPutResult, CommunicationError> {
+    ensure_enabled(state)?;
+    let caller: Caller = args.meta.into();
+    state.communication.note_artifact_op(&caller.id).await;
+    let content = base64::engine::general_purpose::STANDARD
+        .decode(args.content_base64.as_bytes())
+        .map_err(|e| CommunicationError::InvalidBase64(e.to_string()))?;
+    let limit = state.root.manifest.communication.max_artifact_bytes as usize;
+    if content.len() > limit {
+        return Err(CommunicationError::ArtifactTooLarge {
+            actual: content.len(),
+            limit,
+        });
+    }
+    let per_actor_limit = state.root.manifest.communication.max_artifacts_per_actor as usize;
+    let mut artifacts = state.communication.artifacts.write().await;
+    let current_count = artifacts
+        .values()
+        .filter(|artifact| artifact.metadata.owner == caller.id)
+        .count();
+    if current_count >= per_actor_limit {
+        return Err(CommunicationError::ArtifactCountExceeded {
+            actor_id: caller.id,
+            limit: per_actor_limit,
+        });
+    }
+
+    tokio::fs::create_dir_all(&state.communication.artifact_dir)
+        .await
+        .map_err(|e| CommunicationError::Storage(e.to_string()))?;
+    let artifact_id = Uuid::now_v7().to_string();
+    let path = state.communication.artifact_dir.join(&artifact_id);
+    tokio::fs::write(&path, &content)
+        .await
+        .map_err(|e| CommunicationError::Storage(e.to_string()))?;
+
+    let digest = Sha256::digest(&content);
+    let sha256 = format!("{digest:x}");
+    let uri = format!("pitboss://run/{}/artifact/{artifact_id}", state.root.run_id);
+    let metadata = ArtifactMetadata {
+        artifact_id: artifact_id.clone(),
+        uri: uri.clone(),
+        owner: caller.id,
+        name: args.name,
+        mime_type: args.mime_type,
+        size_bytes: content.len() as u64,
+        sha256: sha256.clone(),
+        created_at: Utc::now(),
+        grants: Vec::new(),
+    };
+    artifacts.insert(
+        artifact_id.clone(),
+        StoredArtifact {
+            metadata,
+            path,
+            grants: HashSet::new(),
+        },
+    );
+    Ok(ArtifactPutResult {
+        artifact_id,
+        uri,
+        size_bytes: content.len() as u64,
+        sha256,
+    })
+}
+
+pub async fn handle_artifact_list(
+    state: &Arc<DispatchState>,
+    args: ArtifactListArgs,
+) -> Result<ArtifactListResult, CommunicationError> {
+    ensure_enabled(state)?;
+    let caller: Caller = args.meta.into();
+    state.communication.note_artifact_op(&caller.id).await;
+    let scope = args.scope.as_deref().unwrap_or("visible");
+    let artifacts = state.communication.artifacts.read().await;
+    let mut out = Vec::new();
+    for artifact in artifacts.values() {
+        let visible = match scope {
+            "owned" => artifact.metadata.owner == caller.id,
+            "granted" => artifact.grants.contains(&caller.id),
+            "visible" => can_read_artifact(state, &caller, artifact).await?,
+            "all" => {
+                if caller.role != ActorRole::Lead {
+                    return Err(CommunicationError::Forbidden(
+                        "artifact_list scope=all is root-lead only".into(),
+                    ));
+                }
+                true
+            }
+            other => return Err(CommunicationError::InvalidScope(other.into())),
+        };
+        if visible {
+            out.push(artifact.metadata());
+        }
+    }
+    out.sort_by(|a, b| {
+        a.created_at
+            .cmp(&b.created_at)
+            .then(a.artifact_id.cmp(&b.artifact_id))
+    });
+    Ok(ArtifactListResult { artifacts: out })
+}
+
+pub async fn handle_artifact_read(
+    state: &Arc<DispatchState>,
+    args: ArtifactReadArgs,
+) -> Result<ArtifactReadResult, CommunicationError> {
+    ensure_enabled(state)?;
+    let caller: Caller = args.meta.into();
+    state.communication.note_artifact_op(&caller.id).await;
+    let (metadata, path) = {
+        let artifacts = state.communication.artifacts.read().await;
+        let artifact = artifacts
+            .get(&args.artifact_id)
+            .ok_or_else(|| CommunicationError::NotFound(args.artifact_id.clone()))?;
+        if !can_read_artifact(state, &caller, artifact).await? {
+            return Err(CommunicationError::Forbidden(format!(
+                "{} cannot read artifact {}",
+                caller.id, args.artifact_id
+            )));
+        }
+        (artifact.metadata(), artifact.path.clone())
+    };
+    let content = tokio::fs::read(&path)
+        .await
+        .map_err(|e| CommunicationError::Storage(e.to_string()))?;
+    Ok(ArtifactReadResult {
+        artifact: metadata,
+        content_base64: base64::engine::general_purpose::STANDARD.encode(content),
+    })
+}
+
+pub async fn handle_artifact_grant(
+    state: &Arc<DispatchState>,
+    args: ArtifactGrantArgs,
+) -> Result<OkResult, CommunicationError> {
+    ensure_enabled(state)?;
+    let caller: Caller = args.meta.into();
+    state.communication.note_artifact_op(&caller.id).await;
+    let to = resolve_recipient(state, &caller, &args.to).await?;
+    ensure_can_send(state, &caller, &to).await?;
+    let mut artifacts = state.communication.artifacts.write().await;
+    let artifact = artifacts
+        .get_mut(&args.artifact_id)
+        .ok_or_else(|| CommunicationError::NotFound(args.artifact_id.clone()))?;
+    if !can_read_artifact(state, &caller, artifact).await? {
+        return Err(CommunicationError::Forbidden(format!(
+            "{} cannot grant artifact {}",
+            caller.id, args.artifact_id
+        )));
+    }
+    artifact.grants.insert(to);
+    Ok(OkResult { ok: true })
+}
+
+fn ensure_enabled(state: &Arc<DispatchState>) -> Result<(), CommunicationError> {
+    if state.root.manifest.communication.mode == CommunicationMode::Disabled {
+        Err(CommunicationError::Disabled)
+    } else {
+        Ok(())
+    }
+}
+
+async fn resolve_recipient(
+    state: &Arc<DispatchState>,
+    caller: &Caller,
+    raw: &str,
+) -> Result<String, CommunicationError> {
+    let resolved = match raw {
+        "self" => caller.id.clone(),
+        "root" => state.root.lead_id.clone(),
+        "parent" => parent_for_actor(state, caller)
+            .await?
+            .ok_or_else(|| CommunicationError::UnknownActor("parent".into()))?,
+        other => other.to_string(),
+    };
+    if !actor_exists(state, &resolved).await {
+        return Err(CommunicationError::UnknownActor(resolved));
+    }
+    Ok(resolved)
+}
+
+async fn ensure_can_send(
+    state: &Arc<DispatchState>,
+    caller: &Caller,
+    to: &str,
+) -> Result<(), CommunicationError> {
+    match caller.role {
+        ActorRole::Lead => Ok(()),
+        ActorRole::Sublead => {
+            if to == state.root.lead_id
+                || to == caller.id
+                || worker_parent(state, to).await? == Some(caller.id.clone())
+            {
+                Ok(())
+            } else {
+                Err(CommunicationError::Forbidden(format!(
+                    "sublead {} can only address root or its own workers",
+                    caller.id
+                )))
+            }
+        }
+        ActorRole::Worker => {
+            let parent = parent_for_actor(state, caller).await?;
+            if parent.as_deref() == Some(to) || to == caller.id {
+                Ok(())
+            } else {
+                Err(CommunicationError::Forbidden(format!(
+                    "worker {} can only address its parent",
+                    caller.id
+                )))
+            }
+        }
+    }
+}
+
+async fn can_read_message(
+    state: &Arc<DispatchState>,
+    caller: &Caller,
+    message: &StoredMessage,
+) -> Result<bool, CommunicationError> {
+    Ok(message.from == caller.id
+        || message.to == caller.id
+        || can_observe_actor(state, caller, &message.from).await?
+        || can_observe_actor(state, caller, &message.to).await?)
+}
+
+async fn can_read_artifact(
+    state: &Arc<DispatchState>,
+    caller: &Caller,
+    artifact: &StoredArtifact,
+) -> Result<bool, CommunicationError> {
+    Ok(artifact.metadata.owner == caller.id
+        || artifact.grants.contains(&caller.id)
+        || can_observe_actor(state, caller, &artifact.metadata.owner).await?)
+}
+
+async fn can_observe_actor(
+    state: &Arc<DispatchState>,
+    caller: &Caller,
+    target: &str,
+) -> Result<bool, CommunicationError> {
+    if caller.id == target {
+        return Ok(true);
+    }
+    match caller.role {
+        ActorRole::Lead => Ok(true),
+        ActorRole::Sublead => Ok(worker_parent(state, target).await? == Some(caller.id.clone())),
+        ActorRole::Worker => Ok(false),
+    }
+}
+
+async fn parent_for_actor(
+    state: &Arc<DispatchState>,
+    actor: &Caller,
+) -> Result<Option<String>, CommunicationError> {
+    match actor.role {
+        ActorRole::Lead => Ok(None),
+        ActorRole::Sublead => Ok(Some(state.root.lead_id.clone())),
+        ActorRole::Worker => worker_parent(state, &actor.id).await,
+    }
+}
+
+async fn worker_parent(
+    state: &Arc<DispatchState>,
+    actor_id: &str,
+) -> Result<Option<String>, CommunicationError> {
+    if let Some(owner) = state.worker_layer_index.read().await.get(actor_id).cloned() {
+        return Ok(Some(owner.unwrap_or_else(|| state.root.lead_id.clone())));
+    }
+    if state.root.workers.read().await.contains_key(actor_id) {
+        return Ok(Some(state.root.lead_id.clone()));
+    }
+    let subleads = state.subleads.read().await;
+    for (sublead_id, layer) in subleads.iter() {
+        if layer.workers.read().await.contains_key(actor_id) {
+            return Ok(Some(sublead_id.clone()));
+        }
+    }
+    let terminated = state.terminated_sublead_layers.read().await;
+    for layer in terminated.iter() {
+        if layer.workers.read().await.contains_key(actor_id) {
+            return Ok(Some(layer.lead_id.clone()));
+        }
+    }
+    Ok(None)
+}
+
+async fn actor_exists(state: &Arc<DispatchState>, actor_id: &str) -> bool {
+    if actor_id == state.root.lead_id {
+        return true;
+    }
+    if state.root.workers.read().await.contains_key(actor_id) {
+        return true;
+    }
+    let subleads = state.subleads.read().await;
+    if subleads.contains_key(actor_id) {
+        return true;
+    }
+    for layer in subleads.values() {
+        if layer.workers.read().await.contains_key(actor_id) {
+            return true;
+        }
+    }
+    let terminated = state.terminated_sublead_layers.read().await;
+    for layer in terminated.iter() {
+        if layer.lead_id == actor_id || layer.workers.read().await.contains_key(actor_id) {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dispatch::layer::LayerState;
+    use crate::dispatch::state::{ApprovalPolicy, WorkerState};
+    use crate::manifest::resolve::{ResolvedLead, ResolvedManifest};
+    use crate::manifest::schema::{Effort, WorktreeCleanup};
+    use pitboss_core::process::fake::{FakeScript, FakeSpawner};
+    use pitboss_core::process::ProcessSpawner;
+    use pitboss_core::session::CancelToken;
+    use pitboss_core::store::{JsonFileStore, SessionStore};
+    use pitboss_core::worktree::{CleanupPolicy, WorktreeManager};
+
+    fn meta(actor_id: &str, actor_role: ActorRole) -> MetaField {
+        MetaField {
+            actor_id: actor_id.to_string(),
+            actor_role,
+        }
+    }
+
+    #[test]
+    fn communication_tool_schemas_hide_bridge_meta() {
+        fn assert_schema_hides_meta<T: schemars::JsonSchema>() {
+            let schema = schemars::schema_for!(T);
+            let json = serde_json::to_string(&schema).unwrap();
+            assert!(
+                !json.contains("_meta"),
+                "tool input schema must not expose bridge-owned _meta: {json}"
+            );
+        }
+
+        assert_schema_hides_meta::<MessageSendArgs>();
+        assert_schema_hides_meta::<MessageListArgs>();
+        assert_schema_hides_meta::<MessageReadArgs>();
+        assert_schema_hides_meta::<MessageAckArgs>();
+        assert_schema_hides_meta::<ArtifactPutArgs>();
+        assert_schema_hides_meta::<ArtifactListArgs>();
+        assert_schema_hides_meta::<ArtifactReadArgs>();
+        assert_schema_hides_meta::<ArtifactGrantArgs>();
+    }
+
+    async fn test_state(config: CommunicationConfig) -> Arc<DispatchState> {
+        let dir = tempfile::TempDir::new().unwrap();
+        let lead = ResolvedLead {
+            id: "lead".into(),
+            directory: PathBuf::from("/tmp"),
+            prompt: "lead prompt".into(),
+            branch: None,
+            model: "claude-haiku-4-5".into(),
+            effort: Effort::High,
+            tools: vec![],
+            timeout_secs: 3600,
+            use_worktree: false,
+            env: Default::default(),
+            resume_session_id: None,
+            permission_routing: Default::default(),
+            allow_subleads: true,
+            max_subleads: Some(2),
+            max_sublead_budget_usd: Some(1.0),
+            max_total_workers: None,
+            sublead_defaults: None,
+        };
+        let manifest = ResolvedManifest {
+            manifest_schema_version: 0,
+            name: None,
+            max_parallel_tasks: 4,
+            halt_on_failure: false,
+            run_dir: dir.path().to_path_buf(),
+            worktree_cleanup: WorktreeCleanup::OnSuccess,
+            emit_event_stream: false,
+            tasks: vec![],
+            lead: Some(lead),
+            max_workers: Some(4),
+            budget_usd: Some(5.0),
+            lead_timeout_secs: None,
+            default_approval_policy: None,
+            notifications: vec![],
+            dump_shared_store: false,
+            require_plan_approval: false,
+            approval_rules: vec![],
+            container: None,
+            mcp_servers: vec![],
+            communication: config,
+            lifecycle: None,
+        };
+        let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
+        let run_id = Uuid::now_v7();
+        let spawner: Arc<dyn ProcessSpawner> =
+            Arc::new(FakeSpawner::new(FakeScript::new().hold_until_signal()));
+        let run_subdir = dir.path().join(run_id.to_string());
+        std::mem::forget(dir);
+        Arc::new(DispatchState::new(
+            run_id,
+            manifest,
+            store,
+            CancelToken::new(),
+            "lead".into(),
+            spawner,
+            PathBuf::from("claude"),
+            Arc::new(WorktreeManager::new()),
+            CleanupPolicy::Never,
+            run_subdir,
+            ApprovalPolicy::Block,
+            None,
+            Arc::new(crate::shared_store::SharedStore::new()),
+        ))
+    }
+
+    async fn add_root_worker(state: &Arc<DispatchState>, id: &str) {
+        state
+            .root
+            .workers
+            .write()
+            .await
+            .insert(id.to_string(), WorkerState::Pending);
+        state
+            .worker_layer_index
+            .write()
+            .await
+            .insert(id.to_string(), None);
+    }
+
+    async fn add_sublead_with_worker(state: &Arc<DispatchState>, sublead: &str, worker: &str) {
+        let layer = Arc::new(LayerState::new(
+            state.root.run_id,
+            state.root.manifest.clone(),
+            state.root.store.clone(),
+            CancelToken::new(),
+            sublead.to_string(),
+            state.root.spawner.clone(),
+            PathBuf::from("claude"),
+            Arc::new(WorktreeManager::new()),
+            CleanupPolicy::Never,
+            state.root.run_subdir.join(sublead),
+            ApprovalPolicy::Block,
+            None,
+            Arc::new(crate::shared_store::SharedStore::new()),
+            Some(1.0),
+        ));
+        layer
+            .workers
+            .write()
+            .await
+            .insert(worker.to_string(), WorkerState::Pending);
+        state.register_sublead(sublead.to_string(), layer).await;
+        state
+            .worker_layer_index
+            .write()
+            .await
+            .insert(worker.to_string(), Some(sublead.to_string()));
+    }
+
+    #[tokio::test]
+    async fn worker_can_message_parent_but_not_sibling() {
+        let state = test_state(CommunicationConfig {
+            mode: CommunicationMode::ParentChild,
+            ..Default::default()
+        })
+        .await;
+        add_root_worker(&state, "w1").await;
+        add_root_worker(&state, "w2").await;
+
+        let sent = handle_message_send(
+            &state,
+            MessageSendArgs {
+                to: "parent".into(),
+                subject: "done".into(),
+                body: "ready".into(),
+                refs: vec![],
+                meta: meta("w1", ActorRole::Worker),
+            },
+        )
+        .await
+        .unwrap();
+        assert!(!sent.message_id.is_empty());
+
+        let inbox = handle_message_list(
+            &state,
+            MessageListArgs {
+                scope: Some("inbox".into()),
+                meta: meta("lead", ActorRole::Lead),
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(inbox.messages.len(), 1);
+        assert_eq!(inbox.messages[0].from, "w1");
+
+        let denied = handle_message_send(
+            &state,
+            MessageSendArgs {
+                to: "w2".into(),
+                subject: "side".into(),
+                body: "nope".into(),
+                refs: vec![],
+                meta: meta("w1", ActorRole::Worker),
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(denied, CommunicationError::Forbidden(_)));
+    }
+
+    #[tokio::test]
+    async fn artifact_grant_enables_sibling_read_without_kv_payloads() {
+        let state = test_state(CommunicationConfig {
+            mode: CommunicationMode::ParentChild,
+            ..Default::default()
+        })
+        .await;
+        add_root_worker(&state, "w1").await;
+        add_root_worker(&state, "w2").await;
+
+        let put = handle_artifact_put(
+            &state,
+            ArtifactPutArgs {
+                name: "report.bin".into(),
+                mime_type: Some("application/octet-stream".into()),
+                content_base64: base64::engine::general_purpose::STANDARD.encode([0, 1, 2, 3]),
+                meta: meta("w1", ActorRole::Worker),
+            },
+        )
+        .await
+        .unwrap();
+
+        let denied = handle_artifact_read(
+            &state,
+            ArtifactReadArgs {
+                artifact_id: put.artifact_id.clone(),
+                meta: meta("w2", ActorRole::Worker),
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(denied, CommunicationError::Forbidden(_)));
+
+        handle_artifact_grant(
+            &state,
+            ArtifactGrantArgs {
+                artifact_id: put.artifact_id.clone(),
+                to: "w2".into(),
+                meta: meta("lead", ActorRole::Lead),
+            },
+        )
+        .await
+        .unwrap();
+
+        let read = handle_artifact_read(
+            &state,
+            ArtifactReadArgs {
+                artifact_id: put.artifact_id,
+                meta: meta("w2", ActorRole::Worker),
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(read.artifact.name, "report.bin");
+        assert_eq!(read.content_base64, "AAECAw==");
+    }
+
+    #[tokio::test]
+    async fn activity_counters_track_message_and_artifact_attempts() {
+        let state = test_state(CommunicationConfig {
+            mode: CommunicationMode::ParentChild,
+            ..Default::default()
+        })
+        .await;
+        add_root_worker(&state, "w1").await;
+        add_root_worker(&state, "w2").await;
+
+        handle_message_send(
+            &state,
+            MessageSendArgs {
+                to: "parent".into(),
+                subject: "done".into(),
+                body: "ready".into(),
+                refs: vec![],
+                meta: meta("w1", ActorRole::Worker),
+            },
+        )
+        .await
+        .unwrap();
+
+        let put = handle_artifact_put(
+            &state,
+            ArtifactPutArgs {
+                name: "report.bin".into(),
+                mime_type: Some("application/octet-stream".into()),
+                content_base64: base64::engine::general_purpose::STANDARD.encode([0, 1, 2, 3]),
+                meta: meta("w1", ActorRole::Worker),
+            },
+        )
+        .await
+        .unwrap();
+
+        let _ = handle_artifact_read(
+            &state,
+            ArtifactReadArgs {
+                artifact_id: put.artifact_id,
+                meta: meta("w2", ActorRole::Worker),
+            },
+        )
+        .await
+        .unwrap_err();
+
+        let snapshot = state.communication.activity_snapshot().await;
+        assert_eq!(snapshot["w1"].message_ops, 1);
+        assert_eq!(snapshot["w1"].artifact_ops, 1);
+        assert_eq!(snapshot["w2"].message_ops, 0);
+        assert_eq!(snapshot["w2"].artifact_ops, 1);
+    }
+
+    #[tokio::test]
+    async fn sublead_can_message_own_worker_and_root_only() {
+        let state = test_state(CommunicationConfig {
+            mode: CommunicationMode::ParentChild,
+            ..Default::default()
+        })
+        .await;
+        add_root_worker(&state, "root-worker").await;
+        add_sublead_with_worker(&state, "s1", "sw1").await;
+
+        handle_message_send(
+            &state,
+            MessageSendArgs {
+                to: "parent".into(),
+                subject: "up".into(),
+                body: "status".into(),
+                refs: vec![],
+                meta: meta("sw1", ActorRole::Worker),
+            },
+        )
+        .await
+        .unwrap();
+
+        let sublead_inbox = handle_message_list(
+            &state,
+            MessageListArgs {
+                scope: Some("inbox".into()),
+                meta: meta("s1", ActorRole::Sublead),
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(sublead_inbox.messages.len(), 1);
+        assert_eq!(sublead_inbox.messages[0].from, "sw1");
+
+        handle_message_send(
+            &state,
+            MessageSendArgs {
+                to: "root".into(),
+                subject: "up".into(),
+                body: "sublead status".into(),
+                refs: vec![],
+                meta: meta("s1", ActorRole::Sublead),
+            },
+        )
+        .await
+        .unwrap();
+
+        let denied = handle_message_send(
+            &state,
+            MessageSendArgs {
+                to: "root-worker".into(),
+                subject: "cross".into(),
+                body: "nope".into(),
+                refs: vec![],
+                meta: meta("s1", ActorRole::Sublead),
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(denied, CommunicationError::Forbidden(_)));
+    }
+
+    #[tokio::test]
+    async fn disabled_mode_rejects_communication_tools() {
+        let config = CommunicationConfig {
+            mode: CommunicationMode::Disabled,
+            ..Default::default()
+        };
+        let state = test_state(config).await;
+        add_root_worker(&state, "w1").await;
+
+        let err = handle_message_send(
+            &state,
+            MessageSendArgs {
+                to: "parent".into(),
+                subject: "blocked".into(),
+                body: "blocked".into(),
+                refs: vec![],
+                meta: meta("w1", ActorRole::Worker),
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, CommunicationError::Disabled));
+    }
+
+    /// Boundary: a message body exactly at `max_message_bytes` is accepted;
+    /// one byte more is rejected. Off-by-one regression guard for the
+    /// length check in [`handle_message_send`].
+    #[tokio::test]
+    async fn message_send_size_boundary() {
+        let config = CommunicationConfig {
+            mode: CommunicationMode::ParentChild,
+            max_message_bytes: 16,
+            ..Default::default()
+        };
+        let state = test_state(config).await;
+        add_root_worker(&state, "w1").await;
+
+        // Exactly the limit: accepted.
+        handle_message_send(
+            &state,
+            MessageSendArgs {
+                to: "parent".into(),
+                subject: "ok".into(),
+                body: "x".repeat(16),
+                refs: vec![],
+                meta: meta("w1", ActorRole::Worker),
+            },
+        )
+        .await
+        .expect("exact-limit body must be accepted");
+
+        // One byte over: rejected.
+        let err = handle_message_send(
+            &state,
+            MessageSendArgs {
+                to: "parent".into(),
+                subject: "too-big".into(),
+                body: "x".repeat(17),
+                refs: vec![],
+                meta: meta("w1", ActorRole::Worker),
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                CommunicationError::MessageTooLarge {
+                    actual: 17,
+                    limit: 16
+                }
+            ),
+            "expected MessageTooLarge(actual=17, limit=16), got {err:?}",
+        );
+    }
+
+    /// Boundary: an artifact payload exactly at `max_artifact_bytes` is
+    /// accepted; one byte more is rejected. The check runs after base64
+    /// decoding, so the comparison is against the decoded byte count.
+    #[tokio::test]
+    async fn artifact_put_size_boundary() {
+        use base64::Engine;
+        let config = CommunicationConfig {
+            mode: CommunicationMode::ParentChild,
+            max_artifact_bytes: 32,
+            ..Default::default()
+        };
+        let state = test_state(config).await;
+        add_root_worker(&state, "w1").await;
+
+        let exact = base64::engine::general_purpose::STANDARD.encode(vec![0u8; 32]);
+        handle_artifact_put(
+            &state,
+            ArtifactPutArgs {
+                name: "exact.bin".into(),
+                mime_type: None,
+                content_base64: exact,
+                meta: meta("w1", ActorRole::Worker),
+            },
+        )
+        .await
+        .expect("exact-limit decoded payload must be accepted");
+
+        let over = base64::engine::general_purpose::STANDARD.encode(vec![0u8; 33]);
+        let err = handle_artifact_put(
+            &state,
+            ArtifactPutArgs {
+                name: "too-big.bin".into(),
+                mime_type: None,
+                content_base64: over,
+                meta: meta("w1", ActorRole::Worker),
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                CommunicationError::ArtifactTooLarge {
+                    actual: 33,
+                    limit: 32
+                }
+            ),
+            "expected ArtifactTooLarge(actual=33, limit=32), got {err:?}",
+        );
+    }
+
+    /// `artifact_put` writes the decoded payload to disk under
+    /// `<run_dir>/communication/artifacts/<artifact_id>`. Container-dispatch
+    /// auto-mounts `run_dir`, so this layout makes artifacts visible inside
+    /// the container without extra plumbing. `pitboss prune --remove`
+    /// reclaims them via recursive `remove_dir_all`.
+    #[tokio::test]
+    async fn artifact_put_writes_under_run_subdir() {
+        let state = test_state(CommunicationConfig {
+            mode: CommunicationMode::ParentChild,
+            ..Default::default()
+        })
+        .await;
+        add_root_worker(&state, "w1").await;
+
+        let payload = vec![1u8, 2, 3, 4, 5];
+        let put = handle_artifact_put(
+            &state,
+            ArtifactPutArgs {
+                name: "blob.bin".into(),
+                mime_type: None,
+                content_base64: base64::engine::general_purpose::STANDARD.encode(&payload),
+                meta: meta("w1", ActorRole::Worker),
+            },
+        )
+        .await
+        .unwrap();
+
+        let expected_path = state
+            .root
+            .run_subdir
+            .join("communication")
+            .join("artifacts")
+            .join(&put.artifact_id);
+        assert!(
+            expected_path.exists(),
+            "artifact bytes should land at {expected_path:?}",
+        );
+        let on_disk = std::fs::read(&expected_path).expect("read artifact");
+        assert_eq!(
+            on_disk, payload,
+            "on-disk bytes must round-trip the payload"
+        );
+    }
+}

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -1245,6 +1245,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.to_path_buf()));
@@ -1668,6 +1669,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         let sub_layer = std::sync::Arc::new(LayerState::new(
@@ -2152,6 +2154,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         let sub_layer = std::sync::Arc::new(LayerState::new(
@@ -2260,6 +2263,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         let sub_layer = std::sync::Arc::new(LayerState::new(
@@ -2383,6 +2387,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         let sub_layer = std::sync::Arc::new(LayerState::new(
@@ -2518,6 +2523,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         let sub_layer = std::sync::Arc::new(LayerState::new(

--- a/crates/pitboss-cli/src/dispatch/failure_detection.rs
+++ b/crates/pitboss-cli/src/dispatch/failure_detection.rs
@@ -369,6 +369,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         let store: Arc<dyn pitboss_core::store::SessionStore> =
@@ -460,6 +461,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         let store: Arc<dyn pitboss_core::store::SessionStore> =

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -1070,6 +1070,7 @@ mod await_drained_tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));

--- a/crates/pitboss-cli/src/dispatch/layer.rs
+++ b/crates/pitboss-cli/src/dispatch/layer.rs
@@ -458,6 +458,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));

--- a/crates/pitboss-cli/src/dispatch/resume.rs
+++ b/crates/pitboss-cli/src/dispatch/resume.rs
@@ -609,6 +609,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         std::fs::write(
@@ -721,6 +722,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         std::fs::write(
@@ -836,6 +838,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         std::fs::write(

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -807,6 +807,20 @@ pub const PITBOSS_MCP_TOOLS: &[&str] = &[
     "mcp__pitboss__kv_wait",
     "mcp__pitboss__lease_acquire",
     "mcp__pitboss__lease_release",
+    // Mailbox/artifact communication tools (v0.10+). Payloads move
+    // through the Pitboss-owned message/artifact stores rather than KV.
+    // Server-side `list_tools` filter hides these when
+    // `[communication].mode = "disabled"` (the default), and every
+    // handler returns `CommunicationError::Disabled` as a back-stop —
+    // listing them here is cosmetic for that mode.
+    "mcp__pitboss__message_send",
+    "mcp__pitboss__message_list",
+    "mcp__pitboss__message_read",
+    "mcp__pitboss__message_ack",
+    "mcp__pitboss__artifact_put",
+    "mcp__pitboss__artifact_list",
+    "mcp__pitboss__artifact_read",
+    "mcp__pitboss__artifact_grant",
     // Run-global leases (v0.6+). For cross-sub-tree resource coordination
     // (e.g., serializing access to an operator-facing filesystem dir).
     "mcp__pitboss__run_lease_acquire",
@@ -849,6 +863,17 @@ pub const SUBLEAD_MCP_TOOLS: &[&str] = &[
     "mcp__pitboss__kv_wait",
     "mcp__pitboss__lease_acquire",
     "mcp__pitboss__lease_release",
+    // Mailbox/artifact communication tools (v0.10+). Same opt-in
+    // semantics as PITBOSS_MCP_TOOLS — gated server-side by
+    // `[communication].mode`.
+    "mcp__pitboss__message_send",
+    "mcp__pitboss__message_list",
+    "mcp__pitboss__message_read",
+    "mcp__pitboss__message_ack",
+    "mcp__pitboss__artifact_put",
+    "mcp__pitboss__artifact_list",
+    "mcp__pitboss__artifact_read",
+    "mcp__pitboss__artifact_grant",
     // Run-global leases (v0.6+) for cross-sub-tree resource coordination.
     "mcp__pitboss__run_lease_acquire",
     "mcp__pitboss__run_lease_release",
@@ -1264,6 +1289,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         }
     }
@@ -1409,6 +1435,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
 
@@ -1503,6 +1530,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
 
@@ -1610,6 +1638,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
 

--- a/crates/pitboss-cli/src/dispatch/signals.rs
+++ b/crates/pitboss-cli/src/dispatch/signals.rs
@@ -376,6 +376,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
@@ -464,6 +465,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
@@ -552,6 +554,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -344,6 +344,13 @@ pub struct DispatchState {
     /// Run-global lease registry for cross-sub-tree resource coordination.
     /// Distinct from per-layer /leases/* stored in each layer's KvStore.
     pub run_leases: Arc<RunLeaseRegistry>,
+    /// Run-global mailbox + artifact store for the
+    /// [`crate::communication`] MCP tools. One run-wide plane (not
+    /// per-layer) because parent mediation and `artifact_grant` cross
+    /// sub-tree boundaries. Cheap when `[communication].mode = "disabled"`
+    /// — the store still exists, but every handler returns
+    /// `CommunicationError::Disabled` before touching it.
+    pub communication: Arc<crate::communication::CommunicationStore>,
     /// Most-recent approval response per actor id. Populated by the
     /// approval MCP handlers when they return; consulted at actor-
     /// termination time by `approval_driven_termination` to reclassify
@@ -403,6 +410,8 @@ impl DispatchState {
         notification_router: Option<std::sync::Arc<crate::notify::NotificationRouter>>,
         shared_store: std::sync::Arc<crate::shared_store::SharedStore>,
     ) -> Self {
+        let communication_config = manifest.communication.clone();
+        let communication_dir = run_subdir.clone();
         let root = Arc::new(LayerState::new(
             run_id,
             manifest,
@@ -426,6 +435,10 @@ impl DispatchState {
             terminated_sublead_layers: RwLock::new(Vec::new()),
             worker_layer_index: RwLock::new(HashMap::new()),
             run_leases: Arc::new(RunLeaseRegistry::new()),
+            communication: Arc::new(crate::communication::CommunicationStore::new(
+                communication_config,
+                communication_dir,
+            )),
             last_approval_response: RwLock::new(HashMap::new()),
             api_health: Arc::new(crate::dispatch::failure_detection::ApiHealth::new()),
             actor_tokens: RwLock::new(HashMap::new()),
@@ -589,6 +602,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));

--- a/crates/pitboss-cli/src/lib.rs
+++ b/crates/pitboss-cli/src/lib.rs
@@ -8,6 +8,7 @@ pub mod agents_md;
 pub mod analyze;
 pub mod attach;
 pub mod cli;
+pub mod communication;
 pub mod control;
 pub mod diff;
 pub mod dispatch;

--- a/crates/pitboss-cli/src/manifest/metadata.rs
+++ b/crates/pitboss-cli/src/manifest/metadata.rs
@@ -13,8 +13,8 @@
 use pitboss_schema::SchemaSection;
 
 use super::schema::{
-    ApprovalRuleSpec, ContainerConfig, Defaults, Lead, Lifecycle, McpServerSpec, MountSpec,
-    RunConfig, SubleadDefaults, Task, Template,
+    ApprovalRuleSpec, CommunicationConfig, ContainerConfig, Defaults, Lead, Lifecycle,
+    McpServerSpec, MountSpec, RunConfig, SubleadDefaults, Task, Template,
 };
 
 /// Walk every section of the v0.9 manifest schema in declaration order.
@@ -68,6 +68,11 @@ pub fn sections() -> Vec<SchemaSection> {
             toml_path: "[[mcp_server]]",
             type_name: "McpServerSpec",
             fields: McpServerSpec::field_metadata(),
+        },
+        SchemaSection {
+            toml_path: "[communication]",
+            type_name: "CommunicationConfig",
+            fields: CommunicationConfig::field_metadata(),
         },
         SchemaSection {
             toml_path: "[[template]]",

--- a/crates/pitboss-cli/src/manifest/resolve.rs
+++ b/crates/pitboss-cli/src/manifest/resolve.rs
@@ -7,8 +7,8 @@ use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
 
 use super::schema::{
-    ContainerConfig, Defaults, Effort, Lead, Manifest, SubleadDefaults, Task, Template,
-    WorktreeCleanup,
+    CommunicationConfig, ContainerConfig, Defaults, Effort, Lead, Manifest, SubleadDefaults, Task,
+    Template, WorktreeCleanup,
 };
 
 /// Fully resolved task ready for dispatch.
@@ -159,6 +159,11 @@ pub struct ResolvedManifest {
     pub container: Option<ContainerConfig>,
     #[serde(default)]
     pub mcp_servers: Vec<crate::manifest::schema::McpServerSpec>,
+    /// Pitboss-owned mailbox + artifact policy. `Default` (mode = Disabled)
+    /// when the manifest omits `[communication]`. Pre-v0.10 `resolved.json`
+    /// snapshots without this field also resolve to the disabled default.
+    #[serde(default)]
+    pub communication: CommunicationConfig,
     /// Resolved `[lifecycle]` section. `None` when the manifest omits it
     /// entirely (the common case — pitboss's default semantics apply: dies
     /// with parent, no out-of-band lifecycle notify expected).
@@ -254,6 +259,7 @@ pub fn resolve(
         approval_rules,
         container: manifest.container,
         mcp_servers: manifest.mcp_servers,
+        communication: manifest.communication,
         lifecycle: manifest.lifecycle,
     })
 }

--- a/crates/pitboss-cli/src/manifest/schema.rs
+++ b/crates/pitboss-cli/src/manifest/schema.rs
@@ -21,6 +21,7 @@
 //! | `[container]`             | `ContainerConfig`     | no       | Enables `pitboss container-dispatch`                  |
 //! | `[[container.mount]]`     | `MountSpec`           | no       | Bind mounts (when `[container]` set)                  |
 //! | `[[mcp_server]]`          | `McpServerSpec`       | no       | External MCP servers injected into all actors        |
+//! | `[communication]`         | `CommunicationConfig` | no       | Mailbox + artifact MCP tools (opt-in, default off)   |
 //! | `[[notification]]`        | `NotificationConfig`  | no       | Notification sinks                                   |
 //! | `[[approval_policy]]`     | `ApprovalRuleSpec`    | no       | Declarative approval rules (matched in order)        |
 //! | `[[template]]`            | `Template`            | no       | Prompt templates referenced by `[[task]]`            |
@@ -205,6 +206,79 @@ pub struct McpServerSpec {
     pub env: HashMap<String, String>,
 }
 
+/// Communication policy mode for the Pitboss-owned mailbox + artifact MCP
+/// tools. Default is [`CommunicationMode::Disabled`] — operators opt in by
+/// declaring `[communication] mode = "parent_child"`. Conservative default
+/// so existing manifests upgrading to v0.10 do not silently grow the worker
+/// tool surface.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommunicationMode {
+    /// `message_*` and `artifact_*` MCP tools are hidden from `list_tools`
+    /// and rejected at the handler with `CommunicationError::Disabled`. The
+    /// shared-store KV surface remains available for coordination.
+    #[default]
+    Disabled,
+    /// Parent-child actor transfer: root reads everything, sub-leads read
+    /// their own sub-tree, workers may message only their direct parent.
+    /// Sibling-worker artifact handoff requires the parent (or root) to
+    /// call `artifact_grant`.
+    ParentChild,
+}
+
+/// Default ceilings for [`CommunicationConfig`].
+pub const DEFAULT_MAX_MESSAGE_BYTES: u64 = 8 * 1024;
+pub const DEFAULT_MAX_ARTIFACT_BYTES: u64 = 10 * 1024 * 1024;
+pub const DEFAULT_MAX_ARTIFACTS_PER_ACTOR: u32 = 128;
+
+/// Pitboss-owned directional communication controls for the mailbox and
+/// artifact MCP tools. The public surface is deliberately coarse; the
+/// internal authorization checks can later accept explicit
+/// `[[communication.rule]]` entries without replacing the runtime store.
+///
+/// **Default**: [`CommunicationMode::Disabled`] — opt in via
+/// `[communication] mode = "parent_child"`.
+#[derive(Debug, Clone, Deserialize, Serialize, FieldMetadata)]
+#[serde(default, deny_unknown_fields)]
+pub struct CommunicationConfig {
+    #[field(
+        label = "Mode",
+        help = "Actor communication policy mode. \"disabled\" hides the message_* and artifact_* tools (conservative default). \"parent_child\" enables them with parent/sublead/worker authz.",
+        enum_values = ["disabled", "parent_child"],
+        required = false
+    )]
+    pub mode: CommunicationMode,
+    #[field(
+        label = "Max message bytes",
+        help = "Maximum UTF-8 body size accepted by message_send.",
+        required = false
+    )]
+    pub max_message_bytes: u64,
+    #[field(
+        label = "Max artifact bytes",
+        help = "Maximum decoded artifact payload size accepted by artifact_put.",
+        required = false
+    )]
+    pub max_artifact_bytes: u64,
+    #[field(
+        label = "Max artifacts per actor",
+        help = "Maximum artifacts one actor may publish in a single run.",
+        required = false
+    )]
+    pub max_artifacts_per_actor: u32,
+}
+
+impl Default for CommunicationConfig {
+    fn default() -> Self {
+        Self {
+            mode: CommunicationMode::default(),
+            max_message_bytes: DEFAULT_MAX_MESSAGE_BYTES,
+            max_artifact_bytes: DEFAULT_MAX_ARTIFACT_BYTES,
+            max_artifacts_per_actor: DEFAULT_MAX_ARTIFACTS_PER_ACTOR,
+        }
+    }
+}
+
 /// Top-level manifest. One canonical shape: either flat-mode (`[[task]]`) or
 /// hierarchical-mode (`[lead]`), mutually exclusive.
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -240,6 +314,13 @@ pub struct Manifest {
     /// External MCP servers injected into all actor configs.
     #[serde(default, rename = "mcp_server")]
     pub mcp_servers: Vec<McpServerSpec>,
+    /// Optional `[communication]` section: opt in to the Pitboss-owned
+    /// mailbox + artifact MCP tools. Default
+    /// [`CommunicationMode::Disabled`] hides the tools and rejects calls
+    /// at the handler — coordination falls back to the existing
+    /// shared-store KV surface.
+    #[serde(default)]
+    pub communication: CommunicationConfig,
     /// Optional `[lifecycle]` section: declares run-survival semantics and
     /// orchestrator notification expectations. See [`Lifecycle`] for the
     /// coupling rules enforced at validate time.

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -26,6 +26,7 @@ fn validate_inner(resolved: &ResolvedManifest, skip_dir_check: bool) -> Result<(
     }
     validate_lifecycle(resolved)?;
     validate_container(resolved)?;
+    validate_communication(resolved)?;
     if resolved.lead.is_some() {
         validate_lead(resolved, skip_dir_check)?;
         validate_hierarchical_ranges(resolved)?;
@@ -37,6 +38,23 @@ fn validate_inner(resolved: &ResolvedManifest, skip_dir_check: bool) -> Result<(
         }
         validate_branch_conflicts(resolved)?;
         validate_ranges(resolved)?;
+    }
+    Ok(())
+}
+
+/// Reject zero ceilings on `[communication]`. Zero would silently disable
+/// the corresponding cap, which is a footgun (a max-bytes value of 0
+/// would reject every send). Operators wanting to disable the surface
+/// entirely set `mode = "disabled"`, not zero ceilings.
+fn validate_communication(r: &ResolvedManifest) -> Result<()> {
+    if r.communication.max_message_bytes == 0 {
+        bail!("[communication].max_message_bytes must be > 0");
+    }
+    if r.communication.max_artifact_bytes == 0 {
+        bail!("[communication].max_artifact_bytes must be > 0");
+    }
+    if r.communication.max_artifacts_per_actor == 0 {
+        bail!("[communication].max_artifacts_per_actor must be > 0");
     }
     Ok(())
 }
@@ -565,6 +583,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         }
     }
@@ -594,6 +613,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         f(&mut m);
@@ -679,6 +699,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         let err = validate(&r).unwrap_err().to_string();
@@ -711,6 +732,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         assert!(validate(&r).is_err());
@@ -739,6 +761,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         assert!(validate(&r).is_err());
@@ -772,6 +795,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         (d, r)
@@ -886,6 +910,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         let err = validate(&r).unwrap_err().to_string();
@@ -939,6 +964,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         let err = validate(&r).unwrap_err().to_string();
@@ -973,6 +999,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         assert!(validate(&r).is_err());
@@ -1178,6 +1205,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         // Sanity: with skip_dir_check=false the validator rejects (the

--- a/crates/pitboss-cli/src/mcp/approval.rs
+++ b/crates/pitboss-cli/src/mcp/approval.rs
@@ -442,6 +442,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -1008,6 +1008,118 @@ impl PitbossHandler {
         }))
     }
 
+    #[tool(
+        name = "message_send",
+        description = "Send a small structured message to an actor. Use for coordination notes and artifact refs; use artifact_put for payloads. In parent_child mode workers may address only \"parent\" or their own id, subleads may address \"root\" or workers in their own sub-tree, and the root lead may address any actor. Returns {message_id}. Disabled (returns communication_disabled) when [communication].mode = \"disabled\" — the v0.10 default; opt in via the manifest."
+    )]
+    async fn message_send(
+        &self,
+        Parameters(args): Parameters<crate::communication::MessageSendArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        match crate::communication::handle_message_send(&self.state, args).await {
+            Ok(res) => to_structured_result(&res),
+            Err(e) => Err(communication_err(&e)),
+        }
+    }
+
+    #[tool(
+        name = "message_list",
+        description = "List visible message metadata. scope defaults to inbox; valid scopes are inbox, sent, visible, and all (root lead only). Returns {messages: [...]}."
+    )]
+    async fn message_list(
+        &self,
+        Parameters(args): Parameters<crate::communication::MessageListArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        match crate::communication::handle_message_list(&self.state, args).await {
+            Ok(res) => to_structured_result(&res),
+            Err(e) => Err(communication_err(&e)),
+        }
+    }
+
+    #[tool(
+        name = "message_read",
+        description = "Read a visible message by id. Parents can read child messages; workers can read only messages they sent or received."
+    )]
+    async fn message_read(
+        &self,
+        Parameters(args): Parameters<crate::communication::MessageReadArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        match crate::communication::handle_message_read(&self.state, args).await {
+            Ok(res) => to_structured_result(&res),
+            Err(e) => Err(communication_err(&e)),
+        }
+    }
+
+    #[tool(
+        name = "message_ack",
+        description = "Acknowledge a visible message. Returns {ok:true}."
+    )]
+    async fn message_ack(
+        &self,
+        Parameters(args): Parameters<crate::communication::MessageAckArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        match crate::communication::handle_message_ack(&self.state, args).await {
+            Ok(res) => to_structured_result(&res),
+            Err(e) => Err(communication_err(&e)),
+        }
+    }
+
+    #[tool(
+        name = "artifact_put",
+        description = "Publish an artifact owned by the caller. content_base64 carries the payload; Pitboss stores bytes under <run_dir>/communication/artifacts/<id> and returns {artifact_id, uri, size_bytes, sha256}. Subject to [communication].max_artifact_bytes and max_artifacts_per_actor."
+    )]
+    async fn artifact_put(
+        &self,
+        Parameters(args): Parameters<crate::communication::ArtifactPutArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        match crate::communication::handle_artifact_put(&self.state, args).await {
+            Ok(res) => to_structured_result(&res),
+            Err(e) => Err(communication_err(&e)),
+        }
+    }
+
+    #[tool(
+        name = "artifact_list",
+        description = "List visible artifact metadata. scope defaults to visible; valid scopes are owned, granted, visible, and all (root lead only). Returns {artifacts: [...]}."
+    )]
+    async fn artifact_list(
+        &self,
+        Parameters(args): Parameters<crate::communication::ArtifactListArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        match crate::communication::handle_artifact_list(&self.state, args).await {
+            Ok(res) => to_structured_result(&res),
+            Err(e) => Err(communication_err(&e)),
+        }
+    }
+
+    #[tool(
+        name = "artifact_read",
+        description = "Read a visible artifact by id. Returns {artifact, content_base64}."
+    )]
+    async fn artifact_read(
+        &self,
+        Parameters(args): Parameters<crate::communication::ArtifactReadArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        match crate::communication::handle_artifact_read(&self.state, args).await {
+            Ok(res) => to_structured_result(&res),
+            Err(e) => Err(communication_err(&e)),
+        }
+    }
+
+    #[tool(
+        name = "artifact_grant",
+        description = "Grant a visible artifact to another actor. The caller must already be allowed to read the artifact and address the recipient. The recipient gains read access (no transfer of ownership)."
+    )]
+    async fn artifact_grant(
+        &self,
+        Parameters(args): Parameters<crate::communication::ArtifactGrantArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        match crate::communication::handle_artifact_grant(&self.state, args).await {
+            Ok(res) => to_structured_result(&res),
+            Err(e) => Err(communication_err(&e)),
+        }
+    }
+
     /// Path B permission gate. Claude calls this when it encounters a
     /// tool-use that requires operator approval. Only visible (list_tools)
     /// and callable when `[lead] permission_routing = "path_b"` is set.
@@ -1081,6 +1193,8 @@ impl ServerHandler for PitbossHandler {
         let lead = self.state.root.manifest.lead.as_ref();
         let allow_subleads = lead.is_some_and(|l| l.allow_subleads);
         let path_b = lead.is_some_and(|l| l.permission_routing == PermissionRouting::PathB);
+        let communication_enabled = self.state.root.manifest.communication.mode
+            != crate::manifest::schema::CommunicationMode::Disabled;
 
         let tools: Vec<rmcp::model::Tool> = self
             .tool_router
@@ -1088,6 +1202,7 @@ impl ServerHandler for PitbossHandler {
             .into_iter()
             .filter(|t| allow_subleads || !depth::is_root_only_tool(&t.name))
             .filter(|t| path_b || t.name != "permission_prompt")
+            .filter(|t| communication_enabled || !is_communication_tool(&t.name))
             .collect();
 
         Ok(rmcp::model::ListToolsResult::with_all_items(tools))
@@ -1182,6 +1297,42 @@ fn to_structured_result<T: serde::Serialize>(value: &T) -> Result<CallToolResult
     let v = serde_json::to_value(value)
         .map_err(|e| ErrorData::internal_error(format!("serialize: {e}"), None))?;
     Ok(CallToolResult::structured(v))
+}
+
+fn communication_err(e: &crate::communication::CommunicationError) -> ErrorData {
+    use crate::communication::CommunicationError;
+    let (code, msg) = match e {
+        CommunicationError::Disabled => ("communication_disabled", e.to_string()),
+        CommunicationError::MissingIdentity => ("unauthenticated", e.to_string()),
+        CommunicationError::UnknownActor(_) => ("unknown_actor", e.to_string()),
+        CommunicationError::NotFound(_) => ("not_found", e.to_string()),
+        CommunicationError::Forbidden(_) => ("forbidden", e.to_string()),
+        CommunicationError::MessageTooLarge { .. } => ("message_too_large", e.to_string()),
+        CommunicationError::ArtifactTooLarge { .. } => ("artifact_too_large", e.to_string()),
+        CommunicationError::ArtifactCountExceeded { .. } => {
+            ("artifact_count_exceeded", e.to_string())
+        }
+        CommunicationError::InvalidBase64(_) => ("invalid_base64", e.to_string()),
+        CommunicationError::Storage(_) => ("storage_error", e.to_string()),
+        CommunicationError::InvalidScope(_) => ("invalid_scope", e.to_string()),
+    };
+    ErrorData::invalid_request(msg, Some(serde_json::json!({"code": code})))
+}
+
+/// Predicate matching the 8 communication tool names. Used by
+/// `list_tools` to suppress them when `[communication].mode = "disabled"`.
+fn is_communication_tool(name: &str) -> bool {
+    matches!(
+        name,
+        "message_send"
+            | "message_list"
+            | "message_read"
+            | "message_ack"
+            | "artifact_put"
+            | "artifact_list"
+            | "artifact_read"
+            | "artifact_grant"
+    )
 }
 
 fn shared_store_err(e: &crate::shared_store::StoreError) -> ErrorData {
@@ -1450,6 +1601,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
@@ -1535,6 +1687,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
@@ -1614,6 +1767,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
@@ -1760,6 +1914,7 @@ mod tests {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));

--- a/crates/pitboss-cli/src/mcp/tools/spawn.rs
+++ b/crates/pitboss-cli/src/mcp/tools/spawn.rs
@@ -741,6 +741,19 @@ pub const PITBOSS_WORKER_MCP_TOOLS: &[&str] = &[
     "mcp__pitboss__kv_wait",
     "mcp__pitboss__lease_acquire",
     "mcp__pitboss__lease_release",
+    // Mailbox/artifact communication tools (v0.10+). Same opt-in
+    // semantics as the lead/sublead allowlists in `dispatch::runner` —
+    // server-side `list_tools` filter hides them when
+    // `[communication].mode = "disabled"` (the default), and every
+    // handler returns `CommunicationError::Disabled` as a back-stop.
+    "mcp__pitboss__message_send",
+    "mcp__pitboss__message_list",
+    "mcp__pitboss__message_read",
+    "mcp__pitboss__message_ack",
+    "mcp__pitboss__artifact_put",
+    "mcp__pitboss__artifact_list",
+    "mcp__pitboss__artifact_read",
+    "mcp__pitboss__artifact_grant",
 ];
 
 pub(super) fn worker_spawn_args(

--- a/crates/pitboss-cli/src/mcp/tools/tests.rs
+++ b/crates/pitboss-cli/src/mcp/tools/tests.rs
@@ -94,6 +94,7 @@ async fn test_state_with_budget(budget: f64) -> Arc<DispatchState> {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        communication: Default::default(),
         lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
@@ -566,6 +567,7 @@ async fn completing_test_state_with_budget(budget: Option<f64>) -> Arc<DispatchS
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        communication: Default::default(),
         lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
@@ -1413,6 +1415,7 @@ async fn handle_request_approval_auto_approves() {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        communication: Default::default(),
         lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
@@ -1507,6 +1510,7 @@ async fn permission_prompt_auto_approves_and_returns_gate_response() {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        communication: Default::default(),
         lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
@@ -1610,6 +1614,7 @@ async fn mk_plan_state(
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        communication: Default::default(),
         lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));

--- a/crates/pitboss-cli/tests/cancel_cascade_flows.rs
+++ b/crates/pitboss-cli/tests/cancel_cascade_flows.rs
@@ -102,6 +102,7 @@ fn mk_state() -> (TempDir, Arc<DispatchState>) {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        communication: Default::default(),
         lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));

--- a/crates/pitboss-cli/tests/control_flows.rs
+++ b/crates/pitboss-cli/tests/control_flows.rs
@@ -54,6 +54,7 @@ async fn pause_op_writes_events_jsonl() {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        communication: Default::default(),
         lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
@@ -261,6 +262,7 @@ async fn block_policy_queue_drains_on_tui_connect() {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        communication: Default::default(),
         lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
@@ -377,6 +379,7 @@ async fn auto_approve_policy_responds_without_tui() {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        communication: Default::default(),
         lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
@@ -440,6 +443,7 @@ async fn auto_reject_policy_responds_without_tui() {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        communication: Default::default(),
         lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
@@ -514,6 +518,7 @@ async fn propose_plan_end_to_end_unblocks_spawn_gate() {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        communication: Default::default(),
         lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));

--- a/crates/pitboss-cli/tests/dogfood_fake_flows.rs
+++ b/crates/pitboss-cli/tests/dogfood_fake_flows.rs
@@ -94,6 +94,7 @@ fn mk_state_with_subleads() -> (TempDir, Arc<DispatchState>) {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        communication: Default::default(),
         lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
@@ -1045,6 +1046,7 @@ async fn dogfood_envelope_cap_rejection() {
             approval_rules: vec![],
             container: None,
             mcp_servers: vec![],
+            communication: Default::default(),
             lifecycle: None,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));

--- a/crates/pitboss-cli/tests/e2e_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_flows.rs
@@ -79,6 +79,7 @@ fn mk_state(
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        communication: Default::default(),
         lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(run_dir.to_path_buf()));
@@ -382,6 +383,7 @@ async fn e2e_lead_cancels_worker_mid_flight() {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        communication: Default::default(),
         lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
@@ -639,6 +641,7 @@ async fn e2e_lead_reprompts_running_worker() {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        communication: Default::default(),
         lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
@@ -835,6 +838,7 @@ async fn e2e_lead_propose_plan_gate_unblocks_spawn() {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        communication: Default::default(),
         lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
@@ -1137,6 +1141,7 @@ async fn e2e_freeze_pause_and_continue_real_subprocess_worker() {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        communication: Default::default(),
         lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));

--- a/crates/pitboss-cli/tests/e2e_sublead_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_sublead_flows.rs
@@ -79,6 +79,7 @@ fn mk_state(dir: &std::path::Path) -> (Uuid, Arc<DispatchState>) {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        communication: Default::default(),
         lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.to_path_buf()));
@@ -151,6 +152,7 @@ fn mk_state_hold_workers(dir: &std::path::Path) -> (Uuid, Arc<DispatchState>) {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        communication: Default::default(),
         lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.to_path_buf()));
@@ -797,6 +799,7 @@ async fn sublead_session_spawns_runs_and_reconciles() {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        communication: Default::default(),
         lifecycle: None,
     };
 

--- a/crates/pitboss-cli/tests/hierarchical_flows.rs
+++ b/crates/pitboss-cli/tests/hierarchical_flows.rs
@@ -62,6 +62,7 @@ fn mk_state() -> (TempDir, Arc<DispatchState>) {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        communication: Default::default(),
         lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));

--- a/crates/pitboss-cli/tests/notify_flows.rs
+++ b/crates/pitboss-cli/tests/notify_flows.rs
@@ -256,6 +256,7 @@ async fn approval_pending_notification_fires_on_enqueue() {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        communication: Default::default(),
         lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));

--- a/crates/pitboss-cli/tests/shared_store_flows.rs
+++ b/crates/pitboss-cli/tests/shared_store_flows.rs
@@ -464,6 +464,7 @@ async fn lease_released_when_mcp_connection_drops() {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        communication: Default::default(),
         lifecycle: None,
     };
     let store_trait: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().into()));
@@ -606,6 +607,7 @@ async fn run_global_lease_released_when_mcp_connection_drops() {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        communication: Default::default(),
         lifecycle: None,
     };
     let store_trait: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().into()));

--- a/crates/pitboss-cli/tests/sublead_flows.rs
+++ b/crates/pitboss-cli/tests/sublead_flows.rs
@@ -62,6 +62,7 @@ fn mk_state_with_subleads() -> (TempDir, Arc<DispatchState>) {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        communication: Default::default(),
         lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
@@ -131,6 +132,7 @@ fn mk_state_with_sublead_budget_cap(cap: f64) -> (TempDir, Arc<DispatchState>) {
         approval_rules: vec![],
         container: None,
         mcp_servers: vec![],
+        communication: Default::default(),
         lifecycle: None,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));

--- a/docs/manifest-map.md
+++ b/docs/manifest-map.md
@@ -14,143 +14,154 @@ The annotated example lives at [`pitboss.example.toml`](../pitboss.example.toml)
 
 ## `[run]` — `RunConfig`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:358`](../crates/pitboss-cli/src/manifest/schema.rs#L358).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:439`](../crates/pitboss-cli/src/manifest/schema.rs#L439).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `name` | text | no | Human-readable label used to group related runs in the console (e.g. "build-db", "nightly-sync"). When unset, the manifest filename is used as fallback. | [`../crates/pitboss-cli/src/manifest/schema.rs#L369`](../crates/pitboss-cli/src/manifest/schema.rs#L369) |
-| `max_parallel_tasks` | integer | no | Flat-mode concurrency cap for [[task]] runs. Default 4. Overridden by ANTHROPIC_MAX_CONCURRENT. | [`../crates/pitboss-cli/src/manifest/schema.rs#L378`](../crates/pitboss-cli/src/manifest/schema.rs#L378) |
-| `halt_on_failure` | boolean | no | Stop remaining flat-mode tasks on first failure. | [`../crates/pitboss-cli/src/manifest/schema.rs#L385`](../crates/pitboss-cli/src/manifest/schema.rs#L385) |
-| `run_dir` | path | no | Where per-run artifacts land. Default ~/.local/share/pitboss/runs. | [`../crates/pitboss-cli/src/manifest/schema.rs#L391`](../crates/pitboss-cli/src/manifest/schema.rs#L391) |
-| `worktree_cleanup` | enum (`always` \| `on_success` \| `never`) | no | What to do with each worker's git worktree after it finishes. | [`../crates/pitboss-cli/src/manifest/schema.rs#L399`](../crates/pitboss-cli/src/manifest/schema.rs#L399) |
-| `emit_event_stream` | boolean | no | Write a JSONL event stream alongside summary.jsonl. | [`../crates/pitboss-cli/src/manifest/schema.rs#L406`](../crates/pitboss-cli/src/manifest/schema.rs#L406) |
-| `default_approval_policy` | enum (`block` \| `auto_approve` \| `auto_reject`) | no | Default action for request_approval / propose_plan when no rule matches. `auto_approve`/`auto_reject` are unconditional; `block` routes to the operator if attached, else queues. | [`../crates/pitboss-cli/src/manifest/schema.rs#L434`](../crates/pitboss-cli/src/manifest/schema.rs#L434) |
-| `dump_shared_store` | boolean | no | Write shared-store.json into the run directory on finalize. | [`../crates/pitboss-cli/src/manifest/schema.rs#L442`](../crates/pitboss-cli/src/manifest/schema.rs#L442) |
-| `require_plan_approval` | boolean | no | When true, spawn_worker is blocked until propose_plan has been approved. | [`../crates/pitboss-cli/src/manifest/schema.rs#L450`](../crates/pitboss-cli/src/manifest/schema.rs#L450) |
+| `name` | text | no | Human-readable label used to group related runs in the console (e.g. "build-db", "nightly-sync"). When unset, the manifest filename is used as fallback. | [`../crates/pitboss-cli/src/manifest/schema.rs#L450`](../crates/pitboss-cli/src/manifest/schema.rs#L450) |
+| `max_parallel_tasks` | integer | no | Flat-mode concurrency cap for [[task]] runs. Default 4. Overridden by ANTHROPIC_MAX_CONCURRENT. | [`../crates/pitboss-cli/src/manifest/schema.rs#L459`](../crates/pitboss-cli/src/manifest/schema.rs#L459) |
+| `halt_on_failure` | boolean | no | Stop remaining flat-mode tasks on first failure. | [`../crates/pitboss-cli/src/manifest/schema.rs#L466`](../crates/pitboss-cli/src/manifest/schema.rs#L466) |
+| `run_dir` | path | no | Where per-run artifacts land. Default ~/.local/share/pitboss/runs. | [`../crates/pitboss-cli/src/manifest/schema.rs#L472`](../crates/pitboss-cli/src/manifest/schema.rs#L472) |
+| `worktree_cleanup` | enum (`always` \| `on_success` \| `never`) | no | What to do with each worker's git worktree after it finishes. | [`../crates/pitboss-cli/src/manifest/schema.rs#L480`](../crates/pitboss-cli/src/manifest/schema.rs#L480) |
+| `emit_event_stream` | boolean | no | Write a JSONL event stream alongside summary.jsonl. | [`../crates/pitboss-cli/src/manifest/schema.rs#L487`](../crates/pitboss-cli/src/manifest/schema.rs#L487) |
+| `default_approval_policy` | enum (`block` \| `auto_approve` \| `auto_reject`) | no | Default action for request_approval / propose_plan when no rule matches. `auto_approve`/`auto_reject` are unconditional; `block` routes to the operator if attached, else queues. | [`../crates/pitboss-cli/src/manifest/schema.rs#L515`](../crates/pitboss-cli/src/manifest/schema.rs#L515) |
+| `dump_shared_store` | boolean | no | Write shared-store.json into the run directory on finalize. | [`../crates/pitboss-cli/src/manifest/schema.rs#L523`](../crates/pitboss-cli/src/manifest/schema.rs#L523) |
+| `require_plan_approval` | boolean | no | When true, spawn_worker is blocked until propose_plan has been approved. | [`../crates/pitboss-cli/src/manifest/schema.rs#L531`](../crates/pitboss-cli/src/manifest/schema.rs#L531) |
 
 ## `[defaults]` — `Defaults`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:483`](../crates/pitboss-cli/src/manifest/schema.rs#L483).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:564`](../crates/pitboss-cli/src/manifest/schema.rs#L564).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `model` | text | no | Claude model id (e.g. claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-7). | [`../crates/pitboss-cli/src/manifest/schema.rs#L488`](../crates/pitboss-cli/src/manifest/schema.rs#L488) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Maps to the claude --effort flag. | [`../crates/pitboss-cli/src/manifest/schema.rs#L494`](../crates/pitboss-cli/src/manifest/schema.rs#L494) |
-| `tools` | string list | no | Allowed tool surface. Pitboss auto-appends its MCP tools for leads and workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L499`](../crates/pitboss-cli/src/manifest/schema.rs#L499) |
-| `timeout_secs` | integer | no | Per-task wall-clock cap. No default (no cap). | [`../crates/pitboss-cli/src/manifest/schema.rs#L504`](../crates/pitboss-cli/src/manifest/schema.rs#L504) |
-| `use_worktree` | boolean | no | Isolate each worker in a git worktree. Default true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L509`](../crates/pitboss-cli/src/manifest/schema.rs#L509) |
-| `env` | key-value map | no | Environment variables passed to the claude subprocess. | [`../crates/pitboss-cli/src/manifest/schema.rs#L515`](../crates/pitboss-cli/src/manifest/schema.rs#L515) |
+| `model` | text | no | Claude model id (e.g. claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-7). | [`../crates/pitboss-cli/src/manifest/schema.rs#L569`](../crates/pitboss-cli/src/manifest/schema.rs#L569) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Maps to the claude --effort flag. | [`../crates/pitboss-cli/src/manifest/schema.rs#L575`](../crates/pitboss-cli/src/manifest/schema.rs#L575) |
+| `tools` | string list | no | Allowed tool surface. Pitboss auto-appends its MCP tools for leads and workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L580`](../crates/pitboss-cli/src/manifest/schema.rs#L580) |
+| `timeout_secs` | integer | no | Per-task wall-clock cap. No default (no cap). | [`../crates/pitboss-cli/src/manifest/schema.rs#L585`](../crates/pitboss-cli/src/manifest/schema.rs#L585) |
+| `use_worktree` | boolean | no | Isolate each worker in a git worktree. Default true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L590`](../crates/pitboss-cli/src/manifest/schema.rs#L590) |
+| `env` | key-value map | no | Environment variables passed to the claude subprocess. | [`../crates/pitboss-cli/src/manifest/schema.rs#L596`](../crates/pitboss-cli/src/manifest/schema.rs#L596) |
 
 ## `[container]` — `ContainerConfig`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:71`](../crates/pitboss-cli/src/manifest/schema.rs#L71).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:72`](../crates/pitboss-cli/src/manifest/schema.rs#L72).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `image` | text | no | Container image reference. Defaults to ghcr.io/sds-mode/pitboss-with-claude:latest. | [`../crates/pitboss-cli/src/manifest/schema.rs#L77`](../crates/pitboss-cli/src/manifest/schema.rs#L77) |
-| `runtime` | enum (`docker` \| `podman` \| `auto`) | no | Container runtime to invoke. "auto" prefers podman. | [`../crates/pitboss-cli/src/manifest/schema.rs#L84`](../crates/pitboss-cli/src/manifest/schema.rs#L84) |
-| `extra_args` | string list | no | Verbatim podman/docker run flags. Use for networking, capabilities, DNS, resources, etc. Example: ["--network=corp-fw", "--dns=10.0.0.53", "--cap-add=NET_ADMIN"]. | [`../crates/pitboss-cli/src/manifest/schema.rs#L95`](../crates/pitboss-cli/src/manifest/schema.rs#L95) |
-| `extra_apt` | string list | no | Debian/Ubuntu packages installed inside the container before pitboss dispatch starts. Adds 30–90s spin-up per dispatch. Example: ["mdbook", "jq"]. | [`../crates/pitboss-cli/src/manifest/schema.rs#L110`](../crates/pitboss-cli/src/manifest/schema.rs#L110) |
-| `workdir` | path | no | cwd inside the container; defaults to the first mount's container path. | [`../crates/pitboss-cli/src/manifest/schema.rs#L131`](../crates/pitboss-cli/src/manifest/schema.rs#L131) |
+| `image` | text | no | Container image reference. Defaults to ghcr.io/sds-mode/pitboss-with-claude:latest. | [`../crates/pitboss-cli/src/manifest/schema.rs#L78`](../crates/pitboss-cli/src/manifest/schema.rs#L78) |
+| `runtime` | enum (`docker` \| `podman` \| `auto`) | no | Container runtime to invoke. "auto" prefers podman. | [`../crates/pitboss-cli/src/manifest/schema.rs#L85`](../crates/pitboss-cli/src/manifest/schema.rs#L85) |
+| `extra_args` | string list | no | Verbatim podman/docker run flags. Use for networking, capabilities, DNS, resources, etc. Example: ["--network=corp-fw", "--dns=10.0.0.53", "--cap-add=NET_ADMIN"]. | [`../crates/pitboss-cli/src/manifest/schema.rs#L96`](../crates/pitboss-cli/src/manifest/schema.rs#L96) |
+| `extra_apt` | string list | no | Debian/Ubuntu packages installed inside the container before pitboss dispatch starts. Adds 30–90s spin-up per dispatch. Example: ["mdbook", "jq"]. | [`../crates/pitboss-cli/src/manifest/schema.rs#L111`](../crates/pitboss-cli/src/manifest/schema.rs#L111) |
+| `workdir` | path | no | cwd inside the container; defaults to the first mount's container path. | [`../crates/pitboss-cli/src/manifest/schema.rs#L132`](../crates/pitboss-cli/src/manifest/schema.rs#L132) |
 
 ## `[[container.mount]]` — `MountSpec`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:137`](../crates/pitboss-cli/src/manifest/schema.rs#L137).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:138`](../crates/pitboss-cli/src/manifest/schema.rs#L138).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `host` | path | **yes** | Absolute host path. ~ is expanded. | [`../crates/pitboss-cli/src/manifest/schema.rs#L140`](../crates/pitboss-cli/src/manifest/schema.rs#L140) |
-| `container` | path | **yes** | Absolute path inside the container. | [`../crates/pitboss-cli/src/manifest/schema.rs#L143`](../crates/pitboss-cli/src/manifest/schema.rs#L143) |
-| `readonly` | boolean | no | Mount read-only. | [`../crates/pitboss-cli/src/manifest/schema.rs#L147`](../crates/pitboss-cli/src/manifest/schema.rs#L147) |
+| `host` | path | **yes** | Absolute host path. ~ is expanded. | [`../crates/pitboss-cli/src/manifest/schema.rs#L141`](../crates/pitboss-cli/src/manifest/schema.rs#L141) |
+| `container` | path | **yes** | Absolute path inside the container. | [`../crates/pitboss-cli/src/manifest/schema.rs#L144`](../crates/pitboss-cli/src/manifest/schema.rs#L144) |
+| `readonly` | boolean | no | Mount read-only. | [`../crates/pitboss-cli/src/manifest/schema.rs#L148`](../crates/pitboss-cli/src/manifest/schema.rs#L148) |
 
 ## `[[task]]` — `Task`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:546`](../crates/pitboss-cli/src/manifest/schema.rs#L546).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:627`](../crates/pitboss-cli/src/manifest/schema.rs#L627).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique slug. Alphanumeric + _ + -. Used in logs and worktree names. | [`../crates/pitboss-cli/src/manifest/schema.rs#L551`](../crates/pitboss-cli/src/manifest/schema.rs#L551) |
-| `directory` | path | **yes** | Working directory. Must be inside a git repo if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L556`](../crates/pitboss-cli/src/manifest/schema.rs#L556) |
-| `prompt` | text (multi-line) | no | Prompt body sent to claude via -p. Mutually exclusive with `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L562`](../crates/pitboss-cli/src/manifest/schema.rs#L562) |
-| `template` | text | no | Reference to a [[template]] entry. Mutually exclusive with `prompt`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L567`](../crates/pitboss-cli/src/manifest/schema.rs#L567) |
-| `vars` | key-value map | no | Substitutions for {placeholders} when using `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L573`](../crates/pitboss-cli/src/manifest/schema.rs#L573) |
-| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L578`](../crates/pitboss-cli/src/manifest/schema.rs#L578) |
-| `model` | text | no | Per-task override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L580`](../crates/pitboss-cli/src/manifest/schema.rs#L580) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-task override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L586`](../crates/pitboss-cli/src/manifest/schema.rs#L586) |
-| `tools` | string list | no | Per-task override of [defaults].tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L588`](../crates/pitboss-cli/src/manifest/schema.rs#L588) |
-| `timeout_secs` | integer | no | Per-task wall-clock cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L590`](../crates/pitboss-cli/src/manifest/schema.rs#L590) |
-| `use_worktree` | boolean | no | Per-task override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L595`](../crates/pitboss-cli/src/manifest/schema.rs#L595) |
-| `env` | key-value map | no | Per-task env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L601`](../crates/pitboss-cli/src/manifest/schema.rs#L601) |
+| `id` | text | **yes** | Unique slug. Alphanumeric + _ + -. Used in logs and worktree names. | [`../crates/pitboss-cli/src/manifest/schema.rs#L632`](../crates/pitboss-cli/src/manifest/schema.rs#L632) |
+| `directory` | path | **yes** | Working directory. Must be inside a git repo if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L637`](../crates/pitboss-cli/src/manifest/schema.rs#L637) |
+| `prompt` | text (multi-line) | no | Prompt body sent to claude via -p. Mutually exclusive with `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L643`](../crates/pitboss-cli/src/manifest/schema.rs#L643) |
+| `template` | text | no | Reference to a [[template]] entry. Mutually exclusive with `prompt`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L648`](../crates/pitboss-cli/src/manifest/schema.rs#L648) |
+| `vars` | key-value map | no | Substitutions for {placeholders} when using `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L654`](../crates/pitboss-cli/src/manifest/schema.rs#L654) |
+| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L659`](../crates/pitboss-cli/src/manifest/schema.rs#L659) |
+| `model` | text | no | Per-task override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L661`](../crates/pitboss-cli/src/manifest/schema.rs#L661) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-task override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L667`](../crates/pitboss-cli/src/manifest/schema.rs#L667) |
+| `tools` | string list | no | Per-task override of [defaults].tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L669`](../crates/pitboss-cli/src/manifest/schema.rs#L669) |
+| `timeout_secs` | integer | no | Per-task wall-clock cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L671`](../crates/pitboss-cli/src/manifest/schema.rs#L671) |
+| `use_worktree` | boolean | no | Per-task override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L676`](../crates/pitboss-cli/src/manifest/schema.rs#L676) |
+| `env` | key-value map | no | Per-task env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L682`](../crates/pitboss-cli/src/manifest/schema.rs#L682) |
 
 ## `[lead]` — `Lead`
+
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:692`](../crates/pitboss-cli/src/manifest/schema.rs#L692).
+
+| Field | Type | Required | Help | Source |
+|---|---|---|---|---|
+| `id` | text | **yes** | Unique slug used as the TUI tile label and in run artifact paths. | [`../crates/pitboss-cli/src/manifest/schema.rs#L699`](../crates/pitboss-cli/src/manifest/schema.rs#L699) |
+| `directory` | path | **yes** | Working directory for the lead's claude subprocess. Must be a git work-tree if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L706`](../crates/pitboss-cli/src/manifest/schema.rs#L706) |
+| `prompt` | text (multi-line) | **yes** | Operator instructions passed to claude via -p. Must appear before any [lead.X] subtable in the source. | [`../crates/pitboss-cli/src/manifest/schema.rs#L718`](../crates/pitboss-cli/src/manifest/schema.rs#L718) |
+| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L726`](../crates/pitboss-cli/src/manifest/schema.rs#L726) |
+| `model` | text | no | Per-lead override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L729`](../crates/pitboss-cli/src/manifest/schema.rs#L729) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-lead override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L736`](../crates/pitboss-cli/src/manifest/schema.rs#L736) |
+| `tools` | string list | no | Per-lead override of [defaults].tools. Pitboss auto-appends its MCP tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L742`](../crates/pitboss-cli/src/manifest/schema.rs#L742) |
+| `timeout_secs` | integer | no | Per-actor subprocess wall-clock cap (claude --timeout). | [`../crates/pitboss-cli/src/manifest/schema.rs#L748`](../crates/pitboss-cli/src/manifest/schema.rs#L748) |
+| `use_worktree` | boolean | no | Per-lead override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L754`](../crates/pitboss-cli/src/manifest/schema.rs#L754) |
+| `env` | key-value map | no | Per-lead env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L760`](../crates/pitboss-cli/src/manifest/schema.rs#L760) |
+| `max_workers` | integer | no | Hard cap on the lead's concurrent + queued worker pool (1–16). Required when the lead spawns workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L769`](../crates/pitboss-cli/src/manifest/schema.rs#L769) |
+| `budget_usd` | float | no | Soft cap on lead spend with reservation accounting. spawn_worker fails once spent + reserved + next_estimate > budget. | [`../crates/pitboss-cli/src/manifest/schema.rs#L778`](../crates/pitboss-cli/src/manifest/schema.rs#L778) |
+| `lead_timeout_secs` | integer | no | Wall-clock cap on the lead session. Default 3600. | [`../crates/pitboss-cli/src/manifest/schema.rs#L787`](../crates/pitboss-cli/src/manifest/schema.rs#L787) |
+| `permission_routing` | enum (`path_a` \| `path_b`) | no | path_a (default) makes pitboss the sole permission authority. path_b routes claude's gate through pitboss (rejected at validate time pending stabilization). | [`../crates/pitboss-cli/src/manifest/schema.rs#L800`](../crates/pitboss-cli/src/manifest/schema.rs#L800) |
+| `allow_subleads` | boolean | no | Expose spawn_sublead to the root lead. | [`../crates/pitboss-cli/src/manifest/schema.rs#L809`](../crates/pitboss-cli/src/manifest/schema.rs#L809) |
+| `max_subleads` | integer | no | Hard cap on total live sub-leads under this root. | [`../crates/pitboss-cli/src/manifest/schema.rs#L816`](../crates/pitboss-cli/src/manifest/schema.rs#L816) |
+| `max_sublead_budget_usd` | float | no | Cap on the per-sub-lead budget envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L823`](../crates/pitboss-cli/src/manifest/schema.rs#L823) |
+| `max_total_workers` | integer | no | Cap on total live workers across the entire tree (root + sub-trees). | [`../crates/pitboss-cli/src/manifest/schema.rs#L831`](../crates/pitboss-cli/src/manifest/schema.rs#L831) |
+
+## `[sublead_defaults]` — `SubleadDefaults`
+
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:838`](../crates/pitboss-cli/src/manifest/schema.rs#L838).
+
+| Field | Type | Required | Help | Source |
+|---|---|---|---|---|
+| `budget_usd` | float | no | Per-sub-lead envelope when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L843`](../crates/pitboss-cli/src/manifest/schema.rs#L843) |
+| `max_workers` | integer | no | Per-sub-lead worker pool when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L848`](../crates/pitboss-cli/src/manifest/schema.rs#L848) |
+| `lead_timeout_secs` | integer | no | Wall-clock cap for the sub-lead session. | [`../crates/pitboss-cli/src/manifest/schema.rs#L853`](../crates/pitboss-cli/src/manifest/schema.rs#L853) |
+| `read_down` | boolean | no | When true, sub-lead shares root's budget + worker pool instead of carving its own envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L859`](../crates/pitboss-cli/src/manifest/schema.rs#L859) |
+
+## `[[approval_policy]]` — `ApprovalRuleSpec`
+
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:389`](../crates/pitboss-cli/src/manifest/schema.rs#L389).
+
+| Field | Type | Required | Help | Source |
+|---|---|---|---|---|
+| `action` | enum (`auto_approve` \| `auto_reject` \| `block`) | **yes** | Action when this rule matches. | [`../crates/pitboss-cli/src/manifest/schema.rs#L400`](../crates/pitboss-cli/src/manifest/schema.rs#L400) |
+
+## `[[mcp_server]]` — `McpServerSpec`
+
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:183`](../crates/pitboss-cli/src/manifest/schema.rs#L183).
+
+| Field | Type | Required | Help | Source |
+|---|---|---|---|---|
+| `id` | text | **yes** | Key under mcpServers in the generated config. | [`../crates/pitboss-cli/src/manifest/schema.rs#L189`](../crates/pitboss-cli/src/manifest/schema.rs#L189) |
+| `command` | text | **yes** | Executable to launch (e.g. npx, uvx, or an absolute path). | [`../crates/pitboss-cli/src/manifest/schema.rs#L195`](../crates/pitboss-cli/src/manifest/schema.rs#L195) |
+| `args` | string list | no | Arguments passed to the command. | [`../crates/pitboss-cli/src/manifest/schema.rs#L199`](../crates/pitboss-cli/src/manifest/schema.rs#L199) |
+| `env` | key-value map | no | Environment variables injected into the MCP server process. | [`../crates/pitboss-cli/src/manifest/schema.rs#L206`](../crates/pitboss-cli/src/manifest/schema.rs#L206) |
+
+## `[communication]` — `CommunicationConfig`
+
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:243`](../crates/pitboss-cli/src/manifest/schema.rs#L243).
+
+| Field | Type | Required | Help | Source |
+|---|---|---|---|---|
+| `mode` | enum (`disabled` \| `parent_child`) | no | Actor communication policy mode. "disabled" hides the message_* and artifact_* tools (conservative default). "parent_child" enables them with parent/sublead/worker authz. | [`../crates/pitboss-cli/src/manifest/schema.rs#L250`](../crates/pitboss-cli/src/manifest/schema.rs#L250) |
+| `max_message_bytes` | integer | no | Maximum UTF-8 body size accepted by message_send. | [`../crates/pitboss-cli/src/manifest/schema.rs#L256`](../crates/pitboss-cli/src/manifest/schema.rs#L256) |
+| `max_artifact_bytes` | integer | no | Maximum decoded artifact payload size accepted by artifact_put. | [`../crates/pitboss-cli/src/manifest/schema.rs#L262`](../crates/pitboss-cli/src/manifest/schema.rs#L262) |
+| `max_artifacts_per_actor` | integer | no | Maximum artifacts one actor may publish in a single run. | [`../crates/pitboss-cli/src/manifest/schema.rs#L268`](../crates/pitboss-cli/src/manifest/schema.rs#L268) |
+
+## `[[template]]` — `Template`
 
 Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:611`](../crates/pitboss-cli/src/manifest/schema.rs#L611).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique slug used as the TUI tile label and in run artifact paths. | [`../crates/pitboss-cli/src/manifest/schema.rs#L618`](../crates/pitboss-cli/src/manifest/schema.rs#L618) |
-| `directory` | path | **yes** | Working directory for the lead's claude subprocess. Must be a git work-tree if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L625`](../crates/pitboss-cli/src/manifest/schema.rs#L625) |
-| `prompt` | text (multi-line) | **yes** | Operator instructions passed to claude via -p. Must appear before any [lead.X] subtable in the source. | [`../crates/pitboss-cli/src/manifest/schema.rs#L637`](../crates/pitboss-cli/src/manifest/schema.rs#L637) |
-| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L645`](../crates/pitboss-cli/src/manifest/schema.rs#L645) |
-| `model` | text | no | Per-lead override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L648`](../crates/pitboss-cli/src/manifest/schema.rs#L648) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-lead override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L655`](../crates/pitboss-cli/src/manifest/schema.rs#L655) |
-| `tools` | string list | no | Per-lead override of [defaults].tools. Pitboss auto-appends its MCP tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L661`](../crates/pitboss-cli/src/manifest/schema.rs#L661) |
-| `timeout_secs` | integer | no | Per-actor subprocess wall-clock cap (claude --timeout). | [`../crates/pitboss-cli/src/manifest/schema.rs#L667`](../crates/pitboss-cli/src/manifest/schema.rs#L667) |
-| `use_worktree` | boolean | no | Per-lead override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L673`](../crates/pitboss-cli/src/manifest/schema.rs#L673) |
-| `env` | key-value map | no | Per-lead env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L679`](../crates/pitboss-cli/src/manifest/schema.rs#L679) |
-| `max_workers` | integer | no | Hard cap on the lead's concurrent + queued worker pool (1–16). Required when the lead spawns workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L688`](../crates/pitboss-cli/src/manifest/schema.rs#L688) |
-| `budget_usd` | float | no | Soft cap on lead spend with reservation accounting. spawn_worker fails once spent + reserved + next_estimate > budget. | [`../crates/pitboss-cli/src/manifest/schema.rs#L697`](../crates/pitboss-cli/src/manifest/schema.rs#L697) |
-| `lead_timeout_secs` | integer | no | Wall-clock cap on the lead session. Default 3600. | [`../crates/pitboss-cli/src/manifest/schema.rs#L706`](../crates/pitboss-cli/src/manifest/schema.rs#L706) |
-| `permission_routing` | enum (`path_a` \| `path_b`) | no | path_a (default) makes pitboss the sole permission authority. path_b routes claude's gate through pitboss (rejected at validate time pending stabilization). | [`../crates/pitboss-cli/src/manifest/schema.rs#L719`](../crates/pitboss-cli/src/manifest/schema.rs#L719) |
-| `allow_subleads` | boolean | no | Expose spawn_sublead to the root lead. | [`../crates/pitboss-cli/src/manifest/schema.rs#L728`](../crates/pitboss-cli/src/manifest/schema.rs#L728) |
-| `max_subleads` | integer | no | Hard cap on total live sub-leads under this root. | [`../crates/pitboss-cli/src/manifest/schema.rs#L735`](../crates/pitboss-cli/src/manifest/schema.rs#L735) |
-| `max_sublead_budget_usd` | float | no | Cap on the per-sub-lead budget envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L742`](../crates/pitboss-cli/src/manifest/schema.rs#L742) |
-| `max_total_workers` | integer | no | Cap on total live workers across the entire tree (root + sub-trees). | [`../crates/pitboss-cli/src/manifest/schema.rs#L750`](../crates/pitboss-cli/src/manifest/schema.rs#L750) |
-
-## `[sublead_defaults]` — `SubleadDefaults`
-
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:757`](../crates/pitboss-cli/src/manifest/schema.rs#L757).
-
-| Field | Type | Required | Help | Source |
-|---|---|---|---|---|
-| `budget_usd` | float | no | Per-sub-lead envelope when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L762`](../crates/pitboss-cli/src/manifest/schema.rs#L762) |
-| `max_workers` | integer | no | Per-sub-lead worker pool when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L767`](../crates/pitboss-cli/src/manifest/schema.rs#L767) |
-| `lead_timeout_secs` | integer | no | Wall-clock cap for the sub-lead session. | [`../crates/pitboss-cli/src/manifest/schema.rs#L772`](../crates/pitboss-cli/src/manifest/schema.rs#L772) |
-| `read_down` | boolean | no | When true, sub-lead shares root's budget + worker pool instead of carving its own envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L778`](../crates/pitboss-cli/src/manifest/schema.rs#L778) |
-
-## `[[approval_policy]]` — `ApprovalRuleSpec`
-
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:308`](../crates/pitboss-cli/src/manifest/schema.rs#L308).
-
-| Field | Type | Required | Help | Source |
-|---|---|---|---|---|
-| `action` | enum (`auto_approve` \| `auto_reject` \| `block`) | **yes** | Action when this rule matches. | [`../crates/pitboss-cli/src/manifest/schema.rs#L319`](../crates/pitboss-cli/src/manifest/schema.rs#L319) |
-
-## `[[mcp_server]]` — `McpServerSpec`
-
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:182`](../crates/pitboss-cli/src/manifest/schema.rs#L182).
-
-| Field | Type | Required | Help | Source |
-|---|---|---|---|---|
-| `id` | text | **yes** | Key under mcpServers in the generated config. | [`../crates/pitboss-cli/src/manifest/schema.rs#L188`](../crates/pitboss-cli/src/manifest/schema.rs#L188) |
-| `command` | text | **yes** | Executable to launch (e.g. npx, uvx, or an absolute path). | [`../crates/pitboss-cli/src/manifest/schema.rs#L194`](../crates/pitboss-cli/src/manifest/schema.rs#L194) |
-| `args` | string list | no | Arguments passed to the command. | [`../crates/pitboss-cli/src/manifest/schema.rs#L198`](../crates/pitboss-cli/src/manifest/schema.rs#L198) |
-| `env` | key-value map | no | Environment variables injected into the MCP server process. | [`../crates/pitboss-cli/src/manifest/schema.rs#L205`](../crates/pitboss-cli/src/manifest/schema.rs#L205) |
-
-## `[[template]]` — `Template`
-
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:530`](../crates/pitboss-cli/src/manifest/schema.rs#L530).
-
-| Field | Type | Required | Help | Source |
-|---|---|---|---|---|
-| `id` | text | **yes** | Slug referenced from [[task]].template. | [`../crates/pitboss-cli/src/manifest/schema.rs#L535`](../crates/pitboss-cli/src/manifest/schema.rs#L535) |
-| `prompt` | text (multi-line) | **yes** | Prompt body. Supports {var} placeholders supplied by [[task]].vars. | [`../crates/pitboss-cli/src/manifest/schema.rs#L541`](../crates/pitboss-cli/src/manifest/schema.rs#L541) |
+| `id` | text | **yes** | Slug referenced from [[task]].template. | [`../crates/pitboss-cli/src/manifest/schema.rs#L616`](../crates/pitboss-cli/src/manifest/schema.rs#L616) |
+| `prompt` | text (multi-line) | **yes** | Prompt body. Supports {var} placeholders supplied by [[task]].vars. | [`../crates/pitboss-cli/src/manifest/schema.rs#L622`](../crates/pitboss-cli/src/manifest/schema.rs#L622) |
 
 ## `[lifecycle]` — `Lifecycle`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:285`](../crates/pitboss-cli/src/manifest/schema.rs#L285).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:366`](../crates/pitboss-cli/src/manifest/schema.rs#L366).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `survive_parent` | boolean | no | Allow this dispatch to outlive its parent process. Requires a notify target. | [`../crates/pitboss-cli/src/manifest/schema.rs#L296`](../crates/pitboss-cli/src/manifest/schema.rs#L296) |
+| `survive_parent` | boolean | no | Allow this dispatch to outlive its parent process. Requires a notify target. | [`../crates/pitboss-cli/src/manifest/schema.rs#L377`](../crates/pitboss-cli/src/manifest/schema.rs#L377) |
 

--- a/docs/manifest-reference.toml
+++ b/docs/manifest-reference.toml
@@ -104,6 +104,12 @@ command = "<value>"
 args = []
 env = { EXAMPLE_KEY = "value" }
 
+[communication]
+mode = "disabled"
+max_message_bytes = 0
+max_artifact_bytes = 0
+max_artifacts_per_actor = 0
+
 [[template]]
 id = "<value>"
 prompt = """

--- a/examples/communication-parent-child-demo.toml
+++ b/examples/communication-parent-child-demo.toml
@@ -1,0 +1,74 @@
+# Parent-child communication demo
+#
+# Demonstrates the Pitboss-owned communication plane for hierarchical runs:
+# one worker publishes an artifact and messages the lead, then the lead grants
+# that artifact to a second worker and sends a directional handoff message.
+#
+# This is the coarse v0.9 communication model:
+#   - workers can message their parent
+#   - leads can read child messages
+#   - artifacts are readable by owner, parent/root, and explicit grantees
+#   - sibling worker transfer requires the parent to call artifact_grant
+#
+# Before running, create the demo directory:
+#   mkdir -p /tmp/pitboss-communication-demo
+#
+# Live run:
+#   pitboss dispatch examples/communication-parent-child-demo.toml
+#
+# Attach TUI in a second terminal after the run starts:
+#   pitboss-tui
+
+[run]
+worktree_cleanup = "never"
+default_approval_policy = "auto_approve"
+
+[communication]
+mode = "parent_child"
+max_message_bytes = 4096
+max_artifact_bytes = 1048576
+max_artifacts_per_actor = 16
+
+[defaults]
+model = "claude-haiku-4-5"
+use_worktree = false
+timeout_secs = 180
+
+[lead]
+id = "communication-demo-lead"
+directory = "/tmp/pitboss-communication-demo"
+max_workers = 2
+budget_usd = 0.50
+lead_timeout_secs = 600
+prompt = """
+You are demonstrating Pitboss parent-child communication. Use the Pitboss MCP
+tools directly. Do not use KV for handoff payloads.
+
+Step 1: spawn worker A. Worker A must:
+- call artifact_put with:
+    name="worker-a-note.txt"
+    mime_type="text/plain"
+    content_base64="cGFyZW50LWNoaWxkIGNvbW11bmljYXRpb24gZGVtbwo="
+- call message_send to "parent" with subject="artifact-ready" and body exactly
+  "artifact_id=<ID>" using the artifact_id returned by artifact_put.
+- final response exactly: WORKER_A_DONE
+
+Step 2: wait_actor for worker A. Then call message_list scope="inbox",
+message_read the artifact-ready message, and extract the artifact_id.
+
+Step 3: spawn worker B. After spawn_worker returns worker B's task_id, call
+artifact_grant with the artifact_id and to=<worker B task_id>. Then call
+message_send to worker B with subject="read-artifact" and body exactly
+"artifact_id=<ID>".
+
+Worker B must:
+- poll message_list scope="inbox" until it sees subject="read-artifact".
+- message_read that message, extract the artifact_id, and call artifact_read.
+- final response exactly:
+    WORKER_B_READ: cGFyZW50LWNoaWxkIGNvbW11bmljYXRpb24gZGVtbwo=
+
+Step 4: wait_actor for worker B.
+
+Final response exactly:
+COMMUNICATION_PARENT_CHILD_DEMO_PASS
+"""


### PR DESCRIPTION
## Summary

- Adds 8 new read-write MCP tools — `message_send` / `message_list` / `message_read` / `message_ack` / `artifact_put` / `artifact_list` / `artifact_read` / `artifact_grant` — backed by a Pitboss-owned mailbox + on-disk artifact store. Workers transfer notes and binary payloads through the new plane instead of base64-stuffing serialized blobs into the shared-store KV.
- Introduces `[communication]` manifest section with `mode` (`disabled` | `parent_child`), `max_message_bytes`, `max_artifact_bytes`, `max_artifacts_per_actor`. Default `mode = "disabled"` — conservative for the v0.x bump; existing manifests upgrading to v0.10 do not silently grow the worker tool surface.
- Authz model in `parent_child` mode: root spans the run, sub-leads cover their own sub-tree and may message `"root"`, workers may talk only to direct `"parent"`. Sibling artifact handoff requires the parent (or root) to call `artifact_grant`. Artifacts land at `<run_dir>/communication/artifacts/<id>` (auto-mounted under `pitboss container-dispatch`, prune-able with the run dir).
- 9 unit tests covering schemars-skip on bridge metadata, parent-child authz, sublead semantics, activity counters, `artifact_grant` happy path, `mode = "disabled"` runtime rejection, **size-limit boundaries on `message_send` / `artifact_put`**, and **artifact-on-disk persistence verification**.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace --features pitboss-core/test-support` — all suites green; 9 new communication tests + ~25 ResolvedManifest fixture deltas across 13 source files and 9 integration test files
- [x] `cargo lint` (`-D warnings`) clean
- [x] `cargo tidy` clean
- [x] `scripts/smoke-part1.sh` — 11/11 green
- [x] `pitboss validate examples/communication-parent-child-demo.toml` — OK (hierarchical) — lead='communication-demo-lead', max_workers=2, budget=$0.50
- [x] Schema drift detectors regenerated (`docs/manifest-map.md`, `docs/manifest-reference.toml`)
- [x] `is_communication_tool` filter empirically verified against `list_tools` for both modes
- [ ] Manual end-to-end smoke against a live `mode = "parent_child"` run with the demo manifest (covered in follow-up Phase C console-surfacing PR)

## Followups

Filed as separate tracking issues:

- #282 — `feat(communication)`: persist mailbox + activity to `messages.jsonl` for resume. Today messages and activity counters are in-memory only; `pitboss resume` re-spawns the lead with an empty mailbox.
- #283 — `fix(mcp)`: make worker/lead/sublead `--allowedTools` mode-aware for `[communication]`. Currently the 8 comm tools always appear in every actor's `--allowedTools` argv even when `mode = "disabled"` (cosmetic — `list_tools` filter and `ensure_enabled` runtime check both handle the gate correctly).

Phase C (console activity surfacing in `pitboss-tui` / `pitboss-web`) ships in a separate PR after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)