### PR TITLE
fix(mcp): align permission_prompt with Claude Code's PermissionResult wire shape

### DIFF
--- a/crates/pitboss-cli/src/dispatch/events.rs
+++ b/crates/pitboss-cli/src/dispatch/events.rs
@@ -12,7 +12,7 @@ use serde::Serialize;
 use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
 
-/// Why a Path-B `permission_prompt` ended in `decision = "deny"`.
+/// Why a Path-B `permission_prompt` returned `behavior = "deny"`.
 /// Mirrors `crate::mcp::tools::approval::PermissionDenialReason` but
 /// lives in the events module so the audit log file owns its own
 /// serialization shape (independent of any future refactor of the
@@ -64,10 +64,11 @@ pub enum TaskEvent {
         event_kind: String,
         error: String,
     },
-    /// A Path-B `permission_prompt` returned `decision = "deny"`. The
-    /// model receives a denial it can adapt to without an operator
-    /// round-trip; this row gives the operator post-hoc visibility into
-    /// what was attempted-and-blocked.
+    /// A Path-B `permission_prompt` returned `behavior = "deny"`. The
+    /// model receives a structured `{behavior, message, interrupt}`
+    /// denial it can adapt to without an operator round-trip; this row
+    /// gives the operator post-hoc visibility into what was
+    /// attempted-and-blocked.
     ToolDenied {
         at: DateTime<Utc>,
         /// Name of the claude tool the model wanted to invoke

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -155,14 +155,14 @@ fn validate_lead(r: &ResolvedManifest, skip_dir_check: bool) -> Result<()> {
     let lead = r.lead.as_ref().unwrap();
 
     // Path B permission routing is selectable but in soak. The
-    // `--permission-prompt-tool` CLI flag is now wired in every
-    // hierarchical spawn variant (lead, lead_resume, sublead, worker)
-    // and `permission_prompt` denials carry a `reason` payload + a
-    // `TaskEvent::ToolDenied` row on `events.jsonl`. The remaining
-    // unknowns are upstream-contract fit (whether claude consumes the
-    // `reason` field) and queue-flood ergonomics under a real workload;
-    // emit a one-line stderr warning instead of bailing so operators
-    // can opt in and surface real-world issues.
+    // `--permission-prompt-tool` CLI flag is wired in every hierarchical
+    // spawn variant (lead, lead_resume, sublead, worker) and
+    // `permission_prompt` returns the canonical `PermissionResult` SDK
+    // shape (#368) with a `tool_denied` row on per-actor `events.jsonl`
+    // for every denial. Remaining unknowns are queue-flood ergonomics
+    // under real workloads and the `auto_reject`-vs-operator-rejection
+    // misclassification (#373); emit a one-line stderr warning instead
+    // of bailing so operators can opt in and surface real-world issues.
     if matches!(
         lead.permission_routing,
         crate::manifest::schema::PermissionRouting::PathB
@@ -170,8 +170,8 @@ fn validate_lead(r: &ResolvedManifest, skip_dir_check: bool) -> Result<()> {
         eprintln!(
             "warning: `permission_routing = \"path_b\"` is in soak. Each per-tool \
              permission check routes through pitboss's MCP `permission_prompt`. \
-             Denials are non-terminating warnings — claude receives \
-             {{decision: \"deny\", reason: ...}} and adapts; the row lands on \
+             Denials are non-terminating — claude receives \
+             {{behavior: \"deny\", message: ...}} and adapts; the row lands on \
              <run_dir>/tasks/<actor>/events.jsonl. File issues at \
              https://github.com/SDS-Mode/pitboss/issues"
         );

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -1134,9 +1134,18 @@ impl PitbossHandler {
     /// Path B permission gate. Claude calls this when it encounters a
     /// tool-use that requires operator approval. Only visible (list_tools)
     /// and callable when `[lead] permission_routing = "path_b"` is set.
+    ///
+    /// Wire shape (#368): the response MUST be a single text content
+    /// block whose body is a JSON-encoded `PermissionResult` —
+    /// `{"behavior":"allow","updatedInput":...}` or
+    /// `{"behavior":"deny","message":"...","interrupt":false}`. The
+    /// generic `to_structured_result` helper additionally emits a
+    /// `structuredContent` field which Claude's gate parser appears to
+    /// trip on; build the result by hand here so only the text block
+    /// is sent.
     #[tool(
         name = "permission_prompt",
-        description = "Route a Claude tool-permission request to pitboss's approval queue. Returns {decision, behavior}."
+        description = "Route a Claude tool-permission request to pitboss's approval queue. Returns the Claude Code PermissionResult shape: {behavior:'allow',updatedInput?} or {behavior:'deny',message,interrupt?}."
     )]
     async fn permission_prompt(
         &self,
@@ -1161,7 +1170,17 @@ impl PitbossHandler {
             ));
         }
         match handle_permission_prompt(&self.state, args).await {
-            Ok(res) => to_structured_result(&res),
+            Ok(res) => {
+                let json = serde_json::to_string(&res).map_err(|e| {
+                    ErrorData::internal_error(
+                        format!("permission_prompt result serialize: {e}"),
+                        None,
+                    )
+                })?;
+                Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+                    json,
+                )]))
+            }
             Err(e) => Err(ErrorData::invalid_request(e.to_string(), None)),
         }
     }

