### PR TITLE
fix(mcp): make worker/lead/sublead --allowedTools mode-aware for [communication]

### DIFF
--- a/crates/pitboss-cli/src/dispatch/depth.rs
+++ b/crates/pitboss-cli/src/dispatch/depth.rs
@@ -7,8 +7,9 @@
 //!
 //! 1. **CLI allowlist** — sub-lead claude subprocesses are launched with
 //!    `--allowedTools` deliberately excluding [`ROOT_ONLY_TOOLS`]
-//!    ([`crate::dispatch::runner::SUBLEAD_MCP_TOOLS`] is the static
-//!    allowlist).
+//!    ([`crate::dispatch::runner::SUBLEAD_MCP_TOOLS_BASE`] is the static
+//!    allowlist; [`crate::dispatch::runner::sublead_mcp_tools`] composes
+//!    it with the optional `[communication]` tool surface).
 //! 2. **MCP `list_tools` filter** — root-only tools are hidden from the
 //!    advertised toolset unless the manifest declares `allow_subleads = true`
 //!    AND the connected actor is the root lead.
@@ -23,7 +24,8 @@
 //! `mcp__pitboss__` prefix) to [`ROOT_ONLY_TOOLS`]. The `list_tools` filter
 //! and [`assert_sublead_toolset_excludes_root_only`] (regression-tested) will
 //! pick it up automatically. You also need to remove it from
-//! [`crate::dispatch::runner::SUBLEAD_MCP_TOOLS`] if it was ever added there.
+//! [`crate::dispatch::runner::SUBLEAD_MCP_TOOLS_BASE`] if it was ever added
+//! there.
 
 use thiserror::Error;
 
