### PR TITLE
Implement Path B permission routing with MCP tool denial auditing

### DIFF
--- a/book/src/reference/compatibility.md
+++ b/book/src/reference/compatibility.md
@@ -8,7 +8,7 @@ Pitboss makes specific backward-compatibility guarantees at each version boundar
 
 v0.8 is backward-compatible with v0.7 manifests and tooling with one caveat:
 
-- **Manifests**: All v0.7 manifests run unchanged. The new `[container]` and `permission_routing` fields are optional; their absence preserves v0.7 behavior. `permission_routing = "path_b"` is explicitly rejected with an error until the follow-on stabilization lands (see issues #92–#94).
+- **Manifests**: All v0.7 manifests run unchanged. The new `[container]` and `permission_routing` fields are optional; their absence preserves v0.7 behavior. `permission_routing = "path_b"` is selectable as of v0.10.1 — validate emits a one-line soak warning rather than the prior hard error. Each per-tool check routes through pitboss's MCP `permission_prompt`; denials are non-terminating and recorded in `<run_dir>/tasks/<actor>/events.jsonl` as `tool_denied` rows.
 - **Wire format**: `ApprovalResponse` gains `from_ttl: bool` (default `false`). Existing consumers parsing approval responses see no change. `summary.json` and `summary.jsonl` gain `ApprovalTimedOut` as a `status` string value alongside existing `ApprovalRejected` and `Success`.
 - **Control protocol**: `ControlEvent::Hello` now includes `policy_rules` (skipped when empty). `ControlOp::UpdatePolicy` is a new op; v0.7 TUI clients that don't send it work unchanged.
 - **`approval_bridge` internal type change**: `BridgeEntry` replaces the bare `Sender<ApprovalResponse>` in the bridge map. Entirely internal; no wire or on-disk format change.

--- a/crates/pitboss-cli/src/dispatch/events.rs
+++ b/crates/pitboss-cli/src/dispatch/events.rs
@@ -12,6 +12,23 @@ use serde::Serialize;
 use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
 
+/// Why a Path-B `permission_prompt` ended in `decision = "deny"`.
+/// Mirrors `crate::mcp::tools::approval::PermissionDenialReason` but
+/// lives in the events module so the audit log file owns its own
+/// serialization shape (independent of any future refactor of the
+/// MCP-side enum).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeniedReasonKind {
+    /// An operator-declared `[[approval_policy]]` rule with
+    /// `action = "auto_reject"` matched.
+    DeniedByRule,
+    /// Operator (TUI / web console) responded with reject.
+    OperatorRejected,
+    /// TTL on the queued approval expired and the fallback fired.
+    TtlExpired,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum TaskEvent {
@@ -46,6 +63,24 @@ pub enum TaskEvent {
         sink_id: String,
         event_kind: String,
         error: String,
+    },
+    /// A Path-B `permission_prompt` returned `decision = "deny"`. The
+    /// model receives a denial it can adapt to without an operator
+    /// round-trip; this row gives the operator post-hoc visibility into
+    /// what was attempted-and-blocked.
+    ToolDenied {
+        at: DateTime<Utc>,
+        /// Name of the claude tool the model wanted to invoke
+        /// (e.g. `"Bash"`, `"Write"`).
+        tool_name: String,
+        /// Caller actor id (lead / sublead / worker).
+        actor_id: String,
+        /// Categorical reason for the denial.
+        reason_kind: DeniedReasonKind,
+        /// Free-form text returned to claude (and to the model). Carries
+        /// either the canned per-kind message or, when the operator
+        /// declined with a free-form comment, the operator's text.
+        reason: String,
     },
 }
 

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -33,15 +33,17 @@ use crate::manifest::resolve::{ResolvedManifest, ResolvedTask};
 /// detailed trust-model writeup.
 ///
 /// Operators who want claude's own gate back for a specific actor can
-/// override `CLAUDE_CODE_ENTRYPOINT` via `[defaults.env]`, `[lead.env]`,
-/// `[[task]].env`, or the `env` field on `spawn_sublead` — but the
-/// `--dangerously-skip-permissions` CLI flag is set unconditionally and
-/// is not env-overridable. Operators who need the claude gate fully back
-/// should not use pitboss's headless dispatch.
-///
-/// See `docs/superpowers/specs/2026-04-20-path-b-permission-prompt-routing-pin.md`
-/// for the deferred alternative (routing claude's gate through pitboss's
-/// approval queue rather than bypassing it).
+/// either (a) override `CLAUDE_CODE_ENTRYPOINT` via `[defaults.env]`,
+/// `[lead.env]`, `[[task]].env`, or the `env` field on `spawn_sublead`
+/// to disable Path A's sdk-ts bypass, or (b) opt in to Path B by setting
+/// `[lead].permission_routing = "path_b"`. Under Path B the
+/// `--dangerously-skip-permissions` CLI flag is dropped from every
+/// hierarchical spawn variant and `--permission-prompt-tool
+/// mcp__pitboss__permission_prompt` is added so claude routes each
+/// per-tool check through pitboss's MCP server (see
+/// `mcp::tools::approval::handle_permission_prompt` for the routing
+/// semantics, including how denials are surfaced to the model and
+/// audited via `events.jsonl::TaskEvent::ToolDenied`).
 pub fn apply_pitboss_env_defaults(
     env: &mut std::collections::HashMap<String, String>,
     run_id: &str,
@@ -780,6 +782,12 @@ fn spawn_args(task: &ResolvedTask) -> Vec<String> {
     // claude CLI requires --verbose when combining -p (print mode) with
     // --output-format stream-json. Without it, claude rejects the invocation
     // with "When using --print, --output-format=stream-json requires --verbose".
+    // TODO(path-b/flat-mode): flat-task dispatch is Path-A-only today —
+    // `ResolvedTask` has no `permission_routing` field, so every flat task
+    // gets `--dangerously-skip-permissions`. When a future flat-mode
+    // permission_routing lands, mirror the lead/sublead/worker branches
+    // and gate `--permission-prompt-tool mcp__pitboss__permission_prompt`
+    // here.
     let mut args = vec![
         "--output-format".into(),
         "stream-json".into(),
@@ -969,6 +977,13 @@ pub fn lead_spawn_args(
     // Path B: leave gate active; permission_prompt MCP tool routes each check.
     if lead.permission_routing == PermissionRouting::PathA {
         args.push("--dangerously-skip-permissions".into());
+    } else {
+        // Path B: tell claude to route each tool-permission check through
+        // pitboss's MCP `permission_prompt` tool. Without this flag the
+        // gate falls back to the interactive prompt, which can't be
+        // answered under `-p` and silently stalls.
+        args.push("--permission-prompt-tool".into());
+        args.push("mcp__pitboss__permission_prompt".into());
     }
     // Plugin/skill isolation: prevent operator's ~/.claude/ plugins
     // (skills, MCP servers, agents, hooks) from bleeding in.
@@ -1028,6 +1043,11 @@ pub fn lead_resume_spawn_args(
     ];
     if lead.permission_routing == PermissionRouting::PathA {
         args.push("--dangerously-skip-permissions".into());
+    } else {
+        // Path B: route claude's per-tool gate through pitboss's MCP
+        // permission_prompt (see lead_spawn_args doc).
+        args.push("--permission-prompt-tool".into());
+        args.push("mcp__pitboss__permission_prompt".into());
     }
     // Plugin/skill isolation (see lead_spawn_args doc).
     args.push("--strict-mcp-config".into());
@@ -1098,6 +1118,11 @@ pub fn sublead_spawn_args(
     ];
     if permission_routing == PermissionRouting::PathA {
         args.push("--dangerously-skip-permissions".into());
+    } else {
+        // Path B: route claude's per-tool gate through pitboss's MCP
+        // permission_prompt (see lead_spawn_args doc).
+        args.push("--permission-prompt-tool".into());
+        args.push("mcp__pitboss__permission_prompt".into());
     }
     // Plugin/skill isolation (see lead_spawn_args doc).
     args.push("--strict-mcp-config".into());
@@ -2337,11 +2362,118 @@ mod tests {
             !args.iter().any(|a| a == "--dangerously-skip-permissions"),
             "Path B lead must NOT have --dangerously-skip-permissions: {args:?}"
         );
+        // Path B must pass --permission-prompt-tool so claude knows to
+        // route per-tool permission checks through the MCP server.
+        let ppt_idx = args
+            .iter()
+            .position(|a| a == "--permission-prompt-tool")
+            .unwrap_or_else(|| {
+                panic!("Path B lead must have --permission-prompt-tool: {args:?}")
+            });
+        assert_eq!(
+            args.get(ppt_idx + 1).map(String::as_str),
+            Some("mcp__pitboss__permission_prompt"),
+            "Path B lead --permission-prompt-tool must point at MCP permission_prompt: {args:?}"
+        );
         let idx = args.iter().position(|a| a == "--allowedTools").unwrap();
         let list = &args[idx + 1];
         assert!(
             list.contains("mcp__pitboss__permission_prompt"),
             "Path B lead allowedTools must include permission_prompt: {list}"
         );
+    }
+
+    #[test]
+    fn path_b_emits_permission_prompt_tool_in_all_hierarchical_variants() {
+        // Companion to `every_spawn_variant_has_all_isolation_flags`: when
+        // `permission_routing = "path_b"` is set, every hierarchical spawn
+        // variant (lead, lead_resume, sublead, sublead_resume, worker) must
+        // pass `--permission-prompt-tool mcp__pitboss__permission_prompt`
+        // and must NOT pass `--dangerously-skip-permissions`. Without the
+        // CLI flag claude falls back to its interactive gate, which can't
+        // be answered under `-p` and silently stalls.
+        use crate::manifest::resolve::ResolvedLead;
+        use crate::manifest::schema::PermissionRouting;
+        use std::path::PathBuf;
+        let lead = ResolvedLead {
+            id: "l".into(),
+            directory: PathBuf::from("/tmp"),
+            prompt: "p".into(),
+            branch: None,
+            model: "m".into(),
+            effort: crate::manifest::schema::Effort::High,
+            tools: vec!["Read".into()],
+            timeout_secs: 60,
+            use_worktree: false,
+            env: Default::default(),
+            resume_session_id: None,
+            permission_routing: PermissionRouting::PathB,
+            allow_subleads: true,
+            max_subleads: None,
+            max_sublead_budget_usd: None,
+            max_total_workers: None,
+            sublead_defaults: None,
+        };
+        let cfg = PathBuf::from("/tmp/cfg.json");
+        let cm = crate::manifest::schema::CommunicationMode::Disabled;
+        // NOTE: worker_spawn_args lives in `mcp::tools::spawn` and is
+        // `pub(super)`. Its Path-B variant is asserted in
+        // `mcp::tools::spawn::tests::path_b_worker_emits_permission_prompt_tool`.
+        let cases: Vec<(&str, Vec<String>)> = vec![
+            ("lead", lead_spawn_args(&lead, &cfg, cm)),
+            (
+                "lead_resume",
+                lead_resume_spawn_args(&lead, &cfg, "sess", "new prompt", cm),
+            ),
+            (
+                "sublead",
+                sublead_spawn_args(
+                    "sl-id",
+                    "p",
+                    "m",
+                    &cfg,
+                    None,
+                    None,
+                    PermissionRouting::PathB,
+                    cm,
+                ),
+            ),
+            (
+                "sublead_resume",
+                sublead_spawn_args(
+                    "sl-id",
+                    "p",
+                    "m",
+                    &cfg,
+                    Some("sess"),
+                    None,
+                    PermissionRouting::PathB,
+                    cm,
+                ),
+            ),
+        ];
+        for (name, argv) in cases {
+            assert!(
+                !argv.iter().any(|a| a == "--dangerously-skip-permissions"),
+                "{name} (Path B) must NOT have --dangerously-skip-permissions: {argv:?}"
+            );
+            let ppt_idx = argv
+                .iter()
+                .position(|a| a == "--permission-prompt-tool")
+                .unwrap_or_else(|| {
+                    panic!("{name} (Path B) missing --permission-prompt-tool: {argv:?}")
+                });
+            assert_eq!(
+                argv.get(ppt_idx + 1).map(String::as_str),
+                Some("mcp__pitboss__permission_prompt"),
+                "{name} (Path B) --permission-prompt-tool wrong target: {argv:?}"
+            );
+            let idx = argv.iter().position(|a| a == "--allowedTools").unwrap();
+            let list = &argv[idx + 1];
+            assert!(
+                list.contains("mcp__pitboss__permission_prompt"),
+                "{name} (Path B) allowedTools must include permission_prompt: {list}"
+            );
+        }
     }
 }

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -2367,9 +2367,7 @@ mod tests {
         let ppt_idx = args
             .iter()
             .position(|a| a == "--permission-prompt-tool")
-            .unwrap_or_else(|| {
-                panic!("Path B lead must have --permission-prompt-tool: {args:?}")
-            });
+            .unwrap_or_else(|| panic!("Path B lead must have --permission-prompt-tool: {args:?}"));
         assert_eq!(
             args.get(ppt_idx + 1).map(String::as_str),
             Some("mcp__pitboss__permission_prompt"),

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -154,19 +154,26 @@ fn validate_mode(r: &ResolvedManifest) -> Result<()> {
 fn validate_lead(r: &ResolvedManifest, skip_dir_check: bool) -> Result<()> {
     let lead = r.lead.as_ref().unwrap();
 
-    // Path B permission routing is not yet stable. The required
-    // --permission-prompt-tool CLI flag, correct wire protocol, and env-bypass
-    // guard are being implemented in a follow-on branch. Reject it at validate
-    // time so operators get a clear error rather than a silent stall.
+    // Path B permission routing is selectable but in soak. The
+    // `--permission-prompt-tool` CLI flag is now wired in every
+    // hierarchical spawn variant (lead, lead_resume, sublead, worker)
+    // and `permission_prompt` denials carry a `reason` payload + a
+    // `TaskEvent::ToolDenied` row on `events.jsonl`. The remaining
+    // unknowns are upstream-contract fit (whether claude consumes the
+    // `reason` field) and queue-flood ergonomics under a real workload;
+    // emit a one-line stderr warning instead of bailing so operators
+    // can opt in and surface real-world issues.
     if matches!(
         lead.permission_routing,
         crate::manifest::schema::PermissionRouting::PathB
     ) {
-        bail!(
-            "`permission_routing = \"path_b\"` is not yet stable and will silently \
-             stall on any permission-gated tool use. Use the default \
-             `\"path_a\"` until the follow-on implementation lands. \
-             Track progress at: https://github.com/SDS-Mode/pitboss/issues"
+        eprintln!(
+            "warning: `permission_routing = \"path_b\"` is in soak. Each per-tool \
+             permission check routes through pitboss's MCP `permission_prompt`. \
+             Denials are non-terminating warnings — claude receives \
+             {{decision: \"deny\", reason: ...}} and adapts; the row lands on \
+             <run_dir>/tasks/<actor>/events.jsonl. File issues at \
+             https://github.com/SDS-Mode/pitboss/issues"
         );
     }
 

--- a/crates/pitboss-cli/src/mcp/tools/approval.rs
+++ b/crates/pitboss-cli/src/mcp/tools/approval.rs
@@ -427,11 +427,66 @@ pub struct PermissionPromptResponse {
     /// active for future tool calls.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub behavior: Option<String>,
+    /// Operator/policy/profile-supplied explanation surfaced back to the
+    /// model on `decision == "deny"` so it can adapt without an operator
+    /// round-trip. The upstream `--permission-prompt-tool` contract
+    /// expects denial messages under `message`; we additionally serialize
+    /// this as `reason` to match pitboss's internal vocabulary. Whether
+    /// claude consumes the field is open question 1.2 in the plan; the
+    /// reason is also written to the per-task `events.jsonl` regardless.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// Why a `permission_prompt` ended in `decision == "deny"`. Surfaced to
+/// the requesting actor via `PermissionPromptResponse.reason` and also
+/// recorded as a `TaskEvent::ToolDenied` on the per-task `events.jsonl`
+/// audit log so an operator sees what was attempted-and-blocked even
+/// when the lead silently routes around it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PermissionDenialReason {
+    /// An operator-declared `[[approval_policy]]` rule matched with
+    /// `action = "auto_reject"`.
+    DeniedByRule,
+    /// The operator's TUI / web console responded with reject.
+    OperatorRejected,
+    /// The TTL on the queued approval expired and the fallback fired.
+    TtlExpired,
+}
+
+impl PermissionDenialReason {
+    /// Short, model-readable explanation. Phrasing follows the convention
+    /// "denied: <kind> ..." so a Claude session can detect the prefix and
+    /// adapt without parsing structured fields.
+    pub fn message(self, tool_name: &str) -> String {
+        match self {
+            Self::DeniedByRule => {
+                format!("denied: tool '{tool_name}' rejected by [[approval_policy]] rule")
+            }
+            Self::OperatorRejected => {
+                format!("denied: tool '{tool_name}' rejected by operator")
+            }
+            Self::TtlExpired => format!(
+                "denied: tool '{tool_name}' approval timed out before operator response"
+            ),
+        }
+    }
+}
+
+impl From<PermissionDenialReason> for crate::dispatch::events::DeniedReasonKind {
+    fn from(r: PermissionDenialReason) -> Self {
+        match r {
+            PermissionDenialReason::DeniedByRule => Self::DeniedByRule,
+            PermissionDenialReason::OperatorRejected => Self::OperatorRejected,
+            PermissionDenialReason::TtlExpired => Self::TtlExpired,
+        }
+    }
 }
 
 /// Handle Path B `permission_prompt`: routes claude's per-tool permission
 /// check through pitboss's approval queue and TUI. Returns the Claude Code
-/// permission gate response shape (`decision` + `behavior`).
+/// permission gate response shape (`decision` + `behavior` + optional
+/// `reason` for denials).
 pub async fn handle_permission_prompt(
     state: &Arc<DispatchState>,
     args: PermissionPromptArgs,
@@ -465,12 +520,23 @@ pub async fn handle_permission_prompt(
                     return Ok(PermissionPromptResponse {
                         decision: "allow".into(),
                         behavior: Some("allow_once".into()),
+                        reason: None,
                     });
                 }
                 Some(crate::mcp::policy::ApprovalAction::AutoReject) => {
+                    let reason = PermissionDenialReason::DeniedByRule.message(&args.tool_name);
+                    record_permission_denied(
+                        state,
+                        &caller_id,
+                        &args.tool_name,
+                        PermissionDenialReason::DeniedByRule,
+                        &reason,
+                    )
+                    .await;
                     return Ok(PermissionPromptResponse {
                         decision: "deny".into(),
                         behavior: None,
+                        reason: Some(reason),
                     });
                 }
                 Some(crate::mcp::policy::ApprovalAction::Block) | None => {}
@@ -482,7 +548,7 @@ pub async fn handle_permission_prompt(
     let bridge = crate::mcp::approval::ApprovalBridge::new(Arc::clone(state));
     match bridge
         .request(
-            caller_id,
+            caller_id.clone(),
             summary,
             None,
             crate::control::protocol::ApprovalKind::Action,
@@ -495,11 +561,58 @@ pub async fn handle_permission_prompt(
         Ok(resp) if resp.approved => Ok(PermissionPromptResponse {
             decision: "allow".into(),
             behavior: Some("allow_once".into()),
+            reason: None,
         }),
-        Ok(_) => Ok(PermissionPromptResponse {
-            decision: "deny".into(),
-            behavior: None,
-        }),
+        Ok(resp) => {
+            let kind = if resp.from_ttl {
+                PermissionDenialReason::TtlExpired
+            } else {
+                PermissionDenialReason::OperatorRejected
+            };
+            // Prefer the operator-supplied reason if present (e.g. a
+            // free-form rejection comment); otherwise fall back to the
+            // canned per-kind message so the model still sees something
+            // actionable.
+            let reason = resp.reason.unwrap_or_else(|| kind.message(&args.tool_name));
+            record_permission_denied(state, &caller_id, &args.tool_name, kind, &reason).await;
+            Ok(PermissionPromptResponse {
+                decision: "deny".into(),
+                behavior: None,
+                reason: Some(reason),
+            })
+        }
         Err(e) => anyhow::bail!("permission_prompt failed: {e}"),
+    }
+}
+
+/// Append a `TaskEvent::ToolDenied` to the requesting actor's
+/// `events.jsonl` audit trail. Logs a warning on append failure but
+/// otherwise swallows the error — the deny still flows back to claude
+/// so a missing audit row must not stall the model. The path is
+/// `<run_dir>/tasks/<actor_id>/events.jsonl`, which mirrors the
+/// approval-request audit shape used by `handle_request_approval`.
+async fn record_permission_denied(
+    state: &Arc<DispatchState>,
+    actor_id: &str,
+    tool_name: &str,
+    reason_kind: PermissionDenialReason,
+    reason_text: &str,
+) {
+    let event = crate::dispatch::events::TaskEvent::ToolDenied {
+        at: chrono::Utc::now(),
+        tool_name: tool_name.to_string(),
+        actor_id: actor_id.to_string(),
+        reason_kind: reason_kind.into(),
+        reason: reason_text.to_string(),
+    };
+    if let Err(e) =
+        crate::dispatch::events::append_event(&state.root.run_subdir, actor_id, &event).await
+    {
+        tracing::warn!(
+            actor_id,
+            tool_name,
+            error = %e,
+            "failed to append ToolDenied event; the denial still propagated to claude"
+        );
     }
 }

--- a/crates/pitboss-cli/src/mcp/tools/approval.rs
+++ b/crates/pitboss-cli/src/mcp/tools/approval.rs
@@ -466,9 +466,9 @@ impl PermissionDenialReason {
             Self::OperatorRejected => {
                 format!("denied: tool '{tool_name}' rejected by operator")
             }
-            Self::TtlExpired => format!(
-                "denied: tool '{tool_name}' approval timed out before operator response"
-            ),
+            Self::TtlExpired => {
+                format!("denied: tool '{tool_name}' approval timed out before operator response")
+            }
         }
     }
 }

--- a/crates/pitboss-cli/src/mcp/tools/spawn.rs
+++ b/crates/pitboss-cli/src/mcp/tools/spawn.rs
@@ -789,6 +789,13 @@ pub(super) fn worker_spawn_args(
     ];
     if permission_routing == PermissionRouting::PathA {
         args.push("--dangerously-skip-permissions".into());
+    } else {
+        // Path B: route claude's per-tool gate through pitboss's MCP
+        // permission_prompt (see runner::lead_spawn_args doc). Without
+        // this flag the gate falls back to the interactive prompt,
+        // which can't be answered under `-p` and silently stalls.
+        args.push("--permission-prompt-tool".into());
+        args.push("mcp__pitboss__permission_prompt".into());
     }
     // Plugin/skill isolation (see runner::lead_spawn_args doc).
     args.push("--strict-mcp-config".into());

--- a/crates/pitboss-cli/src/mcp/tools/tests.rs
+++ b/crates/pitboss-cli/src/mcp/tools/tests.rs
@@ -153,6 +153,45 @@ fn worker_spawn_args_passes_dangerously_skip_permissions() {
 }
 
 #[test]
+fn path_b_worker_emits_permission_prompt_tool() {
+    // Path B counterpart to `worker_spawn_args_passes_dangerously_skip_permissions`.
+    // When `permission_routing = "path_b"`, the worker must NOT carry
+    // `--dangerously-skip-permissions` and MUST carry
+    // `--permission-prompt-tool mcp__pitboss__permission_prompt`. Without
+    // the flag claude falls back to its interactive gate — which can't
+    // be answered under `-p` — and the worker silently stalls.
+    use crate::manifest::schema::{CommunicationMode, PermissionRouting};
+    use std::path::PathBuf;
+    let argv = worker_spawn_args(
+        "p",
+        "claude-haiku-4-5",
+        &["Read".to_string()],
+        Some(&PathBuf::from("/tmp/cfg.json")),
+        PermissionRouting::PathB,
+        CommunicationMode::Disabled,
+    );
+    assert!(
+        !argv.iter().any(|a| a == "--dangerously-skip-permissions"),
+        "Path B worker must NOT have --dangerously-skip-permissions: {argv:?}"
+    );
+    let ppt_idx = argv
+        .iter()
+        .position(|a| a == "--permission-prompt-tool")
+        .unwrap_or_else(|| panic!("Path B worker missing --permission-prompt-tool: {argv:?}"));
+    assert_eq!(
+        argv.get(ppt_idx + 1).map(String::as_str),
+        Some("mcp__pitboss__permission_prompt"),
+        "Path B worker --permission-prompt-tool target wrong: {argv:?}"
+    );
+    let idx = argv.iter().position(|a| a == "--allowedTools").unwrap();
+    let list = &argv[idx + 1];
+    assert!(
+        list.contains("mcp__pitboss__permission_prompt"),
+        "Path B worker allowedTools must include permission_prompt: {list}"
+    );
+}
+
+#[test]
 fn worker_spawn_args_excludes_comm_tools_when_mode_disabled() {
     use crate::dispatch::runner::COMMUNICATION_MCP_TOOLS;
     use crate::manifest::schema::CommunicationMode;
@@ -1909,6 +1948,41 @@ async fn permission_prompt_cost_over_rule_denies_when_estimate_exceeds() {
         "cost_estimate=7.5 over threshold=2 must yield deny"
     );
     assert!(resp.behavior.is_none(), "deny carries no behavior field");
+    let reason = resp
+        .reason
+        .as_deref()
+        .expect("rule-driven deny must carry a reason for the model");
+    assert!(
+        reason.contains("Bash") && reason.contains("rule"),
+        "reason should name the tool and the rule path: {reason}"
+    );
+
+    // Verify the denial was logged to events.jsonl so an operator has
+    // post-hoc visibility even though the model silently routes around it.
+    // Path: <run_subdir>/tasks/<actor_id>/events.jsonl. caller_id is the
+    // root lead id ("lead") because PermissionPromptArgs.meta is None and
+    // build_caller_identity falls through to the root identity.
+    let events_path = state
+        .root
+        .run_subdir
+        .join("tasks")
+        .join("lead")
+        .join("events.jsonl");
+    let body = tokio::fs::read_to_string(&events_path)
+        .await
+        .unwrap_or_else(|e| panic!("expected {events_path:?} to exist: {e}"));
+    assert!(
+        body.contains("\"kind\":\"tool_denied\""),
+        "events.jsonl missing tool_denied row: {body}"
+    );
+    assert!(
+        body.contains("\"reason_kind\":\"denied_by_rule\""),
+        "events.jsonl missing denied_by_rule kind: {body}"
+    );
+    assert!(
+        body.contains("\"tool_name\":\"Bash\""),
+        "events.jsonl missing tool_name=Bash: {body}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

This PR completes the Path B permission routing implementation, enabling claude's per-tool permission checks to route through pitboss's MCP `permission_prompt` tool instead of bypassing the gate entirely. Denials are now non-terminating (the model receives a structured response and can adapt), and all denials are audited via a new `TaskEvent::ToolDenied` event in the per-task `events.jsonl`.

## Key Changes

- **CLI flag wiring**: Added `--permission-prompt-tool mcp__pitboss__permission_prompt` to all hierarchical spawn variants (lead, lead_resume, sublead, worker) when `permission_routing = "path_b"`. Removed `--dangerously-skip-permissions` for Path B flows.

- **Permission denial response**: Extended `PermissionPromptResponse` with an optional `reason` field that carries either a canned per-kind message or operator-supplied free-form text, allowing claude to adapt without an operator round-trip.

- **Denial categorization**: Introduced `PermissionDenialReason` enum (DeniedByRule, OperatorRejected, TtlExpired) to classify denials and surface them to both the model and the audit log.

- **Audit logging**: Added `TaskEvent::ToolDenied` variant and `record_permission_denied()` helper to append denial events to `<run_dir>/tasks/<actor_id>/events.jsonl`, giving operators post-hoc visibility into attempted-and-blocked tool calls.

- **Validation relaxation**: Changed Path B validation from a hard error to a one-line stderr warning, allowing operators to opt in while the feature is in soak. The warning documents the current behavior and known unknowns.

- **Test coverage**: Added comprehensive tests verifying that all hierarchical spawn variants emit the permission_prompt tool flag under Path B, and that rule-driven denials are properly logged to events.jsonl with correct reason_kind and tool_name fields.

## Implementation Details

- The `reason` field in `PermissionPromptResponse` follows the convention "denied: <kind> ..." so claude can detect the prefix and adapt without parsing structured fields.
- Denial logging is best-effort; append failures log a warning but do not stall the deny response flowing back to claude.
- The `DeniedReasonKind` enum in the events module mirrors the MCP-side `PermissionDenialReason` but lives independently so the audit log owns its serialization shape.
- Flat-task dispatch remains Path-A-only; a TODO documents the future work needed to support Path B in flat mode.

https://claude.ai/code/session_01BAqgcwNtVnayqJewQX8guM