### PR TITLE
release: prep v0.10.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 ---
 document: pitboss-agent-instructions
 schema_version: 1
-pitboss_version: 0.9.2
-last_updated: 2026-04-30
+pitboss_version: 0.10.0
+last_updated: 2026-05-06
 audience: ai-agent
 canonical_url: https://github.com/SDS-Mode/pitboss/blob/main/AGENTS.md
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,38 +10,68 @@ by `git-cliff` at release time. Hand-editing this file in feature PRs
 is no longer required (or recommended — it causes merge conflicts).
 See #242 for the adoption notes.
 
-## [0.9.2] — 2026-04-30
+## [0.10.0] — 2026-05-06
 
-The container subsystem grows up. Operators iterating against
-`pitboss container-dispatch` get a real toolchain story:
-declare apt packages and host files in the manifest, bake them
-into a derived image once with `pitboss container-build`, and let
-`container-dispatch` pick up the cached tag automatically. Stale
-derived images sweep with `pitboss container-prune`. The published
-`pitboss-with-claude` image now rolls forward on every main merge
-(rolling `:main` and `:main-<sha>` tags) instead of stagnating
-between releases. Plus the usual smaller polish — auto-refresh on
-the runs list and run-detail pages, persisted per-task cost on
-`TaskRecord`, an SSE event-stream filter on the run-detail page,
-and a graceful shutdown contract for `pitboss-web stop`.
+The communication plane lands. A lead can now exchange typed messages
+and binary artifacts with its workers via eight new MCP tools
+(`message_send`/`list`/`read`/`ack` and
+`artifact_put`/`list`/`read`/`grant`), gated by a new `[communication]`
+manifest section that defaults to `mode = "disabled"` — no behavioural
+change for existing manifests. The TUI and web console both render
+mailbox and artifact activity as first-class operator signals. Failure
+triage gets its own command: `pitboss analyze` (and matching MCP tools)
+produces single-run and cross-run reports with cost rollups, hotspot
+detection, and tokenized failure clustering — no more grepping
+`summary.jsonl` to figure out which task burned the budget. Plus a
+security-relevant fix: spawned worker/lead/sublead `--allowedTools` argv
+lists are now mode-aware, so `dispatch --dry-run` output matches runtime
+behaviour when communication is disabled.
 
 Highlights:
 
