### PR TITLE
fix(mcp): close auth bypass cluster (#309 #310 #311)

### DIFF
--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -426,13 +426,20 @@ impl PitbossHandler {
             }
         }
 
-        // No bound identity AND no token. The wire might still carry an
-        // unauthenticated actor_id — accept it for backward compatibility
-        // with code paths that don't have a token (none in production,
-        // but tests construct DispatchState directly without minting).
-        // The defense-in-depth `extract_bound_identity` below treats this
-        // as "no bound identity" so downstream authz checks (Phase 3)
-        // still fire correctly.
+        // No bound identity AND no token. If the wire claims an actor_id,
+        // this is a forgery attempt — reject (matches the docstring at
+        // lines 344-348). Production callers always carry a token (root
+        // lead via `--token` in lead-mcp-config.json, workers/sub-leads
+        // via mint at spawn). A bare `{}` _meta with no actor_id is
+        // permitted; per-tool handlers that require identity will reject
+        // via their MetaField extractor.
+        if meta_obj.contains_key("actor_id") {
+            return Err(ErrorData::invalid_request(
+                "_meta.actor_id present without _meta.token; reconnect via pitboss mcp-bridge"
+                    .to_string(),
+                None,
+            ));
+        }
         Ok(())
     }
 
@@ -447,19 +454,23 @@ impl PitbossHandler {
 
     /// Issue #144 — gate a mutating call against `authorize_target`.
     ///
-    /// Resolves the caller from connection-bound identity (Phase 2) when
-    /// available; otherwise treats the connection as the root lead — the
-    /// only legitimate path to a missing bound identity is a legacy
-    /// caller that predates token issuance, which only the operator's
-    /// own root-lead spawn produces (sub-leads and workers always carry
-    /// tokens minted at spawn time).
+    /// Requires the caller to have a bound connection identity (Phase 2).
+    /// Production callers always reach this with a bound identity because
+    /// every actor mints a token at spawn (root lead in `hierarchical.rs`,
+    /// workers in `mcp/tools/spawn.rs`, sub-leads in `dispatch/sublead.rs`)
+    /// and presents it via `_meta.token` through the bridge. An unbound
+    /// caller is therefore a forged direct-socket connection that should
+    /// be rejected outright — the previous behavior of defaulting to
+    /// root-lead authority was a privilege-escalation backdoor (#310).
     async fn authorize(&self, target_id: &str) -> Result<(), ErrorData> {
         let bound = self.connection_identity.lock().await.clone();
-        let (caller_id, caller_role) = match bound {
-            Some(id) => (id.actor_id, id.actor_role),
-            None => (self.state.root.lead_id.clone(), "root_lead".to_string()),
+        let Some(id) = bound else {
+            return Err(ErrorData::invalid_request(
+                "authentication required; reconnect via pitboss mcp-bridge".to_string(),
+                None,
+            ));
         };
-        authorize_target(&self.state, &caller_id, &caller_role, target_id).await
+        authorize_target(&self.state, &id.actor_id, &id.actor_role, target_id).await
     }
 }
 
@@ -1131,6 +1142,24 @@ impl PitbossHandler {
         &self,
         Parameters(args): Parameters<PermissionPromptArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        // Defense-in-depth: `list_tools` filters this tool unless path_b is
+        // enabled, but a same-UID direct-socket caller could bypass that
+        // filter. Re-check at the handler so the manifest gate is enforced
+        // regardless of how the caller discovered the tool (#311).
+        use crate::manifest::schema::PermissionRouting;
+        let path_b = self
+            .state
+            .root
+            .manifest
+            .lead
+            .as_ref()
+            .is_some_and(|l| l.permission_routing == PermissionRouting::PathB);
+        if !path_b {
+            return Err(ErrorData::invalid_request(
+                "permission_prompt requires [lead].permission_routing = \"path_b\"".to_string(),
+                None,
+            ));
+        }
         match handle_permission_prompt(&self.state, args).await {
             Ok(res) => to_structured_result(&res),
             Err(e) => Err(ErrorData::invalid_request(e.to_string(), None)),

--- a/crates/pitboss-cli/tests/cancel_cascade_flows.rs
+++ b/crates/pitboss-cli/tests/cancel_cascade_flows.rs
@@ -57,6 +57,21 @@ use pitboss_core::worktree::{CleanupPolicy, WorktreeManager};
 use serde_json::json;
 use uuid::Uuid;
 
+/// Mint an actor token via `state.mint_token` and connect a `FakeMcpClient`
+/// that presents it. Required because `authenticate_and_rebind` rejects
+/// calls that present `_meta.actor_id` without a valid token (#309 fix).
+async fn connect_actor(
+    state: &DispatchState,
+    socket: &std::path::Path,
+    actor_id: &str,
+    actor_role: &str,
+) -> FakeMcpClient {
+    let token = state.mint_token(actor_id, actor_role).await;
+    FakeMcpClient::connect_with_token(socket, actor_id, actor_role, &token)
+        .await
+        .expect("connect_with_token")
+}
+
 /// Build a `DispatchState` with `allow_subleads = true` and budgets
 /// generous enough to cover one sub-lead and one worker. Same shape as
 /// `sublead_flows::mk_state_with_subleads`, kept local so the test file
@@ -154,9 +169,7 @@ async fn sublead_spawned_after_root_drain_inherits_drain() {
     state.root.cancel.drain();
     yield_for_cascade_watcher().await;
 
-    let mut root_client = FakeMcpClient::connect_as(&socket, "root", "root_lead")
-        .await
-        .unwrap();
+    let mut root_client = connect_actor(&state, &socket, "root", "root_lead").await;
     let resp = root_client
         .call_tool(
             "spawn_sublead",
@@ -193,9 +206,7 @@ async fn sublead_spawned_after_root_terminate_inherits_terminate() {
     state.root.cancel.terminate();
     yield_for_cascade_watcher().await;
 
-    let mut root_client = FakeMcpClient::connect_as(&socket, "root", "root_lead")
-        .await
-        .unwrap();
+    let mut root_client = connect_actor(&state, &socket, "root", "root_lead").await;
     let resp = root_client
         .call_tool(
             "spawn_sublead",
@@ -230,9 +241,7 @@ async fn worker_spawned_in_subtree_after_subtree_drain_inherits_drain() {
 
     pitboss_cli::dispatch::signals::install_cascade_cancel_watcher(state.clone());
 
-    let mut root_client = FakeMcpClient::connect_as(&socket, "root", "root_lead")
-        .await
-        .unwrap();
+    let mut root_client = connect_actor(&state, &socket, "root", "root_lead").await;
     let resp = root_client
         .call_tool(
             "spawn_sublead",
@@ -251,9 +260,7 @@ async fn worker_spawned_in_subtree_after_subtree_drain_inherits_drain() {
     }
     yield_for_cascade_watcher().await;
 
-    let mut sub_client = FakeMcpClient::connect_as(&socket, &sublead_id, "sublead")
-        .await
-        .unwrap();
+    let mut sub_client = connect_actor(&state, &socket, &sublead_id, "sublead").await;
     let spawn_resp = sub_client
         .call_tool("spawn_worker", json!({"prompt": "late worker"}))
         .await
@@ -290,9 +297,7 @@ async fn worker_spawn_after_subtree_terminate_fails_with_unknown_sublead() {
 
     pitboss_cli::dispatch::signals::install_cascade_cancel_watcher(state.clone());
 
-    let mut root_client = FakeMcpClient::connect_as(&socket, "root", "root_lead")
-        .await
-        .unwrap();
+    let mut root_client = connect_actor(&state, &socket, "root", "root_lead").await;
     let resp = root_client
         .call_tool(
             "spawn_sublead",
@@ -311,9 +316,7 @@ async fn worker_spawn_after_subtree_terminate_fails_with_unknown_sublead() {
     }
     yield_for_cascade_watcher().await;
 
-    let mut sub_client = FakeMcpClient::connect_as(&socket, &sublead_id, "sublead")
-        .await
-        .unwrap();
+    let mut sub_client = connect_actor(&state, &socket, &sublead_id, "sublead").await;
     let result = sub_client
         .call_tool("spawn_worker", json!({"prompt": "late worker"}))
         .await;

--- a/crates/pitboss-cli/tests/dogfood_fake_flows.rs
+++ b/crates/pitboss-cli/tests/dogfood_fake_flows.rs
@@ -48,6 +48,21 @@ use pitboss_core::store::{JsonFileStore, SessionStore};
 use pitboss_core::worktree::{CleanupPolicy, WorktreeManager};
 use uuid::Uuid;
 
+/// Mint an actor token via `state.mint_token` and connect a `FakeMcpClient`
+/// that presents it. Required because `authenticate_and_rebind` rejects
+/// calls that present `_meta.actor_id` without a valid token (#309 fix).
+async fn connect_actor(
+    state: &DispatchState,
+    socket: &std::path::Path,
+    actor_id: &str,
+    actor_role: &str,
+) -> FakeMcpClient {
+    let token = state.mint_token(actor_id, actor_role).await;
+    FakeMcpClient::connect_with_token(socket, actor_id, actor_role, &token)
+        .await
+        .expect("connect_with_token")
+}
+
 /// Build a DispatchState with allow_subleads=true for in-process spotlights.
 ///
 /// Duplicated from `sublead_flows.rs::mk_state_with_subleads` to keep
@@ -302,9 +317,7 @@ async fn dogfood_isolation_strict_tree() {
         .unwrap();
 
     // ── Act as root lead and spawn two sub-leads ──────────────────────────────
-    let mut root = FakeMcpClient::connect_as(&socket, "root", "root_lead")
-        .await
-        .unwrap();
+    let mut root = connect_actor(&state, &socket, "root", "root_lead").await;
 
     let s1_resp = root
         .call_tool(
@@ -341,12 +354,8 @@ async fn dogfood_isolation_strict_tree() {
         .to_string();
 
     // Each sub-lead connects to the MCP server with its own identity.
-    let mut s1_client = FakeMcpClient::connect_as(&socket, &s1_id, "sublead")
-        .await
-        .unwrap();
-    let mut s2_client = FakeMcpClient::connect_as(&socket, &s2_id, "sublead")
-        .await
-        .unwrap();
+    let mut s1_client = connect_actor(&state, &socket, &s1_id, "sublead").await;
+    let mut s2_client = connect_actor(&state, &socket, &s2_id, "sublead").await;
 
     // ── Each sub-lead writes progress to its own /shared/progress ─────────────
     // Values are UTF-8 bytes for the string content.
@@ -420,9 +429,7 @@ async fn dogfood_isolation_strict_tree() {
     // W2 attempts to read it — must be rejected with a strict-peer-visibility
     // error. (Workers are the correct actors here; see test docstring for why
     // sub-leads are not used for this assertion.)
-    let mut worker1 = FakeMcpClient::connect_as(&socket, "worker-W1", "worker")
-        .await
-        .unwrap();
+    let mut worker1 = connect_actor(&state, &socket, "worker-W1", "worker").await;
     worker1
         .call_tool(
             "kv_set",
@@ -434,9 +441,7 @@ async fn dogfood_isolation_strict_tree() {
         .await
         .unwrap();
 
-    let mut worker2 = FakeMcpClient::connect_as(&socket, "worker-W2", "worker")
-        .await
-        .unwrap();
+    let mut worker2 = connect_actor(&state, &socket, "worker-W2", "worker").await;
     let sibling_read = worker2
         .call_tool("kv_get", json!({ "path": "/peer/worker-W1/status" }))
         .await;
@@ -525,9 +530,7 @@ async fn dogfood_kill_cascade_drain() {
     pitboss_cli::dispatch::signals::install_cascade_cancel_watcher(state.clone());
 
     // ── Spawn two sub-leads via MCP ───────────────────────────────────────────
-    let mut root = FakeMcpClient::connect_as(&socket, "root", "root_lead")
-        .await
-        .unwrap();
+    let mut root = connect_actor(&state, &socket, "root", "root_lead").await;
 
     let s1_resp = root
         .call_tool(
@@ -663,9 +666,7 @@ async fn dogfood_run_lease_contention() {
         .unwrap();
 
     // ── Spawn two sub-leads via MCP ───────────────────────────────────────────
-    let mut root = FakeMcpClient::connect_as(&socket, "root", "root_lead")
-        .await
-        .unwrap();
+    let mut root = connect_actor(&state, &socket, "root", "root_lead").await;
 
     let s1_resp = root
         .call_tool(
@@ -702,9 +703,7 @@ async fn dogfood_run_lease_contention() {
         .to_string();
 
     // ── STEP 1: S1 acquires the lease ────────────────────────────────────────
-    let mut s1_client = FakeMcpClient::connect_as(&socket, &s1_id, "sublead")
-        .await
-        .unwrap();
+    let mut s1_client = connect_actor(&state, &socket, &s1_id, "sublead").await;
     let acq1 = s1_client
         .call_tool(
             "run_lease_acquire",
@@ -727,9 +726,7 @@ async fn dogfood_run_lease_contention() {
     );
 
     // ── STEP 2: S2 tries to acquire the same lease — should be blocked ──────
-    let mut s2_client = FakeMcpClient::connect_as(&socket, &s2_id, "sublead")
-        .await
-        .unwrap();
+    let mut s2_client = connect_actor(&state, &socket, &s2_id, "sublead").await;
     let acq2 = s2_client
         .call_tool(
             "run_lease_acquire",
@@ -802,9 +799,7 @@ async fn dogfood_policy_auto_filter() {
         .unwrap();
 
     // ── Spawn two sub-leads via MCP ──────────────────────────────────────
-    let mut root = FakeMcpClient::connect_as(&socket, "root", "root_lead")
-        .await
-        .unwrap();
+    let mut root = connect_actor(&state, &socket, "root", "root_lead").await;
 
     let s1_resp = root
         .call_tool(
@@ -868,9 +863,7 @@ async fn dogfood_policy_auto_filter() {
 
     // ── ACT 1: S1 requests routine tool-use approval ──────────────────────
     // Expected: auto-approved by Rule 1, no queue entry
-    let mut s1_client = FakeMcpClient::connect_as(&socket, &s1_id, "sublead")
-        .await
-        .unwrap();
+    let mut s1_client = connect_actor(&state, &socket, &s1_id, "sublead").await;
     let s1_approval = s1_client
         .call_tool(
             "request_approval",
@@ -908,10 +901,9 @@ async fn dogfood_policy_auto_filter() {
     // so we can let it hang briefly while we verify the queue state.
     let socket_2 = socket.clone();
     let s2_id_clone = s2_id.clone();
+    let state_for_s2 = state.clone();
     let s2_approval_handle = tokio::spawn(async move {
-        let mut s2_client = FakeMcpClient::connect_as(&socket_2, &s2_id_clone, "sublead")
-            .await
-            .unwrap();
+        let mut s2_client = connect_actor(&state_for_s2, &socket_2, &s2_id_clone, "sublead").await;
         s2_client
             .call_tool(
                 "request_approval",
@@ -944,10 +936,9 @@ async fn dogfood_policy_auto_filter() {
     // Expected: blocked by Rule 2 (all Plan approvals require operator), queued
     let socket_3 = socket.clone();
     let s1_id_clone = s1_id.clone();
+    let state_for_s1 = state.clone();
     let plan_req_handle = tokio::spawn(async move {
-        let mut s1_client = FakeMcpClient::connect_as(&socket_3, &s1_id_clone, "sublead")
-            .await
-            .unwrap();
+        let mut s1_client = connect_actor(&state_for_s1, &socket_3, &s1_id_clone, "sublead").await;
         s1_client
             .call_tool(
                 "propose_plan",
@@ -1078,9 +1069,7 @@ async fn dogfood_envelope_cap_rejection() {
         .await
         .unwrap();
 
-    let mut root = FakeMcpClient::connect_as(&socket, "root", "root_lead")
-        .await
-        .unwrap();
+    let mut root = connect_actor(&state, &socket, "root", "root_lead").await;
 
     // ── Act 1: Root attempts to spawn sub-lead with budget_usd = 5.0 ────────
     // Expected: rejected with "exceeds per-sublead cap" error, no state change

--- a/crates/pitboss-cli/tests/dogfood_real_flows.rs
+++ b/crates/pitboss-cli/tests/dogfood_real_flows.rs
@@ -358,11 +358,37 @@ async fn r2_side_channel(run_dir: PathBuf) -> anyhow::Result<()> {
     wait_for_path(&mcp_sock, Duration::from_secs(30)).await?;
 
     // ── Step 3: connect FakeMcpClient ────────────────────────────────────────
-    // Connect with root_lead identity so cancel_worker is accepted without
-    // role-authz issues (cancel_worker has no role check, but the _meta field
-    // is required by some tool handlers; root_lead is always safe).
-    let mut client =
-        fake_mcp_client::FakeMcpClient::connect_as(&mcp_sock, "r2-operator", "root_lead").await?;
+    // Connect with the lead's actual token by reading it from
+    // `lead-mcp-config.json`. This mirrors what `pitboss mcp-bridge` does
+    // in production. Required since #309 — the server now rejects calls
+    // that present `_meta.actor_id` without a valid token.
+    let cfg_path = run_subdir.join("lead-mcp-config.json");
+    let cfg_bytes = tokio::fs::read(&cfg_path).await?;
+    let cfg: serde_json::Value = serde_json::from_slice(&cfg_bytes)?;
+    let args = cfg["mcpServers"]["pitboss"]["args"]
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("lead-mcp-config.json missing args array"))?;
+    let mut token: Option<String> = None;
+    let mut actor_id: Option<String> = None;
+    let mut actor_role: Option<String> = None;
+    for w in args.windows(2) {
+        match w[0].as_str() {
+            Some("--token") => token = w[1].as_str().map(str::to_string),
+            Some("--actor-id") => actor_id = w[1].as_str().map(str::to_string),
+            Some("--actor-role") => actor_role = w[1].as_str().map(str::to_string),
+            _ => {}
+        }
+    }
+    let token = token.ok_or_else(|| anyhow::anyhow!("--token absent in lead-mcp-config"))?;
+    let actor_id = actor_id.unwrap_or_else(|| "lead".into());
+    let actor_role = actor_role.unwrap_or_else(|| "lead".into());
+    let mut client = fake_mcp_client::FakeMcpClient::connect_with_token(
+        &mcp_sock,
+        &actor_id,
+        &actor_role,
+        &token,
+    )
+    .await?;
 
     // ── Step 4: poll list_workers until a non-lead worker appears ─────────────
     let worker_id = wait_for_first_worker_via_mcp(&mut client, Duration::from_secs(90)).await?;

--- a/crates/pitboss-cli/tests/e2e_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_flows.rs
@@ -126,13 +126,16 @@ async fn run_fake_claude_lead(
 /// Variant of `run_fake_claude_lead` that wires fake-claude through a
 /// spawned `pitboss mcp-bridge` subprocess instead of connecting to the
 /// socket directly. `actor_id` / `actor_role` get injected into every
-/// `tools/call` via `_meta` by the bridge.
+/// `tools/call` via `_meta` by the bridge. `token` is required post-#309
+/// for the bridge to authenticate.
+#[allow(clippy::too_many_arguments)]
 async fn run_fake_claude_lead_via_bridge(
     cwd: &std::path::Path,
     script_path: &std::path::Path,
     mcp_sock: &std::path::Path,
     actor_id: &str,
     actor_role: &str,
+    token: &str,
     cancel: CancelToken,
     timeout: Duration,
 ) -> SessionOutcome {
@@ -144,6 +147,7 @@ async fn run_fake_claude_lead_via_bridge(
             support::pitboss_binary(),
             actor_id.into(),
             actor_role.into(),
+            token.into(),
         )),
         cancel,
         timeout,
@@ -155,7 +159,7 @@ async fn run_fake_claude_lead_impl(
     cwd: &std::path::Path,
     script_path: &std::path::Path,
     mcp_sock: &std::path::Path,
-    bridge: Option<(PathBuf, String, String)>,
+    bridge: Option<(PathBuf, String, String, String)>,
     cancel: CancelToken,
     timeout: Duration,
 ) -> SessionOutcome {
@@ -168,13 +172,14 @@ async fn run_fake_claude_lead_impl(
         "PITBOSS_FAKE_MCP_SOCKET".to_string(),
         mcp_sock.to_string_lossy().to_string(),
     );
-    if let Some((pitboss_bin, actor_id, actor_role)) = bridge {
+    if let Some((pitboss_bin, actor_id, actor_role, token)) = bridge {
         env.insert(
             "PITBOSS_FAKE_MCP_BRIDGE_CMD".to_string(),
             pitboss_bin.to_string_lossy().to_string(),
         );
         env.insert("PITBOSS_FAKE_ACTOR_ID".to_string(), actor_id);
         env.insert("PITBOSS_FAKE_ACTOR_ROLE".to_string(), actor_role);
+        env.insert("PITBOSS_FAKE_TOKEN".to_string(), token);
     }
     let cmd = SpawnCmd {
         program: fake_claude_path(),
@@ -421,10 +426,17 @@ async fn e2e_lead_cancels_worker_mid_flight() {
 "#;
     tokio::fs::write(&script, script_body).await.unwrap();
 
-    let outcome = run_fake_claude_lead(
+    // cancel_worker is gated by `authorize` which now hard-rejects unbound
+    // callers (#310). Route through the bridge with a minted token to
+    // mirror the production lead's auth path.
+    let token = state.mint_token("lead", "lead").await;
+    let outcome = run_fake_claude_lead_via_bridge(
         dir.path(),
         &script,
         &sock,
+        "lead",
+        "lead",
+        &token,
         CancelToken::new(),
         Duration::from_secs(30),
     )
@@ -688,10 +700,16 @@ async fn e2e_lead_reprompts_running_worker() {
 "#;
     tokio::fs::write(&script, script_body).await.unwrap();
 
-    let outcome = run_fake_claude_lead(
+    // reprompt_worker is gated by `authorize` (#310 fix). Route through
+    // the bridge with a minted token.
+    let token = state.mint_token("lead", "lead").await;
+    let outcome = run_fake_claude_lead_via_bridge(
         dir.path(),
         &script,
         &sock,
+        "lead",
+        "lead",
+        &token,
         CancelToken::new(),
         Duration::from_secs(30),
     )
@@ -1003,12 +1021,14 @@ async fn e2e_lead_through_mcp_bridge_injects_meta() {
 "#;
     tokio::fs::write(&script, script_body).await.unwrap();
 
+    let token = state.mint_token("lead", "lead").await;
     let outcome = run_fake_claude_lead_via_bridge(
         dir.path(),
         &script,
         &sock,
         "lead", // actor_id the bridge will inject
         "lead", // actor_role
+        &token,
         CancelToken::new(),
         Duration::from_secs(30),
     )
@@ -1190,10 +1210,16 @@ async fn e2e_freeze_pause_and_continue_real_subprocess_worker() {
 "#;
     tokio::fs::write(&script, script_body).await.unwrap();
 
-    let outcome = run_fake_claude_lead(
+    // pause/continue/cancel_worker are all gated by `authorize` (#310 fix).
+    // Route through the bridge with a minted token.
+    let token = state.mint_token("lead", "lead").await;
+    let outcome = run_fake_claude_lead_via_bridge(
         dir.path(),
         &script,
         &mcp_sock,
+        "lead",
+        "lead",
+        &token,
         CancelToken::new(),
         Duration::from_secs(30),
     )

--- a/crates/pitboss-cli/tests/e2e_sublead_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_sublead_flows.rs
@@ -36,6 +36,21 @@ use pitboss_core::store::{JsonFileStore, SessionStore};
 use pitboss_core::worktree::{CleanupPolicy, WorktreeManager};
 use uuid::Uuid;
 
+/// Mint an actor token via `state.mint_token` and connect a `FakeMcpClient`
+/// that presents it. Required because `authenticate_and_rebind` rejects
+/// calls that present `_meta.actor_id` without a valid token (#309 fix).
+async fn connect_actor(
+    state: &DispatchState,
+    socket: &std::path::Path,
+    actor_id: &str,
+    actor_role: &str,
+) -> FakeMcpClient {
+    let token = state.mint_token(actor_id, actor_role).await;
+    FakeMcpClient::connect_with_token(socket, actor_id, actor_role, &token)
+        .await
+        .expect("connect_with_token")
+}
+
 /// Build a DispatchState with allow_subleads=true and a root budget of $20.
 /// Worker spawner uses FakeScript that completes cleanly.
 fn mk_state(dir: &std::path::Path) -> (Uuid, Arc<DispatchState>) {
@@ -406,9 +421,7 @@ async fn run_global_lease_serializes_two_subleads() {
         .unwrap();
 
     // Root lead spawns two sub-leads.
-    let mut root_client = FakeMcpClient::connect_as(&socket, "root", "root_lead")
-        .await
-        .unwrap();
+    let mut root_client = connect_actor(&state, &socket, "root", "root_lead").await;
 
     let resp1 = root_client
         .call_tool(
@@ -435,9 +448,7 @@ async fn run_global_lease_serializes_two_subleads() {
         .to_string();
 
     // S1 acquires the run-global lease for "output.json".
-    let mut s1_client = FakeMcpClient::connect_as(&socket, &s1_id, "sublead")
-        .await
-        .unwrap();
+    let mut s1_client = connect_actor(&state, &socket, &s1_id, "sublead").await;
     let acq1 = s1_client
         .call_tool(
             "run_lease_acquire",
@@ -451,9 +462,7 @@ async fn run_global_lease_serializes_two_subleads() {
     );
 
     // S2 attempts to acquire the same lease — must be rejected with holder info.
-    let mut s2_client = FakeMcpClient::connect_as(&socket, &s2_id, "sublead")
-        .await
-        .unwrap();
+    let mut s2_client = connect_actor(&state, &socket, &s2_id, "sublead").await;
     let acq2 = s2_client
         .call_tool(
             "run_lease_acquire",
@@ -531,9 +540,7 @@ async fn reject_with_reason_reaches_sublead_session() {
     .unwrap();
 
     // Root lead spawns sub-lead S1.
-    let mut root_client = FakeMcpClient::connect_as(&mcp_sock, "root", "root_lead")
-        .await
-        .unwrap();
+    let mut root_client = connect_actor(&state, &mcp_sock, "root", "root_lead").await;
     let spawn_resp = root_client
         .call_tool(
             "spawn_sublead",
@@ -591,9 +598,7 @@ async fn reject_with_reason_reaches_sublead_session() {
     });
 
     // Sub-lead S1 calls request_approval.
-    let mut s1_client = FakeMcpClient::connect_as(&mcp_sock, &s1_id, "sublead")
-        .await
-        .unwrap();
+    let mut s1_client = connect_actor(&state, &mcp_sock, &s1_id, "sublead").await;
     let approval_resp = s1_client
         .call_tool(
             "request_approval",

--- a/crates/pitboss-cli/tests/hierarchical_flows.rs
+++ b/crates/pitboss-cli/tests/hierarchical_flows.rs
@@ -19,6 +19,14 @@ use pitboss_core::store::{JsonFileStore, SessionStore};
 use pitboss_core::worktree::{CleanupPolicy, WorktreeManager};
 use uuid::Uuid;
 
+/// Mint a root-lead token for `state` matching what `hierarchical.rs`
+/// does in production. Returned alongside the state so tests can call
+/// `FakeMcpClient::connect_with_token(&socket, "lead", "lead", &token)`
+/// and pass `authenticate_and_rebind` post-#309-fix.
+async fn mint_root_token(state: &DispatchState) -> String {
+    state.mint_token(&state.root.lead_id, "lead").await
+}
+
 fn mk_state() -> (TempDir, Arc<DispatchState>) {
     let dir = TempDir::new().unwrap();
     // Lead with use_worktree=false so background worker spawns don't require
@@ -99,7 +107,10 @@ async fn mcp_spawn_and_list_round_trip() {
         .await
         .unwrap();
 
-    let mut client = FakeMcpClient::connect(&socket).await.unwrap();
+    let token = mint_root_token(&state).await;
+    let mut client = FakeMcpClient::connect_with_token(&socket, "lead", "lead", &token)
+        .await
+        .unwrap();
     let spawn_result = client
         .call_tool(
             "spawn_worker",
@@ -129,7 +140,10 @@ async fn mcp_spawn_over_max_workers_returns_error() {
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
-    let mut client = FakeMcpClient::connect(&socket).await.unwrap();
+    let token = mint_root_token(&state).await;
+    let mut client = FakeMcpClient::connect_with_token(&socket, "lead", "lead", &token)
+        .await
+        .unwrap();
 
     for i in 0..4 {
         client
@@ -173,7 +187,10 @@ async fn mcp_spawn_over_budget_returns_error() {
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
-    let mut client = FakeMcpClient::connect(&socket).await.unwrap();
+    let token = mint_root_token(&state).await;
+    let mut client = FakeMcpClient::connect_with_token(&socket, "lead", "lead", &token)
+        .await
+        .unwrap();
 
     let err = client
         .call_tool("spawn_worker", json!({"prompt": "p"}))
@@ -206,7 +223,10 @@ async fn mcp_spawn_while_draining_returns_error() {
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
-    let mut client = FakeMcpClient::connect(&socket).await.unwrap();
+    let token = mint_root_token(&state).await;
+    let mut client = FakeMcpClient::connect_with_token(&socket, "lead", "lead", &token)
+        .await
+        .unwrap();
 
     let err = client
         .call_tool("spawn_worker", json!({"prompt": "p"}))
@@ -249,7 +269,10 @@ async fn wait_actor_alias_resolves_worker_id() {
         .await
         .unwrap();
 
-    let mut client = FakeMcpClient::connect(&socket).await.unwrap();
+    let token = mint_root_token(&state).await;
+    let mut client = FakeMcpClient::connect_with_token(&socket, "lead", "lead", &token)
+        .await
+        .unwrap();
     let spawn_result = client
         .call_tool(
             "spawn_worker",

--- a/crates/pitboss-cli/tests/shared_store_flows.rs
+++ b/crates/pitboss-cli/tests/shared_store_flows.rs
@@ -493,14 +493,17 @@ async fn lease_released_when_mcp_connection_drops() {
 
     // Session A: acquire with a very long TTL so only the connection-drop
     // cleanup can release it within the test timeframe.
-    let mut client_a = FakeMcpClient::connect(&socket).await.unwrap();
+    let token_a = state.mint_token("worker-A", "worker").await;
+    let token_b = state.mint_token("worker-B", "worker").await;
+    let mut client_a = FakeMcpClient::connect_with_token(&socket, "worker-A", "worker", &token_a)
+        .await
+        .unwrap();
     let acq_a = client_a
         .call_tool(
             "lease_acquire",
             json!({
                 "name": "job-1",
                 "ttl_secs": 3600,
-                "_meta": { "actor_id": "worker-A", "actor_role": "worker" }
             }),
         )
         .await
@@ -519,14 +522,15 @@ async fn lease_released_when_mcp_connection_drops() {
 
     // Session B: should be able to take the lease — it's free because A
     // disconnected, not because 3600s elapsed.
-    let mut client_b = FakeMcpClient::connect(&socket).await.unwrap();
+    let mut client_b = FakeMcpClient::connect_with_token(&socket, "worker-B", "worker", &token_b)
+        .await
+        .unwrap();
     let acq_b = client_b
         .call_tool(
             "lease_acquire",
             json!({
                 "name": "job-1",
                 "ttl_secs": 60,
-                "_meta": { "actor_id": "worker-B", "actor_role": "worker" }
             }),
         )
         .await
@@ -636,14 +640,17 @@ async fn run_global_lease_released_when_mcp_connection_drops() {
 
     // Session A: acquire with a very long TTL so only the connection-drop
     // cleanup can release it within the test timeframe.
-    let mut client_a = FakeMcpClient::connect(&socket).await.unwrap();
+    let token_a = state.mint_token("worker-A", "worker").await;
+    let token_b = state.mint_token("worker-B", "worker").await;
+    let mut client_a = FakeMcpClient::connect_with_token(&socket, "worker-A", "worker", &token_a)
+        .await
+        .unwrap();
     let acq_a = client_a
         .call_tool(
             "run_lease_acquire",
             json!({
                 "key": "r-job-1",
                 "ttl_secs": 3600,
-                "_meta": { "actor_id": "worker-A", "actor_role": "worker" }
             }),
         )
         .await
@@ -662,14 +669,15 @@ async fn run_global_lease_released_when_mcp_connection_drops() {
 
     // Session B: should be able to take the lease — it's free because A
     // disconnected, not because 3600s elapsed.
-    let mut client_b = FakeMcpClient::connect(&socket).await.unwrap();
+    let mut client_b = FakeMcpClient::connect_with_token(&socket, "worker-B", "worker", &token_b)
+        .await
+        .unwrap();
     let acq_b = client_b
         .call_tool(
             "run_lease_acquire",
             json!({
                 "key": "r-job-1",
                 "ttl_secs": 60,
-                "_meta": { "actor_id": "worker-B", "actor_role": "worker" }
             }),
         )
         .await

--- a/crates/pitboss-cli/tests/sublead_flows.rs
+++ b/crates/pitboss-cli/tests/sublead_flows.rs
@@ -2,7 +2,7 @@
 //! pitboss MCP server using fake-mcp-client, mirroring the
 //! hierarchical_flows.rs pattern.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use tempfile::TempDir;
@@ -18,6 +18,22 @@ use pitboss_core::session::CancelToken;
 use pitboss_core::store::{JsonFileStore, SessionStore};
 use pitboss_core::worktree::{CleanupPolicy, WorktreeManager};
 use uuid::Uuid;
+
+/// Mint an actor token via `state.mint_token` and connect a `FakeMcpClient`
+/// that presents it. Mirrors what `pitboss mcp-bridge --token` does in
+/// production. Required because `authenticate_and_rebind` rejects calls
+/// that present `_meta.actor_id` without a valid token (#309 fix).
+async fn connect_actor(
+    state: &DispatchState,
+    socket: &Path,
+    actor_id: &str,
+    actor_role: &str,
+) -> FakeMcpClient {
+    let token = state.mint_token(actor_id, actor_role).await;
+    FakeMcpClient::connect_with_token(socket, actor_id, actor_role, &token)
+        .await
+        .expect("connect_with_token")
+}
 
 /// Same shape as hierarchical_flows::mk_state but with allow_subleads
 /// enabled on the lead. Used by every test in this file.
@@ -176,9 +192,7 @@ async fn sublead_kv_writes_isolated_from_root() {
         .unwrap();
 
     // Root lead spawns a sub-lead.
-    let mut root_client = FakeMcpClient::connect_as(&socket, "root", "root_lead")
-        .await
-        .unwrap();
+    let mut root_client = connect_actor(&state, &socket, "root", "root_lead").await;
     let resp = root_client
         .call_tool(
             "spawn_sublead",
@@ -192,9 +206,7 @@ async fn sublead_kv_writes_isolated_from_root() {
         .to_string();
 
     // Sub-lead writes /shared/key = "from_sub" into its own sub-tree layer.
-    let mut sub_client = FakeMcpClient::connect_as(&socket, &sublead_id, "sublead")
-        .await
-        .unwrap();
+    let mut sub_client = connect_actor(&state, &socket, &sublead_id, "sublead").await;
     sub_client
         .call_tool(
             "kv_set",
@@ -248,9 +260,7 @@ async fn sublead_workers_cannot_read_sibling_peer_slots() {
 
     // Worker A writes its peer slot.
     // (worker_meta uses ActorRole::Worker → "worker" role → root layer)
-    let mut worker_a = FakeMcpClient::connect_as(&socket, "worker-A", "worker")
-        .await
-        .unwrap();
+    let mut worker_a = connect_actor(&state, &socket, "worker-A", "worker").await;
     worker_a
         .call_tool(
             "kv_set",
@@ -261,9 +271,7 @@ async fn sublead_workers_cannot_read_sibling_peer_slots() {
 
     // Worker B tries to read Worker A's peer slot — must be rejected.
     // (strict peer visibility: only worker-A itself or the layer lead can read /peer/worker-A/*)
-    let mut worker_b = FakeMcpClient::connect_as(&socket, "worker-B", "worker")
-        .await
-        .unwrap();
+    let mut worker_b = connect_actor(&state, &socket, "worker-B", "worker").await;
     let result = worker_b
         .call_tool("kv_get", json!({"path": "/peer/worker-A/status"}))
         .await;
@@ -293,9 +301,7 @@ async fn sublead_workers_cannot_wait_on_sibling_peer_slots() {
     // Worker A will write its peer slot asynchronously.
     // Worker B tries to wait on Worker A's peer slot — must be rejected.
     // (strict peer visibility: only worker-A itself or the layer lead can wait on /peer/worker-A/*)
-    let mut worker_b = FakeMcpClient::connect_as(&socket, "worker-B", "worker")
-        .await
-        .unwrap();
+    let mut worker_b = connect_actor(&state, &socket, "worker-B", "worker").await;
     let result = worker_b
         .call_tool(
             "kv_wait",
@@ -323,7 +329,7 @@ async fn spawn_sublead_tool_is_exposed_to_root() {
         .await
         .unwrap();
 
-    let mut client = FakeMcpClient::connect(&socket).await.unwrap();
+    let mut client = connect_actor(&state, &socket, "root", "root_lead").await;
     let tools = client.list_tools().await.unwrap();
     assert!(
         tools.iter().any(|t| t.name == "spawn_sublead"),
@@ -342,7 +348,7 @@ async fn spawn_sublead_creates_isolated_layer() {
         .unwrap();
 
     // Plain connect() defaults to root_lead identity, which passes the role check.
-    let mut client = FakeMcpClient::connect(&socket).await.unwrap();
+    let mut client = connect_actor(&state, &socket, "root", "root_lead").await;
     let resp = client
         .call_tool(
             "spawn_sublead",
@@ -401,9 +407,7 @@ async fn root_cancel_cascades_to_sublead_workers() {
     // called inside run_hierarchical after the MCP server starts).
     pitboss_cli::dispatch::signals::install_cascade_cancel_watcher(state.clone());
 
-    let mut client = FakeMcpClient::connect_as(&socket, "root", "root_lead")
-        .await
-        .unwrap();
+    let mut client = connect_actor(&state, &socket, "root", "root_lead").await;
     let resp = client
         .call_tool(
             "spawn_sublead",
@@ -461,9 +465,7 @@ async fn sublead_cannot_call_spawn_sublead() {
 
     // Connect as a sub-lead actor (the fake client simulates what mcp-bridge
     // would do in production, injecting _meta into the call_tool request).
-    let mut client = FakeMcpClient::connect_as(&socket, "sublead-x", "sublead")
-        .await
-        .unwrap();
+    let mut client = connect_actor(&state, &socket, "sublead-x", "sublead").await;
     let result = client
         .call_tool(
             "spawn_sublead",
@@ -549,9 +551,7 @@ async fn run_lease_blocks_cross_subtree_acquisition() {
         .await
         .unwrap();
 
-    let mut root_client = FakeMcpClient::connect_as(&socket, "root", "root_lead")
-        .await
-        .unwrap();
+    let mut root_client = connect_actor(&state, &socket, "root", "root_lead").await;
     let resp1 = root_client
         .call_tool(
             "spawn_sublead",
@@ -576,9 +576,7 @@ async fn run_lease_blocks_cross_subtree_acquisition() {
         .to_string();
 
     // S1 acquires the lease
-    let mut s1_client = FakeMcpClient::connect_as(&socket, &s1, "sublead")
-        .await
-        .unwrap();
+    let mut s1_client = connect_actor(&state, &socket, &s1, "sublead").await;
     let acq1 = s1_client
         .call_tool(
             "run_lease_acquire",
@@ -588,9 +586,7 @@ async fn run_lease_blocks_cross_subtree_acquisition() {
     assert!(acq1.is_ok(), "s1 should acquire");
 
     // S2 tries the same key — must fail with holder info
-    let mut s2_client = FakeMcpClient::connect_as(&socket, &s2, "sublead")
-        .await
-        .unwrap();
+    let mut s2_client = connect_actor(&state, &socket, &s2, "sublead").await;
     let acq2 = s2_client
         .call_tool(
             "run_lease_acquire",
@@ -746,9 +742,7 @@ async fn policy_auto_approves_sublead_actor() {
         .unwrap();
 
     // Root lead spawns sub-lead S1.
-    let mut root_client = FakeMcpClient::connect_as(&socket, "root", "root_lead")
-        .await
-        .unwrap();
+    let mut root_client = connect_actor(&state, &socket, "root", "root_lead").await;
     let spawn_resp = root_client
         .call_tool(
             "spawn_sublead",
@@ -784,9 +778,7 @@ async fn policy_auto_approves_sublead_actor() {
     // Sub-lead S1 calls request_approval. FakeMcpClient::connect_as with role
     // "sublead" causes _meta injection of {actor_id: s1_id, actor_role: "sublead"},
     // which build_caller_identity converts to actor_path "root→<s1_id>".
-    let mut s1_client = FakeMcpClient::connect_as(&socket, &s1_id, "sublead")
-        .await
-        .unwrap();
+    let mut s1_client = connect_actor(&state, &socket, &s1_id, "sublead").await;
     let result = s1_client
         .call_tool(
             "request_approval",
@@ -940,9 +932,7 @@ async fn kill_worker_with_reason_reprompts_parent_sublead() {
         .unwrap();
 
     // Root lead spawns sub-lead S1.
-    let mut root_client = FakeMcpClient::connect_as(&socket, "root", "root_lead")
-        .await
-        .unwrap();
+    let mut root_client = connect_actor(&state, &socket, "root", "root_lead").await;
     let resp = root_client
         .call_tool(
             "spawn_sublead",
@@ -1083,9 +1073,7 @@ async fn spawn_sublead_rejected_when_over_max_sublead_budget() {
     let _server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
-    let mut root = FakeMcpClient::connect_as(&socket, "root", "root_lead")
-        .await
-        .unwrap();
+    let mut root = connect_actor(&state, &socket, "root", "root_lead").await;
 
     let result = root
         .call_tool(
@@ -1306,9 +1294,7 @@ async fn sublead_spawn_worker_registers_in_sub_tree_layer() {
         .unwrap();
 
     // Root lead spawns a sub-lead.
-    let mut root_client = FakeMcpClient::connect_as(&socket, "root", "root_lead")
-        .await
-        .unwrap();
+    let mut root_client = connect_actor(&state, &socket, "root", "root_lead").await;
     let resp = root_client
         .call_tool(
             "spawn_sublead",
@@ -1323,9 +1309,7 @@ async fn sublead_spawn_worker_registers_in_sub_tree_layer() {
 
     // Sub-lead calls spawn_worker. FakeMcpClient::connect_as injects
     // _meta = {actor_id: sublead_id, actor_role: "sublead"}.
-    let mut sub_client = FakeMcpClient::connect_as(&socket, &sublead_id, "sublead")
-        .await
-        .unwrap();
+    let mut sub_client = connect_actor(&state, &socket, &sublead_id, "sublead").await;
     let spawn_resp = sub_client
         .call_tool("spawn_worker", json!({"prompt": "sub-task 1"}))
         .await
@@ -1378,9 +1362,7 @@ async fn worker_cannot_spawn_worker() {
         .unwrap();
 
     // Connect as a worker actor.
-    let mut worker_client = FakeMcpClient::connect_as(&socket, "worker-xyz", "worker")
-        .await
-        .unwrap();
+    let mut worker_client = connect_actor(&state, &socket, "worker-xyz", "worker").await;
     let result = worker_client
         .call_tool("spawn_worker", json!({"prompt": "nested spawn attempt"}))
         .await;
@@ -1457,9 +1439,7 @@ async fn kill_with_reason_delivers_synthetic_reprompt_to_running_lead() {
         .unwrap();
 
     // Root lead spawns sub-lead S1.
-    let mut root_client = FakeMcpClient::connect_as(&socket, "root", "root_lead")
-        .await
-        .unwrap();
+    let mut root_client = connect_actor(&state, &socket, "root", "root_lead").await;
     let resp = root_client
         .call_tool(
             "spawn_sublead",
@@ -1553,9 +1533,7 @@ async fn kill_with_reason_skips_delivery_when_lead_already_terminated() {
         .unwrap();
 
     // Root lead spawns sub-lead S1.
-    let mut root_client = FakeMcpClient::connect_as(&socket, "root", "root_lead")
-        .await
-        .unwrap();
+    let mut root_client = connect_actor(&state, &socket, "root", "root_lead").await;
     let resp = root_client
         .call_tool(
             "spawn_sublead",
@@ -1769,9 +1747,7 @@ async fn kill_with_reason_delivers_to_root_lead() {
     state.root.set_reprompt_tx(reprompt_tx).await;
 
     // Operator (acting as root lead) kills worker-root-1 with a reason.
-    let mut root_client = FakeMcpClient::connect_as(&socket, "root", "root_lead")
-        .await
-        .unwrap();
+    let mut root_client = connect_actor(&state, &socket, "root", "root_lead").await;
     root_client
         .call_tool(
             "cancel_worker",

--- a/tests-support/fake-claude/src/mcp_client.rs
+++ b/tests-support/fake-claude/src/mcp_client.rs
@@ -57,6 +57,7 @@ impl McpClient {
         socket: &Path,
         actor_id: &str,
         actor_role: &str,
+        token: Option<&str>,
     ) -> Result<Self> {
         let mut cmd = Command::new(pitboss_bin);
         cmd.arg("mcp-bridge")
@@ -65,6 +66,9 @@ impl McpClient {
             .arg(actor_id)
             .arg("--actor-role")
             .arg(actor_role);
+        if let Some(t) = token {
+            cmd.arg("--token").arg(t);
+        }
         let transport = TokioChildProcess::new(cmd).with_context(|| {
             format!(
                 "spawn mcp-bridge via {} (sock={}, actor={}/{})",
@@ -92,8 +96,15 @@ impl McpClient {
                 .context("PITBOSS_FAKE_MCP_BRIDGE_CMD set but PITBOSS_FAKE_ACTOR_ID missing")?;
             let actor_role = std::env::var("PITBOSS_FAKE_ACTOR_ROLE")
                 .context("PITBOSS_FAKE_MCP_BRIDGE_CMD set but PITBOSS_FAKE_ACTOR_ROLE missing")?;
-            return Self::connect_via_bridge(&PathBuf::from(cmd), socket, &actor_id, &actor_role)
-                .await;
+            let token = std::env::var("PITBOSS_FAKE_TOKEN").ok();
+            return Self::connect_via_bridge(
+                &PathBuf::from(cmd),
+                socket,
+                &actor_id,
+                &actor_role,
+                token.as_deref(),
+            )
+            .await;
         }
         Self::connect(socket).await
     }


### PR DESCRIPTION
## Summary

Closes three High-severity audit findings in the MCP server's per-actor token model. Adjudicated by two independent reviewers — consensus on each.

| Issue | Bug | Fix |
|---|---|---|
| **#309** | `authenticate_and_rebind` accepted `_meta.actor_id` without a token (same-UID socket forgery) | Reject when `_meta` carries `actor_id` but no token; bare `{}` still passes through |
| **#310** | `authorize` defaulted unbound callers to `root_lead` (privilege escalation, only reachable via #309) | Hard-reject unbound callers — production always binds via mint+`--token` |
| **#311** | `permission_prompt` handler had no `path_b` re-check (defense-in-depth) | Handler-level guard mirroring the `list_tools` filter |

Production callers are unchanged: root lead mints in `dispatch/hierarchical.rs:260`, workers in `mcp/tools/spawn.rs:438`, sub-leads in `dispatch/sublead.rs:487`. All flow through `pitboss mcp-bridge --token` already.

## Test migration

30+ integration tests previously connected as a forged actor without minting a token. Each now:
- mints via `state.mint_token(actor_id, role).await`
- connects through `FakeMcpClient::connect_with_token` (or the bridge with `--token` for e2e flows)

`tests-support/fake-claude` gains a `PITBOSS_FAKE_TOKEN` env var passed to `pitboss mcp-bridge --token`.

Three e2e tests that called mutating tools (`cancel_worker`, `reprompt_worker`, `pause_worker`) via direct-socket fake-claude were converted to the bridge path — direct-socket without a bound identity now correctly fails the `authorize` gate.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace --features pitboss-core/test-support` (all 36 suites green; 1000+ tests)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)