### PR TITLE
chore(path-b): umbrella cleanup — docs, tests, dedupe enums, helpers, tracing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 document: pitboss-agent-instructions
 schema_version: 1
 pitboss_version: 0.10.0
-last_updated: 2026-05-06
+last_updated: 2026-05-07
 audience: ai-agent
 canonical_url: https://github.com/SDS-Mode/pitboss/blob/main/AGENTS.md
 ---
@@ -136,6 +136,7 @@ caps (which used to live here in v0.8) moved to `[lead]` in v0.9.
 | `worktree_cleanup` | `"always"` \| `"on_success"` \| `"never"` | no | `"on_success"` | What to do with each worker's worktree after completion. `"never"` for inspection-heavy runs. |
 | `emit_event_stream` | bool | no | false | Emit a JSONL event stream alongside summary.jsonl. |
 | `default_approval_policy` | `"block"` \| `"auto_approve"` \| `"auto_reject"` | no | `"block"` | Hierarchical: default action for `request_approval` / `propose_plan` when no TUI is attached and no `[[approval_policy]]` rule matches. Renamed from `approval_policy` in v0.9 to disambiguate from the rules array. |
+| `denial_termination_policy` | `"adapt"` \| `"reclassify"` | no | `"adapt"` | Path B only: how a denied `permission_prompt` affects the actor's terminal status. `"adapt"` (default, post-#377) trusts the actor's exit code; per-actor `events.jsonl::tool_denied` rows and the `approvals_rejected` counter remain authoritative for what was blocked. `"reclassify"` re-labels clean exits within 30s of a denial as `ApprovalRejected` (legacy heuristic, kept for operators who want fast-give-up distinguished in the status table — accepts that successful adaptation within the window will misclassify as failure). |
 | `require_plan_approval` | bool | no | false | Hierarchical: when true, `spawn_worker` refuses until a plan submitted via `propose_plan` has been operator-approved. |
 | `dump_shared_store` | bool | no | false | Hierarchical: at run finalize, write `shared-store.json` into the run dir for post-mortem inspection. |
 
@@ -229,7 +230,7 @@ Depth-2 controls (sub-leads):
 | `max_subleads` | int | unset | Cap on total sub-leads the root lead may spawn. |
 | `max_sublead_budget_usd` | float | unset | Per-sub-lead envelope cap; `spawn_sublead` rejects envelopes exceeding this. |
 | `max_total_workers` | int | unset | Cap on total live workers including all sub-tree workers. Renamed from `max_workers_across_tree` in v0.9. |
