### PR TITLE
fix(mcp): track approval state on every handle_permission_prompt path

### DIFF
--- a/crates/pitboss-cli/src/mcp/tools/approval.rs
+++ b/crates/pitboss-cli/src/mcp/tools/approval.rs
@@ -517,6 +517,15 @@ pub async fn handle_permission_prompt(
             // never matched for permission_prompt.
             match matcher.evaluate(&pending, Some(&args.tool_name), args.cost_estimate) {
                 Some(crate::mcp::policy::ApprovalAction::AutoApprove) => {
+                    // Mirror `handle_request_approval`'s rule short-circuit:
+                    // record the response so `approval_driven_termination`
+                    // can see a recent decision, and bump both counters
+                    // because the bridge is bypassed on this path. (#367)
+                    state
+                        .record_last_approval_response(&caller_id, true, false)
+                        .await;
+                    crate::mcp::approval::bump_approval_requested(state, &caller_id).await;
+                    crate::mcp::approval::record_approval_outcome(state, &caller_id, true).await;
                     return Ok(PermissionPromptResponse {
                         decision: "allow".into(),
                         behavior: Some("allow_once".into()),
@@ -533,6 +542,16 @@ pub async fn handle_permission_prompt(
                         &reason,
                     )
                     .await;
+                    // Same trio as the AutoApprove path. Without these,
+                    // `approvals_requested` / `approvals_rejected` undercount
+                    // and a worker that exits silently after a rule-driven
+                    // deny is misclassified as `Success` instead of
+                    // `ApprovalRejected`. (#367)
+                    state
+                        .record_last_approval_response(&caller_id, false, false)
+                        .await;
+                    crate::mcp::approval::bump_approval_requested(state, &caller_id).await;
+                    crate::mcp::approval::record_approval_outcome(state, &caller_id, false).await;
                     return Ok(PermissionPromptResponse {
                         decision: "deny".into(),
                         behavior: None,
@@ -558,11 +577,22 @@ pub async fn handle_permission_prompt(
         )
         .await
     {
-        Ok(resp) if resp.approved => Ok(PermissionPromptResponse {
-            decision: "allow".into(),
-            behavior: Some("allow_once".into()),
-            reason: None,
-        }),
+        Ok(resp) if resp.approved => {
+            // Bridge already bumped `approvals_requested` and
+            // `approvals_approved` (or those will land via the
+            // operator-response path in `respond()`). The handler is
+            // still responsible for `record_last_approval_response`
+            // so `approval_driven_termination` can see the outcome —
+            // mirrors `handle_request_approval`. (#367)
+            state
+                .record_last_approval_response(&caller_id, true, resp.from_ttl)
+                .await;
+            Ok(PermissionPromptResponse {
+                decision: "allow".into(),
+                behavior: Some("allow_once".into()),
+                reason: None,
+            })
+        }
         Ok(resp) => {
             let kind = if resp.from_ttl {
                 PermissionDenialReason::TtlExpired
@@ -575,6 +605,14 @@ pub async fn handle_permission_prompt(
             // actionable.
             let reason = resp.reason.unwrap_or_else(|| kind.message(&args.tool_name));
             record_permission_denied(state, &caller_id, &args.tool_name, kind, &reason).await;
+            // Same as the approve arm: bridge owns the counter bumps,
+            // handler owns the last-response record so a fast-exit
+            // worker is reclassified by `approval_driven_termination`
+            // as `ApprovalRejected` (or `ApprovalTimedOut` when
+            // `from_ttl=true`) instead of `Success`. (#367)
+            state
+                .record_last_approval_response(&caller_id, false, resp.from_ttl)
+                .await;
             Ok(PermissionPromptResponse {
                 decision: "deny".into(),
                 behavior: None,

--- a/crates/pitboss-cli/src/mcp/tools/tests.rs
+++ b/crates/pitboss-cli/src/mcp/tools/tests.rs
@@ -1983,6 +1983,178 @@ async fn permission_prompt_cost_over_rule_denies_when_estimate_exceeds() {
         body.contains("\"tool_name\":\"Bash\""),
         "events.jsonl missing tool_name=Bash: {body}"
     );
+
+    // #367: the rule short-circuit must also record approval state so
+    // counters and `approval_driven_termination` work under Path B.
+    let counters = state.root.worker_counters.read().await;
+    let entry = counters
+        .get("lead")
+        .expect("rule-driven deny must bump approval counters for caller");
+    assert_eq!(
+        entry.approvals_requested, 1,
+        "approvals_requested must be 1"
+    );
+    assert_eq!(entry.approvals_rejected, 1, "approvals_rejected must be 1");
+    assert_eq!(
+        entry.approvals_approved, 0,
+        "approvals_approved must stay 0"
+    );
+    drop(counters);
+    assert_eq!(
+        state.approval_driven_termination("lead").await,
+        Some(crate::dispatch::state::ApprovalTerminationKind::Rejected),
+        "rule-driven deny must register a rejected last_approval_response so a \
+         fast-exit worker reclassifies as ApprovalRejected (not Success)"
+    );
+}
+
+/// #367 regression: the policy-matcher AutoApprove path in
+/// `handle_permission_prompt` must record the response and bump
+/// approval counters, mirroring `handle_request_approval`. Pre-fix
+/// the path returned `decision="allow"` without touching either,
+/// silently undercounting Path B approvals.
+#[tokio::test]
+async fn permission_prompt_rule_auto_approve_records_state_and_counters() {
+    use crate::mcp::policy::{ApprovalAction, ApprovalRule, PolicyMatcher};
+
+    // Default Block so the matcher's verdict is the only resolution path.
+    let state = mk_plan_state(crate::dispatch::state::ApprovalPolicy::Block, false).await;
+    state
+        .root
+        .set_policy_matcher(PolicyMatcher::new(vec![ApprovalRule {
+            r#match: crate::mcp::policy::ApprovalMatch {
+                tool_name: Some("Read".into()),
+                ..Default::default()
+            },
+            action: ApprovalAction::AutoApprove,
+        }]))
+        .await;
+
+    let resp = handle_permission_prompt(
+        &state,
+        PermissionPromptArgs {
+            tool_name: "Read".into(),
+            tool_input: None,
+            cost_estimate: None,
+            meta: None,
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(resp.decision, "allow");
+    assert_eq!(resp.behavior.as_deref(), Some("allow_once"));
+
+    let counters = state.root.worker_counters.read().await;
+    let entry = counters
+        .get("lead")
+        .expect("rule-driven approve must bump approval counters for caller");
+    assert_eq!(entry.approvals_requested, 1);
+    assert_eq!(entry.approvals_approved, 1);
+    assert_eq!(entry.approvals_rejected, 0);
+    drop(counters);
+    // approve → no termination reclassification.
+    assert_eq!(state.approval_driven_termination("lead").await, None);
+}
+
+/// #367 regression: the bridge AutoApprove path in
+/// `handle_permission_prompt` must record `last_approval_response` so
+/// `approval_driven_termination` sees the recent positive decision.
+/// The bridge bumps the counters itself; the handler owns the last-
+/// response record (mirrors `handle_request_approval`).
+#[tokio::test]
+async fn permission_prompt_default_policy_auto_approve_records_last_response() {
+    let state = mk_plan_state(crate::dispatch::state::ApprovalPolicy::AutoApprove, false).await;
+
+    let resp = handle_permission_prompt(
+        &state,
+        PermissionPromptArgs {
+            tool_name: "Read".into(),
+            tool_input: None,
+            cost_estimate: None,
+            meta: None,
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(resp.decision, "allow");
+
+    let counters = state.root.worker_counters.read().await;
+    let entry = counters
+        .get("lead")
+        .expect("bridge AutoApprove must bump approval counters");
+    assert_eq!(entry.approvals_requested, 1);
+    assert_eq!(entry.approvals_approved, 1);
+    assert_eq!(entry.approvals_rejected, 0);
+    drop(counters);
+    assert_eq!(
+        state.approval_driven_termination("lead").await,
+        None,
+        "approve outcome must not register as a termination-driving rejection"
+    );
+}
+
+/// #367 regression: the bridge AutoReject path in
+/// `handle_permission_prompt` must record a rejected
+/// `last_approval_response` so a worker that exits silently after the
+/// deny reclassifies as `ApprovalRejected` (not `Success`). Also
+/// asserts that the canned `OperatorRejected` message is the fallback
+/// when the bridge response carries no operator-supplied reason.
+#[tokio::test]
+async fn permission_prompt_default_policy_auto_reject_records_last_response() {
+    let state = mk_plan_state(crate::dispatch::state::ApprovalPolicy::AutoReject, false).await;
+
+    let resp = handle_permission_prompt(
+        &state,
+        PermissionPromptArgs {
+            tool_name: "Bash".into(),
+            tool_input: None,
+            cost_estimate: None,
+            meta: None,
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(resp.decision, "deny");
+    assert!(resp.behavior.is_none());
+    let reason = resp
+        .reason
+        .as_deref()
+        .expect("bridge-driven deny must carry a reason for the model");
+    assert!(
+        reason.contains("Bash"),
+        "reason should name the tool: {reason}"
+    );
+
+    let counters = state.root.worker_counters.read().await;
+    let entry = counters
+        .get("lead")
+        .expect("bridge AutoReject must bump approval counters");
+    assert_eq!(entry.approvals_requested, 1);
+    assert_eq!(entry.approvals_rejected, 1);
+    assert_eq!(entry.approvals_approved, 0);
+    drop(counters);
+    assert_eq!(
+        state.approval_driven_termination("lead").await,
+        Some(crate::dispatch::state::ApprovalTerminationKind::Rejected),
+        "bridge-driven deny must register a rejected last_approval_response"
+    );
+
+    // Per-actor events.jsonl audit row should also be present, since
+    // the deny goes through `record_permission_denied` regardless of
+    // origin (rule vs bridge).
+    let events_path = state
+        .root
+        .run_subdir
+        .join("tasks")
+        .join("lead")
+        .join("events.jsonl");
+    let body = tokio::fs::read_to_string(&events_path)
+        .await
+        .unwrap_or_else(|e| panic!("expected {events_path:?} to exist: {e}"));
+    assert!(
+        body.contains("\"reason_kind\":\"operator_rejected\""),
+        "events.jsonl missing operator_rejected kind: {body}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #367.

`handle_permission_prompt` returned its decision through every terminal path without calling the trio that `handle_request_approval` calls on every resolution: `record_last_approval_response`, `bump_approval_requested`, `record_approval_outcome`. Under Path B this caused:

- A silent-exit-after-deny actor to be misclassified by `approval_driven_termination` as `Success` instead of `ApprovalRejected` / `ApprovalTimedOut`.
- `approvals_requested` to undercount on rule short-circuit paths.
- `approvals_approved` / `approvals_rejected` to undercount on rule short-circuit paths.

The bridge already handles its own counter bumps on the default-policy short-circuits and the queue-full fallback, so the bridge-response arms only need `record_last_approval_response`. The matcher short-circuits bypass the bridge entirely and need all three.

## History

This PR replaces #371 (auto-closed when its base branch was deleted on parent merge). Rebased onto current main; only the single fix commit `850bbc6` applies cleanly. No content change vs the prior #371.

## What changed

`crates/pitboss-cli/src/mcp/tools/approval.rs`:

| Path | Added |
|---|---|
| Rule auto-approve | `record_last_approval_response` + `bump_approval_requested` + `record_approval_outcome` |
| Rule auto-reject | Same trio (in addition to the existing `record_permission_denied`) |
| Bridge approve | `record_last_approval_response` only — bridge owns the counters |
| Bridge reject | `record_last_approval_response` only — same reason |

## Tests

`crates/pitboss-cli/src/mcp/tools/tests.rs`:

- **Extended** `permission_prompt_cost_over_rule_denies_when_estimate_exceeds`: also asserts counters bumped and `approval_driven_termination("lead") == Some(Rejected)`.
- **New** `permission_prompt_rule_auto_approve_records_state_and_counters` — matcher AutoApprove path.
- **New** `permission_prompt_default_policy_auto_approve_records_last_response` — bridge AutoApprove.
- **New** `permission_prompt_default_policy_auto_reject_records_last_response` — bridge AutoReject; also asserts the per-actor `events.jsonl` row.

## Known follow-up

The new test `permission_prompt_default_policy_auto_reject_records_last_response` asserts `reason_kind: operator_rejected` for an AutoReject-policy run. That classification is wrong — see #373. The test will need to be updated when #373 lands. Not blocking this PR; flagged so reviewers know.

## Verification

- 8/8 permission_prompt lib tests pass (5 existing + 3 new).
- 30/30 approval-related lib tests pass.
- Full workspace test suite green.
- cargo fmt --check clean.
- cargo clippy --all-targets --all-features -D warnings clean.

## Test plan

- [x] cargo test -p pitboss-cli --features pitboss-core/test-support --lib permission_prompt
- [x] cargo test -p pitboss-cli --features pitboss-core/test-support --lib approval
- [x] cargo test --workspace --features pitboss-core/test-support
- [x] cargo fmt -p pitboss-cli -- --check
- [x] cargo clippy -p pitboss-cli --all-targets --all-features -- -D warnings
- [x] End-to-end soak: re-dispatched examples/ultrareview-local.toml with permission_routing = path_b; no regression vs pre-fix run; the buggy paths the fix targets aren't exercised by this manifest (no [[approval_policy]] rules; no actors exit silently after denials), so unit tests remain the primary coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)