### PR TITLE
fix(manifest): make max_parallel_tasks Option<u32> in resolved manifest

### DIFF
--- a/crates/pitboss-cli/src/communication.rs
+++ b/crates/pitboss-cli/src/communication.rs
@@ -823,7 +823,7 @@ mod tests {
         let manifest = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: dir.path().to_path_buf(),
             worktree_cleanup: WorktreeCleanup::OnSuccess,

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -1250,7 +1250,7 @@ mod tests {
         let manifest = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: dir.to_path_buf(),
             worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -1728,7 +1728,7 @@ mod tests {
         let sub_manifest = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: dir.path().to_path_buf(),
             worktree_cleanup: WorktreeCleanup::Never,
@@ -2213,7 +2213,7 @@ mod tests {
         let sub_manifest = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: dir.path().to_path_buf(),
             worktree_cleanup: WorktreeCleanup::Never,
@@ -2322,7 +2322,7 @@ mod tests {
         let sub_manifest = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: dir.path().to_path_buf(),
             worktree_cleanup: WorktreeCleanup::Never,
@@ -2446,7 +2446,7 @@ mod tests {
         let sub_manifest = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: dir.path().to_path_buf(),
             worktree_cleanup: WorktreeCleanup::Never,
@@ -2582,7 +2582,7 @@ mod tests {
         let sub_manifest = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: dir.path().to_path_buf(),
             worktree_cleanup: WorktreeCleanup::Never,

--- a/crates/pitboss-cli/src/dispatch/failure_detection.rs
+++ b/crates/pitboss-cli/src/dispatch/failure_detection.rs
@@ -352,7 +352,7 @@ mod tests {
         let manifest = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: dir.path().to_path_buf(),
             worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -444,7 +444,7 @@ mod tests {
         let manifest = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: dir.path().to_path_buf(),
             worktree_cleanup: WorktreeCleanup::OnSuccess,

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -1073,7 +1073,7 @@ mod await_drained_tests {
         let manifest = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: dir.path().to_path_buf(),
             worktree_cleanup: WorktreeCleanup::OnSuccess,

--- a/crates/pitboss-cli/src/dispatch/layer.rs
+++ b/crates/pitboss-cli/src/dispatch/layer.rs
@@ -441,7 +441,7 @@ mod tests {
         let manifest = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: dir.path().to_path_buf(),
             worktree_cleanup: WorktreeCleanup::OnSuccess,

--- a/crates/pitboss-cli/src/dispatch/resume.rs
+++ b/crates/pitboss-cli/src/dispatch/resume.rs
@@ -574,7 +574,7 @@ mod tests {
         let mut resolved = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: run_dir.to_path_buf(),
             worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -687,7 +687,7 @@ mod tests {
         let resolved = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: run_dir.to_path_buf(),
             worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -803,7 +803,7 @@ mod tests {
         let resolved = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: run_dir.to_path_buf(),
             worktree_cleanup: WorktreeCleanup::OnSuccess,

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -270,7 +270,13 @@ async fn setup_run_harness(
         table.lock().await.register(&t.id);
     }
 
-    let semaphore = Arc::new(Semaphore::new(resolved.max_parallel_tasks as usize));
+    // #320: max_parallel_tasks is None in hierarchical mode; this path
+    // only ever runs for flat manifests (resolved.tasks above), so
+    // expect-fail rather than substitute a default.
+    let max_parallel = resolved
+        .max_parallel_tasks
+        .expect("flat-mode dispatch requires resolved.max_parallel_tasks");
+    let semaphore = Arc::new(Semaphore::new(max_parallel as usize));
     let cancel = CancelToken::new();
     crate::dispatch::signals::install_ctrl_c_watcher(cancel.clone());
     let wt_mgr = Arc::new(WorktreeManager::new());
@@ -1374,7 +1380,7 @@ mod tests {
         ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 1,
+            max_parallel_tasks: Some(1),
             halt_on_failure: false,
             run_dir: PathBuf::from("/tmp/pitboss-test"),
             worktree_cleanup: crate::manifest::schema::WorktreeCleanup::OnSuccess,
@@ -1493,7 +1499,7 @@ mod tests {
         let resolved = crate::manifest::resolve::ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 2,
+            max_parallel_tasks: Some(2),
             halt_on_failure: false,
             run_dir: run_dir.path().to_path_buf(),
             worktree_cleanup: crate::manifest::schema::WorktreeCleanup::Always,
@@ -1615,7 +1621,7 @@ mod tests {
         let resolved = crate::manifest::resolve::ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 1, // serialize so ordering is deterministic
+            max_parallel_tasks: Some(1), // serialize so ordering is deterministic
             halt_on_failure: true,
             run_dir: run_dir.path().to_path_buf(),
             worktree_cleanup: crate::manifest::schema::WorktreeCleanup::Always,
@@ -1696,7 +1702,7 @@ mod tests {
         let resolved = crate::manifest::resolve::ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 1,
+            max_parallel_tasks: Some(1),
             halt_on_failure: false,
             run_dir: run_dir.path().to_path_buf(),
             worktree_cleanup: crate::manifest::schema::WorktreeCleanup::Always,

--- a/crates/pitboss-cli/src/dispatch/signals.rs
+++ b/crates/pitboss-cli/src/dispatch/signals.rs
@@ -359,7 +359,7 @@ mod tests {
         let manifest = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 1,
+            max_parallel_tasks: Some(1),
             halt_on_failure: false,
             run_dir: dir.path().to_path_buf(),
             worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -448,7 +448,7 @@ mod tests {
         let manifest = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 1,
+            max_parallel_tasks: Some(1),
             halt_on_failure: false,
             run_dir: dir.path().to_path_buf(),
             worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -537,7 +537,7 @@ mod tests {
         let manifest = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 1,
+            max_parallel_tasks: Some(1),
             halt_on_failure: false,
             run_dir: dir.path().to_path_buf(),
             worktree_cleanup: WorktreeCleanup::OnSuccess,

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -585,7 +585,7 @@ mod tests {
         let manifest = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: dir.path().to_path_buf(),
             worktree_cleanup: WorktreeCleanup::OnSuccess,

--- a/crates/pitboss-cli/src/main.rs
+++ b/crates/pitboss-cli/src/main.rs
@@ -355,10 +355,12 @@ fn run_validate(manifest: &std::path::Path) -> i32 {
             r.budget_usd.unwrap_or(0.0)
         );
     } else {
+        // #320: max_parallel_tasks is guaranteed Some here (we're in the
+        // flat-mode branch — `r.lead.is_none()`).
         println!(
             "OK — {} tasks, max_parallel={}",
             r.tasks.len(),
-            r.max_parallel_tasks
+            r.max_parallel_tasks.unwrap_or(0)
         );
     }
     0

--- a/crates/pitboss-cli/src/manifest/resolve.rs
+++ b/crates/pitboss-cli/src/manifest/resolve.rs
@@ -123,10 +123,17 @@ pub struct ResolvedManifest {
     /// the field.
     #[serde(default)]
     pub name: Option<String>,
-    /// Renamed from `max_parallel` in v0.9 to match the TOML field name.
-    /// `alias` keeps pre-v0.9 `resolved.json` snapshots resumable.
-    #[serde(alias = "max_parallel")]
-    pub max_parallel_tasks: u32,
+    /// Concurrency cap for `[[task]]` flat-mode runs. `None` in
+    /// hierarchical mode (the lead's `max_workers` plays this role; the
+    /// flat-mode semaphore at `runner.rs` is never constructed). Renamed
+    /// from `max_parallel` in v0.9 to match the TOML field name; `alias`
+    /// keeps pre-v0.9 `resolved.json` snapshots resumable.
+    ///
+    /// #320: pre-fix this was always `Some(DEFAULT_MAX_PARALLEL_TASKS)`
+    /// even for hierarchical manifests, which made `resolved.json` lie
+    /// about the run's actual concurrency model.
+    #[serde(alias = "max_parallel", skip_serializing_if = "Option::is_none")]
+    pub max_parallel_tasks: Option<u32>,
     pub halt_on_failure: bool,
     pub run_dir: PathBuf,
     pub worktree_cleanup: WorktreeCleanup,
@@ -212,11 +219,21 @@ pub fn resolve(
         None
     };
 
-    let max_parallel_tasks = manifest
-        .run
-        .max_parallel_tasks
-        .or(env_max_parallel_tasks)
-        .unwrap_or(DEFAULT_MAX_PARALLEL_TASKS);
+    // #320: max_parallel_tasks is flat-mode-only. Hierarchical mode caps
+    // concurrency via `lead.max_workers`; a default applied here would
+    // surface in `resolved.json` as a misleading non-zero value the
+    // dispatcher never reads.
+    let max_parallel_tasks = if resolved_lead.is_some() {
+        None
+    } else {
+        Some(
+            manifest
+                .run
+                .max_parallel_tasks
+                .or(env_max_parallel_tasks)
+                .unwrap_or(DEFAULT_MAX_PARALLEL_TASKS),
+        )
+    };
 
     let run_dir = manifest.run.run_dir.unwrap_or_else(default_run_dir);
 
@@ -597,7 +614,52 @@ mod tests {
         "#);
         let r = resolve(m, None).unwrap();
         assert_eq!(r.tasks[0].prompt, "hi");
-        assert_eq!(r.max_parallel_tasks, 4);
+        assert_eq!(r.max_parallel_tasks, Some(4));
+    }
+
+    /// #320: hierarchical manifests do NOT use `max_parallel_tasks`
+    /// (lead.max_workers caps concurrency there). Resolving such a
+    /// manifest must leave the field as `None` rather than the flat-mode
+    /// default — otherwise `resolved.json` carries a misleading value
+    /// the dispatcher never reads.
+    #[test]
+    fn hierarchical_manifest_resolves_max_parallel_tasks_to_none() {
+        let m = man(r#"
+            [lead]
+            id = "lead"
+            directory = "/tmp"
+            prompt = "p"
+            allow_subleads = false
+            max_workers = 4
+            budget_usd = 5.0
+        "#);
+        let r = resolve(m, None).unwrap();
+        assert!(
+            r.lead.is_some(),
+            "fixture must produce a hierarchical manifest"
+        );
+        assert_eq!(
+            r.max_parallel_tasks, None,
+            "hierarchical mode must leave max_parallel_tasks unset; pre-fix it was Some(4)"
+        );
+    }
+
+    /// Even when an env-var override is supplied, hierarchical mode
+    /// still resolves to `None` — the env var only applies to flat-mode
+    /// `[[task]]` runs.
+    #[test]
+    fn hierarchical_manifest_ignores_env_max_parallel_override() {
+        let m = man(r#"
+            [lead]
+            id = "lead"
+            directory = "/tmp"
+            prompt = "p"
+            allow_subleads = false
+            max_workers = 4
+            budget_usd = 5.0
+        "#);
+        let r = resolve(m, Some(64)).unwrap();
+        assert_eq!(r.max_parallel_tasks, None);
     }
 
     #[test]
@@ -656,7 +718,7 @@ mod tests {
             prompt = "p"
         "#);
         let r = resolve(m, Some(16)).unwrap();
-        assert_eq!(r.max_parallel_tasks, 16);
+        assert_eq!(r.max_parallel_tasks, Some(16));
     }
 
     #[test]
@@ -670,7 +732,7 @@ mod tests {
             prompt = "p"
         "#);
         let r = resolve(m, Some(16)).unwrap();
-        assert_eq!(r.max_parallel_tasks, 2);
+        assert_eq!(r.max_parallel_tasks, Some(2));
     }
 
     #[test]
@@ -938,7 +1000,8 @@ category = "tool_use"
             "snapshot without the field must default to 0 (legacy)"
         );
         assert_eq!(
-            r.max_parallel_tasks, 7,
+            r.max_parallel_tasks,
+            Some(7),
             "alias `max_parallel` must populate max_parallel_tasks"
         );
         assert!(

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -346,7 +346,9 @@ fn validate_branch_conflicts(r: &ResolvedManifest) -> Result<()> {
 }
 
 fn validate_ranges(r: &ResolvedManifest) -> Result<()> {
-    if r.max_parallel_tasks == 0 {
+    // #320: max_parallel_tasks is None in hierarchical mode (the lead's
+    // max_workers caps concurrency there). Only validate when present.
+    if let Some(0) = r.max_parallel_tasks {
         bail!("[run].max_parallel_tasks must be > 0");
     }
     for t in &r.tasks {
@@ -566,7 +568,7 @@ mod tests {
         ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: PathBuf::from("."),
             worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -596,7 +598,7 @@ mod tests {
         let mut m = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: PathBuf::from("."),
             worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -665,7 +667,7 @@ mod tests {
     fn rejects_zero_max_parallel_tasks() {
         let d = with_tmp_repo(true);
         let mut r = rm(vec![rt("a", d.path().to_path_buf(), false, None)]);
-        r.max_parallel_tasks = 0;
+        r.max_parallel_tasks = Some(0);
         assert!(validate(&r).is_err());
     }
 
@@ -682,7 +684,7 @@ mod tests {
         let r = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: PathBuf::from("."),
             worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -715,7 +717,7 @@ mod tests {
         let r = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: PathBuf::from("."),
             worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -744,7 +746,7 @@ mod tests {
         let r = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: PathBuf::from("."),
             worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -778,7 +780,7 @@ mod tests {
         let r = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: PathBuf::from("."),
             worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -893,7 +895,7 @@ mod tests {
         let r = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: PathBuf::from("."),
             worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -947,7 +949,7 @@ mod tests {
         let r = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: PathBuf::from("."),
             worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -982,7 +984,7 @@ mod tests {
         let r = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: PathBuf::from("."),
             worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -1188,7 +1190,7 @@ mod tests {
         let mut m = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: PathBuf::from("."),
             worktree_cleanup: WorktreeCleanup::OnSuccess,

--- a/crates/pitboss-cli/src/mcp/approval.rs
+++ b/crates/pitboss-cli/src/mcp/approval.rs
@@ -425,7 +425,7 @@ mod tests {
         let manifest = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: dir.path().to_path_buf(),
             worktree_cleanup: WorktreeCleanup::OnSuccess,

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -1613,7 +1613,7 @@ mod tests {
         let manifest = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: dir.path().to_path_buf(),
             worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -1699,7 +1699,7 @@ mod tests {
         let manifest = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: dir.path().to_path_buf(),
             worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -1779,7 +1779,7 @@ mod tests {
         let manifest = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: dir.path().to_path_buf(),
             worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -1926,7 +1926,7 @@ mod tests {
         let manifest = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 4,
+            max_parallel_tasks: Some(4),
             halt_on_failure: false,
             run_dir: dir.path().to_path_buf(),
             worktree_cleanup: WorktreeCleanup::OnSuccess,

--- a/crates/pitboss-cli/src/mcp/tools/tests.rs
+++ b/crates/pitboss-cli/src/mcp/tools/tests.rs
@@ -78,7 +78,7 @@ async fn test_state_with_budget(budget: f64) -> Arc<DispatchState> {
     let manifest = ResolvedManifest {
         manifest_schema_version: 0,
         name: None,
-        max_parallel_tasks: 4,
+        max_parallel_tasks: Some(4),
         halt_on_failure: false,
         run_dir: dir.path().to_path_buf(),
         worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -600,7 +600,7 @@ async fn completing_test_state_with_budget(budget: Option<f64>) -> Arc<DispatchS
     let manifest = ResolvedManifest {
         manifest_schema_version: 0,
         name: None,
-        max_parallel_tasks: 4,
+        max_parallel_tasks: Some(4),
         halt_on_failure: false,
         run_dir: dir.path().to_path_buf(),
         worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -1448,7 +1448,7 @@ async fn handle_request_approval_auto_approves() {
     let manifest = ResolvedManifest {
         manifest_schema_version: 0,
         name: None,
-        max_parallel_tasks: 4,
+        max_parallel_tasks: Some(4),
         halt_on_failure: false,
         run_dir: dir.path().to_path_buf(),
         worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -1543,7 +1543,7 @@ async fn permission_prompt_auto_approves_and_returns_gate_response() {
     let manifest = ResolvedManifest {
         manifest_schema_version: 0,
         name: None,
-        max_parallel_tasks: 4,
+        max_parallel_tasks: Some(4),
         halt_on_failure: false,
         run_dir: dir.path().to_path_buf(),
         worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -1647,7 +1647,7 @@ async fn mk_plan_state(
     let manifest = ResolvedManifest {
         manifest_schema_version: 0,
         name: None,
-        max_parallel_tasks: 4,
+        max_parallel_tasks: Some(4),
         halt_on_failure: false,
         run_dir: dir.path().to_path_buf(),
         worktree_cleanup: WorktreeCleanup::OnSuccess,

--- a/crates/pitboss-cli/src/tree.rs
+++ b/crates/pitboss-cli/src/tree.rs
@@ -340,12 +340,15 @@ fn render_envelope(out: &mut String, m: &ResolvedManifest) {
 }
 
 fn render_flat(out: &mut String, m: &ResolvedManifest) {
+    // #320: render_flat is gated on `m.lead.is_none()` by the caller, so
+    // max_parallel_tasks is guaranteed to be Some here.
+    let max_parallel = m.max_parallel_tasks.unwrap_or(0);
     let _ = writeln!(
         out,
         "Flat mode ({} task{}, max_parallel_tasks={})",
         m.tasks.len(),
         if m.tasks.len() == 1 { "" } else { "s" },
-        m.max_parallel_tasks,
+        max_parallel,
     );
     let _ = writeln!(out);
     for t in &m.tasks {

--- a/crates/pitboss-cli/tests/cancel_cascade_flows.rs
+++ b/crates/pitboss-cli/tests/cancel_cascade_flows.rs
@@ -100,7 +100,7 @@ fn mk_state() -> (TempDir, Arc<DispatchState>) {
     let manifest = ResolvedManifest {
         manifest_schema_version: 0,
         name: None,
-        max_parallel_tasks: 8,
+        max_parallel_tasks: Some(8),
         halt_on_failure: false,
         run_dir: dir.path().to_path_buf(),
         worktree_cleanup: WorktreeCleanup::OnSuccess,

--- a/crates/pitboss-cli/tests/control_flows.rs
+++ b/crates/pitboss-cli/tests/control_flows.rs
@@ -37,7 +37,7 @@ async fn pause_op_writes_events_jsonl() {
     let manifest = ResolvedManifest {
         manifest_schema_version: 0,
         name: None,
-        max_parallel_tasks: 4,
+        max_parallel_tasks: Some(4),
         halt_on_failure: false,
         run_dir: dir.path().to_path_buf(),
         worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -245,7 +245,7 @@ async fn block_policy_queue_drains_on_tui_connect() {
     let manifest = ResolvedManifest {
         manifest_schema_version: 0,
         name: None,
-        max_parallel_tasks: 4,
+        max_parallel_tasks: Some(4),
         halt_on_failure: false,
         run_dir: dir.path().to_path_buf(),
         worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -362,7 +362,7 @@ async fn auto_approve_policy_responds_without_tui() {
     let manifest = ResolvedManifest {
         manifest_schema_version: 0,
         name: None,
-        max_parallel_tasks: 4,
+        max_parallel_tasks: Some(4),
         halt_on_failure: false,
         run_dir: dir.path().to_path_buf(),
         worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -426,7 +426,7 @@ async fn auto_reject_policy_responds_without_tui() {
     let manifest = ResolvedManifest {
         manifest_schema_version: 0,
         name: None,
-        max_parallel_tasks: 4,
+        max_parallel_tasks: Some(4),
         halt_on_failure: false,
         run_dir: dir.path().to_path_buf(),
         worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -501,7 +501,7 @@ async fn propose_plan_end_to_end_unblocks_spawn_gate() {
     let manifest = ResolvedManifest {
         manifest_schema_version: 0,
         name: None,
-        max_parallel_tasks: 4,
+        max_parallel_tasks: Some(4),
         halt_on_failure: false,
         run_dir: dir.path().to_path_buf(),
         worktree_cleanup: WorktreeCleanup::OnSuccess,

--- a/crates/pitboss-cli/tests/dogfood_fake_flows.rs
+++ b/crates/pitboss-cli/tests/dogfood_fake_flows.rs
@@ -92,7 +92,7 @@ fn mk_state_with_subleads() -> (TempDir, Arc<DispatchState>) {
     let manifest = ResolvedManifest {
         manifest_schema_version: 0,
         name: None,
-        max_parallel_tasks: 8,
+        max_parallel_tasks: Some(8),
         halt_on_failure: false,
         run_dir: dir.path().to_path_buf(),
         worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -1020,7 +1020,7 @@ async fn dogfood_envelope_cap_rejection() {
         let manifest = ResolvedManifest {
             manifest_schema_version: 0,
             name: None,
-            max_parallel_tasks: 8,
+            max_parallel_tasks: Some(8),
             halt_on_failure: false,
             run_dir: dir.path().to_path_buf(),
             worktree_cleanup: pitboss_cli::manifest::schema::WorktreeCleanup::OnSuccess,

--- a/crates/pitboss-cli/tests/e2e_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_flows.rs
@@ -62,7 +62,7 @@ fn mk_state(
     let manifest = ResolvedManifest {
         manifest_schema_version: 0,
         name: None,
-        max_parallel_tasks: 4,
+        max_parallel_tasks: Some(4),
         halt_on_failure: false,
         run_dir: run_dir.to_path_buf(),
         worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -371,7 +371,7 @@ async fn e2e_lead_cancels_worker_mid_flight() {
     let manifest = ResolvedManifest {
         manifest_schema_version: 0,
         name: None,
-        max_parallel_tasks: 4,
+        max_parallel_tasks: Some(4),
         halt_on_failure: false,
         run_dir: dir.path().to_path_buf(),
         worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -636,7 +636,7 @@ async fn e2e_lead_reprompts_running_worker() {
     let manifest = ResolvedManifest {
         manifest_schema_version: 0,
         name: None,
-        max_parallel_tasks: 4,
+        max_parallel_tasks: Some(4),
         halt_on_failure: false,
         run_dir: dir.path().to_path_buf(),
         worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -839,7 +839,7 @@ async fn e2e_lead_propose_plan_gate_unblocks_spawn() {
     let manifest = ResolvedManifest {
         manifest_schema_version: 0,
         name: None,
-        max_parallel_tasks: 4,
+        max_parallel_tasks: Some(4),
         halt_on_failure: false,
         run_dir: dir.path().to_path_buf(),
         worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -1144,7 +1144,7 @@ async fn e2e_freeze_pause_and_continue_real_subprocess_worker() {
     let manifest = ResolvedManifest {
         manifest_schema_version: 0,
         name: None,
-        max_parallel_tasks: 4,
+        max_parallel_tasks: Some(4),
         halt_on_failure: false,
         run_dir: dir.path().to_path_buf(),
         worktree_cleanup: WorktreeCleanup::OnSuccess,

--- a/crates/pitboss-cli/tests/e2e_sublead_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_sublead_flows.rs
@@ -77,7 +77,7 @@ fn mk_state(dir: &std::path::Path) -> (Uuid, Arc<DispatchState>) {
     let manifest = ResolvedManifest {
         manifest_schema_version: 0,
         name: None,
-        max_parallel_tasks: 4,
+        max_parallel_tasks: Some(4),
         halt_on_failure: false,
         run_dir: dir.to_path_buf(),
         worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -150,7 +150,7 @@ fn mk_state_hold_workers(dir: &std::path::Path) -> (Uuid, Arc<DispatchState>) {
     let manifest = ResolvedManifest {
         manifest_schema_version: 0,
         name: None,
-        max_parallel_tasks: 4,
+        max_parallel_tasks: Some(4),
         halt_on_failure: false,
         run_dir: dir.to_path_buf(),
         worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -787,7 +787,7 @@ async fn sublead_session_spawns_runs_and_reconciles() {
     let manifest = ResolvedManifest {
         manifest_schema_version: 0,
         name: None,
-        max_parallel_tasks: 4,
+        max_parallel_tasks: Some(4),
         halt_on_failure: false,
         run_dir: dir.path().to_path_buf(),
         worktree_cleanup: WorktreeCleanup::OnSuccess,

--- a/crates/pitboss-cli/tests/hierarchical_flows.rs
+++ b/crates/pitboss-cli/tests/hierarchical_flows.rs
@@ -53,7 +53,7 @@ fn mk_state() -> (TempDir, Arc<DispatchState>) {
     let manifest = ResolvedManifest {
         manifest_schema_version: 0,
         name: None,
-        max_parallel_tasks: 4,
+        max_parallel_tasks: Some(4),
         halt_on_failure: false,
         run_dir: dir.path().to_path_buf(),
         worktree_cleanup: WorktreeCleanup::OnSuccess,

--- a/crates/pitboss-cli/tests/notify_flows.rs
+++ b/crates/pitboss-cli/tests/notify_flows.rs
@@ -239,7 +239,7 @@ async fn approval_pending_notification_fires_on_enqueue() {
     let manifest = ResolvedManifest {
         manifest_schema_version: 0,
         name: None,
-        max_parallel_tasks: 4,
+        max_parallel_tasks: Some(4),
         halt_on_failure: false,
         run_dir: dir.path().to_path_buf(),
         worktree_cleanup: WorktreeCleanup::OnSuccess,

--- a/crates/pitboss-cli/tests/shared_store_flows.rs
+++ b/crates/pitboss-cli/tests/shared_store_flows.rs
@@ -447,7 +447,7 @@ async fn lease_released_when_mcp_connection_drops() {
     let manifest = ResolvedManifest {
         manifest_schema_version: 0,
         name: None,
-        max_parallel_tasks: 4,
+        max_parallel_tasks: Some(4),
         halt_on_failure: false,
         run_dir: dir.path().to_path_buf(),
         worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -594,7 +594,7 @@ async fn run_global_lease_released_when_mcp_connection_drops() {
     let manifest = ResolvedManifest {
         manifest_schema_version: 0,
         name: None,
-        max_parallel_tasks: 4,
+        max_parallel_tasks: Some(4),
         halt_on_failure: false,
         run_dir: dir.path().to_path_buf(),
         worktree_cleanup: WorktreeCleanup::OnSuccess,

--- a/crates/pitboss-cli/tests/sublead_flows.rs
+++ b/crates/pitboss-cli/tests/sublead_flows.rs
@@ -61,7 +61,7 @@ fn mk_state_with_subleads() -> (TempDir, Arc<DispatchState>) {
     let manifest = ResolvedManifest {
         manifest_schema_version: 0,
         name: None,
-        max_parallel_tasks: 8,
+        max_parallel_tasks: Some(8),
         halt_on_failure: false,
         run_dir: dir.path().to_path_buf(),
         worktree_cleanup: WorktreeCleanup::OnSuccess,
@@ -131,7 +131,7 @@ fn mk_state_with_sublead_budget_cap(cap: f64) -> (TempDir, Arc<DispatchState>) {
     let manifest = ResolvedManifest {
         manifest_schema_version: 0,
         name: None,
-        max_parallel_tasks: 8,
+        max_parallel_tasks: Some(8),
         halt_on_failure: false,
         run_dir: dir.path().to_path_buf(),
         worktree_cleanup: WorktreeCleanup::OnSuccess,


### PR DESCRIPTION
## Summary

\`resolve()\` unconditionally applied \`DEFAULT_MAX_PARALLEL_TASKS\` (4) to every manifest's \`max_parallel_tasks\`, including hierarchical-mode manifests where the field is never read (concurrency is bounded by \`lead.max_workers\`; the flat-mode semaphore at \`runner.rs:273\` is never constructed for hierarchical runs). Result: \`resolved.json\` showed \`\"max_parallel_tasks\": 4\` for hierarchical runs even though the dispatcher ignored it — confusing operators about the run's actual concurrency model.

Change \`ResolvedManifest.max_parallel_tasks\` from \`u32\` to \`Option<u32>\` with \`#[serde(skip_serializing_if = \"Option::is_none\")]\`. \`resolve()\` sets \`None\` when \`resolved_lead.is_some()\`, otherwise applies env-var override + default as before.

## Why \`Option<u32>\` over alternatives

- The unresolved schema type was already \`Option<u32>\` (\`schema.rs:459\`). The pre-fix asymmetry — \`Option\` in user TOML, \`u32\` after resolve — actively erased applicability information.
- Sentinel-0 (\`u32\` with 0 = "unused") would still type-pun: 0 reads as a deliberate "halt-the-pool" value to anyone scanning resolved.json.
- Compile-time enforcement: any future hierarchical-aware code path must explicitly handle \`None\`.

## Production read sites

- \`runner.rs:273\` (flat-dispatch semaphore) — \`.expect()\`. Only entered for flat manifests, so the invariant is structural.
- \`validate.rs:349\` — only validates when \`Some(0)\` (zero-cap reject preserved).
- \`main.rs:361\` and \`tree.rs:348\` — already gated on \`lead.is_none()\` by their callers.

## Test ripple

~25 test fixtures wrapped from \`max_parallel_tasks: N\` to \`max_parallel_tasks: Some(N)\` via mechanical \`perl -i -pe\`. Compiler enumerated them. Two new regression tests:

- \`hierarchical_manifest_resolves_max_parallel_tasks_to_none\` — pins None for hierarchical
- \`hierarchical_manifest_ignores_env_max_parallel_override\` — pins that the env var is flat-mode-scoped

Closes #320.

## Test plan
- [x] \`cargo build --workspace\` clean
- [x] \`cargo test --workspace --features pitboss-core/test-support\` — all green (~660+ tests)
- [x] \`cargo lint\` clean
- [x] \`cargo tidy\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)