### PR TITLE
feat(communication): Phase C — surface comm activity in TUI + web consoles

### DIFF
--- a/crates/pitboss-cli/src/control/protocol.rs
+++ b/crates/pitboss-cli/src/control/protocol.rs
@@ -116,6 +116,10 @@ fn is_default_approval_kind(k: &ApprovalKind) -> bool {
     matches!(k, ApprovalKind::Action)
 }
 
+fn is_zero_u64(v: &u64) -> bool {
+    *v == 0
+}
+
 /// An operation sent from the TUI (client) to the dispatcher (server).
 ///
 /// Note: `Eq` is NOT derived — `UpdatePolicy` carries `Vec<ApprovalRule>`,
@@ -231,10 +235,11 @@ pub enum ControlEvent {
     RunFinished {
         summary: RunFinishedSummary,
     },
-    /// Periodic broadcast of per-actor shared-store activity. Emitted
-    /// once per `STORE_ACTIVITY_INTERVAL` (~1 s) while there's an active
-    /// TUI connection. TUI uses this to render `kv:N lease:M` inside
-    /// each grid tile so operators can see store utilization at a glance.
+    /// Periodic broadcast of per-actor shared-store and communication
+    /// activity. Emitted once per `STORE_ACTIVITY_INTERVAL` (~1 s) while
+    /// there's an active TUI connection. TUI/web use this to render
+    /// `kv:N lease:M msg:N art:N` inside each grid tile so operators can
+    /// see coordination activity at a glance.
     StoreActivity {
         counters: Vec<ActorActivityEntry>,
     },
@@ -286,8 +291,14 @@ pub enum ControlEvent {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ActorActivityEntry {
     pub actor_id: String,
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
     pub kv_ops: u64,
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
     pub lease_ops: u64,
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub message_ops: u64,
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub artifact_ops: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -644,17 +655,31 @@ mod tests {
                     actor_id: "worker-A".into(),
                     kv_ops: 42,
                     lease_ops: 3,
+                    message_ops: 5,
+                    artifact_ops: 2,
                 },
                 ActorActivityEntry {
                     actor_id: "lead".into(),
                     kv_ops: 7,
                     lease_ops: 0,
+                    message_ops: 0,
+                    artifact_ops: 0,
                 },
             ],
         };
         let s = serde_json::to_string(&ev).unwrap();
         assert!(s.contains("\"event\":\"store_activity\""));
         assert!(s.contains("\"worker-A\""));
+        assert!(s.contains("\"message_ops\":5"));
+        assert!(s.contains("\"artifact_ops\":2"));
+        assert!(
+            !s.contains("\"message_ops\":0"),
+            "zero communication counters should be omitted"
+        );
+        assert!(
+            !s.contains("\"lease_ops\":0"),
+            "zero kv/lease counters should be omitted"
+        );
         assert_eq!(roundtrip_event(&ev), ev);
     }
 }

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -362,17 +362,39 @@ async fn serve_connection(
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
             interval.tick().await;
-            let snapshot = state_activity.root.shared_store.activity_snapshot().await;
-            let counters: Vec<crate::control::protocol::ActorActivityEntry> = snapshot
-                .into_iter()
-                .map(
-                    |(actor_id, c)| crate::control::protocol::ActorActivityEntry {
+            let store_snapshot = state_activity.root.shared_store.activity_snapshot().await;
+            let communication_snapshot = state_activity.communication.activity_snapshot().await;
+            let mut by_actor = std::collections::BTreeMap::<
+                String,
+                crate::control::protocol::ActorActivityEntry,
+            >::new();
+            for (actor_id, c) in store_snapshot {
+                by_actor.insert(
+                    actor_id.clone(),
+                    crate::control::protocol::ActorActivityEntry {
                         actor_id,
                         kv_ops: c.kv_ops,
                         lease_ops: c.lease_ops,
+                        message_ops: 0,
+                        artifact_ops: 0,
                     },
-                )
-                .collect();
+                );
+            }
+            for (actor_id, c) in communication_snapshot {
+                let entry = by_actor.entry(actor_id.clone()).or_insert_with(|| {
+                    crate::control::protocol::ActorActivityEntry {
+                        actor_id,
+                        kv_ops: 0,
+                        lease_ops: 0,
+                        message_ops: 0,
+                        artifact_ops: 0,
+                    }
+                });
+                entry.message_ops = c.message_ops;
+                entry.artifact_ops = c.artifact_ops;
+            }
+            let counters: Vec<crate::control::protocol::ActorActivityEntry> =
+                by_actor.into_values().collect();
             // `try_send` — if the queue is full, skip this tick rather
             // than block the activity pump; the next tick re-reads
             // fresh counters anyway.
@@ -1307,6 +1329,60 @@ mod tests {
                 assert_eq!(run_kind, "flat");
             }
             other => panic!("expected Hello, got {other:?}"),
+        }
+        drop(handle);
+    }
+
+    #[tokio::test]
+    async fn store_activity_includes_communication_counters() {
+        let dir = TempDir::new().unwrap();
+        let run_id = Uuid::now_v7();
+        let state = mk_state(dir.path(), run_id);
+        state.root.shared_store.note_kv_op("lead").await;
+        state.communication.note_message_op("lead").await;
+        state.communication.note_artifact_op("lead").await;
+
+        let sock = dir.path().join("activity.sock");
+        let handle = start_control_server(
+            sock.clone(),
+            "0.4.0".into(),
+            run_id.to_string(),
+            "hierarchical".into(),
+            state,
+        )
+        .await
+        .unwrap();
+
+        let mut stream = tokio::net::UnixStream::connect(&sock).await.unwrap();
+        stream
+            .write_all(b"{\"op\":\"hello\",\"client_version\":\"0.4.0\"}\n")
+            .await
+            .unwrap();
+
+        let (r, _w) = stream.split();
+        let mut lines = BufReader::new(r).lines();
+        let _hello = lines.next_line().await.unwrap().expect("hello line");
+        let activity_line = tokio::time::timeout(
+            std::time::Duration::from_millis(STORE_ACTIVITY_INTERVAL_MS + 500),
+            lines.next_line(),
+        )
+        .await
+        .expect("activity event arrives before timeout")
+        .unwrap()
+        .unwrap();
+        let ev: ControlEvent = serde_json::from_str(&activity_line).unwrap();
+        match ev {
+            ControlEvent::StoreActivity { counters } => {
+                let lead = counters
+                    .iter()
+                    .find(|entry| entry.actor_id == "lead")
+                    .expect("lead activity entry");
+                assert_eq!(lead.kv_ops, 1);
+                assert_eq!(lead.lease_ops, 0);
+                assert_eq!(lead.message_ops, 1);
+                assert_eq!(lead.artifact_ops, 1);
+            }
+            other => panic!("expected StoreActivity, got {other:?}"),
         }
         drop(handle);
     }

