### PR TITLE
fix(shared-store): subscribe-before-try in lease_acquire

### DIFF
--- a/crates/pitboss-cli/src/shared_store/mod.rs
+++ b/crates/pitboss-cli/src/shared_store/mod.rs
@@ -680,7 +680,21 @@ impl SharedStore {
         wait: Option<std::time::Duration>,
         caller: &CallerIdentity,
     ) -> Result<AcquireResult, StoreError> {
-        // Non-blocking attempt first.
+        // Subscribe BEFORE the fast-path try so we don't miss a release
+        // that lands between our first attempt and the subscribe (#347).
+        // `tokio::sync::broadcast` only delivers events sent after the
+        // subscriber is created, so a release in that gap would otherwise
+        // be silently dropped and the waiter would burn its full deadline
+        // before returning a spurious `acquired: false`.
+        //
+        // The non-blocking case (`wait == None`) doesn't strictly need the
+        // subscriber, but creating it before the early return keeps the
+        // pattern symmetric with `wait()` and is essentially free —
+        // broadcast subscribers are cheap and dropped on early return.
+        let mut rx = self.lease_notifier.subscribe();
+
+        // Non-blocking attempt — also serves as the post-subscribe
+        // fast-path check.
         match self.leases.acquire(name, ttl, caller).await {
             Ok((lease, evicted)) => {
                 self.notify_lease_evictions(&evicted);
@@ -718,10 +732,6 @@ impl SharedStore {
                  silent holder crashes won't wake waiters until their own deadline"
             );
         }
-
-        // Subscribe BEFORE retrying so we don't miss a release that lands
-        // between our first attempt and the subscribe.
-        let mut rx = self.lease_notifier.subscribe();
         let deadline = tokio::time::Instant::now() + wait;
         loop {
             let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());

--- a/crates/pitboss-cli/src/shared_store/run_leases.rs
+++ b/crates/pitboss-cli/src/shared_store/run_leases.rs
@@ -85,11 +85,15 @@ impl LeaseRegistry {
     /// so callers don't have to roll their own poll loop. (#153 L6)
     ///
     /// Implementation: the inner `Notify` is poked on every release
-    /// path, so waiters wake without polling. Lost wakeups (release
-    /// fires before subscribe) are absorbed by Notify's
-    /// "permit"-style semantics — the first `notified()` after a
-    /// `notify_one` returns immediately. After waking, retries the
-    /// non-blocking `try_acquire`; loops until success or deadline.
+    /// path via `notify_waiters`, so currently-registered waiters wake
+    /// without polling. A release that lands in the gap between our
+    /// first `try_acquire` and the next `notified()` registration is
+    /// NOT absorbed by `Notify` — `notify_waiters` (unlike `notify_one`)
+    /// stores no permit, so a future `notified()` won't immediately
+    /// complete from a missed wake. The recovery mechanism is the final
+    /// `try_acquire` on deadline expiry below: in the worst case we
+    /// burn the full `wait` budget but don't hang, and the caller's
+    /// outer retry resolves any remaining contention. (#347)
     pub async fn acquire_with_wait(
         &self,
         key: &str,


### PR DESCRIPTION
## Summary

Closes a Medium-severity race in \`SharedStore::lease_acquire\` (\`mod.rs:684\` vs \`:724\`) surfaced during adjudication of #315 (closed as invalid — that audit issue cited \`wait()\`, which uses the correct subscribe-then-check pattern).

The function subscribed to \`lease_notifier\` AFTER the non-blocking \`try_acquire\`. \`tokio::sync::broadcast\` doesn't deliver events to subscribers created after the send, so a release that landed in the gap was silently dropped. The waiter then blocked on \`rx.recv()\` until its deadline and returned a spurious \`acquired: false\` even when the lease was free.

Fix: move \`subscribe()\` to before the first try, mirroring the correct pattern in \`SharedStore::wait\` (\`mod.rs:578-586\`). The first try then serves as the post-subscribe fast-path check.

Adjacent comment fix in \`run_leases.rs\`: the doc-comment at \`:87-92\` incorrectly claimed \`Notify\`'s "permit-style semantics" absorb lost wakeups. The release path uses \`notify_waiters\` which stores no permit (only \`notify_one\` does). The actual recovery mechanism is the final \`try_acquire\` on deadline expiry. The corrected comment prevents a future maintainer from "fixing" it by switching to \`notify_one\` and breaking the thundering-herd defeat.

Closes #347.

## Test plan

- [x] \`cargo build -p pitboss-cli\`
- [x] \`cargo test --workspace --features pitboss-core/test-support\` (all 36 suites green)
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)