### PR TITLE
fix(mcp): attribute default-policy auto-rejection to DeniedByPolicy, not OperatorRejected

### DIFF
--- a/crates/pitboss-cli/src/dispatch/events.rs
+++ b/crates/pitboss-cli/src/dispatch/events.rs
@@ -23,6 +23,11 @@ pub enum DeniedReasonKind {
     /// An operator-declared `[[approval_policy]]` rule with
     /// `action = "auto_reject"` matched.
     DeniedByRule,
+    /// `default_approval_policy = "auto_reject"` fired inside the
+    /// bridge — no operator was involved. Distinguished from
+    /// `OperatorRejected` so audit logs reflect what actually decided
+    /// the denial. (#373)
+    DeniedByPolicy,
     /// Operator (TUI / web console) responded with reject.
     OperatorRejected,
     /// TTL on the queued approval expired and the fallback fired.

--- a/crates/pitboss-cli/src/mcp/approval.rs
+++ b/crates/pitboss-cli/src/mcp/approval.rs
@@ -27,6 +27,14 @@ use uuid::Uuid;
 
 use crate::dispatch::state::{ApprovalPolicy, ApprovalResponse, DispatchState, QueuedApproval};
 
+/// Marker text the bridge writes into `ApprovalResponse.comment` when
+/// the AutoReject default-policy short-circuit fires. Read by Path B's
+/// `handle_permission_prompt` to distinguish policy-driven rejections
+/// from operator-driven rejections (#373) — the two paths are
+/// indistinguishable by `from_ttl` alone, but the audit trail and the
+/// model-facing message text need to differ.
+pub(crate) const BRIDGE_AUTO_REJECT_COMMENT: &str = "auto-rejected by default_approval_policy";
+
 // ── Rich approval-record types (Phase 4) ────────────────────────────────────
 
 /// Re-export of `mcp::tools::ApprovalPlan` so callers can refer to it from
@@ -209,7 +217,11 @@ impl ApprovalBridge {
             ApprovalPolicy::AutoReject => {
                 let _ = tx.send(ApprovalResponse {
                     approved: false,
-                    comment: Some("auto-rejected by default_approval_policy".into()),
+                    // #373: this exact string is the discriminator
+                    // `handle_permission_prompt` reads to attribute the
+                    // denial to the policy rather than to an operator.
+                    // Keep it in sync with `BRIDGE_AUTO_REJECT_COMMENT`.
+                    comment: Some(BRIDGE_AUTO_REJECT_COMMENT.into()),
                     edited_summary: None,
                     reason: None,
                     from_ttl: false,

--- a/crates/pitboss-cli/src/mcp/tools/approval.rs
+++ b/crates/pitboss-cli/src/mcp/tools/approval.rs
@@ -469,6 +469,11 @@ pub enum PermissionDenialReason {
     /// An operator-declared `[[approval_policy]]` rule matched with
     /// `action = "auto_reject"`.
     DeniedByRule,
+    /// `default_approval_policy = "auto_reject"` short-circuited inside
+    /// the bridge — no operator was involved. Surfaces as `denied_by_policy`
+    /// in the audit log and as "denied: tool 'X' blocked by default
+    /// approval policy" in the model-facing message. (#373)
+    DeniedByPolicy,
     /// The operator's TUI / web console responded with reject.
     OperatorRejected,
     /// The TTL on the queued approval expired and the fallback fired.
@@ -484,6 +489,9 @@ impl PermissionDenialReason {
             Self::DeniedByRule => {
                 format!("denied: tool '{tool_name}' rejected by [[approval_policy]] rule")
             }
+            Self::DeniedByPolicy => {
+                format!("denied: tool '{tool_name}' blocked by default approval policy")
+            }
             Self::OperatorRejected => {
                 format!("denied: tool '{tool_name}' rejected by operator")
             }
@@ -498,6 +506,7 @@ impl From<PermissionDenialReason> for crate::dispatch::events::DeniedReasonKind 
     fn from(r: PermissionDenialReason) -> Self {
         match r {
             PermissionDenialReason::DeniedByRule => Self::DeniedByRule,
+            PermissionDenialReason::DeniedByPolicy => Self::DeniedByPolicy,
             PermissionDenialReason::OperatorRejected => Self::OperatorRejected,
             PermissionDenialReason::TtlExpired => Self::TtlExpired,
         }
@@ -610,8 +619,20 @@ pub async fn handle_permission_prompt(
             })
         }
         Ok(resp) => {
+            // #373: distinguish three bridge-driven rejection sources.
+            // `from_ttl=true` is the TTL watcher; the bridge's
+            // `BRIDGE_AUTO_REJECT_COMMENT` marker means it was
+            // `default_approval_policy = "auto_reject"` short-circuiting
+            // (no operator involvement); anything else is operator-driven.
+            // Pre-fix, `default_approval_policy` rejections were mislabeled
+            // as `OperatorRejected` in both the audit log and the
+            // model-facing message.
             let kind = if resp.from_ttl {
                 PermissionDenialReason::TtlExpired
+            } else if resp.comment.as_deref()
+                == Some(crate::mcp::approval::BRIDGE_AUTO_REJECT_COMMENT)
+            {
+                PermissionDenialReason::DeniedByPolicy
             } else {
                 PermissionDenialReason::OperatorRejected
             };

--- a/crates/pitboss-cli/src/mcp/tools/tests.rs
+++ b/crates/pitboss-cli/src/mcp/tools/tests.rs
@@ -2094,14 +2094,17 @@ async fn permission_prompt_default_policy_auto_approve_records_last_response() {
     );
 }
 
-/// #367 regression: the bridge AutoReject path in
-/// `handle_permission_prompt` must record a rejected
-/// `last_approval_response` so a worker that exits silently after the
-/// deny reclassifies as `ApprovalRejected` (not `Success`). Also
-/// asserts that the canned `OperatorRejected` message is the fallback
-/// when the bridge response carries no operator-supplied reason.
+/// #367 + #373 regression: the bridge AutoReject path in
+/// `handle_permission_prompt` must (a) record a rejected
+/// `last_approval_response` so termination reclassifies to
+/// `ApprovalRejected` (#367), and (b) attribute the denial to
+/// `DeniedByPolicy` — NOT `OperatorRejected` — because no operator
+/// was involved. Pre-#373 this was misclassified as `operator_rejected`
+/// in both the audit log and the model-facing message, causing
+/// operators to read audit trails and incorrectly conclude a human
+/// clicked reject.
 #[tokio::test]
-async fn permission_prompt_default_policy_auto_reject_records_last_response() {
+async fn permission_prompt_default_policy_auto_reject_records_denied_by_policy() {
     let state = mk_plan_state(crate::dispatch::state::ApprovalPolicy::AutoReject, false).await;
 
     let resp = handle_permission_prompt(
@@ -2126,15 +2129,18 @@ async fn permission_prompt_default_policy_auto_reject_records_last_response() {
         reason.contains("Bash"),
         "reason should name the tool: {reason}"
     );
-
-    // ─── Wire-format unit tests (#368) ─────────────────────────────────────────
-    //
-    // The Rust struct shape is one thing; the JSON Claude actually parses
-    // is another. Pre-#368 the unit tests asserted the Rust struct fields
-    // (`decision`, `reason`, ...) while the wire format silently mismatched
-    // the upstream `PermissionResult` SDK type — every gate call failed
-    // with "Permission prompt tool returned an invalid result" but tests
-    // stayed green. These tests pin the on-the-wire JSON exactly.
+    // #373: the message must attribute the denial to the policy, not
+    // to a non-existent operator.
+    assert!(
+        reason.contains("policy"),
+        "reason should attribute the denial to the policy, not an \
+         operator (#373): {reason}"
+    );
+    assert!(
+        !reason.contains("operator"),
+        "reason must NOT claim 'operator' rejected when default policy \
+         did (#373): {reason}"
+    );
 
     let counters = state.root.worker_counters.read().await;
     let entry = counters
@@ -2150,9 +2156,104 @@ async fn permission_prompt_default_policy_auto_reject_records_last_response() {
         "bridge-driven deny must register a rejected last_approval_response"
     );
 
-    // Per-actor events.jsonl audit row should also be present, since
-    // the deny goes through `record_permission_denied` regardless of
-    // origin (rule vs bridge).
+    // Per-actor events.jsonl audit row should attribute the denial
+    // correctly — `denied_by_policy`, not `operator_rejected` (#373).
+    let events_path = state
+        .root
+        .run_subdir
+        .join("tasks")
+        .join("lead")
+        .join("events.jsonl");
+    let body = tokio::fs::read_to_string(&events_path)
+        .await
+        .unwrap_or_else(|e| panic!("expected {events_path:?} to exist: {e}"));
+    assert!(
+        body.contains("\"reason_kind\":\"denied_by_policy\""),
+        "events.jsonl must record reason_kind=denied_by_policy for \
+         default-policy auto-reject (#373): {body}"
+    );
+    assert!(
+        !body.contains("\"reason_kind\":\"operator_rejected\""),
+        "events.jsonl must NOT misattribute default-policy auto-reject \
+         to operator (#373): {body}"
+    );
+}
+
+/// #373 companion: ensure the genuine operator-driven rejection path
+/// still classifies as `OperatorRejected` (no over-correction). Drives
+/// a Block-policy approval, captures the request_id, calls `respond()`
+/// with `approved=false` and no comment marker — the only path that
+/// should produce `OperatorRejected`.
+#[tokio::test]
+async fn permission_prompt_operator_driven_reject_records_operator_rejected() {
+    use crate::control::protocol::ControlEvent;
+    use crate::dispatch::state::{ApprovalPolicy, ApprovalResponse};
+    use std::time::Duration;
+    use tokio::sync::mpsc;
+
+    let state = mk_plan_state(ApprovalPolicy::Block, false).await;
+    let (tx, mut rx) = mpsc::channel::<ControlEvent>(8);
+    *state.root.control_writer.lock().await = Some(crate::dispatch::layer::ControlWriterSlot {
+        id: uuid::Uuid::now_v7(),
+        sender: tx,
+    });
+
+    // Driver: wait for the bridge to emit the request, then respond
+    // operator-reject with no marker comment (the genuine human-action
+    // path — distinct from the bridge's policy auto-reject which sets
+    // `BRIDGE_AUTO_REJECT_COMMENT`).
+    let state_for_resp = std::sync::Arc::clone(&state);
+    let driver = tokio::spawn(async move {
+        let request_id = match rx.recv().await.unwrap() {
+            ControlEvent::ApprovalRequest { request_id, .. } => request_id,
+            other => panic!("unexpected event: {other:?}"),
+        };
+        let bridge = crate::mcp::approval::ApprovalBridge::new(state_for_resp);
+        bridge
+            .respond(
+                &request_id,
+                ApprovalResponse {
+                    approved: false,
+                    comment: None,
+                    edited_summary: None,
+                    reason: None,
+                    from_ttl: false,
+                },
+            )
+            .await
+            .unwrap();
+    });
+
+    let resp = tokio::time::timeout(
+        Duration::from_secs(2),
+        handle_permission_prompt(
+            &state,
+            PermissionPromptArgs {
+                tool_name: "Bash".into(),
+                tool_input: None,
+                cost_estimate: None,
+                meta: None,
+            },
+        ),
+    )
+    .await
+    .expect("handler must resolve before timeout")
+    .unwrap();
+    driver.await.unwrap();
+
+    let reason = match &resp {
+        PermissionPromptResponse::Deny { message, .. } => message.as_str(),
+        _ => panic!("expected Deny: {resp:?}"),
+    };
+    assert!(
+        reason.contains("operator"),
+        "operator-driven rejection must attribute to operator: {reason}"
+    );
+    assert!(
+        !reason.contains("policy"),
+        "operator-driven rejection must NOT attribute to policy: {reason}"
+    );
+
     let events_path = state
         .root
         .run_subdir
@@ -2164,7 +2265,12 @@ async fn permission_prompt_default_policy_auto_reject_records_last_response() {
         .unwrap_or_else(|e| panic!("expected {events_path:?} to exist: {e}"));
     assert!(
         body.contains("\"reason_kind\":\"operator_rejected\""),
-        "events.jsonl missing operator_rejected kind: {body}"
+        "events.jsonl must record reason_kind=operator_rejected for \
+         genuine operator action: {body}"
+    );
+    assert!(
+        !body.contains("\"reason_kind\":\"denied_by_policy\""),
+        "events.jsonl must NOT label operator action as denied_by_policy: {body}"
     );
 }
 


### PR DESCRIPTION
## Summary

Closes #373.

`handle_permission_prompt` mislabeled every bridge-driven non-TTL rejection as `OperatorRejected`, even when the rejection came from `default_approval_policy = "auto_reject"` short-circuiting inside the bridge with no operator involvement. Two harms post-#368:

- Audit log: `events.jsonl` recorded `reason_kind: operator_rejected` for policy-driven denials. Operators reading audit trails saw an apparent human action when none happened.
- Model context: claude received `\"denied: tool 'X' rejected by operator\"`, potentially adapting to a non-existent operator decision (apologies, social framing, delayed retries) rather than a structural policy denial.

## Discriminator

The bridge already populates `comment = Some(\"auto-rejected by default_approval_policy\")` for the AutoReject default-policy case. Promoted that string to a shared `pub(crate) const BRIDGE_AUTO_REJECT_COMMENT` so the bridge writer (`mcp/approval.rs`) and the handler reader (`mcp/tools/approval.rs`) stay in sync, and use it as the signal:

```rust
let kind = if resp.from_ttl {
    PermissionDenialReason::TtlExpired
} else if resp.comment.as_deref() == Some(BRIDGE_AUTO_REJECT_COMMENT) {
    PermissionDenialReason::DeniedByPolicy
} else {
    PermissionDenialReason::OperatorRejected
};
```

No new field on `ApprovalResponse` — would have churned 15 constructor sites with no behavioral benefit. The marker-comment approach uses the discriminator that already exists on the wire.

## Enum updates

Added `DeniedByPolicy` variant to:
- `crates/pitboss-cli/src/mcp/tools/approval.rs::PermissionDenialReason` + new `message()` text: \"denied: tool 'X' blocked by default approval policy\"
- `crates/pitboss-cli/src/dispatch/events.rs::DeniedReasonKind` + the `From` impl

(#370's umbrella will eventually collapse these two enums into one; until then the variants are added in lockstep.)

## Tests

- **Renamed** `permission_prompt_default_policy_auto_reject_records_last_response` → `..._records_denied_by_policy`. Pre-fix this test asserted the *wrong* behavior — that AutoReject policy produces `operator_rejected` in events.jsonl. Now asserts:
  - Model-facing `message` contains \"policy\" and does NOT contain \"operator\"
  - `events.jsonl` row contains `\"reason_kind\":\"denied_by_policy\"` and does NOT contain `\"operator_rejected\"`
- **New** `permission_prompt_operator_driven_reject_records_operator_rejected` — drives a Block-policy approval, captures the request_id, calls `respond()` with `approved=false` and no marker comment. Asserts the genuine operator-action path still classifies as `OperatorRejected` (no over-correction).

## Verification

- 14/14 `permission_prompt` lib tests pass (was 13 + 1 new).
- Workspace test suite green; no regressions.
- cargo fmt --check clean.
- cargo clippy --all-targets --all-features -D warnings clean.

Empirical evidence from previous run `019e0222` (which ran with the bug): 6 workers all received \"rejected by operator\" text despite no operator. After this fix the same dispatch will produce \"blocked by default approval policy\" (model-facing) and `denied_by_policy` (audit log).

## Test plan

- [x] cargo test -p pitboss-cli --features pitboss-core/test-support --lib permission_prompt
- [x] cargo test --workspace --features pitboss-core/test-support
- [x] cargo fmt -p pitboss-cli -- --check
- [x] cargo clippy -p pitboss-cli --all-targets --all-features -- -D warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)