--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -955,6 +955,8 @@ fn apply_control_event(state: &mut AppState, ev: pitboss_cli::control::protocol:
                         crate::state::StoreActivityCounters {
                             kv_ops: e.kv_ops,
                             lease_ops: e.lease_ops,
+                            message_ops: e.message_ops,
+                            artifact_ops: e.artifact_ops,
                         },
                     )
                 })

--- a/crates/pitboss-tui/src/state.rs
+++ b/crates/pitboss-tui/src/state.rs
@@ -272,11 +272,11 @@ pub struct AppState {
     /// from the wrong reactor and async I/O would silently hang. `None`
     /// only in tests where no control socket is in play.
     pub runtime_handle: Option<tokio::runtime::Handle>,
-    /// Per-actor shared-store activity counters received via the control
+    /// Per-actor coordination activity counters received via the control
     /// socket's periodic `StoreActivity` broadcast. Rendered as
-    /// `kv:N lease:M` on each grid tile. Keyed by `actor_id` (matches
-    /// `TileState.id` for the lead + each worker). Empty until the first
-    /// broadcast arrives (~1 s after TUI connects).
+    /// `kv:N lease:M msg:N art:N` on each grid tile. Keyed by `actor_id`
+    /// (matches `TileState.id` for the lead + each worker). Empty until
+    /// the first broadcast arrives (~1 s after TUI connects).
     pub store_activity: std::collections::HashMap<String, StoreActivityCounters>,
     /// Bounding rectangles of each tile, populated by `render_tile_grid`
     /// each frame. Used by the mouse-click handler to hit-test which
@@ -332,6 +332,8 @@ pub struct AppState {
 pub struct StoreActivityCounters {
     pub kv_ops: u64,
     pub lease_ops: u64,
+    pub message_ops: u64,
+    pub artifact_ops: u64,
 }
 
 /// Summary of a worker's worktree diff vs its base branch.

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -155,6 +155,21 @@ pub fn format_tile_subtitle(state: &crate::state::AppState, idx: usize) -> Strin
     }
 }
 
