### PR TITLE
fix(dispatch): abort kill+resume bridge task at iteration end

### DIFF
--- a/crates/pitboss-cli/src/dispatch/kill_resume.rs
+++ b/crates/pitboss-cli/src/dispatch/kill_resume.rs
@@ -133,14 +133,14 @@ pub async fn run_kill_resume_loop(
         // kill+restart this iteration without terminating the whole
         // tree.
         let proc_cancel = CancelToken::new();
-        {
+        let bridge = {
             let tree_cancel = layer.cancel.clone();
             let proc = proc_cancel.clone();
             tokio::spawn(async move {
                 tree_cancel.await_terminate().await;
                 proc.terminate();
-            });
-        }
+            })
+        };
 
         let outcome = SessionHandle::new(
             actor_id.clone(),
@@ -152,6 +152,14 @@ pub async fn run_kill_resume_loop(
         .with_session_id_tx(session_id_tx)
         .run_to_completion(proc_cancel, args.timeout)
         .await;
+
+        // The bridge task awaits `tree_cancel.await_terminate()` which
+        // does not fire until the run ends. Without this abort, every
+        // iteration leaks a task holding a CancelToken clone — N
+        // resumes accumulates N orphans bounded only by run lifetime.
+        // The session has already returned, so the bridge has nothing
+        // useful left to do regardless of cancel state.
+        bridge.abort();
 
         // Capture session_id from the per-iteration channel (preferred,
         // fires on the `system{subtype:"init"}` event so it's available


### PR DESCRIPTION
## Summary

- Captures the per-iteration bridge `JoinHandle` and aborts it after `run_to_completion` returns, preventing the kill+resume loop from leaking one orphan task per iteration.
- Closes #341 (filed during adjudication of #292, which was closed as an audit hallucination).

## Background

`run_kill_resume_loop` spawns a bridge task on each iteration to forward tree-level terminate to the per-iteration `proc_cancel`. The bridge awaits `tree_cancel.await_terminate()`, which does not fire until run-end. Without retaining the handle, N resume iterations accumulated N orphan tasks each holding a `CancelToken` clone (`watch::Receiver` × 2 + `Arc`s).

Practical impact: small per-task overhead on long-running root leads with frequent reprompts. Bounded only by run lifetime.

## Test plan

- [x] `cargo build -p pitboss-cli`
- [x] `cargo clippy -p pitboss-cli --all-targets`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace --features pitboss-core/test-support` (all green; sublead/reprompt flows unchanged)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)