### PR TITLE
docs(roadmap): drop closed #95 entry, bump refresh date

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,7 +20,7 @@ GitHub issue, not here.
 - **No version targeting.** Use GitHub Milestones for release-train
   scheduling. Strategic horizons can stay inline as `parked:` notes.
 
-Last refreshed: v0.9.2 (2026-04-30).
+Last refreshed: v0.9.2 (2026-05-05).
 
 ---
 
@@ -163,10 +163,6 @@ upstream.
   Depth=2 cap is enforced at both the MCP handler and the sub-lead's
   `--allowedTools` list. **Status:** parked: no concrete need that
   can't be served by a wider flat fan-out. **Tracking:** none yet.
-
-- **Full TUI approval-replay on run-switch (#95).** Drain of stale
-  events on `SwitchRun` shipped (#104); replay of pending approvals
-  on re-connect remains. **Status:** scoped. **Tracking:** #95.
 
 ---
 


### PR DESCRIPTION
## Summary

Issue #95 (TUI pending-approvals not shown when navigating to a run from the run-selection list) is closed, but its `Deferred` entry was still in `ROADMAP.md`. The file's own rules state:

> **Closed items live in `CHANGELOG.md`, not here.** When a roadmap item ships, delete it from this file. Don't strikethrough, don't leave a "Closed —" marker. Git history and the changelog carry that load.

This drops the entry and bumps the `Last refreshed` line to today's date.

## Out of scope

Two adjacent observations not addressed here:

1. **Path B `permission_routing` stabilization** entry (lines 149-154) references closed PRs #92/#93/#94, but its premise still holds — the validate gate at `crates/pitboss-cli/src/manifest/validate.rs:157` is still in place. Not stale.
2. **Communication-plane siblings** (#282, #283) are labeled `roadmap` but have no inline abstracts in `ROADMAP.md`. The file's contract says roadmap-labeled issues should have 3-line abstracts pointing at the tracking issue. Filing as a follow-up rather than expanding scope here.

## Test plan

- [x] `git diff` review — only the closed `#95` block + the date line changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)