+/// Render the per-tile activity strip. Always shows `kv:N lease:M`; appends
+/// ` msg:N art:N` only when either is non-zero, so `mode = "disabled"` runs
+/// render without comm clutter while `mode = "parent_child"` runs surface
+/// mailbox/artifact activity as soon as it fires.
+fn format_activity_strip(c: &crate::state::StoreActivityCounters) -> String {
+    if c.message_ops > 0 || c.artifact_ops > 0 {
+        format!(
+            "kv:{} lease:{} msg:{} art:{}",
+            c.kv_ops, c.lease_ops, c.message_ops, c.artifact_ops
+        )
+    } else {
+        format!("kv:{} lease:{}", c.kv_ops, c.lease_ops)
+    }
+}
+
 /// Count tiles that were spawned as workers (i.e. have a `parent_task_id`).
 pub fn workers_spawned(state: &crate::state::AppState) -> usize {
     state
@@ -1064,10 +1079,10 @@ fn render_subtree_worker_tile(
     let activity_line = state
         .store_activity
         .get(&tile.id)
-        .filter(|c| c.kv_ops > 0 || c.lease_ops > 0)
+        .filter(|c| c.kv_ops > 0 || c.lease_ops > 0 || c.message_ops > 0 || c.artifact_ops > 0)
         .map(|c| {
             ratatui::text::Line::from(ratatui::text::Span::styled(
-                format!("kv:{} lease:{}", c.kv_ops, c.lease_ops),
+                format_activity_strip(c),
                 theme::muted_style(),
             ))
         });
@@ -1175,19 +1190,16 @@ fn render_tile(frame: &mut Frame, area: Rect, state: &AppState, tile_idx: usize,
         },
     );
 
-    // Shared-store activity line: `kv:N lease:M`. Skip when both are 0
-    // (almost all tiles during the first second + the lead in flat-mode
-    // runs), so quiet tiles don't waste a row on a useless "kv:0 lease:0".
+    // Coordination activity line. Skip when all counters are 0 (almost all
+    // tiles during the first second + the lead in flat-mode runs), so quiet
+    // tiles don't waste a row on a useless all-zero line. The msg/art segment
+    // is only appended when at least one is non-zero, so disabled-mode runs
+    // (msg=0 art=0 forever) render `kv:N lease:M` without comm clutter.
     let activity_line = state
         .store_activity
         .get(&tile.id)
-        .filter(|c| c.kv_ops > 0 || c.lease_ops > 0)
-        .map(|c| {
-            Line::from(Span::styled(
-                format!("kv:{} lease:{}", c.kv_ops, c.lease_ops),
-                theme::muted_style(),
-            ))
-        });
+        .filter(|c| c.kv_ops > 0 || c.lease_ops > 0 || c.message_ops > 0 || c.artifact_ops > 0)
+        .map(|c| Line::from(Span::styled(format_activity_strip(c), theme::muted_style())));
 
     let mut lines = vec![
         Line::from(vec![
@@ -2620,5 +2632,84 @@ mod tests {
         ];
         let s = state(tiles);
         assert_eq!(crate::tui::workers_spawned(&s), 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Activity strip — kv/lease/msg/art rendering on the per-tile activity
+    // line. Suppresses the msg/art segment when both are zero so disabled-mode
+    // runs don't render `msg:0 art:0` clutter.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn format_activity_strip_omits_comm_when_zero() {
+        let c = crate::state::StoreActivityCounters {
+            kv_ops: 4,
+            lease_ops: 1,
+            message_ops: 0,
+            artifact_ops: 0,
+        };
+        assert_eq!(crate::tui::format_activity_strip(&c), "kv:4 lease:1");
+    }
+
+    #[test]
+    fn format_activity_strip_includes_comm_when_nonzero() {
+        let c = crate::state::StoreActivityCounters {
+            kv_ops: 4,
+            lease_ops: 1,
+            message_ops: 3,
+            artifact_ops: 2,
+        };
+        assert_eq!(
+            crate::tui::format_activity_strip(&c),
+            "kv:4 lease:1 msg:3 art:2"
+        );
+    }
+
+    #[test]
+    fn format_activity_strip_includes_comm_when_only_one_nonzero() {
+        let c = crate::state::StoreActivityCounters {
+            kv_ops: 0,
+            lease_ops: 0,
+            message_ops: 0,
+            artifact_ops: 1,
+        };
+        assert_eq!(
+            crate::tui::format_activity_strip(&c),
+            "kv:0 lease:0 msg:0 art:1"
+        );
+    }
+
+    #[test]
+    fn render_tile_shows_comm_counters_in_activity_line() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let task_id = "worker-comm";
+        let mut s = state(vec![tile(task_id, TileStatus::Running, None, 0, 0)]);
+        s.store_activity.insert(
+            task_id.to_string(),
+            crate::state::StoreActivityCounters {
+                kv_ops: 2,
+                lease_ops: 0,
+                message_ops: 5,
+                artifact_ops: 1,
+            },
+        );
+
+        let backend = TestBackend::new(120, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|frame| render(frame, &s)).unwrap();
+
+        let buf = terminal.backend().buffer();
+        let rendered: String = (0..30)
+            .flat_map(|y| (0..120u16).map(move |x| (x, y)))
+            .map(|(x, y)| buf.cell((x, y)).unwrap().symbol().to_string())
+            .collect();
+
+        assert!(
+            rendered.contains("msg:5 art:1"),
+            "tile should render comm counters; got snippet: {:?}",
+            &rendered[..rendered.len().min(400)]
+        );
     }
 }

--- a/crates/pitboss-web/spa/src/lib/api.ts
+++ b/crates/pitboss-web/spa/src/lib/api.ts
@@ -241,6 +241,8 @@ export interface ActorActivity {
   actor_id: string;
   kv_ops: number;
   lease_ops: number;
+  message_ops?: number;
+  artifact_ops?: number;
 }
 
 /** Snapshot of a sublead derived from `SubleadSpawned` (+ Terminated). */

--- a/crates/pitboss-web/spa/src/lib/components/run-graph-node.svelte
+++ b/crates/pitboss-web/spa/src/lib/components/run-graph-node.svelte
@@ -64,8 +64,11 @@
     {/if}
   </div>
   {#if d.activity}
+    {@const msgOps = d.activity.message_ops ?? 0}
+    {@const artOps = d.activity.artifact_ops ?? 0}
     <div class="text-muted-foreground mt-1 text-[9px] tabular-nums">
       kv:{d.activity.kv_ops} lease:{d.activity.lease_ops}
+      {#if msgOps > 0 || artOps > 0}msg:{msgOps} art:{artOps}{/if}
     </div>
   {/if}
   <Handle type="source" position={Position.Bottom} class="!bg-muted-foreground/40" />

--- a/crates/pitboss-web/spa/src/lib/components/run-tile-grid.svelte
+++ b/crates/pitboss-web/spa/src/lib/components/run-tile-grid.svelte
@@ -137,7 +137,12 @@
     <div class="text-muted-foreground flex items-center justify-between gap-2 text-[11px]">
       <div class="flex items-center gap-2 tabular-nums">
         {#if activity}
-          <span title="store ops">kv:{activity.kv_ops} lease:{activity.lease_ops}</span>
+          {@const msgOps = activity.message_ops ?? 0}
+          {@const artOps = activity.artifact_ops ?? 0}
+          <span title="coordination ops">
+            kv:{activity.kv_ops} lease:{activity.lease_ops}
+            {#if msgOps > 0 || artOps > 0}msg:{msgOps} art:{artOps}{/if}
+          </span>
         {/if}
         {#if w.started_at}
           <span>{relativeStarted(w.started_at)}</span>


### PR DESCRIPTION
## Summary

Closes #284. Phase C of the parent-child communication plane (Phase A landed in #281). Extends the periodic `StoreActivity` broadcast with per-actor `message_ops` / `artifact_ops` counters, then surfaces them in `pitboss-tui` and `pitboss-web` alongside the existing `kv:N lease:M` shared-store render. Pure wire-protocol extension + console-side rendering — no new data sources, no new MCP tools, no manifest changes.

## What changed

**Wire protocol** (`control/protocol.rs`)
- `ActorActivityEntry` gains `message_ops` + `artifact_ops`. `skip_serializing_if = "is_zero_u64"` on all four counters keeps quiet actors off the wire and `#[serde(default)]` keeps pre-Phase-C TUI clients forward-compat.
- Doc comment on `ControlEvent::StoreActivity` updated; serde round-trip test extended to assert zero counters are omitted.

**Dispatcher** (`control/server.rs`)
- Activity-pump loop now merges `state.root.shared_store.activity_snapshot()` and `state.communication.activity_snapshot()` via a `BTreeMap<String, ActorActivityEntry>`, so an actor with both KV and comm activity collapses into a single row.
- New `store_activity_includes_communication_counters` integration test drives a hello+tick round-trip end-to-end.

**TUI** (`pitboss-tui/{state,app,tui}.rs`)
- `StoreActivityCounters` mirrors the wire shape; `apply_control_event` carries the new fields through.
- New `format_activity_strip` helper renders `kv:N lease:M`, appending ` msg:N art:N` only when at least one is non-zero — so default `mode = "disabled"` runs render without `msg:0 art:0` clutter while `mode = "parent_child"` runs surface mailbox/artifact activity as soon as it fires. Applied at both render sites (`render_tile` and `render_subtree_worker_tile`).
- 3 formatter unit tests + 1 `TestBackend` render test asserting the strip surfaces in actual tile output.

**SPA** (`spa/src/lib/api.ts`, `run-tile-grid.svelte`, `run-graph-node.svelte`)
- `ActorActivity` extended with optional `message_ops` / `artifact_ops`.
- Same suppress-when-zero behavior in both the tile grid and the graph node.
- SPA bundle rebuilt (`npm run build`) so `rust-embed` picks up the new bundle in the `pitboss-web` binary.

## Out of scope

The source commit at `feat/issue-272-goose-pivot:3c205fc` also includes a `TerminalSession` refactor and an `async { ... }` `block_on` wrapper in `pitboss-tui`. Those are unrelated drive-bys and were **deliberately excluded** from this PR.

## Tests

- [x] `cargo test --workspace --features pitboss-core/test-support` — all green
- [x] `cargo lint` clean
- [x] `cargo tidy` clean
- [x] SPA `npm run check` — 0 errors, 0 warnings
- [x] SPA `npm run build` — clean
- [x] `scripts/smoke-part1.sh` — 11/11 pass
- [ ] After merge: dispatch `examples/communication-parent-child-demo.toml`, open `pitboss-tui`, confirm `msg:N art:N` rises on the worker tile after `message_send` and `artifact_put` fire
- [ ] After merge: same dispatch, navigate to `/runs/<id>` in `pitboss-web`, confirm tile-grid + graph-node both render the new counters
- [ ] After merge: dispatch a default-mode (`disabled`) manifest, confirm tiles render `kv:N lease:M` only — no `msg:0 art:0` clutter

🤖 Generated with [Claude Code](https://claude.com/claude-code)