--- a/crates/pitboss-cli/src/mcp/tools/approval.rs
+++ b/crates/pitboss-cli/src/mcp/tools/approval.rs
@@ -418,31 +418,52 @@ pub struct PermissionPromptArgs {
     pub meta: Option<crate::shared_store::tools::MetaField>,
 }
 
-/// Response shape matching Claude Code's permission gate contract.
+/// Response shape matching Claude Code's `--permission-prompt-tool`
+/// contract — the `PermissionResult` SDK type. Internally tagged on
+/// `behavior` so `{"behavior": "allow", ...}` / `{"behavior": "deny", ...}`
+/// JSON round-trips cleanly. (#368)
+///
+/// Pre-#368 this struct used `decision` / `behavior: "allow_once"` /
+/// `reason`, which Claude's gate parser silently rejected at the wire
+/// level — every Path B permission check failed with "Permission prompt
+/// tool returned an invalid result," and the model treated denials as
+/// generic tool errors rather than structured allow/deny.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-pub struct PermissionPromptResponse {
-    /// `"allow"` or `"deny"`.
-    pub decision: String,
-    /// Present when `decision == "allow"`. `"allow_once"` keeps the gate
-    /// active for future tool calls.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub behavior: Option<String>,
-    /// Operator/policy/profile-supplied explanation surfaced back to the
-    /// model on `decision == "deny"` so it can adapt without an operator
-    /// round-trip. The upstream `--permission-prompt-tool` contract
-    /// expects denial messages under `message`; we additionally serialize
-    /// this as `reason` to match pitboss's internal vocabulary. Whether
-    /// claude consumes the field is open question 1.2 in the plan; the
-    /// reason is also written to the per-task `events.jsonl` regardless.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub reason: Option<String>,
+#[serde(tag = "behavior", rename_all = "lowercase")]
+pub enum PermissionPromptResponse {
+    /// Permit the tool call. `updated_input` lets the gate edit the
+    /// input claude proposed; pitboss currently passes the input through
+    /// unchanged (no operator-side editing surface yet).
+    Allow {
+        #[serde(
+            rename = "updatedInput",
+            default,
+            skip_serializing_if = "Option::is_none"
+        )]
+        updated_input: Option<serde_json::Value>,
+    },
+    /// Deny the tool call. `message` is surfaced to the model so it can
+    /// adapt (e.g. switch tools) without an operator round-trip.
+    /// `interrupt` requests claude halt the current turn entirely;
+    /// pitboss leaves it `false` so the model can keep working through
+    /// non-denied tools.
+    Deny {
+        message: String,
+        #[serde(default, skip_serializing_if = "is_default_false")]
+        interrupt: bool,
+    },
 }
 
-/// Why a `permission_prompt` ended in `decision == "deny"`. Surfaced to
-/// the requesting actor via `PermissionPromptResponse.reason` and also
-/// recorded as a `TaskEvent::ToolDenied` on the per-task `events.jsonl`
-/// audit log so an operator sees what was attempted-and-blocked even
-/// when the lead silently routes around it.
+fn is_default_false(b: &bool) -> bool {
+    !b
+}
+
+/// Why a `permission_prompt` returned `behavior == "deny"`. Surfaced
+/// to the requesting actor as the `message` field of
+/// `PermissionPromptResponse::Deny` and also recorded as a
+/// `TaskEvent::ToolDenied` on the per-task `events.jsonl` audit log
+/// so an operator sees what was attempted-and-blocked even when the
+/// lead silently routes around it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PermissionDenialReason {
     /// An operator-declared `[[approval_policy]]` rule matched with