@@ -118,7 +120,10 @@ pub fn assert_sublead_toolset_excludes_root_only(sublead_allowlist: &[&str]) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::dispatch::runner::{PITBOSS_MCP_TOOLS, SUBLEAD_MCP_TOOLS};
+    use crate::dispatch::runner::{
+        pitboss_mcp_tools, sublead_mcp_tools, PITBOSS_MCP_TOOLS_BASE, SUBLEAD_MCP_TOOLS_BASE,
+    };
+    use crate::manifest::schema::CommunicationMode;
 
     #[test]
     fn is_root_only_tool_recognises_known_entries() {
@@ -127,38 +132,56 @@ mod tests {
         assert!(!is_root_only_tool("kv_get"));
     }
 
-    /// Regression: the static `SUBLEAD_MCP_TOOLS` allowlist (used to
-    /// construct sub-lead claude subprocess `--allowedTools`) must never
-    /// contain any tool that `ROOT_ONLY_TOOLS` declares as root-only. If
-    /// this fails, a sub-lead would be able to invoke a depth-2-violating
-    /// tool from the CLI side even though the MCP server's `list_tools`
-    /// filter would still hide it (defense-in-depth would degrade to
-    /// single-line-of-defense).
+    /// Regression: the sub-lead allowlist (used to construct sub-lead
+    /// claude subprocess `--allowedTools`) must never contain any tool that
+    /// `ROOT_ONLY_TOOLS` declares as root-only — for ANY communication
+    /// mode. If this fails, a sub-lead would be able to invoke a depth-2-
+    /// violating tool from the CLI side even though the MCP server's
+    /// `list_tools` filter would still hide it (defense-in-depth would
+    /// degrade to single-line-of-defense).
     #[test]
     fn sublead_allowlist_excludes_all_root_only_tools() {
-        let leaks = assert_sublead_toolset_excludes_root_only(SUBLEAD_MCP_TOOLS);
+        let leaks_base = assert_sublead_toolset_excludes_root_only(SUBLEAD_MCP_TOOLS_BASE);
         assert!(
-            leaks.is_empty(),
-            "SUBLEAD_MCP_TOOLS leaks root-only tools: {leaks:?}. \
-             Either remove them from SUBLEAD_MCP_TOOLS or remove them from \
+            leaks_base.is_empty(),
+            "SUBLEAD_MCP_TOOLS_BASE leaks root-only tools: {leaks_base:?}. \
+             Either remove them from SUBLEAD_MCP_TOOLS_BASE or remove them from \
              ROOT_ONLY_TOOLS — they are mutually exclusive by design."
         );
+        // Same invariant must hold once the comm tools are appended.
+        for mode in [CommunicationMode::Disabled, CommunicationMode::ParentChild] {
+            let composed = sublead_mcp_tools(mode);
+            let leaks = assert_sublead_toolset_excludes_root_only(&composed);
+            assert!(
+                leaks.is_empty(),
+                "sublead_mcp_tools({mode:?}) leaks root-only tools: {leaks:?}"
+            );
+        }
     }
 
-    /// Regression: the root-lead base allowlist (`PITBOSS_MCP_TOOLS`) must
-    /// also exclude root-only tools by default. Spawn paths that need to
-    /// permit them (only the root lead, only when `allow_subleads = true`)
-    /// add them explicitly via `runner::root_lead_allowed_tools` — see
-    /// `runner.rs` argv builders. This keeps the static const honest.
+    /// Regression: the root-lead base allowlist must also exclude
+    /// root-only tools by default. Spawn paths that need to permit them
+    /// (only the root lead, only when `allow_subleads = true`) add them
+    /// explicitly in `runner.rs` argv builders. This keeps the static
+    /// const honest.
     #[test]
     fn pitboss_base_allowlist_excludes_root_only_tools() {
-        let leaks = assert_sublead_toolset_excludes_root_only(PITBOSS_MCP_TOOLS);
+        let leaks = assert_sublead_toolset_excludes_root_only(PITBOSS_MCP_TOOLS_BASE);
         assert!(
             leaks.is_empty(),
-            "PITBOSS_MCP_TOOLS unexpectedly contains root-only tools: {leaks:?}. \
+            "PITBOSS_MCP_TOOLS_BASE unexpectedly contains root-only tools: {leaks:?}. \
              Root-only tools must be added conditionally at the spawn site, not \
              baked into the static base."
         );
+        // Same invariant for the composed lead set across both modes.
+        for mode in [CommunicationMode::Disabled, CommunicationMode::ParentChild] {
+            let composed = pitboss_mcp_tools(mode);
+            let leaks = assert_sublead_toolset_excludes_root_only(&composed);
+            assert!(
+                leaks.is_empty(),
+                "pitboss_mcp_tools({mode:?}) leaks root-only tools: {leaks:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -102,10 +102,20 @@ pub async fn run_hierarchical(
         .clone();
 
     if dry_run {
+        // Use a placeholder mcp-config path — the real path is run-id
+        // dependent and dry-run doesn't allocate a run dir. The argv
+        // structure (allowedTools composition included) is faithful.
+        let placeholder_cfg = PathBuf::from("<run-subdir>/mcp-config.json");
+        let args = crate::dispatch::runner::lead_spawn_args(
+            &lead,
+            &placeholder_cfg,
+            resolved.communication.mode,
+        );
         println!("DRY-RUN lead: {}", lead.id);
         println!(
-            "DRY-RUN command: {} --verbose (mcp socket TBD)",
-            claude_binary.display()
+            "DRY-RUN command: {} {}",
+            claude_binary.display(),
+            args.join(" ")
         );
         return Ok(0);
     }
@@ -306,9 +316,10 @@ pub async fn run_hierarchical(
     //     vs. `sublead_spawn_args`).
     let mut lead_env = lead.env.clone();
     crate::dispatch::runner::apply_pitboss_env_defaults(&mut lead_env, lead.permission_routing);
+    let communication_mode = resolved.communication.mode;
     let initial_cmd = pitboss_core::process::SpawnCmd {
         program: claude_binary.clone(),
-        args: crate::dispatch::runner::lead_spawn_args(&lead, &mcp_config_path),
+        args: crate::dispatch::runner::lead_spawn_args(&lead, &mcp_config_path, communication_mode),
         cwd: lead_cwd.clone(),
         env: lead_env,
     };
@@ -336,6 +347,7 @@ pub async fn run_hierarchical(
                     &mcp_config_path,
                     sid,
                     new_prompt,
+                    communication_mode,
                 ),
                 cwd: lead_cwd.clone(),
                 env: resume_env,
@@ -985,8 +997,9 @@ pub async fn write_worker_mcp_config(
     Ok(())
 }
 
-/// Emit a sublead-scoped `--mcp-config` file. Lists only the SUBLEAD_MCP_TOOLS
-/// (no spawn_sublead, no wait_for_sublead — depth-2 cap enforced).
+/// Emit a sublead-scoped `--mcp-config` file. Lists only the sub-lead
+/// tool surface (no `spawn_sublead`, no `wait_for_sublead` — depth-2 cap
+/// enforced) plus the optional `[communication]` tools when `mode != "disabled"`.
 /// The bridge command includes the sublead's actor_id + actor_role=sublead
 /// so the dispatcher can identify the caller and enforce namespace authz.
 ///
@@ -998,8 +1011,9 @@ pub async fn build_sublead_mcp_config(
     run_subdir: &std::path::Path,
     token: Option<&str>,
     extra_servers: &[crate::manifest::schema::McpServerSpec],
+    communication_mode: crate::manifest::schema::CommunicationMode,
 ) -> Result<PathBuf> {
-    use crate::dispatch::runner::SUBLEAD_MCP_TOOLS;
+    use crate::dispatch::runner::sublead_mcp_tools;
 
     let pitboss_exe =
         std::env::current_exe().context("resolve current exe for mcp-bridge subcommand")?;
@@ -1013,7 +1027,7 @@ pub async fn build_sublead_mcp_config(
     );
     let cfg = serde_json::json!({
         "mcpServers": mcp_servers,
-        "allowedTools": SUBLEAD_MCP_TOOLS.iter().collect::<Vec<_>>()
+        "allowedTools": sublead_mcp_tools(communication_mode)
     });
     let bytes = serde_json::to_vec_pretty(&cfg)?;
 

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -777,12 +777,15 @@ fn spawn_args(task: &ResolvedTask) -> Vec<String> {
     args
 }
 
-/// MCP tool names the lead needs permission to call. Pre-approved via the
-/// lead's `--allowedTools` flag so claude never stalls at the interactive
-/// permission prompt (which can't be answered in `-p` non-interactive mode).
-/// Format: `mcp__<server-name>__<tool>`, where `pitboss` is the server name
-/// we emit in `write_mcp_config`.
-pub const PITBOSS_MCP_TOOLS: &[&str] = &[
+/// MCP tool names the lead needs permission to call when communication is
+/// disabled. Pre-approved via the lead's `--allowedTools` flag so claude
+/// never stalls at the interactive permission prompt (which can't be
+/// answered in `-p` non-interactive mode). Format: `mcp__<server>__<tool>`,
+/// where `pitboss` is the server name emitted by `write_mcp_config`.
+///
+/// Use [`pitboss_mcp_tools`] at spawn sites so the comm tools are appended
+/// only when `[communication].mode != "disabled"`.
+pub const PITBOSS_MCP_TOOLS_BASE: &[&str] = &[
     // Worker orchestration tools (v0.3+).
     "mcp__pitboss__spawn_worker",
     "mcp__pitboss__worker_status",
@@ -807,12 +810,19 @@ pub const PITBOSS_MCP_TOOLS: &[&str] = &[
     "mcp__pitboss__kv_wait",
     "mcp__pitboss__lease_acquire",
     "mcp__pitboss__lease_release",
-    // Mailbox/artifact communication tools (v0.10+). Payloads move
-    // through the Pitboss-owned message/artifact stores rather than KV.
-    // Server-side `list_tools` filter hides these when
-    // `[communication].mode = "disabled"` (the default), and every
-    // handler returns `CommunicationError::Disabled` as a back-stop —
-    // listing them here is cosmetic for that mode.
+    // Run-global leases (v0.6+). For cross-sub-tree resource coordination
+    // (e.g., serializing access to an operator-facing filesystem dir).
+    "mcp__pitboss__run_lease_acquire",
+    "mcp__pitboss__run_lease_release",
+];
+
+/// Mailbox + artifact MCP tools (v0.10+). Listed separately from the
+/// per-actor base allowlists so they can be conditionally appended only
+/// when `[communication].mode != "disabled"`. Server-side `list_tools`
+/// filter and per-handler `ensure_enabled` check provide the runtime
+/// gate; composing these into the spawn argv keeps `pitboss dispatch
+/// --dry-run` honest.
+pub const COMMUNICATION_MCP_TOOLS: &[&str] = &[
     "mcp__pitboss__message_send",
     "mcp__pitboss__message_list",
     "mcp__pitboss__message_read",
@@ -821,10 +831,6 @@ pub const PITBOSS_MCP_TOOLS: &[&str] = &[
     "mcp__pitboss__artifact_list",
     "mcp__pitboss__artifact_read",
     "mcp__pitboss__artifact_grant",
-    // Run-global leases (v0.6+). For cross-sub-tree resource coordination
-    // (e.g., serializing access to an operator-facing filesystem dir).
-    "mcp__pitboss__run_lease_acquire",
-    "mcp__pitboss__run_lease_release",
 ];
 
 /// Sub-lead tools: all root-lead tools EXCEPT root-only entries listed in
@@ -836,12 +842,15 @@ pub const PITBOSS_MCP_TOOLS: &[&str] = &[
 /// both routed through `dispatch::depth`. This CLI allowlist provides
 /// defense-in-depth at the subprocess `--allowedTools` flag level.
 ///
+/// Use [`sublead_mcp_tools`] at spawn sites so [`COMMUNICATION_MCP_TOOLS`]
+/// are appended only when `[communication].mode != "disabled"`.
+///
 /// **If you add a new root-only tool**, append its bare name to
 /// [`crate::dispatch::depth::ROOT_ONLY_TOOLS`] and ensure it is NOT in this
 /// list. The regression test
 /// `dispatch::depth::tests::sublead_allowlist_excludes_all_root_only_tools`
 /// keeps the two in sync.
-pub const SUBLEAD_MCP_TOOLS: &[&str] = &[
+pub const SUBLEAD_MCP_TOOLS_BASE: &[&str] = &[
     // Worker orchestration tools (v0.3+).
     "mcp__pitboss__spawn_worker",
     "mcp__pitboss__worker_status",
@@ -863,22 +872,36 @@ pub const SUBLEAD_MCP_TOOLS: &[&str] = &[
     "mcp__pitboss__kv_wait",
     "mcp__pitboss__lease_acquire",
     "mcp__pitboss__lease_release",
-    // Mailbox/artifact communication tools (v0.10+). Same opt-in
-    // semantics as PITBOSS_MCP_TOOLS — gated server-side by
-    // `[communication].mode`.
-    "mcp__pitboss__message_send",
-    "mcp__pitboss__message_list",
-    "mcp__pitboss__message_read",
-    "mcp__pitboss__message_ack",
-    "mcp__pitboss__artifact_put",
-    "mcp__pitboss__artifact_list",
-    "mcp__pitboss__artifact_read",
-    "mcp__pitboss__artifact_grant",
     // Run-global leases (v0.6+) for cross-sub-tree resource coordination.
     "mcp__pitboss__run_lease_acquire",
     "mcp__pitboss__run_lease_release",
     // NOTE: spawn_sublead is intentionally NOT included (depth-2 cap).
 ];
+
+/// Compose the lead's `--allowedTools` set: the base orchestration +
+/// shared-store tools, with [`COMMUNICATION_MCP_TOOLS`] appended when
+/// `mode` enables the comm surface. Mirrors the const + helper split
+/// used by `dispatch::depth::is_root_only_tool`.
+pub fn pitboss_mcp_tools(mode: crate::manifest::schema::CommunicationMode) -> Vec<&'static str> {
+    use crate::manifest::schema::CommunicationMode;
+    let mut out: Vec<&'static str> = PITBOSS_MCP_TOOLS_BASE.to_vec();
+    if mode != CommunicationMode::Disabled {
+        out.extend(COMMUNICATION_MCP_TOOLS.iter().copied());
+    }
+    out
+}
+
+/// Compose a sub-lead's `--allowedTools` set. Same shape as
+/// [`pitboss_mcp_tools`] but uses [`SUBLEAD_MCP_TOOLS_BASE`] (no
+/// `spawn_sublead`).
+pub fn sublead_mcp_tools(mode: crate::manifest::schema::CommunicationMode) -> Vec<&'static str> {
+    use crate::manifest::schema::CommunicationMode;
+    let mut out: Vec<&'static str> = SUBLEAD_MCP_TOOLS_BASE.to_vec();
+    if mode != CommunicationMode::Disabled {
+        out.extend(COMMUNICATION_MCP_TOOLS.iter().copied());
+    }
+    out
+}
 
 /// Builds the argv for spawning the lead subprocess, including the
 /// `--mcp-config` pointer to the generated MCP server config file.
@@ -906,6 +929,7 @@ pub const SUBLEAD_MCP_TOOLS: &[&str] = &[
 pub fn lead_spawn_args(
     lead: &crate::manifest::resolve::ResolvedLead,
     mcp_config: &std::path::Path,
+    communication_mode: crate::manifest::schema::CommunicationMode,
 ) -> Vec<String> {
     use crate::manifest::schema::PermissionRouting;
     let mut args = vec![
@@ -925,8 +949,8 @@ pub fn lead_spawn_args(
 
     // Build the allowed-tools set: user tools + pitboss MCP tools.
     let mut allowed: Vec<String> = lead.tools.clone();
-    for t in PITBOSS_MCP_TOOLS {
-        allowed.push((*t).to_string());
+    for t in pitboss_mcp_tools(communication_mode) {
+        allowed.push(t.to_string());
     }
     // v0.6: when allow_subleads=true, add the depth-2 tools to the allowlist
     // so claude's --allowedTools gate doesn't block them. The MCP server's
@@ -966,6 +990,7 @@ pub fn lead_resume_spawn_args(
     mcp_config: &std::path::Path,
     session_id: &str,
     new_prompt: &str,
+    communication_mode: crate::manifest::schema::CommunicationMode,
 ) -> Vec<String> {
     use crate::manifest::schema::PermissionRouting;
     let mut args = vec![
@@ -980,8 +1005,8 @@ pub fn lead_resume_spawn_args(
     args.push("--strict-mcp-config".into());
     args.push("--disable-slash-commands".into());
     let mut allowed: Vec<String> = lead.tools.clone();
-    for t in PITBOSS_MCP_TOOLS {
-        allowed.push((*t).to_string());
+    for t in pitboss_mcp_tools(communication_mode) {
+        allowed.push(t.to_string());
     }
     if lead.allow_subleads {
         allowed.push("mcp__pitboss__spawn_sublead".into());
@@ -1026,6 +1051,7 @@ pub fn lead_resume_spawn_args(
 ///   De-duplicated to keep the resulting `--allowedTools` flag tidy.
 /// - `permission_routing`: controls whether `--dangerously-skip-permissions`
 ///   is included and whether `permission_prompt` is pre-allowed.
+#[allow(clippy::too_many_arguments)]
 pub fn sublead_spawn_args(
     _sublead_id: &str,
     prompt: &str,
@@ -1034,6 +1060,7 @@ pub fn sublead_spawn_args(
     resume_session_id: Option<&str>,
     tools_override: Option<&[String]>,
     permission_routing: crate::manifest::schema::PermissionRouting,
+    communication_mode: crate::manifest::schema::CommunicationMode,
 ) -> Vec<String> {
     use crate::manifest::schema::PermissionRouting;
     let mut args = vec![
@@ -1055,8 +1082,8 @@ pub fn sublead_spawn_args(
         Some(ts) => ts.to_vec(),
         None => Vec::new(),
     };
-    for t in SUBLEAD_MCP_TOOLS {
-        allowed.push((*t).to_string());
+    for t in sublead_mcp_tools(communication_mode) {
+        allowed.push(t.to_string());
     }
     if permission_routing == PermissionRouting::PathB {
         allowed.push("mcp__pitboss__permission_prompt".into());
@@ -1769,16 +1796,17 @@ mod tests {
             sublead_defaults: None,
         };
         let cfg = PathBuf::from("/tmp/cfg.json");
+        let cm = crate::manifest::schema::CommunicationMode::Disabled;
         let cases: Vec<(&str, Vec<String>)> = vec![
             ("flat task", spawn_args(&task)),
-            ("lead", lead_spawn_args(&lead, &cfg)),
+            ("lead", lead_spawn_args(&lead, &cfg, cm)),
             (
                 "lead_resume",
-                lead_resume_spawn_args(&lead, &cfg, "sess", "new prompt"),
+                lead_resume_spawn_args(&lead, &cfg, "sess", "new prompt", cm),
             ),
             (
                 "sublead",
-                sublead_spawn_args("sl-id", "p", "m", &cfg, None, None, Default::default()),
+                sublead_spawn_args("sl-id", "p", "m", &cfg, None, None, Default::default(), cm),
             ),
             (
                 "sublead_resume",
@@ -1790,6 +1818,7 @@ mod tests {
                     Some("sess"),
                     None,
                     Default::default(),
+                    cm,
                 ),
             ),
         ];
@@ -1832,7 +1861,11 @@ mod tests {
             max_total_workers: None,
             sublead_defaults: None,
         };
-        let args = lead_spawn_args(&lead, &PathBuf::from("/tmp/cfg.json"));
+        let args = lead_spawn_args(
+            &lead,
+            &PathBuf::from("/tmp/cfg.json"),
+            crate::manifest::schema::CommunicationMode::Disabled,
+        );
         assert!(args.iter().any(|a| a == "--verbose"));
         assert!(args.iter().any(|a| a == "--mcp-config"));
         assert!(args.iter().any(|a| a == "/tmp/cfg.json"));
@@ -1863,16 +1896,66 @@ mod tests {
             max_total_workers: None,
             sublead_defaults: None,
         };
-        let args = lead_spawn_args(&lead, &PathBuf::from("/tmp/cfg.json"));
+        let args = lead_spawn_args(
+            &lead,
+            &PathBuf::from("/tmp/cfg.json"),
+            crate::manifest::schema::CommunicationMode::Disabled,
+        );
         let idx = args.iter().position(|a| a == "--allowedTools").unwrap();
         let list = &args[idx + 1];
         // User-declared tool preserved
         assert!(list.contains("Read"), "expected user tool, got {list}");
-        // All six pitboss MCP tools present under the `mcp__pitboss__` prefix.
-        for t in PITBOSS_MCP_TOOLS {
+        // All base pitboss MCP tools present under the `mcp__pitboss__` prefix.
+        for t in PITBOSS_MCP_TOOLS_BASE {
             assert!(
                 list.contains(t),
                 "expected {t} in allowedTools, got: {list}"
+            );
+        }
+        // Communication tools must NOT be present when mode=disabled.
+        for t in COMMUNICATION_MCP_TOOLS {
+            assert!(
+                !list.contains(t),
+                "communication tool {t} must NOT be in allowedTools when mode=disabled, \
+                 got: {list}"
+            );
+        }
+    }
+
+    #[test]
+    fn lead_spawn_args_includes_comm_tools_when_mode_parent_child() {
+        use crate::manifest::resolve::ResolvedLead;
+        use std::path::PathBuf;
+        let lead = ResolvedLead {
+            id: "l".into(),
+            directory: PathBuf::from("/tmp"),
+            prompt: "p".into(),
+            branch: None,
+            model: "m".into(),
+            effort: crate::manifest::schema::Effort::High,
+            tools: vec!["Read".into()],
+            timeout_secs: 60,
+            use_worktree: false,
+            env: Default::default(),
+            resume_session_id: None,
+            permission_routing: Default::default(),
+            allow_subleads: false,
+            max_subleads: None,
+            max_sublead_budget_usd: None,
+            max_total_workers: None,
+            sublead_defaults: None,
+        };
+        let args = lead_spawn_args(
+            &lead,
+            &PathBuf::from("/tmp/cfg.json"),
+            crate::manifest::schema::CommunicationMode::ParentChild,
+        );
+        let idx = args.iter().position(|a| a == "--allowedTools").unwrap();
+        let list = &args[idx + 1];
+        for t in COMMUNICATION_MCP_TOOLS {
+            assert!(
+                list.contains(t),
+                "expected comm tool {t} in allowedTools (mode=parent_child), got: {list}"
             );
         }
     }
@@ -1905,7 +1988,11 @@ mod tests {
             max_total_workers: None,
             sublead_defaults: None,
         };
-        let args = lead_spawn_args(&lead, &PathBuf::from("/tmp/cfg.json"));
+        let args = lead_spawn_args(
+            &lead,
+            &PathBuf::from("/tmp/cfg.json"),
+            crate::manifest::schema::CommunicationMode::Disabled,
+        );
         let idx = args.iter().position(|a| a == "--allowedTools").unwrap();
         let list = &args[idx + 1];
         for t in [
@@ -1944,6 +2031,7 @@ mod tests {
             None,
             None,
             Default::default(),
+            crate::manifest::schema::CommunicationMode::Disabled,
         );
         let idx = args.iter().position(|a| a == "--allowedTools").unwrap();
         let list = &args[idx + 1];
@@ -1970,6 +2058,7 @@ mod tests {
             None,
             None,
             Default::default(),
+            crate::manifest::schema::CommunicationMode::Disabled,
         );
         let idx = args.iter().position(|a| a == "--allowedTools").unwrap();
         let list = &args[idx + 1];
@@ -1986,6 +2075,52 @@ mod tests {
     }
 
     #[test]
+    fn sublead_spawn_args_excludes_comm_tools_when_mode_disabled() {
+        let args = sublead_spawn_args(
+            "test-sublead-id",
+            "do some work",
+            "claude-opus-4-1",
+            &PathBuf::from("/tmp/sublead-cfg.json"),
+            None,
+            None,
+            Default::default(),
+            crate::manifest::schema::CommunicationMode::Disabled,
+        );
+        let idx = args.iter().position(|a| a == "--allowedTools").unwrap();
+        let list = &args[idx + 1];
+        for t in COMMUNICATION_MCP_TOOLS {
+            assert!(
+                !list.contains(t),
+                "comm tool {t} must NOT be in sublead allowedTools when mode=disabled, \
+                 got: {list}"
+            );
+        }
+    }
+
+    #[test]
+    fn sublead_spawn_args_includes_comm_tools_when_mode_parent_child() {
+        let args = sublead_spawn_args(
+            "test-sublead-id",
+            "do some work",
+            "claude-opus-4-1",
+            &PathBuf::from("/tmp/sublead-cfg.json"),
+            None,
+            None,
+            Default::default(),
+            crate::manifest::schema::CommunicationMode::ParentChild,
+        );
+        let idx = args.iter().position(|a| a == "--allowedTools").unwrap();
+        let list = &args[idx + 1];
+        for t in COMMUNICATION_MCP_TOOLS {
+            assert!(
+                list.contains(t),
+                "expected comm tool {t} in sublead allowedTools (mode=parent_child), \
+                 got: {list}"
+            );
+        }
+    }
+
+    #[test]
     fn sublead_spawn_args_includes_spawn_worker() {
         let args = sublead_spawn_args(
             "test-sublead-id",
@@ -1995,6 +2130,7 @@ mod tests {
             None,
             None,
             Default::default(),
+            crate::manifest::schema::CommunicationMode::Disabled,
         );
         let idx = args.iter().position(|a| a == "--allowedTools").unwrap();
         let list = &args[idx + 1];
@@ -2015,6 +2151,7 @@ mod tests {
             Some("resume-session-123"),
             None,
             Default::default(),
+            crate::manifest::schema::CommunicationMode::Disabled,
         );
         // Verify the basic arg structure is correct
         assert!(args.contains(&"--output-format".to_string()));
@@ -2041,6 +2178,7 @@ mod tests {
             None,
             Some(&custom),
             Default::default(),
+            crate::manifest::schema::CommunicationMode::Disabled,
         );
         let idx = args.iter().position(|a| a == "--allowedTools").unwrap();
         let list = &args[idx + 1];
@@ -2067,6 +2205,7 @@ mod tests {
             None,
             Some(&custom),
             Default::default(),
+            crate::manifest::schema::CommunicationMode::Disabled,
         );
         let idx = args.iter().position(|a| a == "--allowedTools").unwrap();
         let list = &args[idx + 1];
@@ -2099,7 +2238,11 @@ mod tests {
             sublead_defaults: None,
         };
         let cfg = PathBuf::from("/tmp/cfg.json");
-        let args = lead_spawn_args(&lead, &cfg);
+        let args = lead_spawn_args(
+            &lead,
+            &cfg,
+            crate::manifest::schema::CommunicationMode::Disabled,
+        );
         assert!(
             !args.iter().any(|a| a == "--dangerously-skip-permissions"),
             "Path B lead must NOT have --dangerously-skip-permissions: {args:?}"

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -485,12 +485,14 @@ async fn spawn_sublead_session(
     // into every tools/call's `_meta.token`, and the server uses the
     // bound identity for authz. Closes #145 for the sublead path.
     let sublead_token = state.mint_token(&sublead_id, "sublead").await;
+    let communication_mode = state.root.manifest.communication.mode;
     let mcp_config_path = build_sublead_mcp_config(
         &sublead_id,
         &socket_path,
         &state.root.run_subdir,
         Some(&sublead_token),
         &state.root.manifest.mcp_servers,
+        communication_mode,
     )
     .await
     .context("build sublead mcp-config")?;
@@ -517,6 +519,7 @@ async fn spawn_sublead_session(
         resume_session_id.as_deref(),
         tools_for_args,
         spawn_routing,
+        communication_mode,
     );
 
     // 4. Task log directory (mirrors workers' layout for consistency).
@@ -646,6 +649,7 @@ async fn spawn_sublead_session(
                     .as_ref()
                     .map(|l| l.permission_routing)
                     .unwrap_or_default();
+                let resume_communication_mode = state_bg.root.manifest.communication.mode;
                 let resume_args = sublead_spawn_args(
                     &sublead_id_bg,
                     new_prompt,
@@ -654,6 +658,7 @@ async fn spawn_sublead_session(
                     Some(sid),
                     tools_for_resume,
                     resume_routing,
+                    resume_communication_mode,
                 );
                 // Env precedence: lead → operator → pitboss defaults
                 // (see compose_sublead_env). Same cwd rationale as the

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -42,7 +42,10 @@ pub use lifecycle::{
     handle_cancel_worker, handle_continue_worker, handle_list_workers, handle_pause_worker,
     handle_reprompt_worker, handle_worker_status,
 };
-pub use spawn::{handle_spawn_worker, spawn_resume_worker, PITBOSS_WORKER_MCP_TOOLS};
+pub use spawn::{
+    handle_spawn_worker, pitboss_worker_mcp_tools, spawn_resume_worker,
+    PITBOSS_WORKER_MCP_TOOLS_BASE,
+};
 pub use wait::{handle_wait_for_actor, handle_wait_for_any, handle_wait_for_worker};
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]

--- a/crates/pitboss-cli/src/mcp/tools/spawn.rs
+++ b/crates/pitboss-cli/src/mcp/tools/spawn.rs
@@ -504,6 +504,7 @@ async fn run_worker(
         &std::collections::HashMap::new(),
         worker_routing,
     );
+    let worker_communication_mode = state.root.manifest.communication.mode;
     let cmd = SpawnCmd {
         program: layer.claude_binary.clone(),
         args: worker_spawn_args(
@@ -512,6 +513,7 @@ async fn run_worker(
             &tools,
             mcp_config_arg.as_deref(),
             worker_routing,
+            worker_communication_mode,
         ),
         cwd: cwd.clone(),
         env: worker_env,
@@ -728,12 +730,18 @@ async fn estimate_new_worker_cost_for_layer(layer: &Arc<LayerState>, intended_mo
     costs[costs.len() / 2]
 }
 
-/// MCP tool names workers need permission to call. Narrower than the lead's
-/// `PITBOSS_MCP_TOOLS` — workers only get the shared-store surface, never
-/// the orchestration tools (spawn_worker / cancel_worker / request_approval
-/// / etc.). Pre-approved via `--allowedTools` so claude doesn't stall at
-/// the interactive permission prompt.
-pub const PITBOSS_WORKER_MCP_TOOLS: &[&str] = &[
+/// MCP tool names workers need permission to call when communication is
+/// disabled. Narrower than the lead's [`PITBOSS_MCP_TOOLS_BASE`] — workers
+/// only get the shared-store surface, never the orchestration tools
+/// (spawn_worker / cancel_worker / request_approval / etc.). Pre-approved
+/// via `--allowedTools` so claude doesn't stall at the interactive
+/// permission prompt.
+///
+/// Use [`pitboss_worker_mcp_tools`] at spawn sites so the comm tools are
+/// appended only when `[communication].mode != "disabled"`.
+///
+/// [`PITBOSS_MCP_TOOLS_BASE`]: crate::dispatch::runner::PITBOSS_MCP_TOOLS_BASE
+pub const PITBOSS_WORKER_MCP_TOOLS_BASE: &[&str] = &[
     "mcp__pitboss__kv_get",
     "mcp__pitboss__kv_set",
     "mcp__pitboss__kv_cas",
@@ -741,20 +749,24 @@ pub const PITBOSS_WORKER_MCP_TOOLS: &[&str] = &[
     "mcp__pitboss__kv_wait",
     "mcp__pitboss__lease_acquire",
     "mcp__pitboss__lease_release",
-    // Mailbox/artifact communication tools (v0.10+). Same opt-in
-    // semantics as the lead/sublead allowlists in `dispatch::runner` —
-    // server-side `list_tools` filter hides them when
-    // `[communication].mode = "disabled"` (the default), and every
-    // handler returns `CommunicationError::Disabled` as a back-stop.
-    "mcp__pitboss__message_send",
-    "mcp__pitboss__message_list",
-    "mcp__pitboss__message_read",
-    "mcp__pitboss__message_ack",
-    "mcp__pitboss__artifact_put",
-    "mcp__pitboss__artifact_list",
-    "mcp__pitboss__artifact_read",
-    "mcp__pitboss__artifact_grant",
 ];
+
+/// Compose a worker's `--allowedTools` set. Returns the base shared-store
+/// tools, plus [`COMMUNICATION_MCP_TOOLS`] when `mode` enables the comm
+/// surface.
+///
+/// [`COMMUNICATION_MCP_TOOLS`]: crate::dispatch::runner::COMMUNICATION_MCP_TOOLS
+pub fn pitboss_worker_mcp_tools(
+    mode: crate::manifest::schema::CommunicationMode,
+) -> Vec<&'static str> {
+    use crate::dispatch::runner::COMMUNICATION_MCP_TOOLS;
+    use crate::manifest::schema::CommunicationMode;
+    let mut out: Vec<&'static str> = PITBOSS_WORKER_MCP_TOOLS_BASE.to_vec();
+    if mode != CommunicationMode::Disabled {
+        out.extend(COMMUNICATION_MCP_TOOLS.iter().copied());
+    }
+    out
+}
 
 pub(super) fn worker_spawn_args(
     prompt: &str,
@@ -762,6 +774,7 @@ pub(super) fn worker_spawn_args(
     tools: &[String],
     mcp_config: Option<&std::path::Path>,
     permission_routing: crate::manifest::schema::PermissionRouting,
+    communication_mode: crate::manifest::schema::CommunicationMode,
 ) -> Vec<String> {
     use crate::manifest::schema::PermissionRouting;
     let mut args = vec![
@@ -781,8 +794,8 @@ pub(super) fn worker_spawn_args(
     // can't be answered in non-interactive mode.
     let mut allowed: Vec<String> = tools.to_vec();
     if mcp_config.is_some() {
-        for t in PITBOSS_WORKER_MCP_TOOLS {
-            allowed.push((*t).to_string());
+        for t in pitboss_worker_mcp_tools(communication_mode) {
+            allowed.push(t.to_string());
         }
         // Path B: pre-allow permission_prompt so workers can route checks.
         if permission_routing == PermissionRouting::PathB {
@@ -929,6 +942,7 @@ pub async fn spawn_resume_worker(
                 .map(|l| l.permission_routing)
         })
         .unwrap_or_default();
+    let resume_communication_mode = state.root.manifest.communication.mode;
     // Build spawn args with --resume.
     let mut spawn_args_v = worker_spawn_args(
         &prompt,
@@ -936,6 +950,7 @@ pub async fn spawn_resume_worker(
         &tools,
         mcp_config_arg.as_deref(),
         resume_routing,
+        resume_communication_mode,
     );
     spawn_args_v.insert(0, "--resume".into());
     spawn_args_v.insert(1, session_id);

--- a/crates/pitboss-cli/src/mcp/tools/tests.rs
+++ b/crates/pitboss-cli/src/mcp/tools/tests.rs
@@ -25,6 +25,7 @@ fn worker_spawn_args_has_plugin_isolation_flags() {
         &["Read".to_string()],
         Some(&PathBuf::from("/tmp/cfg.json")),
         Default::default(),
+        crate::manifest::schema::CommunicationMode::Disabled,
     );
     assert!(
         argv.iter().any(|a| a == "--strict-mcp-config"),
@@ -143,11 +144,60 @@ fn worker_spawn_args_passes_dangerously_skip_permissions() {
         &["Read".to_string()],
         Some(&PathBuf::from("/tmp/cfg.json")),
         Default::default(),
+        crate::manifest::schema::CommunicationMode::Disabled,
     );
     assert!(
         argv.iter().any(|a| a == "--dangerously-skip-permissions"),
         "worker_spawn_args missing --dangerously-skip-permissions: {argv:?}"
     );
+}
+
+#[test]
+fn worker_spawn_args_excludes_comm_tools_when_mode_disabled() {
+    use crate::dispatch::runner::COMMUNICATION_MCP_TOOLS;
+    use crate::manifest::schema::CommunicationMode;
+    use std::path::PathBuf;
+    let argv = worker_spawn_args(
+        "p",
+        "claude-haiku-4-5",
+        &["Read".to_string()],
+        Some(&PathBuf::from("/tmp/cfg.json")),
+        Default::default(),
+        CommunicationMode::Disabled,
+    );
+    let idx = argv.iter().position(|a| a == "--allowedTools").unwrap();
+    let list = &argv[idx + 1];
+    for t in COMMUNICATION_MCP_TOOLS {
+        assert!(
+            !list.contains(t),
+            "comm tool {t} must NOT be in worker allowedTools when mode=disabled, \
+             got: {list}"
+        );
+    }
+}
+
+#[test]
+fn worker_spawn_args_includes_comm_tools_when_mode_parent_child() {
+    use crate::dispatch::runner::COMMUNICATION_MCP_TOOLS;
+    use crate::manifest::schema::CommunicationMode;
+    use std::path::PathBuf;
+    let argv = worker_spawn_args(
+        "p",
+        "claude-haiku-4-5",
+        &["Read".to_string()],
+        Some(&PathBuf::from("/tmp/cfg.json")),
+        Default::default(),
+        CommunicationMode::ParentChild,
+    );
+    let idx = argv.iter().position(|a| a == "--allowedTools").unwrap();
+    let list = &argv[idx + 1];
+    for t in COMMUNICATION_MCP_TOOLS {
+        assert!(
+            list.contains(t),
+            "expected comm tool {t} in worker allowedTools (mode=parent_child), \
+             got: {list}"
+        );
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #283. The 8 mailbox/artifact MCP tool names were unconditionally embedded in every spawned actor's `--allowedTools` argv, even when `[communication].mode = "disabled"` (the default). Runtime gating still worked via the server-side `list_tools` filter + per-handler `ensure_enabled` check, but `pitboss dispatch --dry-run` printed phantom tool names that the agent would never actually invoke.

## Approach

- Split each static allowlist into a base const (`PITBOSS_MCP_TOOLS_BASE`, `SUBLEAD_MCP_TOOLS_BASE`, `PITBOSS_WORKER_MCP_TOOLS_BASE`) + a single shared `COMMUNICATION_MCP_TOOLS` const.
- Add `pitboss_mcp_tools(mode)`, `sublead_mcp_tools(mode)`, `pitboss_worker_mcp_tools(mode)` helpers that compose `BASE + (COMMUNICATION when mode != Disabled)`. Mirrors the existing `dispatch::depth::ROOT_ONLY_TOOLS` const + `is_root_only_tool` fn split.
- Thread `CommunicationMode` through `lead_spawn_args`, `lead_resume_spawn_args`, `sublead_spawn_args`, `worker_spawn_args`, and the sublead `build_sublead_mcp_config` emitter.
- Enrich the hierarchical dry-run output so it prints the lead's full argv (was just `"(mcp socket TBD)"` placeholder).

## DoD

- [x] `pitboss dispatch --dry-run` against `mode = "disabled"` shows no comm tool names in the lead argv (manually verified — `grep -E "message_|artifact_"` returns nothing).
- [x] `pitboss dispatch --dry-run` against `mode = "parent_child"` shows all 8 comm tool names in the lead argv (manually verified — count = 8).
- [x] Unit tests assert mode-aware presence/absence for all three actors (lead, sublead, worker).
- [x] `dispatch::depth::tests::sublead_allowlist_excludes_all_root_only_tools` still passes — the depth invariant test was extended to assert the mode-composed allowlist also excludes root-only tools across both modes.

**Note on dry-run scope:** the issue lists "in lead, sublead, and worker argv" for the dry-run check, but hierarchical dry-run is lead-only by design — subleads and workers are spawned dynamically through MCP, so their argv doesn't exist at dry-run time. Mode-aware behavior for those actors is covered by the new unit tests in `runner.rs` and `mcp/tools/tests.rs`.

## Test

- 1142 tests pass workspace-wide (`cargo test --workspace --features pitboss-core/test-support`).
- `cargo lint` clean (`sublead_spawn_args` now has 8 args; existing one is 7, so the `#[allow(clippy::too_many_arguments)]` is the smallest fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)