### PR TITLE
fix(dispatch): prune worker_layer_index on SpawnFailed and resume paths

### DIFF
--- a/crates/pitboss-cli/src/mcp/tools/spawn.rs
+++ b/crates/pitboss-cli/src/mcp/tools/spawn.rs
@@ -404,6 +404,10 @@ async fn run_worker(
                     .write()
                     .await
                     .insert(task_id.clone(), WorkerState::Done(rec));
+                // Mirror the normal-exit cleanup at spawn.rs:674 — without
+                // this, a worker whose worktree prep failed leaks its entry
+                // in worker_layer_index for the lifetime of the run (#344).
+                state.worker_layer_index.write().await.remove(&task_id);
                 // Fan out to root so cross-layer wait_actor subscribers wake
                 // even on early-exit paths like SpawnFailed. Same rationale
                 // as the normal-exit fan-out below.
@@ -1077,6 +1081,14 @@ pub async fn spawn_resume_worker(
             .write()
             .await
             .insert(task_id_bg.clone(), WorkerState::Done(rec));
+        // Mirror the normal-exit cleanup at spawn.rs:674 — without this,
+        // every paused-then-resumed worker leaks its entry in
+        // worker_layer_index on completion (#344).
+        state_bg
+            .worker_layer_index
+            .write()
+            .await
+            .remove(&task_id_bg);
         let _ = layer_bg.done_tx.send(task_id_bg);
     });
 


### PR DESCRIPTION
## Summary

Closes two narrow leak paths in \`worker_layer_index\` surfaced during adjudication of #300 (closed as invalid). Both paths now mirror the normal-exit cleanup at \`spawn.rs:674\`.

| Path | Before | Now |
|---|---|---|
| \`SpawnFailed\` worktree-prep error (\`spawn.rs:401-414\`) | early \`return\` skipped cleanup | adds \`worker_layer_index.remove\` before return |
| \`spawn_resume_worker\` background task (\`spawn.rs:993-1081\`) | resumed worker's entry persisted on completion | adds cleanup after \`WorkerState::Done\` insertion |

The originating audit issue #300 framed this as a sub-tree termination bug. Two independent reviewers confirmed the cancel cascade does drive the \`spawn.rs:674\` cleanup reliably — these two paths are adjacent leaks, not the audit's claim.

Closes #344.

## Test plan

- [x] \`cargo build -p pitboss-cli\`
- [x] \`cargo test --workspace --features pitboss-core/test-support\` (all 36 suites green)
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)