@@ -526,10 +547,8 @@ pub async fn handle_permission_prompt(
                         .await;
                     crate::mcp::approval::bump_approval_requested(state, &caller_id).await;
                     crate::mcp::approval::record_approval_outcome(state, &caller_id, true).await;
-                    return Ok(PermissionPromptResponse {
-                        decision: "allow".into(),
-                        behavior: Some("allow_once".into()),
-                        reason: None,
+                    return Ok(PermissionPromptResponse::Allow {
+                        updated_input: args.tool_input.clone(),
                     });
                 }
                 Some(crate::mcp::policy::ApprovalAction::AutoReject) => {
@@ -552,10 +571,9 @@ pub async fn handle_permission_prompt(
                         .await;
                     crate::mcp::approval::bump_approval_requested(state, &caller_id).await;
                     crate::mcp::approval::record_approval_outcome(state, &caller_id, false).await;
-                    return Ok(PermissionPromptResponse {
-                        decision: "deny".into(),
-                        behavior: None,
-                        reason: Some(reason),
+                    return Ok(PermissionPromptResponse::Deny {
+                        message: reason,
+                        interrupt: false,
                     });
                 }
                 Some(crate::mcp::policy::ApprovalAction::Block) | None => {}
@@ -587,10 +605,8 @@ pub async fn handle_permission_prompt(
             state
                 .record_last_approval_response(&caller_id, true, resp.from_ttl)
                 .await;
-            Ok(PermissionPromptResponse {
-                decision: "allow".into(),
-                behavior: Some("allow_once".into()),
-                reason: None,
+            Ok(PermissionPromptResponse::Allow {
+                updated_input: args.tool_input.clone(),
             })
         }
         Ok(resp) => {
@@ -613,10 +629,9 @@ pub async fn handle_permission_prompt(
             state
                 .record_last_approval_response(&caller_id, false, resp.from_ttl)
                 .await;
-            Ok(PermissionPromptResponse {
-                decision: "deny".into(),
-                behavior: None,
-                reason: Some(reason),
+            Ok(PermissionPromptResponse::Deny {
+                message: reason,
+                interrupt: false,
             })
         }
         Err(e) => anyhow::bail!("permission_prompt failed: {e}"),

--- a/crates/pitboss-cli/src/mcp/tools/tests.rs
+++ b/crates/pitboss-cli/src/mcp/tools/tests.rs
@@ -1635,11 +1635,9 @@ async fn permission_prompt_auto_approves_and_returns_gate_response() {
     )
     .await
     .unwrap();
-    assert_eq!(resp.decision, "allow", "auto-approve should yield allow");
-    assert_eq!(
-        resp.behavior.as_deref(),
-        Some("allow_once"),
-        "allow_once behavior expected"
+    assert!(
+        matches!(resp, PermissionPromptResponse::Allow { .. }),
+        "auto-approve should yield Allow variant, got: {resp:?}"
     );
 }
 
@@ -1943,15 +1941,13 @@ async fn permission_prompt_cost_over_rule_denies_when_estimate_exceeds() {
     )
     .await
     .unwrap();
-    assert_eq!(
-        resp.decision, "deny",
-        "cost_estimate=7.5 over threshold=2 must yield deny"
-    );
-    assert!(resp.behavior.is_none(), "deny carries no behavior field");
-    let reason = resp
-        .reason
-        .as_deref()
-        .expect("rule-driven deny must carry a reason for the model");
+    let reason = match &resp {
+        PermissionPromptResponse::Deny { message, interrupt } => {
+            assert!(!interrupt, "deny should not request interrupt by default");
+            message.as_str()
+        }
+        _ => panic!("cost_estimate=7.5 over threshold=2 must yield Deny: {resp:?}"),
+    };
     assert!(
         reason.contains("Bash") && reason.contains("rule"),
         "reason should name the tool and the rule path: {reason}"
@@ -2041,8 +2037,10 @@ async fn permission_prompt_rule_auto_approve_records_state_and_counters() {
     )
     .await
     .unwrap();
-    assert_eq!(resp.decision, "allow");
-    assert_eq!(resp.behavior.as_deref(), Some("allow_once"));
+    assert!(
+        matches!(resp, PermissionPromptResponse::Allow { .. }),
+        "rule-driven approve must yield Allow: {resp:?}"
+    );
 
     let counters = state.root.worker_counters.read().await;
     let entry = counters
@@ -2076,7 +2074,10 @@ async fn permission_prompt_default_policy_auto_approve_records_last_response() {
     )
     .await
     .unwrap();
-    assert_eq!(resp.decision, "allow");
+    assert!(
+        matches!(resp, PermissionPromptResponse::Allow { .. }),
+        "bridge AutoApprove must yield Allow: {resp:?}"
+    );
 
     let counters = state.root.worker_counters.read().await;
     let entry = counters
@@ -2114,16 +2115,26 @@ async fn permission_prompt_default_policy_auto_reject_records_last_response() {
     )
     .await
     .unwrap();
-    assert_eq!(resp.decision, "deny");
-    assert!(resp.behavior.is_none());
-    let reason = resp
-        .reason
-        .as_deref()
-        .expect("bridge-driven deny must carry a reason for the model");
+    let reason = match &resp {
+        PermissionPromptResponse::Deny { message, interrupt } => {
+            assert!(!interrupt, "deny should not request interrupt by default");
+            message.as_str()
+        }
+        _ => panic!("bridge-driven deny must yield Deny: {resp:?}"),
+    };
     assert!(
         reason.contains("Bash"),
         "reason should name the tool: {reason}"
     );
+
+    // ─── Wire-format unit tests (#368) ─────────────────────────────────────────
+    //
+    // The Rust struct shape is one thing; the JSON Claude actually parses
+    // is another. Pre-#368 the unit tests asserted the Rust struct fields
+    // (`decision`, `reason`, ...) while the wire format silently mismatched
+    // the upstream `PermissionResult` SDK type — every gate call failed
+    // with "Permission prompt tool returned an invalid result" but tests
+    // stayed green. These tests pin the on-the-wire JSON exactly.
 
     let counters = state.root.worker_counters.read().await;
     let entry = counters
@@ -2155,6 +2166,119 @@ async fn permission_prompt_default_policy_auto_reject_records_last_response() {
         body.contains("\"reason_kind\":\"operator_rejected\""),
         "events.jsonl missing operator_rejected kind: {body}"
     );
+}
+
+/// #368: Allow variant must serialize as `{"behavior":"allow", "updatedInput": ...}`
+/// when input is provided. `updatedInput` (camelCase) is the upstream
+/// SDK field name; `updated_input` (snake_case) would silently fail the
+/// gate parser.
+#[test]
+fn permission_prompt_response_allow_with_input_serializes_canonical_shape() {
+    let resp = PermissionPromptResponse::Allow {
+        updated_input: Some(serde_json::json!({"command": "ls -la"})),
+    };
+    let parsed: serde_json::Value = serde_json::to_value(&resp).unwrap();
+    assert_eq!(
+        parsed["behavior"].as_str(),
+        Some("allow"),
+        "behavior must be the literal string 'allow' (matches PermissionResultAllow): {parsed}"
+    );
+    assert_eq!(
+        parsed["updatedInput"]["command"].as_str(),
+        Some("ls -la"),
+        "input must round-trip under camelCase 'updatedInput': {parsed}"
+    );
+    // No legacy fields — these are what pre-#368 shipped, and would
+    // silently fail Claude's parser.
+    assert!(parsed.get("decision").is_none(), "no legacy 'decision' key");
+    assert!(parsed.get("reason").is_none(), "no legacy 'reason' key");
+}
+
+/// #368: Allow without input must omit `updatedInput` entirely (not
+/// emit `null`). Some MCP-tool consumers reject explicit nulls.
+#[test]
+fn permission_prompt_response_allow_without_input_omits_updated_input() {
+    let resp = PermissionPromptResponse::Allow {
+        updated_input: None,
+    };
+    let parsed: serde_json::Value = serde_json::to_value(&resp).unwrap();
+    assert_eq!(parsed["behavior"].as_str(), Some("allow"));
+    assert!(
+        parsed.get("updatedInput").is_none(),
+        "updatedInput must be omitted, not null: {parsed}"
+    );
+    // The whole response is essentially a single-key object on the
+    // wire when the input isn't being modified.
+    let obj = parsed.as_object().unwrap();
+    assert_eq!(obj.len(), 1, "expected exactly {{behavior}}, got: {parsed}");
+}
+
+/// #368: Deny variant must serialize as `{"behavior":"deny","message":"..."}`
+/// — `message` is the upstream SDK field name. `interrupt` defaults to
+/// false and is omitted in that case so the wire stays compact.
+#[test]
+fn permission_prompt_response_deny_serializes_canonical_shape() {
+    let resp = PermissionPromptResponse::Deny {
+        message: "denied: tool 'Bash' rejected by [[approval_policy]] rule".to_string(),
+        interrupt: false,
+    };
+    let parsed: serde_json::Value = serde_json::to_value(&resp).unwrap();
+    assert_eq!(parsed["behavior"].as_str(), Some("deny"));
+    assert_eq!(
+        parsed["message"].as_str(),
+        Some("denied: tool 'Bash' rejected by [[approval_policy]] rule"),
+        "message must round-trip under 'message' key: {parsed}"
+    );
+    assert!(
+        parsed.get("interrupt").is_none(),
+        "interrupt=false must be omitted to keep wire compact: {parsed}"
+    );
+    assert!(parsed.get("reason").is_none(), "no legacy 'reason' key");
+    assert!(parsed.get("decision").is_none(), "no legacy 'decision' key");
+}
+
+/// #368: when interrupt is explicitly set true, it must be serialized
+/// (claude treats it as a request to halt the current turn).
+#[test]
+fn permission_prompt_response_deny_emits_interrupt_when_true() {
+    let resp = PermissionPromptResponse::Deny {
+        message: "stop".to_string(),
+        interrupt: true,
+    };
+    let parsed: serde_json::Value = serde_json::to_value(&resp).unwrap();
+    assert_eq!(parsed["interrupt"].as_bool(), Some(true));
+}
+
+/// #368: round-trip the wire shape through serde to catch any tag
+/// configuration error. `behavior: "allow"` must deserialize into the
+/// Allow variant; `behavior: "deny"` into Deny.
+#[test]
+fn permission_prompt_response_round_trips_via_canonical_wire() {
+    let allow_wire = serde_json::json!({
+        "behavior": "allow",
+        "updatedInput": {"a": 1}
+    });
+    let allow: PermissionPromptResponse = serde_json::from_value(allow_wire).unwrap();
+    assert!(matches!(
+        allow,
+        PermissionPromptResponse::Allow {
+            updated_input: Some(_)
+        }
+    ));
+
+    let deny_wire = serde_json::json!({
+        "behavior": "deny",
+        "message": "no",
+        "interrupt": true
+    });
+    let deny: PermissionPromptResponse = serde_json::from_value(deny_wire).unwrap();
+    match deny {
+        PermissionPromptResponse::Deny { message, interrupt } => {
+            assert_eq!(message, "no");
+            assert!(interrupt);
+        }
+        _ => panic!("expected Deny"),
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #368.

Path B's `permission_prompt` MCP tool was non-functional in production v0.10.x. Claude Code's `--permission-prompt-tool` gate parser expects the SDK \`PermissionResult\` shape — \`{behavior: \"allow\", updatedInput?}\` or \`{behavior: \"deny\", message, interrupt?}\` — delivered as a single text content block. Pitboss was shipping \`{decision, behavior: \"allow_once\", reason}\` via \`to_structured_result\`, which Claude rejected at the wire with:

```
Permission prompt tool returned an invalid result.
Expected a single text block param with type=\"text\" and a string text value.
```

Every Path B permission check failed, the originating tool surfaced as a \`tool_use_error\`, and the model only adapted because it got a parser error — never seeing the structured \`reason\` text the gate was supposed to deliver. The non-terminating-warning UX worked by accident.

## What changed

### `crates/pitboss-cli/src/mcp/tools/approval.rs`

\`PermissionPromptResponse\` reshaped from a flat struct to an internally-tagged enum on the \`behavior\` discriminator, matching the SDK \`PermissionResult\` types verified via Claude Code docs:

\`\`\`rust
#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
#[serde(tag = \"behavior\", rename_all = \"lowercase\")]
pub enum PermissionPromptResponse {
    Allow {
        #[serde(rename = \"updatedInput\", default, skip_serializing_if = \"Option::is_none\")]
        updated_input: Option<serde_json::Value>,
    },
    Deny {
        message: String,
        #[serde(default, skip_serializing_if = \"is_default_false\")]
        interrupt: bool,
    },
}
\`\`\`

\`handle_permission_prompt\`'s five terminal paths (rule auto-approve, rule auto-reject, bridge approve, bridge reject, bridge error) updated to construct the appropriate variant. Tool input passes through unchanged on Allow paths; pitboss has no operator-side input-editing surface yet.

### `crates/pitboss-cli/src/mcp/server.rs`

The \`permission_prompt\` tool dispatch switched from \`to_structured_result(&res)\` (which sets both \`content[]\` text and \`structuredContent\`) to:

\`\`\`rust
Ok(CallToolResult::success(vec![rmcp::model::Content::text(json)]))
\`\`\`

Removes the \`structured_content\` field from the response — the gate parser appears to trip on it. Single text content block with the JSON-encoded \`PermissionResult\` body, exactly as the SDK contract specifies.

### Doc rot

Stale references to the old \`decision\`/\`reason\` vocabulary updated in:
- \`manifest/validate.rs:170\` — soak warning text now says \`{behavior: \"deny\", message: ...}\`
- \`dispatch/events.rs:15\` — \`DeniedReasonKind\` doc-comment
- \`dispatch/events.rs:67\` — \`TaskEvent::ToolDenied\` doc-comment
- \`mcp/tools/approval.rs:461\` — \`PermissionDenialReason\` doc-comment

## Tests

Five new wire-format unit tests pin the on-the-wire JSON exactly:

- \`permission_prompt_response_allow_with_input_serializes_canonical_shape\`
- \`permission_prompt_response_allow_without_input_omits_updated_input\`
- \`permission_prompt_response_deny_serializes_canonical_shape\`
- \`permission_prompt_response_deny_emits_interrupt_when_true\`
- \`permission_prompt_response_round_trips_via_canonical_wire\`

Pre-fix none of these would have caught the bug — the existing tests asserted the Rust struct's own field names, which were green even though the wire was broken. The new tests pin the JSON keys (\`behavior\`, \`updatedInput\`, \`message\`, \`interrupt\`) directly.

Five existing handler tests updated to pattern-match the new enum variants instead of accessing legacy fields.

## End-to-end verification

**Run 1** — \`default_approval_policy = \"auto_approve\"\` (run \`019e0217\`):
- 3 workers exercised the full path: \`Write\` (not in worker allowlist) → \`permission_prompt\` → bridge AutoApprove → wire response in canonical shape → claude parses → tool actually executes → file created.
- Pre-fix the equivalent call failed with the parser error.

**Run 2** — \`default_approval_policy = \"auto_reject\"\` (run \`019e0222\`, soft-denial path):
- 0 wire errors. \`Permission prompt tool returned an invalid result\` failure mode gone.
- All 6 workers received structured \`is_error=true\` tool_results with the gate's \`message\` text (\"denied: tool 'Write' rejected by operator\").
- Workers exited cleanly (exit_code 0); \`approval_driven_termination\` reclassified them to \`ApprovalRejected\` (#367 working in concert).
- Per-actor \`events.jsonl\` files populated correctly (#366 working in concert).
- One worker adapted to use only allowlisted tools (kv_set instead of Write) and completed its review successfully — proving the model-adaptation path is real.
- Dispatch exit 1 correctly signaled \"5 of 6 workers blocked by policy\" — the right CI signal.

## Known follow-up surfaced by run 2

The \"soft denial\" UX makes \#373 (\`auto_reject\` misclassified as \`operator_rejected\`) visible: every worker received \"rejected by operator\" text despite no operator being involved. The fix here exposes that bug to operators and models; the fix THERE will update the \`message\` text and \`reason_kind\` to a \`DeniedByPolicy\` variant.

## Verification

- 13/13 \`permission_prompt\` lib tests pass (8 existing + 5 new wire-format).
- Full workspace test suite green; no regressions.
- cargo fmt --check clean.
- cargo clippy --all-targets --all-features -D warnings clean.
- Two end-to-end soak runs against a real claude binary (auto_approve and auto_reject) — both confirm the wire fix and the surrounding mechanics.

## Test plan

- [x] cargo test -p pitboss-cli --features pitboss-core/test-support --lib permission_prompt
- [x] cargo test --workspace --features pitboss-core/test-support
- [x] cargo fmt -p pitboss-cli -- --check
- [x] cargo clippy -p pitboss-cli --all-targets --all-features -- -D warnings
- [x] e2e soak with default_approval_policy = \"auto_approve\" (run 019e0217)
- [x] e2e soak with default_approval_policy = \"auto_reject\" (run 019e0222)

🤖 Generated with [Claude Code](https://claude.com/claude-code)