### PR TITLE
fix(notify): inject PITBOSS_RUN_ID per-spawn instead of mutating parent env

### DIFF
--- a/crates/pitboss-cli/src/dispatch/entrypoint.rs
+++ b/crates/pitboss-cli/src/dispatch/entrypoint.rs
@@ -70,18 +70,20 @@ pub async fn init_run_state(
     pre_minted_run_id: Option<Uuid>,
     run_dir_override: Option<PathBuf>,
 ) -> Result<RunInit> {
-    // Snapshot any `PITBOSS_RUN_ID` already in our env BEFORE we
-    // overwrite it with our own run_id. If we're running under a
-    // parent orchestrator (or as a sub-dispatch the agent triggered
-    // from inside a worktree), the prior value is the parent run id
-    // reported on `RunDispatched`. See the `notify::parent` module for
-    // the full env-var contract introduced for issue #133.
+    // Snapshot any `PITBOSS_RUN_ID` already in our env. If we're running
+    // under a parent orchestrator (or as a sub-dispatch the agent
+    // triggered from inside a worktree), the inherited value is the parent
+    // run id reported on `RunDispatched`. See `notify::parent` for the env
+    // contract introduced for issue #133. Our own run_id is propagated to
+    // spawned claude subprocesses via per-spawn `Command::env` injection
+    // through `apply_pitboss_env_defaults` (closes #328 — pre-fix this was
+    // a parent-process `std::env::set_var`, which is UB-leaning under a
+    // multi-threaded tokio runtime).
     let parent_run_id = crate::notify::parent::parent_run_id();
     // Honor a pre-minted id from `--background` (issue #133-C);
     // otherwise mint fresh. Background pre-mints in the parent so it
     // can announce the id on stdout before the detached child boots.
     let run_id = pre_minted_run_id.unwrap_or_else(Uuid::now_v7);
-    crate::notify::parent::set_run_id_env(&run_id.to_string());
 
     let run_dir = run_dir_override.unwrap_or_else(|| resolved.run_dir.clone());
     tokio::fs::create_dir_all(&run_dir).await.ok();

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -315,7 +315,12 @@ pub async fn run_hierarchical(
     //     lead and sub-lead use different builders (`lead_resume_spawn_args`
     //     vs. `sublead_spawn_args`).
     let mut lead_env = lead.env.clone();
-    crate::dispatch::runner::apply_pitboss_env_defaults(&mut lead_env, lead.permission_routing);
+    let lead_run_id_str = init.run_id.to_string();
+    crate::dispatch::runner::apply_pitboss_env_defaults(
+        &mut lead_env,
+        &lead_run_id_str,
+        lead.permission_routing,
+    );
     let communication_mode = resolved.communication.mode;
     let initial_cmd = pitboss_core::process::SpawnCmd {
         program: claude_binary.clone(),
@@ -338,6 +343,7 @@ pub async fn run_hierarchical(
             let mut resume_env = lead.env.clone();
             crate::dispatch::runner::apply_pitboss_env_defaults(
                 &mut resume_env,
+                &lead_run_id_str,
                 lead.permission_routing,
             );
             pitboss_core::process::SpawnCmd {

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -44,9 +44,22 @@ use crate::manifest::resolve::{ResolvedManifest, ResolvedTask};
 /// approval queue rather than bypassing it).
 pub fn apply_pitboss_env_defaults(
     env: &mut std::collections::HashMap<String, String>,
+    run_id: &str,
     permission_routing: crate::manifest::schema::PermissionRouting,
 ) {
     use crate::manifest::schema::PermissionRouting;
+    // #133: every spawned claude subprocess inherits PITBOSS_RUN_ID so any
+    // nested `pitboss dispatch` invoked from inside its session can report the
+    // current run as `parent_run_id` on RunDispatched. Force-overwrite any
+    // operator-supplied value — operator env layers in BEFORE this helper, so
+    // an inherited PITBOSS_RUN_ID from a parent pitboss process would leak
+    // through. The child must see *this* run's id, not its grandparent's.
+    // (#328: replaces the previous parent-process std::env::set_var, which is
+    // UB-leaning under a multi-threaded tokio runtime.)
+    env.insert(
+        crate::notify::parent::RUN_ID_ENV.to_string(),
+        run_id.to_string(),
+    );
     match permission_routing {
         PermissionRouting::PathA => {
             // Path A (default): sdk-ts entrypoint bypasses claude's built-in gate.
@@ -647,7 +660,7 @@ async fn execute_task(
     };
 
     let mut cmd_env = task.env.clone();
-    apply_pitboss_env_defaults(&mut cmd_env, Default::default());
+    apply_pitboss_env_defaults(&mut cmd_env, &run_id.to_string(), Default::default());
     let cmd = SpawnCmd {
         program: claude.to_path_buf(),
         args: spawn_args(task),
@@ -1263,7 +1276,7 @@ mod tests {
     #[test]
     fn apply_pitboss_env_defaults_sets_entrypoint_when_absent() {
         let mut env: HashMap<String, String> = HashMap::new();
-        apply_pitboss_env_defaults(&mut env, Default::default());
+        apply_pitboss_env_defaults(&mut env, "test-run-id", Default::default());
         assert_eq!(
             env.get("CLAUDE_CODE_ENTRYPOINT"),
             Some(&"sdk-ts".to_string()),
@@ -1275,7 +1288,7 @@ mod tests {
     fn apply_pitboss_env_defaults_honors_operator_override() {
         let mut env: HashMap<String, String> = HashMap::new();
         env.insert("CLAUDE_CODE_ENTRYPOINT".to_string(), "cli".to_string());
-        apply_pitboss_env_defaults(&mut env, Default::default());
+        apply_pitboss_env_defaults(&mut env, "test-run-id", Default::default());
         assert_eq!(
             env.get("CLAUDE_CODE_ENTRYPOINT"),
             Some(&"cli".to_string()),
@@ -1287,11 +1300,31 @@ mod tests {
     fn apply_pitboss_env_defaults_preserves_other_keys() {
         let mut env: HashMap<String, String> = HashMap::new();
         env.insert("FOO".to_string(), "bar".to_string());
-        apply_pitboss_env_defaults(&mut env, Default::default());
+        apply_pitboss_env_defaults(&mut env, "test-run-id", Default::default());
         assert_eq!(env.get("FOO"), Some(&"bar".to_string()));
         assert_eq!(
             env.get("CLAUDE_CODE_ENTRYPOINT"),
             Some(&"sdk-ts".to_string())
+        );
+    }
+
+    /// #328 regression: PITBOSS_RUN_ID must be force-overwritten even when
+    /// the operator (or an inherited parent env) supplies a different value.
+    /// Reading PITBOSS_RUN_ID inside a nested `pitboss dispatch` is the
+    /// parent-correlation contract — letting an inherited value win would
+    /// make the child report its grandparent as parent_run_id.
+    #[test]
+    fn apply_pitboss_env_defaults_overrides_inherited_run_id() {
+        let mut env: HashMap<String, String> = HashMap::new();
+        env.insert(
+            crate::notify::parent::RUN_ID_ENV.to_string(),
+            "stale-grandparent-id".to_string(),
+        );
+        apply_pitboss_env_defaults(&mut env, "the-real-run-id", Default::default());
+        assert_eq!(
+            env.get(crate::notify::parent::RUN_ID_ENV),
+            Some(&"the-real-run-id".to_string()),
+            "PITBOSS_RUN_ID must be unconditionally overwritten with the current run's id"
         );
     }
 

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -37,11 +37,12 @@ use pitboss_core::worktree::CleanupPolicy;
 pub fn compose_sublead_env(
     lead_env: &HashMap<String, String>,
     operator_env: &HashMap<String, String>,
+    run_id: &str,
     permission_routing: crate::manifest::schema::PermissionRouting,
 ) -> HashMap<String, String> {
     let mut out = lead_env.clone();
     out.extend(operator_env.clone());
-    crate::dispatch::runner::apply_pitboss_env_defaults(&mut out, permission_routing);
+    crate::dispatch::runner::apply_pitboss_env_defaults(&mut out, run_id, permission_routing);
     out
 }
 
@@ -573,7 +574,12 @@ async fn spawn_sublead_session(
         .as_ref()
         .map(|l| l.permission_routing)
         .unwrap_or_default();
-    let sublead_env = compose_sublead_env(&lead_env, &operator_env, routing);
+    let sublead_env = compose_sublead_env(
+        &lead_env,
+        &operator_env,
+        &sub_layer.run_id.to_string(),
+        routing,
+    );
     let sublead_cwd = state
         .root
         .manifest
@@ -671,8 +677,12 @@ async fn spawn_sublead_session(
                     .as_ref()
                     .map(|l| l.env.clone())
                     .unwrap_or_default();
-                let resume_env =
-                    compose_sublead_env(&lead_env_resume, &operator_env_bg, resume_routing);
+                let resume_env = compose_sublead_env(
+                    &lead_env_resume,
+                    &operator_env_bg,
+                    &sub_layer_bg.run_id.to_string(),
+                    resume_routing,
+                );
                 let resume_cwd = state_bg
                     .root
                     .manifest
@@ -989,7 +999,7 @@ mod env_composition_tests {
             ("ARTIFACTS_DIR", "/run/artifacts"),
             ("ADVENTURE_OUT", "/run/out"),
         ]);
-        let out = compose_sublead_env(&lead, &HashMap::new(), Default::default());
+        let out = compose_sublead_env(&lead, &HashMap::new(), "test-run-id", Default::default());
         assert_eq!(out.get("WORK_DIR").map(String::as_str), Some("/run/work"));
         assert_eq!(
             out.get("ARTIFACTS_DIR").map(String::as_str),
@@ -1007,7 +1017,7 @@ mod env_composition_tests {
         // specific sublead to a different WORK_DIR without editing the manifest.
         let lead = env(&[("WORK_DIR", "/lead/path")]);
         let operator = env(&[("WORK_DIR", "/operator/path")]);
-        let out = compose_sublead_env(&lead, &operator, Default::default());
+        let out = compose_sublead_env(&lead, &operator, "test-run-id", Default::default());
         assert_eq!(
             out.get("WORK_DIR").map(String::as_str),
             Some("/operator/path")
@@ -1019,14 +1029,14 @@ mod env_composition_tests {
         // CLAUDE_CODE_ENTRYPOINT is only set when neither lead nor operator
         // supplied it. If either did, that value wins.
         let empty = HashMap::new();
-        let out = compose_sublead_env(&empty, &empty, Default::default());
+        let out = compose_sublead_env(&empty, &empty, "test-run-id", Default::default());
         assert_eq!(
             out.get("CLAUDE_CODE_ENTRYPOINT").map(String::as_str),
             Some("sdk-ts")
         );
 
         let lead = env(&[("CLAUDE_CODE_ENTRYPOINT", "cli")]);
-        let out = compose_sublead_env(&lead, &HashMap::new(), Default::default());
+        let out = compose_sublead_env(&lead, &HashMap::new(), "test-run-id", Default::default());
         assert_eq!(
             out.get("CLAUDE_CODE_ENTRYPOINT").map(String::as_str),
             Some("cli"),
@@ -1038,7 +1048,12 @@ mod env_composition_tests {
     fn empty_lead_env_still_applies_pitboss_defaults() {
         // No [defaults.env] and no operator env → sublead still gets
         // CLAUDE_CODE_ENTRYPOINT so the MCP permission bypass engages.
-        let out = compose_sublead_env(&HashMap::new(), &HashMap::new(), Default::default());
+        let out = compose_sublead_env(
+            &HashMap::new(),
+            &HashMap::new(),
+            "test-run-id",
+            Default::default(),
+        );
         assert!(out.contains_key("CLAUDE_CODE_ENTRYPOINT"));
     }
 }

--- a/crates/pitboss-cli/src/mcp/tools/spawn.rs
+++ b/crates/pitboss-cli/src/mcp/tools/spawn.rs
@@ -506,6 +506,7 @@ async fn run_worker(
     let worker_env = crate::dispatch::sublead::compose_sublead_env(
         &lead_env_for_worker,
         &std::collections::HashMap::new(),
+        &layer.run_id.to_string(),
         worker_routing,
     );
     let worker_communication_mode = state.root.manifest.communication.mode;
@@ -972,6 +973,7 @@ pub async fn spawn_resume_worker(
     let resume_env = crate::dispatch::sublead::compose_sublead_env(
         &lead_env_for_resume,
         &std::collections::HashMap::new(),
+        &layer.run_id.to_string(),
         resume_routing,
     );
     let cmd = pitboss_core::process::SpawnCmd {

--- a/crates/pitboss-cli/src/notify/parent.rs
+++ b/crates/pitboss-cli/src/notify/parent.rs
@@ -17,11 +17,15 @@
 //!   manifest-declared `[[notification]]` sinks — they don't conflict.
 //!
 //! - `PITBOSS_RUN_ID` — propagated automatically into every spawned
-//!   claude subprocess's env. A nested `pitboss dispatch` from inside that
-//!   subprocess inherits the value and reports it as `parent_run_id` on the
-//!   `RunDispatched` event so the orchestrator can correlate parent ↔ child.
-//!   Top-level dispatches see the var unset and report `parent_run_id =
-//!   None`.
+//!   claude subprocess's env (per-spawn via `Command::env` —
+//!   `apply_pitboss_env_defaults` in `dispatch/runner.rs` is the single
+//!   injection site). A nested `pitboss dispatch` from inside that
+//!   subprocess inherits the value and reports it as `parent_run_id` on
+//!   the `RunDispatched` event so the orchestrator can correlate parent ↔
+//!   child. Top-level dispatches see the var unset and report
+//!   `parent_run_id = None`. Pitboss never mutates its own process env
+//!   for this; doing so would race the multi-threaded tokio runtime
+//!   (issue #328).
 //!
 //! ## Why bypass the SSRF guard
 //!
@@ -86,36 +90,6 @@ pub fn parent_run_id() -> Option<String> {
         .ok()
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
-}
-
-/// Set `PITBOSS_RUN_ID` in the current process env so any pitboss-spawned
-/// claude subprocess (and any nested `pitboss dispatch` invoked from inside
-/// that subprocess) inherits the value. `tokio::process::Command::envs()`
-/// adds keys without clearing the inherited env, so a single set here
-/// propagates through the whole spawn tree without per-site plumbing.
-///
-/// # Safety
-///
-/// `std::env::set_var` is `unsafe` in Rust edition 2024 (and warned in
-/// 2021 since 1.82) because mutating the process env is unsynchronised
-/// with concurrent reads from libc and other threads. Call only:
-///
-/// 1. From the dispatcher entry point, **before** any worker, MCP server,
-///    or notification task is spawned — there are no concurrent env
-///    readers at that point.
-/// 2. Exactly once per process. The value is never re-set after dispatch
-///    starts; nested `pitboss dispatch` invocations get a fresh process
-///    that re-runs this gate from a clean slate.
-///
-/// Both invariants are upheld by the single call site in the dispatcher
-/// runners. Nothing else in pitboss writes to the env after startup.
-pub fn set_run_id_env(run_id: &str) {
-    // SAFETY: see doc-comment above. The dispatcher calls this before any
-    // worker / MCP / notification task is spawned, so there are no
-    // concurrent env readers at this point.
-    unsafe {
-        std::env::set_var(RUN_ID_ENV, run_id);
-    }
 }
 
 /// Build a [`NotificationRouter`] combining manifest `[[notification]]`


### PR DESCRIPTION
## Summary

Removes the parent-process `std::env::set_var` that propagated `PITBOSS_RUN_ID` to spawned claude subprocesses. Even with the documented "called once before any spawn" invariant and the `unsafe` block, mutating the process env from a multi-threaded tokio runtime is UB-leaning: glibc `setenv` may reallocate the `environ` array, invalidating any pointer held by a concurrent `getenv` on another thread (locale init, `tracing-subscriber` EnvFilter, `reqwest` proxy reads, etc.).

Routes the same value to every claude subprocess via `tokio::process::Command::env()` at each `SpawnCmd` construction site. This only mutates the child's env and preserves the #133 subprocess-inheritance contract.

## Why

Two independent reviewers (one `feature-dev:code-reviewer`, one general-purpose) reached the same verdict on audit issue #328: **valid-and-unfixed**, audit's literal fix wrong (passing as `&str` doesn't preserve subprocess inheritance), correct fix is per-spawn `Command::env()`.

The audit's framing ("Rust 2024 unsafe") is moot on this 2021 codebase — the `unsafe { }` block already compiles cleanly. The real hazard is the libc race, which exists regardless of edition.

## Mechanism

`apply_pitboss_env_defaults` gains a `run_id: &str` parameter that is **unconditionally inserted** (force-overwrite) so an inherited grandparent value can't leak through if the operator set `PITBOSS_RUN_ID` in `[lead.env]`. `compose_sublead_env` threads the value through. All 7 `SpawnCmd` construction sites now route through one of these helpers:

- `runner.rs:651` (flat task)
- `hierarchical.rs:320` (lead initial) and `:347` (lead resume closure)
- `sublead.rs:585` (sublead initial) and `:679` (sublead resume closure)
- `mcp/tools/spawn.rs:512` (MCP-spawned worker initial) and `:977` (worker resume)

Background dispatch uses `--internal-run-id` (no env), so its detached child re-runs `init_run_state` with the pre-minted id and resumes the per-spawn injection pattern from a clean slate. The nested `pitboss dispatch` case (an agent invoking pitboss from inside its claude session) still works: the worker's env carries `PITBOSS_RUN_ID=<parent-run>`, and `parent_run_id()` reads it at the nested process's startup before the new dispatch overwrites the child env at its own spawn sites.

## Test

- New regression `apply_pitboss_env_defaults_overrides_inherited_run_id` pins the force-overwrite contract against future drift to `or_insert_with`.
- All existing `apply_pitboss_env_defaults_*` and `compose_sublead_env_*` tests updated for the new signatures.

## Out of scope

The reviewers identified an adjacent test-side hazard: `parent.rs:174` `ENV_GUARD` only serializes tests inside `notify::parent::tests`, but `notify/config.rs:429` (and others) set `PITBOSS_RUN_ID` from different modules without the guard. `cargo test` runs in parallel, so cross-module env races are a real flake source. Filing as a separate Medium follow-up — independent of the production fix.

Closes #328.

## Test plan
- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace --features pitboss-core/test-support` — all green (~1100+ tests across all crates)
- [x] `cargo lint` clean
- [x] `cargo tidy` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)