-| `permission_routing` | `"path_a"` \| `"path_b"` | `"path_a"` | `"path_a"` sets `CLAUDE_CODE_ENTRYPOINT=sdk-ts` so pitboss is the sole permission authority. `"path_b"` routes claude's built-in gate through pitboss's approval queue — rejected at validate time until stabilization (issues #92–#94). |
+| `permission_routing` | `"path_a"` \| `"path_b"` | `"path_a"` | `"path_a"` sets `CLAUDE_CODE_ENTRYPOINT=sdk-ts` so pitboss is the sole permission authority. `"path_b"` (in soak) drops `--dangerously-skip-permissions` and wires `--permission-prompt-tool mcp__pitboss__permission_prompt`; each per-tool check the model wants outside its `--allowedTools` routes through pitboss's approval queue and returns the SDK `PermissionResult` shape (`{behavior:"allow",updatedInput?}` or `{behavior:"deny",message,interrupt?}`). Denials are non-terminating — claude receives the structured response and adapts. Per-actor `<run_dir>/tasks/<actor>/events.jsonl` records each denial as a `tool_denied` row. Validate emits a one-line stderr soak warning. See `[run].denial_termination_policy` for how denials affect the actor's terminal status. |
 
 ### Top-level `[sublead_defaults]` (v0.9+, promoted from `[lead.sublead_defaults]`)
 

--- a/crates/pitboss-cli/src/dispatch/events.rs
+++ b/crates/pitboss-cli/src/dispatch/events.rs
@@ -13,10 +13,16 @@ use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
 
 /// Why a Path-B `permission_prompt` returned `behavior = "deny"`.
-/// Mirrors `crate::mcp::tools::approval::PermissionDenialReason` but
-/// lives in the events module so the audit log file owns its own
-/// serialization shape (independent of any future refactor of the
-/// MCP-side enum).
+/// Surfaced to the model as the `message` field of
+/// `PermissionPromptResponse::Deny` and recorded as the `reason_kind`
+/// on `TaskEvent::ToolDenied` rows of the per-actor `events.jsonl`.
+///
+/// This was previously duplicated as
+/// `mcp::tools::approval::PermissionDenialReason` (with a `From` impl
+/// connecting the two) — collapsed into a single canonical type in
+/// #370 (item 4) since the duplication couldn't actually diverge:
+/// adding a variant on either side broke the `From` impl at compile
+/// time.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DeniedReasonKind {
@@ -32,6 +38,28 @@ pub enum DeniedReasonKind {
     OperatorRejected,
     /// TTL on the queued approval expired and the fallback fired.
     TtlExpired,
+}
+
+impl DeniedReasonKind {
+    /// Short, model-readable explanation. Phrasing follows the
+    /// convention "denied: <kind> ..." so a Claude session can detect
+    /// the prefix and adapt without parsing structured fields.
+    pub fn message(self, tool_name: &str) -> String {
+        match self {
+            Self::DeniedByRule => {
+                format!("denied: tool '{tool_name}' rejected by [[approval_policy]] rule")
+            }
+            Self::DeniedByPolicy => {
+                format!("denied: tool '{tool_name}' blocked by default approval policy")
+            }
+            Self::OperatorRejected => {
+                format!("denied: tool '{tool_name}' rejected by operator")
+            }
+            Self::TtlExpired => {
+                format!("denied: tool '{tool_name}' approval timed out before operator response")
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -1010,7 +1010,6 @@ pub fn lead_spawn_args(
     mcp_config: &std::path::Path,
     communication_mode: crate::manifest::schema::CommunicationMode,
 ) -> Vec<String> {
-    use crate::manifest::schema::PermissionRouting;
     let mut args = vec![
         "--output-format".into(),
         "stream-json".into(),
@@ -1064,7 +1063,6 @@ pub fn lead_resume_spawn_args(
     new_prompt: &str,
     communication_mode: crate::manifest::schema::CommunicationMode,
 ) -> Vec<String> {
-    use crate::manifest::schema::PermissionRouting;
     let mut args = vec![
         "--output-format".into(),
         "stream-json".into(),
@@ -1130,7 +1128,6 @@ pub fn sublead_spawn_args(
     permission_routing: crate::manifest::schema::PermissionRouting,
     communication_mode: crate::manifest::schema::CommunicationMode,
 ) -> Vec<String> {
-    use crate::manifest::schema::PermissionRouting;
     let mut args = vec![
         "--output-format".into(),
         "stream-json".into(),

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -76,6 +76,49 @@ pub fn apply_pitboss_env_defaults(
     }
 }
 
+/// Push the per-route permission CLI args.
+///
+/// - Path A (default): `--dangerously-skip-permissions`. Pitboss is the
+///   sole permission authority via its own approval queue.
+/// - Path B: `--permission-prompt-tool mcp__pitboss__permission_prompt`.
+///   Claude's gate stays active and every per-tool check routes through
+///   pitboss's MCP server. Without this flag the gate falls back to the
+///   interactive prompt, which can't be answered under `-p` and silently
+///   stalls.
+///
+/// Extracted in #370 (item 5) so the four hierarchical spawn variants
+/// (lead, lead_resume, sublead, worker) share one implementation. A
+/// future routing mode (e.g. `Cancel` per #377) becomes a one-line
+/// edit here instead of a four-place change.
+pub(crate) fn push_permission_routing_args(
+    args: &mut Vec<String>,
+    routing: crate::manifest::schema::PermissionRouting,
+) {
+    use crate::manifest::schema::PermissionRouting;
+    match routing {
+        PermissionRouting::PathA => {
+            args.push("--dangerously-skip-permissions".into());
+        }
+        PermissionRouting::PathB => {
+            args.push("--permission-prompt-tool".into());
+            args.push("mcp__pitboss__permission_prompt".into());
+        }
+    }
+}
+
+/// Allowlist `mcp__pitboss__permission_prompt` under Path B so claude's
+/// `--allowedTools` gate doesn't block the gate-routing tool itself.
+/// No-op under Path A. (#370 item 5.)
+pub(crate) fn push_permission_routing_allowed(
+    allowed: &mut Vec<String>,
+    routing: crate::manifest::schema::PermissionRouting,
+) {
+    use crate::manifest::schema::PermissionRouting;
+    if routing == PermissionRouting::PathB {
+        allowed.push("mcp__pitboss__permission_prompt".into());
+    }
+}
+
 /// Check whether a manifest has approval gates that will block indefinitely
 /// in a headless (no-TUI) dispatch. Returns warning strings describing each
 /// gate; empty if the manifest can run cleanly headless. Callers typically
@@ -973,18 +1016,7 @@ pub fn lead_spawn_args(
         "stream-json".into(),
         "--verbose".into(),
     ];
-    // Path A (default): pitboss is the permission authority; bypass claude's gate.
-    // Path B: leave gate active; permission_prompt MCP tool routes each check.
-    if lead.permission_routing == PermissionRouting::PathA {
-        args.push("--dangerously-skip-permissions".into());
-    } else {
-        // Path B: tell claude to route each tool-permission check through
-        // pitboss's MCP `permission_prompt` tool. Without this flag the
-        // gate falls back to the interactive prompt, which can't be
-        // answered under `-p` and silently stalls.
-        args.push("--permission-prompt-tool".into());
-        args.push("mcp__pitboss__permission_prompt".into());
-    }
+    push_permission_routing_args(&mut args, lead.permission_routing);
     // Plugin/skill isolation: prevent operator's ~/.claude/ plugins
     // (skills, MCP servers, agents, hooks) from bleeding in.
     args.push("--strict-mcp-config".into());
@@ -1001,10 +1033,7 @@ pub fn lead_spawn_args(
     if lead.allow_subleads {
         allowed.push("mcp__pitboss__spawn_sublead".into());
     }
-    // Path B: pre-allow permission_prompt so claude can route checks without stalling.
-    if lead.permission_routing == PermissionRouting::PathB {
-        allowed.push("mcp__pitboss__permission_prompt".into());
-    }
+    push_permission_routing_allowed(&mut allowed, lead.permission_routing);
     args.push("--allowedTools".into());
     args.push(allowed.join(","));
 
@@ -1041,14 +1070,7 @@ pub fn lead_resume_spawn_args(
         "stream-json".into(),
         "--verbose".into(),
     ];
-    if lead.permission_routing == PermissionRouting::PathA {
-        args.push("--dangerously-skip-permissions".into());
-    } else {
-        // Path B: route claude's per-tool gate through pitboss's MCP
-        // permission_prompt (see lead_spawn_args doc).
-        args.push("--permission-prompt-tool".into());
-        args.push("mcp__pitboss__permission_prompt".into());
-    }
+    push_permission_routing_args(&mut args, lead.permission_routing);
     // Plugin/skill isolation (see lead_spawn_args doc).
     args.push("--strict-mcp-config".into());
     args.push("--disable-slash-commands".into());
@@ -1059,9 +1081,7 @@ pub fn lead_resume_spawn_args(
     if lead.allow_subleads {
         allowed.push("mcp__pitboss__spawn_sublead".into());
     }
-    if lead.permission_routing == PermissionRouting::PathB {
-        allowed.push("mcp__pitboss__permission_prompt".into());
-    }
+    push_permission_routing_allowed(&mut allowed, lead.permission_routing);
     args.push("--allowedTools".into());
     args.push(allowed.join(","));
 
@@ -1116,14 +1136,7 @@ pub fn sublead_spawn_args(
         "stream-json".into(),
         "--verbose".into(),
     ];
-    if permission_routing == PermissionRouting::PathA {
-        args.push("--dangerously-skip-permissions".into());
-    } else {
-        // Path B: route claude's per-tool gate through pitboss's MCP
-        // permission_prompt (see lead_spawn_args doc).
-        args.push("--permission-prompt-tool".into());
-        args.push("mcp__pitboss__permission_prompt".into());
-    }
+    push_permission_routing_args(&mut args, permission_routing);
     // Plugin/skill isolation (see lead_spawn_args doc).
     args.push("--strict-mcp-config".into());
     args.push("--disable-slash-commands".into());
@@ -1138,9 +1151,7 @@ pub fn sublead_spawn_args(
     for t in sublead_mcp_tools(communication_mode) {
         allowed.push(t.to_string());
     }
-    if permission_routing == PermissionRouting::PathB {
-        allowed.push("mcp__pitboss__permission_prompt".into());
-    }
+    push_permission_routing_allowed(&mut allowed, permission_routing);
     // De-duplicate while preserving order.
     let mut seen = std::collections::HashSet::new();
     allowed.retain(|t| seen.insert(t.clone()));

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -167,8 +167,14 @@ fn validate_lead(r: &ResolvedManifest, skip_dir_check: bool) -> Result<()> {
         lead.permission_routing,
         crate::manifest::schema::PermissionRouting::PathB
     ) {
-        eprintln!(
-            "warning: `permission_routing = \"path_b\"` is in soak. Each per-tool \
+        // #370 (item 6): switched from `eprintln!` to `tracing::warn!`
+        // for consistency with the rest of the codebase. Subscriber
+        // defaults to info-level on stderr (see `init_tracing` in
+        // main.rs), so operators running `pitboss validate` still see
+        // this; structured-log consumers and CI pipelines that filter
+        // on RUST_LOG can suppress it explicitly.
+        tracing::warn!(
+            "`permission_routing = \"path_b\"` is in soak. Each per-tool \
              permission check routes through pitboss's MCP `permission_prompt`. \
              Denials are non-terminating — claude receives \
              {{behavior: \"deny\", message: ...}} and adapts; the row lands on \

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -1515,4 +1515,76 @@ mod tests {
         });
         validate(&m).expect("tilde host + absolute container must validate");
     }
+
+    /// #370 (item 2): pin the post-#368 contract that
+    /// `permission_routing = "path_b"` is selectable. Pre-#368 this
+    /// returned `Err`; the change to a stderr soak warning is
+    /// behavioral and deserves a regression test so an accidental
+    /// revert to `bail!` would show up in CI rather than at runtime.
+    /// Path A (the default) gets a sibling assertion to pin baseline.
+    #[test]
+    fn path_b_permission_routing_passes_validate() {
+        use super::super::schema::PermissionRouting;
+        let d = with_tmp_repo(true);
+        let mut lead = rl("l", d.path().to_path_buf());
+        lead.permission_routing = PermissionRouting::PathB;
+        let r = ResolvedManifest {
+            manifest_schema_version: 0,
+            name: None,
+            max_parallel_tasks: Some(4),
+            halt_on_failure: false,
+            run_dir: PathBuf::from("."),
+            worktree_cleanup: WorktreeCleanup::OnSuccess,
+            emit_event_stream: false,
+            tasks: vec![],
+            lead: Some(lead),
+            max_workers: Some(4),
+            budget_usd: Some(1.0),
+            lead_timeout_secs: Some(600),
+            default_approval_policy: None,
+            denial_termination_policy: None,
+            notifications: vec![],
+            dump_shared_store: false,
+            require_plan_approval: false,
+            approval_rules: vec![],
+            container: None,
+            mcp_servers: vec![],
+            communication: Default::default(),
+            lifecycle: None,
+        };
+        validate(&r).expect("path_b must validate (in soak); pre-#368 this bailed");
+    }
+
+    #[test]
+    fn path_a_permission_routing_passes_validate() {
+        use super::super::schema::PermissionRouting;
+        let d = with_tmp_repo(true);
+        let mut lead = rl("l", d.path().to_path_buf());
+        lead.permission_routing = PermissionRouting::PathA;
+        let r = ResolvedManifest {
+            manifest_schema_version: 0,
+            name: None,
+            max_parallel_tasks: Some(4),
+            halt_on_failure: false,
+            run_dir: PathBuf::from("."),
+            worktree_cleanup: WorktreeCleanup::OnSuccess,
+            emit_event_stream: false,
+            tasks: vec![],
+            lead: Some(lead),
+            max_workers: Some(4),
+            budget_usd: Some(1.0),
+            lead_timeout_secs: Some(600),
+            default_approval_policy: None,
+            denial_termination_policy: None,
+            notifications: vec![],
+            dump_shared_store: false,
+            require_plan_approval: false,
+            approval_rules: vec![],
+            container: None,
+            mcp_servers: vec![],
+            communication: Default::default(),
+            lifecycle: None,
+        };
+        validate(&r).expect("path_a is the default and must validate");
+    }
 }

--- a/crates/pitboss-cli/src/mcp/tools/approval.rs
+++ b/crates/pitboss-cli/src/mcp/tools/approval.rs
@@ -458,60 +458,11 @@ fn is_default_false(b: &bool) -> bool {
     !b
 }
 
-/// Why a `permission_prompt` returned `behavior == "deny"`. Surfaced
-/// to the requesting actor as the `message` field of
-/// `PermissionPromptResponse::Deny` and also recorded as a
-/// `TaskEvent::ToolDenied` on the per-task `events.jsonl` audit log
-/// so an operator sees what was attempted-and-blocked even when the
-/// lead silently routes around it.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PermissionDenialReason {
-    /// An operator-declared `[[approval_policy]]` rule matched with
-    /// `action = "auto_reject"`.
-    DeniedByRule,
-    /// `default_approval_policy = "auto_reject"` short-circuited inside
-    /// the bridge — no operator was involved. Surfaces as `denied_by_policy`
-    /// in the audit log and as "denied: tool 'X' blocked by default
-    /// approval policy" in the model-facing message. (#373)
-    DeniedByPolicy,
-    /// The operator's TUI / web console responded with reject.
-    OperatorRejected,
-    /// The TTL on the queued approval expired and the fallback fired.
-    TtlExpired,
-}
-
-impl PermissionDenialReason {
-    /// Short, model-readable explanation. Phrasing follows the convention
-    /// "denied: <kind> ..." so a Claude session can detect the prefix and
-    /// adapt without parsing structured fields.
-    pub fn message(self, tool_name: &str) -> String {
-        match self {
-            Self::DeniedByRule => {
-                format!("denied: tool '{tool_name}' rejected by [[approval_policy]] rule")
-            }
-            Self::DeniedByPolicy => {
-                format!("denied: tool '{tool_name}' blocked by default approval policy")
-            }
-            Self::OperatorRejected => {
-                format!("denied: tool '{tool_name}' rejected by operator")
-            }
-            Self::TtlExpired => {
-                format!("denied: tool '{tool_name}' approval timed out before operator response")
-            }
-        }
-    }
-}
-
-impl From<PermissionDenialReason> for crate::dispatch::events::DeniedReasonKind {
-    fn from(r: PermissionDenialReason) -> Self {
-        match r {
-            PermissionDenialReason::DeniedByRule => Self::DeniedByRule,
-            PermissionDenialReason::DeniedByPolicy => Self::DeniedByPolicy,
-            PermissionDenialReason::OperatorRejected => Self::OperatorRejected,
-            PermissionDenialReason::TtlExpired => Self::TtlExpired,
-        }
-    }
-}
+/// Re-export of the canonical denial-reason enum, owned by the events
+/// module so the audit-log serialization shape is single-sourced.
+/// (#370 item 4 — collapsed the previous duplicate
+/// `PermissionDenialReason` into this type.)
+pub use crate::dispatch::events::DeniedReasonKind as PermissionDenialReason;
 
 /// Handle Path B `permission_prompt`: routes claude's per-tool permission
 /// check through pitboss's approval queue and TUI. Returns the Claude Code
@@ -676,7 +627,7 @@ async fn record_permission_denied(
         at: chrono::Utc::now(),
         tool_name: tool_name.to_string(),
         actor_id: actor_id.to_string(),
-        reason_kind: reason_kind.into(),
+        reason_kind,
         reason: reason_text.to_string(),
     };
     if let Err(e) =

--- a/crates/pitboss-cli/src/mcp/tools/spawn.rs
+++ b/crates/pitboss-cli/src/mcp/tools/spawn.rs
@@ -781,7 +781,6 @@ pub(super) fn worker_spawn_args(
     permission_routing: crate::manifest::schema::PermissionRouting,
     communication_mode: crate::manifest::schema::CommunicationMode,
 ) -> Vec<String> {
-    use crate::manifest::schema::PermissionRouting;
     let mut args = vec![
         "--output-format".into(),
         "stream-json".into(),

--- a/crates/pitboss-cli/src/mcp/tools/spawn.rs
+++ b/crates/pitboss-cli/src/mcp/tools/spawn.rs
@@ -787,16 +787,7 @@ pub(super) fn worker_spawn_args(
         "stream-json".into(),
         "--verbose".into(),
     ];
-    if permission_routing == PermissionRouting::PathA {
-        args.push("--dangerously-skip-permissions".into());
-    } else {
-        // Path B: route claude's per-tool gate through pitboss's MCP
-        // permission_prompt (see runner::lead_spawn_args doc). Without
-        // this flag the gate falls back to the interactive prompt,
-        // which can't be answered under `-p` and silently stalls.
-        args.push("--permission-prompt-tool".into());
-        args.push("mcp__pitboss__permission_prompt".into());
-    }
+    crate::dispatch::runner::push_permission_routing_args(&mut args, permission_routing);
     // Plugin/skill isolation (see runner::lead_spawn_args doc).
     args.push("--strict-mcp-config".into());
     args.push("--disable-slash-commands".into());
@@ -809,10 +800,7 @@ pub(super) fn worker_spawn_args(
         for t in pitboss_worker_mcp_tools(communication_mode) {
             allowed.push(t.to_string());
         }
-        // Path B: pre-allow permission_prompt so workers can route checks.
-        if permission_routing == PermissionRouting::PathB {
-            allowed.push("mcp__pitboss__permission_prompt".into());
-        }
+        crate::dispatch::runner::push_permission_routing_allowed(&mut allowed, permission_routing);
     }
     if !allowed.is_empty() {
         args.push("--allowedTools".into());

--- a/crates/pitboss-cli/src/mcp/tools/tests.rs
+++ b/crates/pitboss-cli/src/mcp/tools/tests.rs
@@ -2382,6 +2382,115 @@ async fn permission_prompt_operator_driven_reject_records_operator_rejected() {
     );
 }
 
+/// #370 (item 3): the `TtlExpired` denial path in
+/// `handle_permission_prompt` was untested through #378. Drives a
+/// Block-policy approval and responds via `bridge.respond()` with
+/// `from_ttl=true` (the same shape the TTL watcher would produce
+/// when a queued approval's `ttl_secs` elapses without operator
+/// action). Asserts:
+///
+/// - response carries the canonical TTL-denial message
+/// - per-actor `events.jsonl` records `reason_kind=ttl_expired`
+/// - under `Reclassify` policy, `approval_driven_termination`
+///   returns `TimedOut` (not `Rejected`) — the only path that
+///   distinguishes silent-exit-after-TTL from silent-exit-after-deny
+///   in `pitboss status` / `summary.json`.
+#[tokio::test]
+async fn permission_prompt_ttl_driven_reject_records_ttl_expired() {
+    use crate::control::protocol::ControlEvent;
+    use crate::dispatch::state::{ApprovalPolicy, ApprovalResponse, DenialTerminationPolicy};
+    use std::time::Duration;
+    use tokio::sync::mpsc;
+
+    // Reclassify policy so the termination assertion is meaningful.
+    let state = mk_plan_state_with_termination_policy(
+        ApprovalPolicy::Block,
+        false,
+        DenialTerminationPolicy::Reclassify,
+    )
+    .await;
+    let (tx, mut rx) = mpsc::channel::<ControlEvent>(8);
+    *state.root.control_writer.lock().await = Some(crate::dispatch::layer::ControlWriterSlot {
+        id: uuid::Uuid::now_v7(),
+        sender: tx,
+    });
+
+    let state_for_resp = std::sync::Arc::clone(&state);
+    let driver = tokio::spawn(async move {
+        let request_id = match rx.recv().await.unwrap() {
+            ControlEvent::ApprovalRequest { request_id, .. } => request_id,
+            other => panic!("unexpected event: {other:?}"),
+        };
+        let bridge = crate::mcp::approval::ApprovalBridge::new(state_for_resp);
+        bridge
+            .respond(
+                &request_id,
+                ApprovalResponse {
+                    approved: false,
+                    // No comment marker — distinguishes this from
+                    // policy auto-reject. TTL is signaled by `from_ttl`.
+                    comment: None,
+                    edited_summary: None,
+                    reason: None,
+                    from_ttl: true,
+                },
+            )
+            .await
+            .unwrap();
+    });
+
+    let resp = tokio::time::timeout(
+        Duration::from_secs(2),
+        handle_permission_prompt(
+            &state,
+            PermissionPromptArgs {
+                tool_name: "Bash".into(),
+                tool_input: None,
+                cost_estimate: None,
+                meta: None,
+            },
+        ),
+    )
+    .await
+    .expect("handler must resolve before timeout")
+    .unwrap();
+    driver.await.unwrap();
+
+    let reason = match &resp {
+        PermissionPromptResponse::Deny { message, .. } => message.as_str(),
+        _ => panic!("expected Deny: {resp:?}"),
+    };
+    assert!(
+        reason.contains("timed out"),
+        "TTL-driven denial must mention timeout in the message: {reason}"
+    );
+
+    let events_path = state
+        .root
+        .run_subdir
+        .join("tasks")
+        .join("lead")
+        .join("events.jsonl");
+    let body = tokio::fs::read_to_string(&events_path)
+        .await
+        .unwrap_or_else(|e| panic!("expected {events_path:?} to exist: {e}"));
+    assert!(
+        body.contains("\"reason_kind\":\"ttl_expired\""),
+        "events.jsonl must record reason_kind=ttl_expired for TTL-driven \
+         denial: {body}"
+    );
+
+    // Under Reclassify, TTL-driven denial reclassifies as TimedOut,
+    // not Rejected — the distinction in `pitboss status` between
+    // "operator declined" and "no operator responded in time."
+    assert_eq!(
+        state.approval_driven_termination("lead").await,
+        Some(crate::dispatch::state::ApprovalTerminationKind::TimedOut),
+        "TTL denial must reclassify as TimedOut, not Rejected, under \
+         Reclassify policy"
+    );
+}
+
 /// #368: Allow variant must serialize as `{"behavior":"allow", "updatedInput": ...}`
 /// when input is provided. `updatedInput` (camelCase) is the upstream
 /// SDK field name; `updated_input` (snake_case) would silently fail the


### PR DESCRIPTION
## Summary

Closes #370.

Six follow-up cleanup items from the Path B soak that didn't warrant individual PRs. One commit per item for atomic review.

## Items

### 1. \`docs(agents): describe Path B current state and denial_termination_policy\`

AGENTS.md is the canonical machine-targeted reference per CLAUDE.md. The \`[lead].permission_routing\` row claimed Path B was rejected at validate time pending stabilization (#92–#94). Reality after the recent stack of fixes: Path B is selectable in soak; \`--permission-prompt-tool mcp__pitboss__permission_prompt\` is wired into every hierarchical spawn variant; the wire shape is the SDK \`PermissionResult\`; denials are non-terminating; per-actor \`events.jsonl::tool_denied\` rows record each denial; counters bump consistently; \`denial_termination_policy\` controls reclassification with \`adapt\` as default. Updated the row + added a new row for \`denial_termination_policy\`. Bumped \`last_updated\` frontmatter.

### 2. \`test(manifest): pin path_a/path_b permission_routing validate behavior\`

Pre-#368 \`validate_lead\` returned \`Err\` for path_b; post-fix it emits a stderr soak warning and returns \`Ok\`. All existing \`manifest::validate\` tests use the default (Path A via the \`rl()\` helper), so an accidental revert to \`bail!\` would only show up at dispatch time. Adds \`path_b_permission_routing_passes_validate\` (asserts Ok) and \`path_a_permission_routing_passes_validate\` (pins baseline).

### 3. \`test(mcp): cover TtlExpired denial path in handle_permission_prompt\`

Through #378 the \`OperatorRejected\` and \`DeniedByRule\` denial paths have explicit tests; \`TtlExpired\` was the gap. Drives a Block-policy approval and responds via \`bridge.respond()\` with \`from_ttl=true\`. Asserts the deny carries the canonical TTL-attribution message, \`events.jsonl\` records \`reason_kind=ttl_expired\`, and under \`Reclassify\` policy \`approval_driven_termination\` returns \`TimedOut\` (not \`Rejected\`).

### 4. \`refactor(events): collapse PermissionDenialReason into DeniedReasonKind\`

\`PermissionDenialReason\` (mcp/tools/approval.rs) and \`DeniedReasonKind\` (dispatch/events.rs) had structurally identical 4-variant shapes joined by a \`From\` impl. The duplication couldn't actually diverge — adding a variant on one side broke the \`From\` impl at compile time. Moved \`message()\` to \`DeniedReasonKind\` (events module owns the canonical type), replaced the duplicate enum with a \`pub use\` re-export so existing call sites keep their syntax. Net: -52 lines, single source of truth, dependency direction is now mcp::tools → dispatch::events (the natural layering).

### 5. \`refactor(dispatch): extract push_permission_routing_args helper\`

Four hierarchical spawn variants (\`lead_spawn_args\`, \`lead_resume_spawn_args\`, \`sublead_spawn_args\` in runner.rs; \`worker_spawn_args\` in mcp/tools/spawn.rs) all duplicated the routing-mode CLI args push and the Path B \`mcp__pitboss__permission_prompt\` allowlist push. Extracted into \`push_permission_routing_args\` and \`push_permission_routing_allowed\` (both \`pub(crate)\` in runner.rs). Future routing changes — e.g. \`Cancel\` mode, or a flat-mode policy hook — become a one-line edit.

### 6. \`refactor(manifest): switch Path B soak warning from eprintln! to tracing::warn!\`

The validate-time soak warning bypassed RUST_LOG filtering and structured-log capture. Switched to \`tracing::warn!\` for consistency with the rest of the codebase. Default subscriber (info-level on stderr) keeps the warning visible for operators running \`pitboss validate\`; CI / scripts can suppress via RUST_LOG. Also drops two unused \`use PermissionRouting\` imports that became dead after item 5 — folded in here to keep clippy green.

## Verification

- 16/16 lib tests covering Path B (\`permission_prompt\`, \`approval_driven_termination\`, \`path_b\` spawn args, validate) pass.
- Full workspace test suite green (no regressions across docs, integration suites, etc.).
- cargo fmt --check clean.
- cargo clippy --all-targets --all-features -D warnings clean.

## Test plan

- [x] cargo test -p pitboss-cli --features pitboss-core/test-support --lib permission_prompt
- [x] cargo test -p pitboss-cli --features pitboss-core/test-support --lib path_b
- [x] cargo test --workspace --features pitboss-core/test-support
- [x] cargo fmt -p pitboss-cli -- --check
- [x] cargo clippy -p pitboss-cli --all-targets --all-features -- -D warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)