### PR TITLE
chore(tests-support): add comm-activity-live-check verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,6 +368,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "comm-activity-live-check"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "fake-control-client",
+ "pitboss-cli",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "tests-support/fake-claude",
     "tests-support/fake-mcp-client",
     "tests-support/fake-control-client",
+    "tests-support/comm-activity-live-check",
 ]
 
 [workspace.package]

--- a/tests-support/comm-activity-live-check/Cargo.toml
+++ b/tests-support/comm-activity-live-check/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name         = "comm-activity-live-check"
+version      = "0.0.0"
+edition      = "2021"
+rust-version = "1.82"
+publish      = false
+
+[[bin]]
+name = "comm-activity-live-check"
+path = "src/main.rs"
+
+[dependencies]
+tokio                = { workspace = true, features = ["rt-multi-thread","io-util","sync","time","macros","net","process"] }
+anyhow               = { workspace = true }
+serde_json           = { workspace = true }
+fake-control-client  = { path = "../fake-control-client" }
+pitboss-cli          = { path = "../../crates/pitboss-cli" }

--- a/tests-support/comm-activity-live-check/src/main.rs
+++ b/tests-support/comm-activity-live-check/src/main.rs
@@ -1,0 +1,227 @@
+//! Live verifier for the Phase C `StoreActivity` extension.
+//!
+//! Spawns `pitboss dispatch <manifest>` as a child, watches the
+//! `$XDG_RUNTIME_DIR/pitboss/` socket directory for the run's new
+//! `<run-id>.control.sock`, attaches a `FakeControlClient` to it, and
+//! streams `StoreActivity` events while the dispatch runs. After the
+//! child exits, asserts that at least one event surfaced
+//! `message_ops > 0` AND `artifact_ops > 0` for some actor — i.e. that
+//! the wire-protocol extension landed end-to-end on a real claude run,
+//! not just in unit tests.
+//!
+//! Usage:
+//!
+//! ```bash
+//! cargo build -p comm-activity-live-check
+//! ./target/debug/comm-activity-live-check examples/communication-parent-child-demo.toml
+//! ```
+//!
+//! Exit code 0 = pass. Anything else = failure with diagnostic on stderr.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::{Duration, Instant};
+
+use anyhow::{bail, Context, Result};
+use pitboss_cli::control::protocol::ControlEvent;
+use tokio::process::Command;
+
+use fake_control_client::FakeControlClient;
+
+const POLL_INTERVAL: Duration = Duration::from_millis(200);
+const SOCKET_WAIT: Duration = Duration::from_secs(15);
+const MAX_RUN_DURATION: Duration = Duration::from_secs(180);
+const POST_EXIT_DRAIN: Duration = Duration::from_secs(2);
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 2)]
+async fn main() -> Result<()> {
+    let manifest = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "examples/communication-parent-child-demo.toml".into());
+    let pitboss_bin =
+        std::env::var("PITBOSS_BIN").unwrap_or_else(|_| "./target/debug/pitboss".into());
+
+    eprintln!("== comm-activity-live-check ==");
+    eprintln!("manifest: {manifest}");
+    eprintln!("binary:   {pitboss_bin}");
+
+    let socket_dir = pick_socket_dir().context("locate socket directory")?;
+    eprintln!("sockets:  {}", socket_dir.display());
+    let before = list_sockets(&socket_dir);
+
+    eprintln!("\n-- spawning dispatch --");
+    let mut child = Command::new(&pitboss_bin)
+        .arg("dispatch")
+        .arg(&manifest)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .with_context(|| format!("spawn `{pitboss_bin} dispatch {manifest}`"))?;
+
+    let new_socket = wait_new_socket(&socket_dir, &before, SOCKET_WAIT)
+        .await
+        .context("waiting for run's control.sock")?;
+    eprintln!("socket:   {}", new_socket.display());
+
+    let mut client = FakeControlClient::connect(&new_socket, env!("CARGO_PKG_VERSION"))
+        .await
+        .context("connect to control socket")?;
+    eprintln!("connected.\n");
+
+    let mut max_kv = 0u64;
+    let mut max_lease = 0u64;
+    let mut max_msg = 0u64;
+    let mut max_art = 0u64;
+    let mut events_seen = 0u64;
+
+    let deadline = Instant::now() + MAX_RUN_DURATION;
+    eprintln!("-- streaming control events --");
+    'stream: while Instant::now() < deadline {
+        if let Some(status) = child.try_wait()? {
+            eprintln!("dispatch exited: {status}; draining for {POST_EXIT_DRAIN:?}.");
+            let drain_until = Instant::now() + POST_EXIT_DRAIN;
+            while Instant::now() < drain_until {
+                match client.recv_timeout(Duration::from_millis(200)).await {
+                    Ok(Some(ev)) => record(
+                        ev,
+                        &mut events_seen,
+                        &mut max_kv,
+                        &mut max_lease,
+                        &mut max_msg,
+                        &mut max_art,
+                    ),
+                    Ok(None) => {}
+                    // Dispatcher closes the socket on clean shutdown — expected here.
+                    Err(_) => break,
+                }
+            }
+            break 'stream;
+        }
+
+        match client.recv_timeout(Duration::from_secs(1)).await {
+            Ok(Some(ev)) => record(
+                ev,
+                &mut events_seen,
+                &mut max_kv,
+                &mut max_lease,
+                &mut max_msg,
+                &mut max_art,
+            ),
+            Ok(None) => {}
+            Err(e) => {
+                // Socket closed while dispatch is still running — surface as a
+                // failure unless the child is on its way out.
+                eprintln!("control socket closed: {e}");
+                break 'stream;
+            }
+        }
+    }
+
+    let _ = child.wait().await;
+
+    println!();
+    println!("== results ==");
+    println!("StoreActivity events observed: {events_seen}");
+    println!("max kv_ops:        {max_kv}");
+    println!("max lease_ops:     {max_lease}");
+    println!("max message_ops:   {max_msg}");
+    println!("max artifact_ops:  {max_art}");
+    println!();
+
+    if max_msg > 0 && max_art > 0 {
+        println!("PASS: Phase C surfaced message_ops AND artifact_ops on the wire.");
+        Ok(())
+    } else {
+        bail!(
+            "FAIL: missing nonzero {} (saw kv_ops={max_kv} msg_ops={max_msg} art_ops={max_art} across {events_seen} StoreActivity events)",
+            if max_msg == 0 && max_art == 0 {
+                "message_ops/artifact_ops"
+            } else if max_msg == 0 {
+                "message_ops"
+            } else {
+                "artifact_ops"
+            }
+        )
+    }
+}
+
+fn record(
+    ev: ControlEvent,
+    events: &mut u64,
+    max_kv: &mut u64,
+    max_lease: &mut u64,
+    max_msg: &mut u64,
+    max_art: &mut u64,
+) {
+    if let ControlEvent::StoreActivity { counters } = ev {
+        *events += 1;
+        for c in &counters {
+            *max_kv = (*max_kv).max(c.kv_ops);
+            *max_lease = (*max_lease).max(c.lease_ops);
+            *max_msg = (*max_msg).max(c.message_ops);
+            *max_art = (*max_art).max(c.artifact_ops);
+        }
+        eprintln!(
+            "[#{events}] actors={} max-so-far kv={max_kv} lease={max_lease} msg={max_msg} art={max_art}",
+            counters.len()
+        );
+    }
+}
+
+fn pick_socket_dir() -> Result<PathBuf> {
+    if let Some(xdg) = std::env::var_os("XDG_RUNTIME_DIR") {
+        let p = PathBuf::from(xdg).join("pitboss");
+        std::fs::create_dir_all(&p).ok();
+        if p.exists() {
+            return Ok(p);
+        }
+    }
+    bail!("XDG_RUNTIME_DIR not set / unwritable; this checker only supports XDG-mode runs")
+}
+
+fn list_sockets(dir: &Path) -> HashSet<PathBuf> {
+    let mut out = HashSet::new();
+    let Ok(read) = std::fs::read_dir(dir) else {
+        return out;
+    };
+    for e in read.flatten() {
+        let p = e.path();
+        if p.extension().is_none_or(|s| s != "sock") {
+            // catch *.control.sock — extension is "sock" only when filename ends with .sock
+            if p.file_name()
+                .and_then(|s| s.to_str())
+                .is_some_and(|s| s.ends_with(".control.sock"))
+            {
+                out.insert(p);
+            }
+            continue;
+        }
+        out.insert(p);
+    }
+    out
+}
+
+async fn wait_new_socket(
+    dir: &Path,
+    before: &HashSet<PathBuf>,
+    timeout: Duration,
+) -> Result<PathBuf> {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        for p in list_sockets(dir) {
+            if !before.contains(&p) {
+                // Wait for the socket to be bind-accepting before returning.
+                if tokio::net::UnixStream::connect(&p).await.is_ok() {
+                    return Ok(p);
+                }
+            }
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+    bail!(
+        "no new control.sock appeared in {} within {:?}",
+        dir.display(),
+        timeout
+    )
+}


### PR DESCRIPTION
## Summary

Adds a tests-support utility that programmatically verifies the Phase C `StoreActivity` extension end-to-end on a **real claude run** — closing the gap between the unit-test ladder shipped with #285 and the "did this actually work in production" question, without requiring a human-in-the-loop TUI attach.

## What it does

Spawns `pitboss dispatch <manifest>` as a child, watches `\$XDG_RUNTIME_DIR/pitboss/` for the run's new `<run-id>.control.sock`, attaches a \`FakeControlClient\` to it, and streams \`StoreActivity\` events while the dispatch runs. After the child exits, asserts that at least one event surfaced \`message_ops > 0\` AND \`artifact_ops > 0\` — i.e. that the wire-protocol extension landed correctly through the dispatcher's activity-pump loop on real comm-tool calls.

Defaults to \`examples/communication-parent-child-demo.toml\` (which already exists on \`main\` as part of #281). Override the manifest via the first positional argument and the dispatcher binary via \`PITBOSS_BIN\`.

\`\`\`bash
cargo build -p comm-activity-live-check
./target/debug/comm-activity-live-check
\`\`\`

## Why a separate binary, not a \`#[test]\`

This needs a real \`claude\` binary on \`PATH\` and spends real API credits. Putting it in \`crates/pitboss-cli/tests/\` would either run on every \`cargo test\` (expensive, flaky on no-network) or live behind a feature flag (gated tests are the worst of both worlds). Modeling it as a peer to \`fake-claude\` / \`fake-control-client\` in \`tests-support/\` keeps it out of the default test surface while making it trivial to re-run.

## Verification (this PR)

Ran the verifier locally against the parent-child demo on \`main\` post-#285:

\`\`\`
== results ==
StoreActivity events observed: 31
max kv_ops:        0
max lease_ops:     0
max message_ops:   3
max artifact_ops:  1

PASS: Phase C surfaced message_ops AND artifact_ops on the wire.
\`\`\`

\`kv_ops\` / \`lease_ops\` are zero because the demo doesn't exercise the shared store — it only drives the comm plane. That's the correct null result.

## Tests

- [x] \`cargo build -p comm-activity-live-check\`
- [x] \`cargo lint\` clean
- [x] \`cargo tidy\` clean
- [x] Verifier reports \`PASS\` on the parent-child demo (~\$0.06 per run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)