### PR TITLE
feat(schema): reject enum_select without enum_values at macro expansion

### DIFF
--- a/crates/pitboss-schema-derive/src/lib.rs
+++ b/crates/pitboss-schema-derive/src/lib.rs
@@ -215,6 +215,18 @@ fn build_entry(field: &syn::Field) -> syn::Result<Option<TokenStream2>> {
         infer_form_type(&field.ty)
     };
     let form_type_str = form_type.unwrap_or_else(|| inferred.to_string());
+
+    // `enum_select` form-type without `enum_values` produces an empty
+    // dropdown in the wizard at runtime — discoverable only by opening
+    // the manifest wizard. Catch the gap at macro-expand time.
+    if form_type_str == "enum_select" && enum_values.is_empty() {
+        return Err(syn::Error::new_spanned(
+            field,
+            "`#[field(form_type = \"enum_select\")]` requires a non-empty \
+             `enum_values = [...]` list; the wizard would render an empty \
+             dropdown otherwise",
+        ));
+    }
     // Required iff (a) not wrapped in Option AND (b) no `#[serde(default)]`
     // / `#[serde(default = "...")]`. The serde-default branch matters for
     // primitives like `bool`/`u32` that have a Rust default but should still

--- a/crates/pitboss-schema/src/lib.rs
+++ b/crates/pitboss-schema/src/lib.rs
@@ -39,6 +39,26 @@
 
 pub use pitboss_schema_derive::FieldMetadata;
 
+/// Compile-fail coverage for ISSUE-schema-prior-2: a field annotated
+/// with `form_type = "enum_select"` but no `enum_values` must be a hard
+/// compile error from the derive. Pre-fix this compiled silently and
+/// the manifest wizard rendered an empty dropdown at runtime.
+///
+/// Lives as a `compile_fail` doctest rather than a `trybuild` test to
+/// avoid pulling in a dev-dep for one negative case.
+///
+/// ```compile_fail
+/// use pitboss_schema::FieldMetadata;
+///
+/// #[derive(FieldMetadata)]
+/// struct BadEnumSelect {
+///     #[field(form_type = "enum_select")]
+///     value: String,
+/// }
+/// ```
+#[doc(hidden)]
+pub fn _enum_select_requires_enum_values_compile_fail() {}
+
 /// Per-field descriptor emitted by `#[derive(FieldMetadata)]`.
 ///
 /// All fields are `&'static` so the descriptor table can live in `.rodata` —

--- a/crates/pitboss-schema/tests/derive.rs
+++ b/crates/pitboss-schema/tests/derive.rs
@@ -117,3 +117,40 @@ fn combined_default_with_rename_still_optional() {
     let meta = DefaultMixedWithRename::field_metadata();
     assert!(!meta[0].required);
 }
+
+// ── ISSUE-schema-prior-2: enum_select must carry enum_values ───────────
+
+/// Happy-path counterpart to the compile-fail check in the derive: a
+/// field annotated with `form_type = "enum_select"` AND a non-empty
+/// `enum_values = [...]` compiles cleanly and emits the expected
+/// `FormType::EnumSelect` variant with the values on the descriptor.
+#[derive(FieldMetadata)]
+#[allow(dead_code)]
+struct ValidEnumSelect {
+    #[field(form_type = "enum_select", enum_values = ["a", "b", "c"])]
+    color: String,
+}
+
+#[test]
+fn explicit_enum_select_with_values_emits_descriptor() {
+    let meta = ValidEnumSelect::field_metadata();
+    assert_eq!(meta[0].form_type, FormType::EnumSelect);
+    assert_eq!(meta[0].enum_values, &["a", "b", "c"]);
+}
+
+/// `enum_values = [...]` alone (without an explicit `form_type`) infers
+/// `enum_select` — pre-existing behavior at lib.rs:212-216. Pinning the
+/// inference path so the new compile-time guard can't regress it.
+#[derive(FieldMetadata)]
+#[allow(dead_code)]
+struct InferredEnumSelect {
+    #[field(enum_values = ["x", "y"])]
+    mode: String,
+}
+
+#[test]
+fn enum_values_alone_infers_enum_select() {
+    let meta = InferredEnumSelect::field_metadata();
+    assert_eq!(meta[0].form_type, FormType::EnumSelect);
+    assert_eq!(meta[0].enum_values, &["x", "y"]);
+}


### PR DESCRIPTION
## Summary

A field annotated with \`#[field(form_type = \"enum_select\")]\` but no \`enum_values = [...]\` list previously compiled silently — at runtime the manifest wizard rendered an empty dropdown that a developer could only discover by opening the wizard and noticing the empty select element.

The fix adds a compile-time check inside the derive macro at \`crates/pitboss-schema-derive/src/lib.rs\` that fires after both \`form_type\` and \`enum_values\` are parsed. When \`form_type_str == \"enum_select\"\` and \`enum_values.is_empty()\`, the macro emits a \`syn::Error\` spanned to the offending field with the message \"requires a non-empty \`enum_values = [...]\` list; the wizard would render an empty dropdown otherwise.\"

The pre-existing inference path (\`enum_values = [...]\` without an explicit \`form_type\` infers \`enum_select\`, lib.rs:212-216) is unchanged — the guard only fires when the explicit \`form_type\` is set without values.

## Test plan

- [x] Positive integration test: \`explicit_enum_select_with_values_emits_descriptor\` — asserts a correctly-annotated struct emits \`FormType::EnumSelect\` with the values on the descriptor.
- [x] Inference-path regression: \`enum_values_alone_infers_enum_select\` — pins the implicit-inference behavior so the new guard can't regress it.
- [x] \`compile_fail\` doctest in \`crates/pitboss-schema/src/lib.rs\` — exercises the bug pattern and asserts the build breaks. \`cargo test -p pitboss-schema\` reports it as \"compile fail ... ok\" (a \`compile_fail\` doctest passes when its inner code fails to compile).
- [x] \`cargo test --workspace --features pitboss-core/test-support\` — green
- [x] \`cargo lint\` — clean
- [x] \`cargo tidy\` — clean

\`compile_fail\` doctest chosen over \`trybuild\` so we don't pull in a dev-dep for one negative case.

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)