-- **`[container].extra_apt` + `[[container.copy]]`** — declare
-  apt packages and host-file copies in the manifest. Two paths:
-  install at dispatch start (slow) or `pitboss container-build` to
-  bake into a derived image and amortize across runs.
-- **`pitboss container-build` + `pitboss container-prune`** —
-  deterministic SHA-tagged derived images with idempotent re-runs,
-  and a sweeper for the stale tags that accumulate as manifests
-  evolve.
-- **Image-cadence fix (#258)** — `:main`, `:main-<sha>`, and
-  `:latest` now roll forward on every main merge, ending the
-  "0.9.1 is two days old, my fix is in main, why isn't it in the
-  image" mode that bit operators twice in the post-0.9.1 window.
-- **Cost telemetry** — per-task `cost_usd` now persists on
-  `TaskRecord` at finalize time and the run-detail page renders
-  per-task and run-total cost estimates client-side.
+- **`[communication]` manifest section + 8 new MCP tools** —
+  parent-child mailbox (`message_send` / `list` / `read` / `ack`) and
+  artifact registry (`artifact_put` / `list` / `read` / `grant`) with
+  per-actor quotas, scope-based authorization, and bytes/count caps.
+  Default `mode = "disabled"` keeps the toolset out of every actor's
+  `--allowedTools` unless explicitly enabled.
+- **Phase C operator surfaces** — TUI and web console both stream
+  `StoreActivity` events showing per-actor mailbox and artifact ops
+  alongside the existing KV/lease counters.
+- **`pitboss analyze [--recent N] [--failed-only] [--json]`** —
+  single-run and cross-run triage with `RunAnalysis`, `CostRollup`,
+  and `FailureGroup`. Hotspot detection (slowest, costliest,
+  token-heaviest tasks). Failure clustering by tokenized error
+  patterns. Pre-v0.11 records get opportunistic cost recomputation;
+  v0.11+ uses the stored `cost_usd`. Same engine exposed as MCP tools
+  (`analyze_run`, `analyze_recent`) for in-run lead consumption.
+- **Mode-aware `--allowedTools` (#283)** — `pitboss_mcp_tools(mode)`,
+  `sublead_mcp_tools(mode)`, and `pitboss_worker_mcp_tools(mode)`
+  helpers replace the old static `const` arrays. Communication tools
+  are now omitted from spawned actor argv when `mode = "disabled"`
+  instead of being silently filtered only at runtime — closes a
+  cosmetic-but-operator-confusing gap surfaced via
+  `dispatch --dry-run`.
+
+### Added
+
+- Phase C — surface comm activity in TUI + web consoles ([#285](https://github.com/SDS-Mode/pitboss/pull/285))
+- Add parent-child mailbox + artifact MCP tools ([#281](https://github.com/SDS-Mode/pitboss/pull/281))
+- Add analyze triage command and MCP tools ([#280](https://github.com/SDS-Mode/pitboss/pull/280))
+
+
+### Dependencies
+
+- Bump the rust-minor-and-patch group across 1 directory with 3 updates ([#288](https://github.com/SDS-Mode/pitboss/pull/288))
+- Bump lru from 0.16.4 to 0.18.0 ([#279](https://github.com/SDS-Mode/pitboss/pull/279))
+
+
+### Fixed
+
+- Make worker/lead/sublead --allowedTools mode-aware for [communication] ([#289](https://github.com/SDS-Mode/pitboss/pull/289))
+
+
+## [0.9.2] — 2026-04-30
 
 ### Added
 
@@ -61,7 +91,6 @@ Highlights:
 
 ### Changed
 
-- **Image-cadence fix (#258, [#265](https://github.com/SDS-Mode/pitboss/pull/265))** — `:main`, `:main-<sha>`, and `:latest` on `ghcr.io/sds-mode/pitboss-with-claude` now roll forward on every main merge, not only on release-tag pushes. **Behavior change**: `:latest` strictly tracks main HEAD now, not the most recent release tag. To pin a release, use a version tag (`:0.9.1`, `:0.9`, `:0`); for fixes-since-release use `:main` or `:latest`. Reproducibility: `:main-<short-sha>` is the SHA-pinned alternative.
 - Schema-first matching against API error envelopes (#185 medium) ([#219](https://github.com/SDS-Mode/pitboss/pull/219))
 - Split tools.rs into per-feature submodules (#151 L6) ([#218](https://github.com/SDS-Mode/pitboss/pull/218))
 - SqliteStore migration version table (#149 L11) ([#212](https://github.com/SDS-Mode/pitboss/pull/212))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1895,7 +1895,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pitboss-cli"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "pitboss-core"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1954,7 +1954,7 @@ dependencies = [
 
 [[package]]
 name = "pitboss-schema"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "pitboss-schema-derive",
  "serde",
@@ -1963,7 +1963,7 @@ dependencies = [
 
 [[package]]
 name = "pitboss-schema-derive"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "pitboss-tui"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "pitboss-web"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version     = "0.9.2"
+version     = "0.10.0"
 edition     = "2021"
 rust-version = "1.82"
 license     = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -16,24 +16,29 @@ To browse offline:
     cargo install mdbook  # one time
     mdbook serve --open
 
-**v0.9.2** turns the container subsystem into a real toolchain.
-`pitboss container-dispatch` now reads two new manifest fields:
-`[container].extra_apt` for distro packages installed at dispatch
-start (the simple slow path) and `[[container.copy]]` for host
-files baked into a derived image at build time. The new
-`pitboss container-build` subcommand synthesizes a thin Dockerfile
-from those fields and tags the result deterministically as
-`pitboss-derived-<sha>:local`; subsequent dispatches pick up the
-cached tag automatically and drop the apt-at-spin-up cost.
-`pitboss container-prune` sweeps the stale tags that accumulate as
-manifests evolve. Image cadence also gets fixed: the published
-`pitboss-with-claude` rolls forward on every main merge with
-`:main`, `:main-<sha>`, and `:latest` tags instead of stagnating
-between release tags. Cost telemetry persists per-task
-`cost_usd` on `TaskRecord`, and the run-detail page now renders
-per-task and run-total cost estimates client-side. See
-`CHANGELOG.md` for the full per-version history and `AGENTS.md`
-for the MCP tool reference, keybindings, and manifest schema.
+**v0.10.0** lands the communication plane. A lead can now exchange
+typed messages and binary artifacts with its workers via eight new
+MCP tools — `message_send` / `list` / `read` / `ack` for the
+parent-child mailbox and `artifact_put` / `list` / `read` / `grant`
+for the artifact registry. The whole surface is gated behind a new
+`[communication]` manifest section that defaults to
+`mode = "disabled"`, so existing manifests see no behavioural change
+until they opt in with `mode = "parent_child"`. The TUI and web
+console both stream per-actor mailbox and artifact activity as
+first-class operator signals alongside the existing KV and lease
+counters. Failure triage gets its own command:
+`pitboss analyze [--recent N] [--failed-only] [--json]` produces
+single-run and cross-run reports with cost rollups, hotspot
+detection (slowest, costliest, token-heaviest tasks), and
+tokenized failure clustering — and the same engine is exposed as
+`analyze_run` / `analyze_recent` MCP tools so leads can self-triage
+mid-run. A security-relevant fix: spawned worker, lead, and
+sub-lead `--allowedTools` argv lists are now mode-aware
+(`pitboss_mcp_tools(mode)` etc.), so `pitboss dispatch --dry-run`
+output finally matches runtime behaviour when communication is
+disabled. See `CHANGELOG.md` for the full per-version history and
+`AGENTS.md` for the MCP tool reference, keybindings, and manifest
+schema.
 
 Rust toolkit for running and observing parallel Claude Code sessions. A
 dispatcher (`pitboss`) fans out `claude` subprocesses under a concurrency
@@ -137,7 +142,10 @@ pitboss dispatch <manifest>               deal a run; --background detaches & re
 pitboss resume <run-id>                   re-deal a prior run, reusing claude_session_id
 pitboss attach <run-id> <task-id>         follow-mode log viewer for a single worker
 pitboss diff <run-a> <run-b>              compare two runs side-by-side
+pitboss analyze [<run-id>|--recent N]     triage report: cost rollup, failure clusters, hotspots; --json
 pitboss container-dispatch <manifest>     run dispatch inside a Docker/Podman container
+pitboss container-build <manifest>        bake [container] apt + copy entries into a derived image
+pitboss container-prune                   sweep stale derived images
 pitboss status <run-id>                   snapshot task table for any run; supports --json
 pitboss list                              inventory of recent runs; --active narrows to live
 pitboss prune                             sweep orphaned run dirs; dry-run by default, --apply commits


### PR DESCRIPTION
## Summary

- Bump workspace version `0.9.2` → `0.10.0`
- Regenerate `CHANGELOG.md` via `git cliff --tag v0.10.0` and hand-write the release-headline paragraph at the top of the new section
- Update `AGENTS.md` frontmatter (`pitboss_version`, `last_updated`)
- Update `README.md` lead paragraph for v0.10.0 and add `analyze`, `container-build`, `container-prune` to the Subcommands list

## What's in v0.10.0

The communication plane lands plus the `analyze` triage command. Cliff picked up:

**Added** — `feat(communication): Phase C — surface comm activity in TUI + web consoles` (#285), `feat(communication): add parent-child mailbox + artifact MCP tools` (#281), `feat(cli): add analyze triage command and MCP tools` (#280)
**Fixed** — `fix(mcp): make worker/lead/sublead --allowedTools mode-aware for [communication]` (#289)
**Dependencies** — `chore(deps): bump the rust-minor-and-patch group` (#288), `chore(deps): bump lru from 0.16.4 to 0.18.0` (#279)

## Release path

Per `RELEASE.md`: merge this PR, then `git tag v0.10.0 && git push origin v0.10.0` from `main` to fire `release.yml` (cargo-dist) and `container.yml` in parallel.

The cargo-dist `announcement_*` strip-patch in `.github/workflows/release.yml` is intact (untouched by this PR).

## Test plan

- [x] `git cliff --tag v0.10.0 -o CHANGELOG.md` regenerates cleanly
- [x] `cargo update -w` refreshes workspace entries in `Cargo.lock`
- [x] `cargo metadata --no-deps` confirms all 6 pitboss crates resolve to 0.10.0
- [x] CI passes
- [ ] After merge: tag `v0.10.0` from main; `release.yml` builds tarballs + installers; `container.yml` publishes images

🤖 Generated with [Claude Code](https://claude.com/claude-code)