### PR TITLE
feat(manifest): typed worker/sublead profiles with dispatcher caps (#252)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,6 +351,47 @@ All declared servers are injected into all actors (scope = all). Per-actor scopi
 
 **Tools from injected servers are available immediately** — no additional `--allowedTools` configuration is needed; claude's MCP client discovers the tools from the server at startup.
 
+### `[[worker_type]]` / `[[sublead_type]]` (v0.12+, typed actor profiles)
+
+Declare per-class capability caps that the dispatcher enforces at spawn time. The lead can never widen these caps — `tools` arg must be a subset of the profile's allowlist; `model` must be in `allowed_models` (when set); `timeout_secs` / `budget_usd` only clamp DOWN. (#252)
+
+```toml
+[[worker_type]]
+id               = "extraction"
+tools            = ["Read", "Glob", "Grep"]
+allowed_models   = ["claude-haiku-4-5", "claude-sonnet-4-6"]
+max_timeout_secs = 900
+
+[[worker_type]]
+id    = "writer"
+tools = ["Read", "Glob", "Grep", "Write"]
+
+[[sublead_type]]
+id              = "planner"
+tools           = ["Read", "Glob", "Grep"]
+allowed_models  = ["claude-opus-4-7"]
+max_budget_usd  = 2.00
+```
+
+The `spawn_worker` and `spawn_sublead` MCP tools gain optional `worker_type` / `sublead_type` args. **Naming a profile overrides the legacy `[lead].tools` cascade** for that spawn — the manifest profile is the single source of truth for capability:
+
+1. Unknown id → spawn rejected at the dispatcher.
+2. `tools` arg must be a **subset** of the profile's allowlist — any tool not in the allowlist rejects the spawn with `denied: tool 'X' is not in worker_type 'Y' allowlist`.
+3. When `tools` is omitted, the spawn gets the profile's full allowlist verbatim — NOT the legacy `[lead].tools` cascade. Untyped spawns continue to follow the cascade unchanged.
+4. `model` must be in `allowed_models` when non-empty (empty = unrestricted).
+5. `timeout_secs` is clamped DOWN to `max_timeout_secs`; smaller values pass through.
+6. `[[sublead_type]]` additionally clamps `budget_usd` down to `max_budget_usd`.
+
+Set `[run].require_actor_type = true` to make every `spawn_worker` / `spawn_sublead` call REQUIRE a profile arg — type-less spawns are rejected. The flag is inert in flat mode (warning logged at validate time).
+
+The resolved profile id is persisted to each `TaskRecord.actor_type`, surfaced in `summary.json` / `summary.jsonl` so the TUI, `pitboss-web`, and `pitboss status` can group actors by class without re-deriving from the manifest snapshot.
+
+**v0.12 limitations (Phase 1, follow-ups in #252 backlog):**
+- Per-actor MCP server scoping (`[[mcp_server].scope = "type:<id>"`) is deferred.
+- Resumed workers (`continue_worker` / `reprompt_worker`) drop `actor_type` on the appended record; the original spawn's record retains the type.
+- Synthesized cancellation records on lead-exit cleanup also drop `actor_type`.
+- SQLite-backed runs lose `actor_type` on round-trip (JsonFileStore preserves it).
+
 ### `[communication]` (v0.10+, opt-in)
 
 Declares the policy for the Pitboss-owned mailbox + artifact MCP tools.

--- a/crates/pitboss-cli/src/analyze.rs
+++ b/crates/pitboss-cli/src/analyze.rs
@@ -1042,6 +1042,7 @@ mod tests {
             model: Some("claude-haiku-4-5".to_string()),
             failure_reason: None,
             cost_usd: None,
+            actor_type: None,
         }
     }
 

--- a/crates/pitboss-cli/src/communication.rs
+++ b/crates/pitboss-cli/src/communication.rs
@@ -855,6 +855,9 @@ mod tests {
             mcp_servers: vec![],
             communication: config,
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -1270,6 +1270,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -1749,6 +1752,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         let sub_layer = std::sync::Arc::new(LayerState::new(
             run_id,
@@ -2235,6 +2241,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         let sub_layer = std::sync::Arc::new(LayerState::new(
             run_id,
@@ -2345,6 +2354,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         let sub_layer = std::sync::Arc::new(LayerState::new(
             run_id,
@@ -2470,6 +2482,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         let sub_layer = std::sync::Arc::new(LayerState::new(
             run_id,
@@ -2523,6 +2538,7 @@ mod tests {
                 model: None,
                 failure_reason: None,
                 cost_usd: None,
+                actor_type: None,
             }),
         );
         state
@@ -2607,6 +2623,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         let sub_layer = std::sync::Arc::new(LayerState::new(
             run_id,

--- a/crates/pitboss-cli/src/diff.rs
+++ b/crates/pitboss-cli/src/diff.rs
@@ -521,6 +521,7 @@ mod tests {
             model: None,
             failure_reason: None,
             cost_usd: None,
+            actor_type: None,
         }
     }
 

--- a/crates/pitboss-cli/src/dispatch/failure_detection.rs
+++ b/crates/pitboss-cli/src/dispatch/failure_detection.rs
@@ -372,6 +372,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         let store: Arc<dyn pitboss_core::store::SessionStore> =
             Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
@@ -465,6 +468,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         let store: Arc<dyn pitboss_core::store::SessionStore> =
             Arc::new(JsonFileStore::new(dir.path().to_path_buf()));

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -451,6 +451,7 @@ pub async fn run_hierarchical(
             }
         }),
         cost_usd: lead_cost_usd,
+        actor_type: None,
     };
 
     // Cleanup worktree per policy. Surface the result via tracing
@@ -629,6 +630,12 @@ pub async fn run_hierarchical(
             model,
             failure_reason: None,
             cost_usd,
+            // Cancellation records are synthesized post-hoc when the lead
+            // exits while workers are still running; the original spawn's
+            // actor_type was lost when the prior TaskRecord (if any) was
+            // overwritten. Phase 1.5 will preserve the attribution on this
+            // path by reading the prior record before synthesizing.
+            actor_type: None,
         }
     };
     {
@@ -1099,6 +1106,9 @@ mod await_drained_tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();
@@ -1250,6 +1260,7 @@ mod await_drained_tests {
                     model: None,
                     failure_reason: None,
                     cost_usd: None,
+                    actor_type: None,
                 }),
             );
             workers.insert("running-root".into(), WorkerState::Pending);
@@ -1303,6 +1314,7 @@ mod summary_jsonl_aggregation_tests {
             model: None,
             failure_reason: None,
             cost_usd: None,
+            actor_type: None,
         }
     }
 

--- a/crates/pitboss-cli/src/dispatch/kill_resume.rs
+++ b/crates/pitboss-cli/src/dispatch/kill_resume.rs
@@ -290,6 +290,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         }
     }
 

--- a/crates/pitboss-cli/src/dispatch/layer.rs
+++ b/crates/pitboss-cli/src/dispatch/layer.rs
@@ -461,6 +461,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(FakeSpawner::new(FakeScript::new()));

--- a/crates/pitboss-cli/src/dispatch/resume.rs
+++ b/crates/pitboss-cli/src/dispatch/resume.rs
@@ -370,6 +370,7 @@ mod tests {
                 model: None,
                 failure_reason: None,
                 cost_usd: None,
+                actor_type: None,
             })
             .collect();
 
@@ -613,6 +614,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         std::fs::write(
             run_dir.join("resolved.json"),
@@ -643,6 +647,7 @@ mod tests {
             model: None,
             failure_reason: None,
             cost_usd: None,
+            actor_type: None,
         };
         let summary = RunSummary {
             run_id: Uuid::now_v7(),
@@ -728,6 +733,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         std::fs::write(
             run_dir.join("resolved.json"),
@@ -761,6 +769,7 @@ mod tests {
             model: None,
             failure_reason: None,
             cost_usd: None,
+            actor_type: None,
         };
         let summary = RunSummary {
             run_id: Uuid::now_v7(),
@@ -846,6 +855,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         std::fs::write(
             run_dir.join("resolved.json"),
@@ -875,6 +887,7 @@ mod tests {
             model: None,
             failure_reason: None,
             cost_usd: None,
+            actor_type: None,
         };
         let summary = RunSummary {
             run_id: Uuid::now_v7(),

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -712,6 +712,9 @@ async fn execute_task(
                     model: Some(task.model.clone()),
                     failure_reason: None,
                     cost_usd,
+                    // Flat-mode tasks don't carry profile attribution
+                    // today (#252 covers hierarchical only).
+                    actor_type: None,
                 };
             }
         }
@@ -790,6 +793,9 @@ async fn execute_task(
         model: Some(task.model.clone()),
         failure_reason,
         cost_usd,
+        // Flat-mode tasks don't carry profile attribution today
+        // (#252 covers hierarchical only).
+        actor_type: None,
     }
 }
 
@@ -1442,6 +1448,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         }
     }
 
@@ -1589,6 +1598,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
 
         // Script: first call succeeds, second call fails. FakeSpawner is single-shot,
@@ -1685,6 +1697,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
 
         let spawner = Arc::new(CyclingFake(
@@ -1794,6 +1809,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
 
         let spawner = Arc::new(CyclingFake(

--- a/crates/pitboss-cli/src/dispatch/signals.rs
+++ b/crates/pitboss-cli/src/dispatch/signals.rs
@@ -379,6 +379,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -469,6 +472,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -559,6 +565,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -648,6 +648,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -105,6 +105,10 @@ pub struct SubleadSpawnRequest {
     /// `pitboss resume` seeds `/resume/subleads` in the shared store with
     /// prior session IDs. `None` for fresh spawns.
     pub resume_session_id: Option<String>,
+    /// Resolved `[[sublead_type]]` id (#252). Persisted on the sub-lead's
+    /// TaskRecord so consumers can attribute the actor to its profile.
+    /// `None` for untyped spawns.
+    pub sublead_type: Option<String>,
 }
 
 /// Validated, defaults-applied resource envelope for a sub-lead spawn.
@@ -380,6 +384,7 @@ pub async fn spawn_sublead(
             req.env,
             req.tools,
             req.resume_session_id,
+            req.sublead_type,
         )
         .await
         .context("sub-lead claude session spawn failed")?;
@@ -467,6 +472,7 @@ async fn spawn_sublead_session(
     operator_env: std::collections::HashMap<String, String>,
     tools_override: Vec<String>,
     resume_session_id: Option<String>,
+    sublead_type: Option<String>,
 ) -> Result<()> {
     use crate::dispatch::hierarchical::build_sublead_mcp_config;
     use crate::dispatch::runner::sublead_spawn_args;
@@ -624,6 +630,9 @@ async fn spawn_sublead_session(
     // Unknown failure, the operator gets a hint pointing at the session
     // id rather than a bare excerpt.
     let resume_session_id_bg = resume_session_id.clone();
+    // Captured for the sub-lead's TaskRecord so consumers can attribute
+    // the actor to its `[[sublead_type]]` profile (#252).
+    let sublead_type_bg = sublead_type.clone();
 
     tokio::spawn(async move {
         // Run the kill+resume loop via the shared helper. The closure
@@ -795,6 +804,7 @@ async fn spawn_sublead_session(
                 }
             }),
             cost_usd,
+            actor_type: sublead_type_bg.clone(),
         };
         if let Err(e) = sub_layer_bg
             .store

--- a/crates/pitboss-cli/src/manifest/actor_type.rs
+++ b/crates/pitboss-cli/src/manifest/actor_type.rs
@@ -1,0 +1,350 @@
+//! Typed actor profile resolution and enforcement (#252).
+//!
+//! Operators declare `[[worker_type]]` / `[[sublead_type]]` in the
+//! manifest to cap the capability surface a `spawn_worker` /
+//! `spawn_sublead` call may request. The lead can never widen those
+//! caps — `tools` arg must be a subset of the profile's allowlist;
+//! `model` must be in `allowed_models` (when set); `timeout_secs`
+//! / `budget_usd` only clamp DOWN.
+//!
+//! This module is the single source of truth for that enforcement.
+//! Both `handle_spawn_worker` and the `spawn_sublead` MCP handler
+//! call into [`resolve_worker_profile`] / [`resolve_sublead_profile`]
+//! before applying any defaults.
+//!
+//! Behavior matrix:
+//!
+//! | `require_actor_type` | requested type | manifest declares any profiles? | outcome                                     |
+//! |----------------------|----------------|---------------------------------|---------------------------------------------|
+//! | true                 | None           | —                               | reject ("must name a worker_type")          |
+//! | true                 | Some(unknown)  | —                               | reject ("unknown worker_type")              |
+//! | true                 | Some(known)    | —                               | enforce caps                                |
+//! | false                | None           | yes / no                        | back-compat: skip enforcement, legacy cascade |
+//! | false                | Some(unknown)  | —                               | reject ("unknown worker_type")              |
+//! | false                | Some(known)    | —                               | enforce caps                                |
+
+use anyhow::{bail, Result};
+
+use crate::manifest::schema::{SubleadType, WorkerType};
+
+/// The outcome of resolving an actor type against the manifest's
+/// declared profiles.
+///
+/// `Untyped` is the back-compat path: no `worker_type` arg supplied
+/// AND `require_actor_type = false`. The caller should fall through
+/// to the legacy `[lead].tools` cascade.
+///
+/// `Typed` carries a borrow of the resolved profile — the caller uses
+/// it both to derive defaults (when args are omitted) and to clamp
+/// numeric caps (timeouts, budgets) before spawning.
+#[derive(Debug)]
+pub enum WorkerProfileResolution<'m> {
+    Untyped,
+    Typed(&'m WorkerType),
+}
+
+#[derive(Debug)]
+pub enum SubleadProfileResolution<'m> {
+    Untyped,
+    Typed(&'m SubleadType),
+}
+
+/// Resolve a `spawn_worker(worker_type = ...)` arg against the
+/// manifest's `[[worker_type]]` profiles. Returns the resolution
+/// (`Typed` for further enforcement, `Untyped` for back-compat) or
+/// an error message suitable for surfacing to the lead's claude
+/// session as the spawn rejection reason.
+pub fn resolve_worker_profile<'m>(
+    requested: Option<&str>,
+    profiles: &'m [WorkerType],
+    require_actor_type: bool,
+) -> Result<WorkerProfileResolution<'m>> {
+    match requested {
+        Some(id) => match profiles.iter().find(|wt| wt.id == id) {
+            Some(wt) => Ok(WorkerProfileResolution::Typed(wt)),
+            None => {
+                if profiles.is_empty() {
+                    bail!(
+                        "spawn_worker rejected: worker_type {id:?} requested \
+                         but the manifest declares no `[[worker_type]]` \
+                         profiles"
+                    );
+                }
+                let known: Vec<&str> = profiles.iter().map(|wt| wt.id.as_str()).collect();
+                bail!(
+                    "spawn_worker rejected: unknown worker_type {id:?} (known: {})",
+                    known.join(", ")
+                );
+            }
+        },
+        None => {
+            if require_actor_type {
+                let known: Vec<&str> = profiles.iter().map(|wt| wt.id.as_str()).collect();
+                if known.is_empty() {
+                    bail!(
+                        "spawn_worker rejected: [run].require_actor_type = true \
+                         but no `[[worker_type]]` declared"
+                    );
+                }
+                bail!(
+                    "spawn_worker rejected: [run].require_actor_type = true \
+                     requires every spawn_worker call to name a worker_type \
+                     (known: {})",
+                    known.join(", ")
+                );
+            }
+            Ok(WorkerProfileResolution::Untyped)
+        }
+    }
+}
+
+/// Sub-lead twin of [`resolve_worker_profile`].
+pub fn resolve_sublead_profile<'m>(
+    requested: Option<&str>,
+    profiles: &'m [SubleadType],
+    require_actor_type: bool,
+) -> Result<SubleadProfileResolution<'m>> {
+    match requested {
+        Some(id) => match profiles.iter().find(|st| st.id == id) {
+            Some(st) => Ok(SubleadProfileResolution::Typed(st)),
+            None => {
+                if profiles.is_empty() {
+                    bail!(
+                        "spawn_sublead rejected: sublead_type {id:?} requested \
+                         but the manifest declares no `[[sublead_type]]` \
+                         profiles"
+                    );
+                }
+                let known: Vec<&str> = profiles.iter().map(|st| st.id.as_str()).collect();
+                bail!(
+                    "spawn_sublead rejected: unknown sublead_type {id:?} (known: {})",
+                    known.join(", ")
+                );
+            }
+        },
+        None => {
+            if require_actor_type {
+                let known: Vec<&str> = profiles.iter().map(|st| st.id.as_str()).collect();
+                if known.is_empty() {
+                    bail!(
+                        "spawn_sublead rejected: [run].require_actor_type = true \
+                         but no `[[sublead_type]]` declared"
+                    );
+                }
+                bail!(
+                    "spawn_sublead rejected: [run].require_actor_type = true \
+                     requires every spawn_sublead call to name a sublead_type \
+                     (known: {})",
+                    known.join(", ")
+                );
+            }
+            Ok(SubleadProfileResolution::Untyped)
+        }
+    }
+}
+
+/// Validate that `requested_tools` (the lead's `tools` arg) is a
+/// subset of `profile_tools`. Returns Ok(()) on subset; on violation
+/// returns an error naming the first offending tool — the model
+/// can fix it and retry without parsing a list.
+pub fn check_tool_subset(
+    spawn_kind: &str,
+    profile_id: &str,
+    profile_tools: &[String],
+    requested_tools: &[String],
+) -> Result<()> {
+    for t in requested_tools {
+        if !profile_tools.iter().any(|allowed| allowed == t) {
+            bail!(
+                "{spawn_kind} rejected: tool {t:?} is not in {spawn_kind_short}_type \
+                 {profile_id:?} allowlist (allowed: {allowed})",
+                spawn_kind_short = spawn_kind.trim_start_matches("spawn_"),
+                allowed = profile_tools.join(", "),
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Validate that `model` is in `allowed_models` (when non-empty).
+/// An empty `allowed_models` means no restriction.
+pub fn check_model_allowed(
+    spawn_kind: &str,
+    profile_id: &str,
+    allowed_models: &[String],
+    model: &str,
+) -> Result<()> {
+    if allowed_models.is_empty() {
+        return Ok(());
+    }
+    if !allowed_models.iter().any(|m| m == model) {
+        bail!(
+            "{spawn_kind} rejected: model {model:?} is not in {spawn_kind_short}_type \
+             {profile_id:?} allowed_models (allowed: {allowed})",
+            spawn_kind_short = spawn_kind.trim_start_matches("spawn_"),
+            allowed = allowed_models.join(", "),
+        );
+    }
+    Ok(())
+}
+
+/// Clamp `requested` down to `cap` when both are present.
+/// Returns the smaller of the two; preserves `requested` when it's
+/// already within budget.
+pub fn clamp_down_u64(requested: u64, cap: Option<u64>) -> u64 {
+    match cap {
+        Some(c) => requested.min(c),
+        None => requested,
+    }
+}
+
+/// Clamp `requested` (USD) down to `cap` when both are present.
+pub fn clamp_down_f64(requested: Option<f64>, cap: Option<f64>) -> Option<f64> {
+    match (requested, cap) {
+        (Some(r), Some(c)) => Some(r.min(c)),
+        (Some(r), None) => Some(r),
+        (None, Some(c)) => Some(c),
+        (None, None) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn wt(id: &str) -> WorkerType {
+        WorkerType {
+            id: id.to_string(),
+            tools: vec!["Read".into(), "Glob".into(), "Grep".into()],
+            allowed_models: vec!["claude-haiku-4-5".into()],
+            max_timeout_secs: Some(900),
+        }
+    }
+
+    fn st(id: &str) -> SubleadType {
+        SubleadType {
+            id: id.to_string(),
+            tools: vec!["Read".into(), "Write".into()],
+            allowed_models: vec!["claude-opus-4-7".into()],
+            max_timeout_secs: Some(1800),
+            max_budget_usd: Some(2.0),
+        }
+    }
+
+    #[test]
+    fn worker_resolution_typed_match() {
+        let profiles = vec![wt("extraction")];
+        match resolve_worker_profile(Some("extraction"), &profiles, false).unwrap() {
+            WorkerProfileResolution::Typed(p) => assert_eq!(p.id, "extraction"),
+            _ => panic!("expected Typed"),
+        }
+    }
+
+    #[test]
+    fn worker_resolution_unknown_id_listed() {
+        let profiles = vec![wt("extraction"), wt("writer")];
+        let err = resolve_worker_profile(Some("nope"), &profiles, false).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("unknown worker_type"), "{msg}");
+        assert!(msg.contains("extraction"), "{msg}");
+        assert!(msg.contains("writer"), "{msg}");
+    }
+
+    #[test]
+    fn worker_resolution_untyped_passes_when_not_required() {
+        let profiles = vec![wt("extraction")];
+        assert!(matches!(
+            resolve_worker_profile(None, &profiles, false).unwrap(),
+            WorkerProfileResolution::Untyped
+        ));
+    }
+
+    #[test]
+    fn worker_resolution_untyped_rejected_when_required() {
+        let profiles = vec![wt("extraction")];
+        let err = resolve_worker_profile(None, &profiles, true).unwrap_err();
+        assert!(err.to_string().contains("require_actor_type"));
+    }
+
+    #[test]
+    fn worker_resolution_unknown_id_no_profiles() {
+        let err = resolve_worker_profile(Some("x"), &[], false).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("manifest declares no `[[worker_type]]` profiles"));
+    }
+
+    #[test]
+    fn tool_subset_accepts_subset() {
+        check_tool_subset(
+            "spawn_worker",
+            "x",
+            &["Read".into(), "Glob".into()],
+            &["Read".into()],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn tool_subset_rejects_unknown() {
+        let err = check_tool_subset(
+            "spawn_worker",
+            "extraction",
+            &["Read".into()],
+            &["Read".into(), "Bash".into()],
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("\"Bash\""), "{msg}");
+        assert!(msg.contains("worker_type \"extraction\""), "{msg}");
+    }
+
+    #[test]
+    fn model_allowed_empty_list_means_unrestricted() {
+        check_model_allowed("spawn_worker", "x", &[], "anything").unwrap();
+    }
+
+    #[test]
+    fn model_allowed_rejects_outside_list() {
+        let err = check_model_allowed(
+            "spawn_worker",
+            "extraction",
+            &["claude-haiku-4-5".into()],
+            "claude-opus-4-7",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("claude-opus-4-7"));
+    }
+
+    #[test]
+    fn clamp_down_u64_caps() {
+        assert_eq!(clamp_down_u64(500, Some(900)), 500);
+        assert_eq!(clamp_down_u64(2000, Some(900)), 900);
+        assert_eq!(clamp_down_u64(2000, None), 2000);
+    }
+
+    #[test]
+    fn clamp_down_f64_caps() {
+        assert_eq!(clamp_down_f64(Some(1.5), Some(2.0)), Some(1.5));
+        assert_eq!(clamp_down_f64(Some(5.0), Some(2.0)), Some(2.0));
+        assert_eq!(clamp_down_f64(None, Some(2.0)), Some(2.0));
+        assert_eq!(clamp_down_f64(Some(1.0), None), Some(1.0));
+        assert_eq!(clamp_down_f64(None, None), None);
+    }
+
+    #[test]
+    fn sublead_resolution_typed_match() {
+        let profiles = vec![st("planner")];
+        assert!(matches!(
+            resolve_sublead_profile(Some("planner"), &profiles, false).unwrap(),
+            SubleadProfileResolution::Typed(_)
+        ));
+    }
+
+    #[test]
+    fn sublead_resolution_required_without_arg_rejected() {
+        let profiles = vec![st("planner")];
+        let err = resolve_sublead_profile(None, &profiles, true).unwrap_err();
+        assert!(err.to_string().contains("require_actor_type"));
+    }
+}

--- a/crates/pitboss-cli/src/manifest/metadata.rs
+++ b/crates/pitboss-cli/src/manifest/metadata.rs
@@ -14,7 +14,7 @@ use pitboss_schema::SchemaSection;
 
 use super::schema::{
     ApprovalRuleSpec, CommunicationConfig, ContainerConfig, Defaults, Lead, Lifecycle,
-    McpServerSpec, MountSpec, RunConfig, SubleadDefaults, Task, Template,
+    McpServerSpec, MountSpec, RunConfig, SubleadDefaults, SubleadType, Task, Template, WorkerType,
 };
 
 /// Walk every section of the v0.9 manifest schema in declaration order.
@@ -68,6 +68,16 @@ pub fn sections() -> Vec<SchemaSection> {
             toml_path: "[[mcp_server]]",
             type_name: "McpServerSpec",
             fields: McpServerSpec::field_metadata(),
+        },
+        SchemaSection {
+            toml_path: "[[worker_type]]",
+            type_name: "WorkerType",
+            fields: WorkerType::field_metadata(),
+        },
+        SchemaSection {
+            toml_path: "[[sublead_type]]",
+            type_name: "SubleadType",
+            fields: SubleadType::field_metadata(),
         },
         SchemaSection {
             toml_path: "[communication]",

--- a/crates/pitboss-cli/src/manifest/mod.rs
+++ b/crates/pitboss-cli/src/manifest/mod.rs
@@ -1,3 +1,4 @@
+pub mod actor_type;
 pub mod error;
 pub mod example_doc;
 pub mod init_template;

--- a/crates/pitboss-cli/src/manifest/resolve.rs
+++ b/crates/pitboss-cli/src/manifest/resolve.rs
@@ -181,6 +181,21 @@ pub struct ResolvedManifest {
     /// with parent, no out-of-band lifecycle notify expected).
     #[serde(default)]
     pub lifecycle: Option<crate::manifest::schema::Lifecycle>,
+    /// Typed worker profiles (`[[worker_type]]`). Looked up by id in
+    /// `handle_spawn_worker` to enforce per-class capability caps.
+    /// Empty in v0.11 manifests that pre-date this surface.
+    /// (#252)
+    #[serde(default)]
+    pub worker_types: Vec<crate::manifest::schema::WorkerType>,
+    /// Typed sub-lead profiles (`[[sublead_type]]`). Looked up by id in
+    /// the `spawn_sublead` MCP handler. (#252)
+    #[serde(default)]
+    pub sublead_types: Vec<crate::manifest::schema::SubleadType>,
+    /// When true, every `spawn_worker` / `spawn_sublead` call MUST name
+    /// a profile; type-less spawns are rejected. Default `false` for
+    /// back-compat. (#252)
+    #[serde(default)]
+    pub require_actor_type: bool,
 }
 
 const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
@@ -284,6 +299,9 @@ pub fn resolve(
         mcp_servers: manifest.mcp_servers,
         communication: manifest.communication,
         lifecycle: manifest.lifecycle,
+        worker_types: manifest.worker_types,
+        sublead_types: manifest.sublead_types,
+        require_actor_type: manifest.run.require_actor_type,
     })
 }
 

--- a/crates/pitboss-cli/src/manifest/schema.rs
+++ b/crates/pitboss-cli/src/manifest/schema.rs
@@ -314,6 +314,19 @@ pub struct Manifest {
     /// External MCP servers injected into all actor configs.
     #[serde(default, rename = "mcp_server")]
     pub mcp_servers: Vec<McpServerSpec>,
+    /// Typed worker profiles. Each entry caps the capability surface for
+    /// `spawn_worker(worker_type = "<id>")` calls. The lead can never
+    /// widen these caps — `tools` arg must be a subset of the profile's
+    /// allowlist; `model` must be in `allowed_models`; `timeout_secs`
+    /// only clamps downward. See [`WorkerType`]. (#252)
+    #[serde(default, rename = "worker_type")]
+    pub worker_types: Vec<WorkerType>,
+    /// Typed sub-lead profiles. Same semantics as `[[worker_type]]`,
+    /// applied to `spawn_sublead(sublead_type = "<id>")`. Adds a
+    /// `max_budget_usd` cap that clamps the sub-tree's envelope.
+    /// (#252)
+    #[serde(default, rename = "sublead_type")]
+    pub sublead_types: Vec<SubleadType>,
     /// Optional `[communication]` section: opt in to the Pitboss-owned
     /// mailbox + artifact MCP tools. Default
     /// [`CommunicationMode::Disabled`] hides the tools and rejects calls
@@ -540,6 +553,17 @@ pub struct RunConfig {
         help = "When true, spawn_worker is blocked until propose_plan has been approved."
     )]
     pub require_plan_approval: bool,
+    /// When true, every `spawn_worker` and `spawn_sublead` call MUST name
+    /// a `worker_type` / `sublead_type` declared in the manifest;
+    /// type-less spawns are rejected at the dispatcher. Default `false`
+    /// for back-compat with manifests that pre-date typed profiles
+    /// (#252).
+    #[serde(default)]
+    #[field(
+        label = "Require actor type",
+        help = "When true, every spawn_worker and spawn_sublead call must name a declared [[worker_type]]/[[sublead_type]]. Default false."
+    )]
+    pub require_actor_type: bool,
 }
 
 impl Default for RunConfig {
@@ -555,6 +579,7 @@ impl Default for RunConfig {
             denial_termination_policy: None,
             dump_shared_store: false,
             require_plan_approval: false,
+            require_actor_type: false,
         }
     }
 }
@@ -569,6 +594,93 @@ pub enum WorktreeCleanup {
     Always,
     OnSuccess,
     Never,
+}
+
+/// Typed worker profile (`[[worker_type]]`). Caps the capability
+/// surface a `spawn_worker(worker_type = "<id>")` call may request.
+/// The lead-supplied `tools` arg must be a subset of `tools`;
+/// `model` must be in `allowed_models` (when set); `timeout_secs`
+/// is clamped *down* to `max_timeout_secs` (never up). When the
+/// caller omits `tools`, the spawn gets the profile's full
+/// allowlist — explicitly, not the lead's `[lead].tools` cascade.
+/// (#252)
+#[derive(Debug, Clone, Deserialize, Serialize, Default, FieldMetadata)]
+#[serde(deny_unknown_fields)]
+pub struct WorkerType {
+    /// Unique id referenced by `spawn_worker(worker_type = "<id>")`.
+    /// Must match `^[A-Za-z0-9_-]+$` (validate-time check).
+    #[field(
+        label = "Worker type id",
+        help = "Unique id used in spawn_worker(worker_type = \"<id>\"). Match: ^[A-Za-z0-9_-]+$."
+    )]
+    pub id: String,
+    /// Allowed tool surface for this worker class. Lead must request a
+    /// subset; omit-on-spawn means "give me the whole allowlist."
+    #[serde(default)]
+    #[field(
+        label = "Tools",
+        help = "Allowed tool surface for this worker class. Lead's spawn_worker(tools=...) must be a subset; omit means \"give me the whole allowlist.\""
+    )]
+    pub tools: Vec<String>,
+    /// When non-empty, the lead's `model` arg must appear in this list.
+    /// Empty = no model restriction (any model the lead can pay for).
+    #[serde(default)]
+    #[field(
+        label = "Allowed models",
+        help = "When non-empty, spawn_worker(model=...) must be in this list. Empty means any model."
+    )]
+    pub allowed_models: Vec<String>,
+    /// Hard cap on `spawn_worker(timeout_secs = ...)`. Lead values larger
+    /// than this clamp DOWN; smaller values are honored.
+    #[serde(default)]
+    #[field(
+        label = "Max timeout (seconds)",
+        help = "Hard cap on spawn_worker(timeout_secs=...). Lead values clamp DOWN; smaller values pass through."
+    )]
+    pub max_timeout_secs: Option<u64>,
+}
+
+/// Typed sub-lead profile (`[[sublead_type]]`). Same enforcement model
+/// as [`WorkerType`] with an additional `max_budget_usd` clamp on the
+/// sub-tree's spawn-time budget. (#252)
+#[derive(Debug, Clone, Deserialize, Serialize, Default, FieldMetadata)]
+#[serde(deny_unknown_fields)]
+pub struct SubleadType {
+    /// Unique id referenced by `spawn_sublead(sublead_type = "<id>")`.
+    /// Must match `^[A-Za-z0-9_-]+$` (validate-time check).
+    #[field(
+        label = "Sub-lead type id",
+        help = "Unique id used in spawn_sublead(sublead_type = \"<id>\"). Match: ^[A-Za-z0-9_-]+$."
+    )]
+    pub id: String,
+    /// Allowed tool surface for this sub-lead class.
+    #[serde(default)]
+    #[field(
+        label = "Tools",
+        help = "Allowed tool surface for this sub-lead class. spawn_sublead(tools=...) must be a subset; empty means \"give me the whole allowlist.\""
+    )]
+    pub tools: Vec<String>,
+    /// When non-empty, the caller's `model` arg must appear in this list.
+    #[serde(default)]
+    #[field(
+        label = "Allowed models",
+        help = "When non-empty, spawn_sublead(model=...) must be in this list."
+    )]
+    pub allowed_models: Vec<String>,
+    /// Hard cap on `spawn_sublead(lead_timeout_secs = ...)`. Clamps DOWN.
+    #[serde(default)]
+    #[field(
+        label = "Max lead timeout (seconds)",
+        help = "Hard cap on spawn_sublead(lead_timeout_secs=...). Clamps DOWN."
+    )]
+    pub max_timeout_secs: Option<u64>,
+    /// Hard cap on `spawn_sublead(budget_usd = ...)`. Clamps DOWN.
+    #[serde(default)]
+    #[field(
+        label = "Max budget (USD)",
+        help = "Hard cap on spawn_sublead(budget_usd=...). Clamps DOWN."
+    )]
+    pub max_budget_usd: Option<f64>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default, FieldMetadata)]

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -27,6 +27,7 @@ fn validate_inner(resolved: &ResolvedManifest, skip_dir_check: bool) -> Result<(
     validate_lifecycle(resolved)?;
     validate_container(resolved)?;
     validate_communication(resolved)?;
+    validate_actor_types(resolved)?;
     if resolved.lead.is_some() {
         validate_lead(resolved, skip_dir_check)?;
         validate_hierarchical_ranges(resolved)?;
@@ -39,6 +40,89 @@ fn validate_inner(resolved: &ResolvedManifest, skip_dir_check: bool) -> Result<(
         validate_branch_conflicts(resolved)?;
         validate_ranges(resolved)?;
     }
+    Ok(())
+}
+
+/// Validate `[[worker_type]]` / `[[sublead_type]]` profile invariants.
+///
+/// - `id` must match `^[A-Za-z0-9_-]+$`. The id appears in error
+///   messages returned to the model and in `summary.jsonl`; restricting
+///   to a portable charset avoids quoting puzzles in both surfaces.
+/// - Ids must be unique within their kind (worker_type / sublead_type).
+///   A duplicate would silently shadow the earlier definition since
+///   the lookup is "first match wins"; rejecting at validate time
+///   surfaces the typo loudly.
+/// - `require_actor_type = true` requires AT LEAST ONE profile of the
+///   relevant kind to exist (otherwise the run can spawn nothing).
+///   Flat-mode ignores both surfaces — profiles only apply to the
+///   hierarchical spawn path.
+///
+/// (#252)
+fn validate_actor_types(r: &ResolvedManifest) -> Result<()> {
+    fn is_valid_id(s: &str) -> bool {
+        !s.is_empty()
+            && s.chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    }
+
+    let mut worker_ids: HashSet<&str> = HashSet::new();
+    for wt in &r.worker_types {
+        if !is_valid_id(&wt.id) {
+            bail!(
+                "[[worker_type]].id {:?}: must match ^[A-Za-z0-9_-]+$ \
+                 (allowed: ASCII alphanumeric, underscore, hyphen)",
+                wt.id
+            );
+        }
+        if !worker_ids.insert(&wt.id) {
+            bail!(
+                "[[worker_type]].id {:?}: duplicate; ids must be unique \
+                 within `[[worker_type]]` (the lookup is first-match-wins, \
+                 a duplicate would silently shadow the earlier entry)",
+                wt.id
+            );
+        }
+    }
+
+    let mut sublead_ids: HashSet<&str> = HashSet::new();
+    for st in &r.sublead_types {
+        if !is_valid_id(&st.id) {
+            bail!(
+                "[[sublead_type]].id {:?}: must match ^[A-Za-z0-9_-]+$ \
+                 (allowed: ASCII alphanumeric, underscore, hyphen)",
+                st.id
+            );
+        }
+        if !sublead_ids.insert(&st.id) {
+            bail!(
+                "[[sublead_type]].id {:?}: duplicate; ids must be unique \
+                 within `[[sublead_type]]`",
+                st.id
+            );
+        }
+    }
+
+    if r.require_actor_type {
+        // The flag is only meaningful in hierarchical mode (it gates
+        // spawn_worker / spawn_sublead). In flat mode the flag is
+        // inert — we don't reject it, but we do warn so an operator
+        // who set it expecting any effect notices.
+        if r.lead.is_none() {
+            tracing::warn!(
+                "[run].require_actor_type = true is ignored in flat mode \
+                 (no [lead] declared); the flag only applies to hierarchical \
+                 spawn_worker / spawn_sublead calls"
+            );
+        } else if r.worker_types.is_empty() && r.sublead_types.is_empty() {
+            bail!(
+                "[run].require_actor_type = true but no `[[worker_type]]` \
+                 or `[[sublead_type]]` declared; the flag would reject every \
+                 spawn call. Declare at least one profile or set \
+                 require_actor_type = false."
+            );
+        }
+    }
+
     Ok(())
 }
 
@@ -632,6 +716,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         }
     }
 
@@ -663,6 +750,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         f(&mut m);
         m
@@ -750,6 +840,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         let err = validate(&r).unwrap_err().to_string();
         assert!(
@@ -784,6 +877,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         assert!(validate(&r).is_err());
     }
@@ -814,6 +910,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         assert!(validate(&r).is_err());
     }
@@ -858,6 +957,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         }
     }
 
@@ -954,6 +1056,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         (d, r)
     }
@@ -1070,6 +1175,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         let err = validate(&r).unwrap_err().to_string();
         assert!(err.contains("empty manifest"), "got: {err}");
@@ -1125,6 +1233,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         let err = validate(&r).unwrap_err().to_string();
         assert!(
@@ -1161,6 +1272,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         assert!(validate(&r).is_err());
     }
@@ -1368,6 +1482,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         // Sanity: with skip_dir_check=false the validator rejects (the
         // host-side path is bogus).
@@ -1557,6 +1674,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         validate(&r).expect("path_b must validate (in soak); pre-#368 this bailed");
     }
@@ -1590,7 +1710,177 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         validate(&r).expect("path_a is the default and must validate");
+    }
+
+    #[test]
+    fn rejects_invalid_worker_type_id_chars() {
+        use crate::manifest::schema::WorkerType;
+        let r = rm_with(|m| {
+            m.worker_types = vec![WorkerType {
+                id: "bad id!".into(),
+                tools: vec!["Read".into()],
+                allowed_models: vec![],
+                max_timeout_secs: None,
+            }];
+        });
+        let err = validate(&r).unwrap_err().to_string();
+        assert!(err.contains("worker_type"), "{err}");
+        assert!(err.contains("^[A-Za-z0-9_-]+$"), "{err}");
+    }
+
+    #[test]
+    fn rejects_duplicate_worker_type_ids() {
+        use crate::manifest::schema::WorkerType;
+        let r = rm_with(|m| {
+            m.worker_types = vec![
+                WorkerType {
+                    id: "extraction".into(),
+                    tools: vec!["Read".into()],
+                    allowed_models: vec![],
+                    max_timeout_secs: None,
+                },
+                WorkerType {
+                    id: "extraction".into(),
+                    tools: vec!["Write".into()],
+                    allowed_models: vec![],
+                    max_timeout_secs: None,
+                },
+            ];
+        });
+        let err = validate(&r).unwrap_err().to_string();
+        assert!(err.contains("duplicate"), "{err}");
+        assert!(err.contains("extraction"), "{err}");
+    }
+
+    #[test]
+    fn rejects_duplicate_sublead_type_ids() {
+        use crate::manifest::schema::SubleadType;
+        let r = rm_with(|m| {
+            m.sublead_types = vec![
+                SubleadType {
+                    id: "planner".into(),
+                    tools: vec![],
+                    allowed_models: vec![],
+                    max_timeout_secs: None,
+                    max_budget_usd: None,
+                },
+                SubleadType {
+                    id: "planner".into(),
+                    tools: vec![],
+                    allowed_models: vec![],
+                    max_timeout_secs: None,
+                    max_budget_usd: None,
+                },
+            ];
+        });
+        let err = validate(&r).unwrap_err().to_string();
+        assert!(err.contains("duplicate"), "{err}");
+        assert!(err.contains("planner"), "{err}");
+    }
+
+    #[test]
+    fn rejects_require_actor_type_with_no_profiles() {
+        let r = rm_with(|m| {
+            m.require_actor_type = true;
+        });
+        let err = validate(&r).unwrap_err().to_string();
+        assert!(err.contains("require_actor_type"), "{err}");
+        assert!(err.contains("no `[[worker_type]]`"), "{err}");
+    }
+
+    #[test]
+    fn accepts_require_actor_type_with_at_least_one_profile() {
+        use crate::manifest::schema::WorkerType;
+        // Bind the tempdir at test scope so the lead's directory survives
+        // the validate(&r) call — rm_with drops its own tempdir on return,
+        // which would trip validate_lead's directory check.
+        let d = with_tmp_repo(true);
+        let mut m = ResolvedManifest {
+            manifest_schema_version: 0,
+            name: None,
+            max_parallel_tasks: Some(4),
+            halt_on_failure: false,
+            run_dir: PathBuf::from("."),
+            worktree_cleanup: WorktreeCleanup::OnSuccess,
+            emit_event_stream: false,
+            tasks: vec![],
+            lead: Some(rl("lead", d.path().to_path_buf())),
+            max_workers: Some(4),
+            budget_usd: Some(1.0),
+            lead_timeout_secs: Some(600),
+            default_approval_policy: None,
+            denial_termination_policy: None,
+            notifications: vec![],
+            dump_shared_store: false,
+            require_plan_approval: false,
+            approval_rules: vec![],
+            container: None,
+            mcp_servers: vec![],
+            communication: Default::default(),
+            lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
+        };
+        m.require_actor_type = true;
+        m.worker_types = vec![WorkerType {
+            id: "extraction".into(),
+            tools: vec!["Read".into()],
+            allowed_models: vec![],
+            max_timeout_secs: None,
+        }];
+        validate(&m).expect("require_actor_type with profile must validate");
+    }
+
+    #[test]
+    fn accepts_typed_profiles_without_require_flag() {
+        use crate::manifest::schema::{SubleadType, WorkerType};
+        let d = with_tmp_repo(true);
+        let mut m = ResolvedManifest {
+            manifest_schema_version: 0,
+            name: None,
+            max_parallel_tasks: Some(4),
+            halt_on_failure: false,
+            run_dir: PathBuf::from("."),
+            worktree_cleanup: WorktreeCleanup::OnSuccess,
+            emit_event_stream: false,
+            tasks: vec![],
+            lead: Some(rl("lead", d.path().to_path_buf())),
+            max_workers: Some(4),
+            budget_usd: Some(1.0),
+            lead_timeout_secs: Some(600),
+            default_approval_policy: None,
+            denial_termination_policy: None,
+            notifications: vec![],
+            dump_shared_store: false,
+            require_plan_approval: false,
+            approval_rules: vec![],
+            container: None,
+            mcp_servers: vec![],
+            communication: Default::default(),
+            lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
+        };
+        m.worker_types = vec![WorkerType {
+            id: "extraction".into(),
+            tools: vec!["Read".into(), "Glob".into()],
+            allowed_models: vec!["claude-haiku-4-5".into()],
+            max_timeout_secs: Some(900),
+        }];
+        m.sublead_types = vec![SubleadType {
+            id: "planner".into(),
+            tools: vec!["Read".into()],
+            allowed_models: vec!["claude-opus-4-7".into()],
+            max_timeout_secs: Some(1800),
+            max_budget_usd: Some(2.0),
+        }];
+        validate(&m).expect("declared profiles without require flag must validate");
     }
 }

--- a/crates/pitboss-cli/src/mcp/approval.rs
+++ b/crates/pitboss-cli/src/mcp/approval.rs
@@ -475,6 +475,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -71,6 +71,12 @@ struct SpawnSubleadRequest {
     /// that omit this field get a fresh sub-lead session (default behavior).
     #[serde(default)]
     resume_session_id: Option<String>,
+    /// Optional `[[sublead_type]]` id (#252). When set, the dispatcher
+    /// enforces the named profile's caps (tools subset, model allowlist,
+    /// budget/timeout clamps) before launching the sub-tree. Required
+    /// when `[run].require_actor_type = true`.
+    #[serde(default)]
+    sublead_type: Option<String>,
     /// Caller identity injected by mcp-bridge (actor_id + actor_role).
     #[serde(rename = "_meta", default)]
     #[schemars(skip)]
@@ -499,6 +505,10 @@ impl PitbossHandler {
     ) -> Result<CallToolResult, ErrorData> {
         use crate::dispatch::depth;
         use crate::dispatch::sublead::{spawn_sublead as do_spawn, SubleadSpawnRequest};
+        use crate::manifest::actor_type::{
+            check_model_allowed, check_tool_subset, clamp_down_f64, clamp_down_u64,
+            resolve_sublead_profile, SubleadProfileResolution,
+        };
 
         // Depth-2 invariants are owned by `dispatch::depth`. Two distinct
         // checks: (1) manifest opt-in (`allow_subleads = true`), the
@@ -508,17 +518,57 @@ impl PitbossHandler {
             .map_err(|e| ErrorData::invalid_request(e.to_string(), None))?;
         extract_and_check_root_lead(&req.meta)?;
 
+        // #252: resolve typed sub-lead profile and enforce caps before
+        // mutating sub-tree state. Mirrors `handle_spawn_worker`'s
+        // approach: unknown id and "required but missing" reject up
+        // front; tools subset and model-allowlist enforced when typed;
+        // budget and timeout clamp downward only.
+        let manifest = &self.state.root.manifest;
+        let profile = resolve_sublead_profile(
+            req.sublead_type.as_deref(),
+            &manifest.sublead_types,
+            manifest.require_actor_type,
+        )
+        .map_err(|e| ErrorData::invalid_request(e.to_string(), None))?;
+
+        let (resolved_tools, resolved_budget, resolved_timeout, resolved_type_id) = match &profile {
+            SubleadProfileResolution::Typed(p) => {
+                if !req.tools.is_empty() {
+                    check_tool_subset("spawn_sublead", &p.id, &p.tools, &req.tools)
+                        .map_err(|e| ErrorData::invalid_request(e.to_string(), None))?;
+                }
+                check_model_allowed("spawn_sublead", &p.id, &p.allowed_models, &req.model)
+                    .map_err(|e| ErrorData::invalid_request(e.to_string(), None))?;
+                let tools = if req.tools.is_empty() {
+                    p.tools.clone()
+                } else {
+                    req.tools.clone()
+                };
+                let budget = clamp_down_f64(req.budget_usd, p.max_budget_usd);
+                let timeout = req
+                    .lead_timeout_secs
+                    .map(|t| clamp_down_u64(t, p.max_timeout_secs));
+                (tools, budget, timeout, Some(p.id.clone()))
+            }
+            SubleadProfileResolution::Untyped => (
+                req.tools.clone(),
+                req.budget_usd,
+                req.lead_timeout_secs,
+                None,
+            ),
+        };
         let spawn_req = SubleadSpawnRequest {
             prompt: req.prompt,
             model: req.model,
-            budget_usd: req.budget_usd,
+            budget_usd: resolved_budget,
             max_workers: req.max_workers,
-            lead_timeout_secs: req.lead_timeout_secs,
+            lead_timeout_secs: resolved_timeout,
             initial_ref: req.initial_ref,
             read_down: req.read_down,
             env: req.env,
-            tools: req.tools,
+            tools: resolved_tools,
             resume_session_id: req.resume_session_id,
+            sublead_type: resolved_type_id,
         };
 
         match do_spawn(&self.state, spawn_req).await {
@@ -1652,6 +1702,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();
@@ -1739,6 +1792,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();
@@ -1820,6 +1876,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();
@@ -1968,6 +2027,9 @@ mod tests {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -62,6 +62,15 @@ pub struct SpawnWorkerArgs {
     pub timeout_secs: Option<u64>,
     #[serde(default)]
     pub model: Option<String>,
+    /// Optional `[[worker_type]]` id. When set, the dispatcher resolves
+    /// the named profile and enforces its caps (tools subset, model
+    /// allowlist, timeout clamp) before spawning. Unknown id → reject.
+    /// When `[run].require_actor_type = true` this field is REQUIRED.
+    /// When omitted on a manifest that *does* declare profiles but
+    /// doesn't require them, the spawn falls through to the legacy
+    /// `[lead].tools` cascade — preserving v0.11 behavior. (#252)
+    #[serde(default)]
+    pub worker_type: Option<String>,
     /// Caller identity injected by mcp-bridge. Used to route the new worker
     /// into the caller's layer (sub-lead callers land in their sub-tree;
     /// root-lead callers land in root). Absent for v0.5 back-compat callers —

--- a/crates/pitboss-cli/src/mcp/tools/spawn.rs
+++ b/crates/pitboss-cli/src/mcp/tools/spawn.rs
@@ -115,6 +115,41 @@ pub async fn handle_spawn_worker(
         }
     }
 
+    // Guard 2a: resolve typed worker profile (#252). Profiles live on the
+    // root manifest (run-global), not per-layer. Sub-lead spawns look up
+    // the same `[[worker_type]]` table as root spawns.
+    //
+    // Returns `Typed(profile)` for further enforcement, or `Untyped` for
+    // the back-compat path (no profile arg + require_actor_type = false).
+    // An unknown id, or a type-less call under `require_actor_type = true`,
+    // bails here before any state mutation — operators see a clear
+    // "spawn_worker rejected: ..." in the lead's session.
+    let root_manifest = &state.root.manifest;
+    let profile_resolution = crate::manifest::actor_type::resolve_worker_profile(
+        args.worker_type.as_deref(),
+        &root_manifest.worker_types,
+        root_manifest.require_actor_type,
+    )?;
+
+    // When typed, validate the lead's `tools` arg is a subset of the
+    // profile allowlist. Omitted `tools` is allowed: the spawn gets the
+    // profile's full allowlist verbatim (per #252 — explicit, not the
+    // legacy `[lead].tools` cascade).
+    let resolved_worker_type_id: Option<String> = match &profile_resolution {
+        crate::manifest::actor_type::WorkerProfileResolution::Typed(p) => {
+            if let Some(requested) = args.tools.as_deref() {
+                crate::manifest::actor_type::check_tool_subset(
+                    "spawn_worker",
+                    &p.id,
+                    &p.tools,
+                    requested,
+                )?;
+            }
+            Some(p.id.clone())
+        }
+        crate::manifest::actor_type::WorkerProfileResolution::Untyped => None,
+    };
+
     // Resolve the worker's model up-front so the budget guard can price it.
     let lead = target_layer.manifest.lead.as_ref();
     let worker_model = args
@@ -122,6 +157,20 @@ pub async fn handle_spawn_worker(
         .clone()
         .or_else(|| lead.map(|l| l.model.clone()))
         .unwrap_or_else(|| "claude-haiku-4-5".to_string());
+
+    // When typed, the resolved model must be in the profile's
+    // `allowed_models` (when non-empty). Empty allowed_models = no
+    // restriction. We validate AFTER the cascade because the lead may
+    // have omitted `model` and inherited from `[lead].model` — that
+    // inherited value still has to satisfy the cap.
+    if let crate::manifest::actor_type::WorkerProfileResolution::Typed(p) = &profile_resolution {
+        crate::manifest::actor_type::check_model_allowed(
+            "spawn_worker",
+            &p.id,
+            &p.allowed_models,
+            &worker_model,
+        )?;
+    }
 
     let task_id = format!("worker-{}", Uuid::now_v7());
 
@@ -261,17 +310,36 @@ pub async fn handle_spawn_worker(
 
     // Resolve tools, timeout: per-args override -> lead defaults -> fallback.
     // (worker_model was resolved above for the budget guard.)
-    let worker_tools = args
-        .tools
-        .clone()
-        .or_else(|| lead.map(|l| l.tools.clone()))
-        .or_else(|| root_lead.map(|l| l.tools.clone()))
-        .unwrap_or_default();
-    let worker_timeout_secs = args
+    //
+    // When a `[[worker_type]]` profile is in effect (#252), it overrides
+    // the legacy cascade:
+    //   - tools: lead's `args.tools` if set (already validated as a
+    //     subset above), else the profile's full allowlist.
+    //   - timeout_secs: clamped DOWN to `profile.max_timeout_secs` after
+    //     the cascade resolves.
+    let worker_tools: Vec<String> = match &profile_resolution {
+        crate::manifest::actor_type::WorkerProfileResolution::Typed(p) => {
+            match args.tools.clone() {
+                Some(requested) => requested,
+                None => p.tools.clone(),
+            }
+        }
+        crate::manifest::actor_type::WorkerProfileResolution::Untyped => args
+            .tools
+            .clone()
+            .or_else(|| lead.map(|l| l.tools.clone()))
+            .or_else(|| root_lead.map(|l| l.tools.clone()))
+            .unwrap_or_default(),
+    };
+    let mut worker_timeout_secs = args
         .timeout_secs
         .or_else(|| lead.map(|l| l.timeout_secs))
         .or_else(|| root_lead.map(|l| l.timeout_secs))
         .unwrap_or(3600);
+    if let crate::manifest::actor_type::WorkerProfileResolution::Typed(p) = &profile_resolution {
+        worker_timeout_secs =
+            crate::manifest::actor_type::clamp_down_u64(worker_timeout_secs, p.max_timeout_secs);
+    }
     let worker_branch = args.branch.clone();
     // Mirror the directory cascade: target lead → root lead → default(true).
     // Without the root-lead step, sub-lead workers always made a worktree
@@ -297,6 +365,7 @@ pub async fn handle_spawn_worker(
     let lead_id_bg = target_layer.lead_id.clone();
     let prompt_bg = args.prompt.clone();
 
+    let worker_type_id_bg = resolved_worker_type_id.clone();
     tokio::spawn(async move {
         run_worker(
             state_bg,
@@ -311,6 +380,7 @@ pub async fn handle_spawn_worker(
             worker_timeout_secs,
             worker_use_worktree,
             worker_cancel_bg,
+            worker_type_id_bg,
         )
         .await;
     });
@@ -337,6 +407,7 @@ async fn run_worker(
     timeout_secs: u64,
     use_worktree: bool,
     cancel: pitboss_core::session::CancelToken,
+    actor_type: Option<String>,
 ) {
     use chrono::Utc;
     use pitboss_core::process::SpawnCmd;
@@ -397,6 +468,7 @@ async fn run_worker(
                     model: Some(model.clone()),
                     failure_reason: None,
                     cost_usd,
+                    actor_type: actor_type.clone(),
                 };
                 let _ = layer.store.append_record(layer.run_id, &rec).await;
                 layer
@@ -638,6 +710,7 @@ async fn run_worker(
         model: Some(model.clone()),
         failure_reason,
         cost_usd,
+        actor_type: actor_type.clone(),
     };
 
     // Persist record.
@@ -1084,6 +1157,11 @@ pub async fn spawn_resume_worker(
                 Some(&stderr_path),
             ),
             cost_usd,
+            // TODO(#252 Phase 1.5): plumb actor_type through resume so a
+            // continue/reprompt of a typed worker keeps its profile
+            // attribution on the appended record. For now Phase 1 drops it
+            // on resume — the original spawn record retains the type.
+            actor_type: None,
         };
         let _ = layer_bg.store.append_record(layer_bg.run_id, &rec).await;
         if let Some(reason) = rec.failure_reason.clone() {

--- a/crates/pitboss-cli/src/mcp/tools/tests.rs
+++ b/crates/pitboss-cli/src/mcp/tools/tests.rs
@@ -98,6 +98,9 @@ async fn test_state_with_budget(budget: f64) -> Arc<DispatchState> {
         mcp_servers: vec![],
         communication: Default::default(),
         lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();
@@ -368,6 +371,7 @@ async fn spawn_worker_adds_entry_to_state() {
         tools: None,
         timeout_secs: None,
         model: None,
+        worker_type: None,
         meta: None,
     };
     let result = handle_spawn_worker(&state, args).await.unwrap();
@@ -404,6 +408,7 @@ async fn spawn_worker_refuses_when_max_workers_reached() {
             tools: None,
             timeout_secs: None,
             model: None,
+            worker_type: None,
             meta: None,
         };
         handle_spawn_worker(&state, args).await.unwrap();
@@ -416,6 +421,7 @@ async fn spawn_worker_refuses_when_max_workers_reached() {
         tools: None,
         timeout_secs: None,
         model: None,
+        worker_type: None,
         meta: None,
     };
     let err = handle_spawn_worker(&state, args).await.unwrap_err();
@@ -433,6 +439,7 @@ async fn spawn_worker_refuses_when_budget_exceeded() {
         tools: None,
         timeout_secs: None,
         model: None,
+        worker_type: None,
         meta: None,
     };
     let err = handle_spawn_worker(&state, args).await.unwrap_err();
@@ -459,6 +466,7 @@ async fn spawn_worker_refuses_when_api_rate_limited() {
         tools: None,
         timeout_secs: None,
         model: None,
+        worker_type: None,
         meta: None,
     };
     let err = handle_spawn_worker(&state, args).await.unwrap_err();
@@ -480,6 +488,7 @@ async fn spawn_worker_refuses_when_api_auth_failed() {
         tools: None,
         timeout_secs: None,
         model: None,
+        worker_type: None,
         meta: None,
     };
     let err = handle_spawn_worker(&state, args).await.unwrap_err();
@@ -500,6 +509,7 @@ async fn spawn_worker_refuses_when_draining() {
         tools: None,
         timeout_secs: None,
         model: None,
+        worker_type: None,
         meta: None,
     };
     let err = handle_spawn_worker(&state, args).await.unwrap_err();
@@ -516,6 +526,7 @@ async fn worker_status_reads_state() {
         tools: None,
         timeout_secs: None,
         model: None,
+        worker_type: None,
         meta: None,
     };
     let spawn = handle_spawn_worker(&state, args).await.unwrap();
@@ -549,6 +560,7 @@ async fn cancel_worker_sets_cancelled_state() {
         tools: None,
         timeout_secs: None,
         model: None,
+        worker_type: None,
         meta: None,
     };
     let spawn = handle_spawn_worker(&state, args).await.unwrap();
@@ -601,6 +613,7 @@ async fn wait_for_worker_returns_outcome_on_completion() {
             model: None,
             failure_reason: None,
             cost_usd: None,
+            actor_type: None,
         };
         let mut w = state_clone.root.workers.write().await;
         w.insert(task_id_clone.clone(), WorkerState::Done(rec));
@@ -676,6 +689,7 @@ async fn wait_for_any_returns_first_completed() {
             model: None,
             failure_reason: None,
             cost_usd: None,
+            actor_type: None,
         };
         let mut w = state_clone.root.workers.write().await;
         w.insert("w-b".into(), WorkerState::Done(rec));
@@ -748,6 +762,9 @@ async fn completing_test_state_with_budget(budget: Option<f64>) -> Arc<DispatchS
         mcp_servers: vec![],
         communication: Default::default(),
         lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();
@@ -792,6 +809,7 @@ async fn spawn_worker_completes_and_updates_spent_usd_and_parent_task_id() {
         tools: None,
         timeout_secs: None,
         model: None, // falls back to lead model (claude-haiku-4-5)
+        worker_type: None,
         meta: None,
     };
 
@@ -862,6 +880,7 @@ async fn burst_spawn_is_budget_capped_via_reservation() {
         tools: None,
         timeout_secs: None,
         model: None,
+        worker_type: None,
         meta: None,
     };
 
@@ -907,6 +926,7 @@ async fn reservation_released_on_worker_completion() {
             tools: None,
             timeout_secs: None,
             model: None,
+            worker_type: None,
             meta: None,
         },
     )
@@ -964,6 +984,7 @@ async fn running_worker_state_gets_session_id_after_init() {
         tools: None,
         timeout_secs: None,
         model: None,
+        worker_type: None,
         meta: None,
     };
     let spawn = handle_spawn_worker(&state, args).await.unwrap();
@@ -1295,6 +1316,7 @@ async fn handle_reprompt_worker_from_done_errors() {
         model: None,
         failure_reason: None,
         cost_usd: None,
+        actor_type: None,
     };
     state
         .root
@@ -1597,6 +1619,9 @@ async fn handle_request_approval_auto_approves() {
         mcp_servers: vec![],
         communication: Default::default(),
         lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let script = FakeScript::new().hold_until_signal();
@@ -1693,6 +1718,9 @@ async fn permission_prompt_auto_approves_and_returns_gate_response() {
         mcp_servers: vec![],
         communication: Default::default(),
         lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let script = FakeScript::new().hold_until_signal();
@@ -1815,6 +1843,9 @@ async fn mk_plan_state_with_termination_policy(
         mcp_servers: vec![],
         communication: Default::default(),
         lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let script = FakeScript::new().hold_until_signal();
@@ -1855,6 +1886,7 @@ async fn spawn_worker_blocks_when_plan_not_approved() {
             tools: None,
             timeout_secs: None,
             model: None,
+            worker_type: None,
             meta: None,
         },
     )
@@ -1883,6 +1915,7 @@ async fn spawn_worker_allowed_when_require_plan_approval_off() {
             tools: None,
             timeout_secs: None,
             model: None,
+            worker_type: None,
             meta: None,
         },
     )
@@ -2715,5 +2748,237 @@ async fn propose_plan_auto_reject_leaves_flag_false() {
             .plan_approved
             .load(std::sync::atomic::Ordering::Acquire),
         "rejected plan must not flip plan_approved — lead should be able to retry"
+    );
+}
+
+// ----------------------------------------------------------------------
+// #252 — typed worker profiles, dispatcher-side enforcement
+// ----------------------------------------------------------------------
+
+/// Build a `DispatchState` with the given worker_types profiles and
+/// `require_actor_type` flag. Mirrors `test_state` but lets the caller
+/// inject typed profile config without forking the whole helper.
+async fn test_state_with_worker_types(
+    worker_types: Vec<crate::manifest::schema::WorkerType>,
+    require_actor_type: bool,
+) -> Arc<DispatchState> {
+    use crate::manifest::resolve::{ResolvedLead, ResolvedManifest};
+    use crate::manifest::schema::{Effort, WorktreeCleanup};
+    use pitboss_core::process::fake::{FakeScript, FakeSpawner};
+    use pitboss_core::process::ProcessSpawner;
+    use pitboss_core::session::CancelToken;
+    use pitboss_core::store::{JsonFileStore, SessionStore};
+    use pitboss_core::worktree::{CleanupPolicy, WorktreeManager};
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+    use uuid::Uuid;
+
+    let dir = TempDir::new().unwrap();
+    let lead = ResolvedLead {
+        id: "lead".into(),
+        directory: PathBuf::from("/tmp"),
+        prompt: "lead prompt".into(),
+        branch: None,
+        model: "claude-haiku-4-5".into(),
+        effort: Effort::High,
+        tools: vec![],
+        timeout_secs: 3600,
+        use_worktree: false,
+        env: Default::default(),
+        resume_session_id: None,
+        permission_routing: Default::default(),
+        allow_subleads: false,
+        max_subleads: None,
+        max_sublead_budget_usd: None,
+        max_total_workers: None,
+        sublead_defaults: None,
+    };
+    let manifest = ResolvedManifest {
+        manifest_schema_version: 0,
+        name: None,
+        max_parallel_tasks: Some(4),
+        halt_on_failure: false,
+        run_dir: dir.path().to_path_buf(),
+        worktree_cleanup: WorktreeCleanup::OnSuccess,
+        emit_event_stream: false,
+        tasks: vec![],
+        lead: Some(lead),
+        max_workers: Some(4),
+        budget_usd: Some(5.0),
+        lead_timeout_secs: None,
+        default_approval_policy: None,
+        denial_termination_policy: None,
+        notifications: vec![],
+        dump_shared_store: false,
+        require_plan_approval: false,
+        approval_rules: vec![],
+        container: None,
+        mcp_servers: vec![],
+        communication: Default::default(),
+        lifecycle: None,
+        worker_types,
+        sublead_types: vec![],
+        require_actor_type,
+    };
+    let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
+    let run_id = Uuid::now_v7();
+    let script = FakeScript::new().hold_until_signal();
+    let spawner: Arc<dyn ProcessSpawner> = Arc::new(FakeSpawner::new(script));
+    let wt_mgr = Arc::new(WorktreeManager::new());
+    let run_subdir = dir.path().join(run_id.to_string());
+    let dir_path = dir.path().to_path_buf();
+    std::mem::forget(dir);
+    let _ = dir_path;
+    Arc::new(DispatchState::new(
+        run_id,
+        manifest,
+        store,
+        CancelToken::new(),
+        "lead".into(),
+        spawner,
+        PathBuf::from("claude"),
+        wt_mgr,
+        CleanupPolicy::Never,
+        run_subdir,
+        ApprovalPolicy::Block,
+        None,
+        std::sync::Arc::new(crate::shared_store::SharedStore::new()),
+    ))
+}
+
+fn extraction_profile() -> crate::manifest::schema::WorkerType {
+    crate::manifest::schema::WorkerType {
+        id: "extraction".into(),
+        tools: vec!["Read".into(), "Glob".into(), "Grep".into()],
+        allowed_models: vec!["claude-haiku-4-5".into()],
+        max_timeout_secs: Some(900),
+    }
+}
+
+#[tokio::test]
+async fn spawn_worker_rejects_unknown_worker_type() {
+    let state = test_state_with_worker_types(vec![extraction_profile()], false).await;
+    let args = SpawnWorkerArgs {
+        prompt: "p".into(),
+        worker_type: Some("nope".into()),
+        ..Default::default()
+    };
+    let err = handle_spawn_worker(&state, args).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("unknown worker_type"), "{msg}");
+    assert!(msg.contains("extraction"), "{msg}");
+}
+
+#[tokio::test]
+async fn spawn_worker_rejects_tool_outside_profile() {
+    let state = test_state_with_worker_types(vec![extraction_profile()], false).await;
+    let args = SpawnWorkerArgs {
+        prompt: "p".into(),
+        worker_type: Some("extraction".into()),
+        tools: Some(vec!["Read".into(), "Bash".into()]),
+        ..Default::default()
+    };
+    let err = handle_spawn_worker(&state, args).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("\"Bash\""), "{msg}");
+    assert!(msg.contains("worker_type \"extraction\""), "{msg}");
+}
+
+#[tokio::test]
+async fn spawn_worker_rejects_model_outside_allowlist() {
+    let state = test_state_with_worker_types(vec![extraction_profile()], false).await;
+    let args = SpawnWorkerArgs {
+        prompt: "p".into(),
+        worker_type: Some("extraction".into()),
+        model: Some("claude-opus-4-7".into()),
+        ..Default::default()
+    };
+    let err = handle_spawn_worker(&state, args).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("claude-opus-4-7"), "{msg}");
+    assert!(msg.contains("allowed_models"), "{msg}");
+}
+
+#[tokio::test]
+async fn spawn_worker_rejects_typeless_when_required() {
+    let state = test_state_with_worker_types(vec![extraction_profile()], true).await;
+    let args = SpawnWorkerArgs {
+        prompt: "p".into(),
+        worker_type: None,
+        ..Default::default()
+    };
+    let err = handle_spawn_worker(&state, args).await.unwrap_err();
+    assert!(err.to_string().contains("require_actor_type"));
+}
+
+#[tokio::test]
+async fn spawn_worker_typed_subset_succeeds() {
+    let state = test_state_with_worker_types(vec![extraction_profile()], true).await;
+    let args = SpawnWorkerArgs {
+        prompt: "investigate".into(),
+        directory: Some("/tmp".into()),
+        worker_type: Some("extraction".into()),
+        tools: Some(vec!["Read".into(), "Glob".into()]),
+        model: Some("claude-haiku-4-5".into()),
+        ..Default::default()
+    };
+    let res = handle_spawn_worker(&state, args).await.unwrap();
+    assert!(res.task_id.starts_with("worker-"));
+}
+
+/// End-to-end check that `actor_type` reaches the persisted record.
+/// The helper's `FakeSpawner` holds workers in Running until signaled;
+/// we drive the worker to Done by terminating its cancel token, then
+/// poll briefly for the `WorkerState::Done(rec)` whose `actor_type`
+/// is the source of truth for `summary.jsonl` and downstream
+/// consumers. Earlier rejection tests only prove the guard rejects
+/// invalid spawns; this is the test that pins the spawn →
+/// `run_worker` → `TaskRecord` plumbing.
+#[tokio::test]
+async fn spawn_worker_typed_persists_actor_type_on_record() {
+    let state = test_state_with_worker_types(vec![extraction_profile()], true).await;
+    let args = SpawnWorkerArgs {
+        prompt: "investigate".into(),
+        directory: Some("/tmp".into()),
+        worker_type: Some("extraction".into()),
+        tools: Some(vec!["Read".into(), "Glob".into()]),
+        model: Some("claude-haiku-4-5".into()),
+        ..Default::default()
+    };
+    let res = handle_spawn_worker(&state, args).await.unwrap();
+
+    // Drive the worker to terminate so `run_worker` writes the record.
+    // The helper's FakeSpawner is `hold_until_signal`; without this,
+    // the worker stays Running and the test would just timeout.
+    for _ in 0..50 {
+        if let Some(tok) = state
+            .root
+            .worker_cancels
+            .read()
+            .await
+            .get(&res.task_id)
+            .cloned()
+        {
+            tok.terminate();
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+
+    // Bounded poll for the Done(rec). If the writer ever silently
+    // failed to land the record, we want the test to fail loudly
+    // rather than retry forever.
+    let mut found_actor_type: Option<String> = None;
+    for _ in 0..50 {
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        if let Some(WorkerState::Done(rec)) = state.root.workers.read().await.get(&res.task_id) {
+            found_actor_type = rec.actor_type.clone();
+            break;
+        }
+    }
+    assert_eq!(
+        found_actor_type.as_deref(),
+        Some("extraction"),
+        "TaskRecord.actor_type must reflect the resolved [[worker_type]] id"
     );
 }

--- a/crates/pitboss-cli/src/status.rs
+++ b/crates/pitboss-cli/src/status.rs
@@ -213,6 +213,7 @@ mod tests {
             model: None,
             failure_reason: None,
             cost_usd: None,
+            actor_type: None,
         }
     }
 

--- a/crates/pitboss-cli/src/tui_table.rs
+++ b/crates/pitboss-cli/src/tui_table.rs
@@ -177,6 +177,7 @@ mod tests {
             model: None,
             failure_reason: None,
             cost_usd: None,
+            actor_type: None,
         }
     }
 

--- a/crates/pitboss-cli/tests/cancel_cascade_flows.rs
+++ b/crates/pitboss-cli/tests/cancel_cascade_flows.rs
@@ -120,6 +120,9 @@ fn mk_state() -> (TempDir, Arc<DispatchState>) {
         mcp_servers: vec![],
         communication: Default::default(),
         lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/tests/control_flows.rs
+++ b/crates/pitboss-cli/tests/control_flows.rs
@@ -57,6 +57,9 @@ async fn pause_op_writes_events_jsonl() {
         mcp_servers: vec![],
         communication: Default::default(),
         lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -266,6 +269,9 @@ async fn block_policy_queue_drains_on_tui_connect() {
         mcp_servers: vec![],
         communication: Default::default(),
         lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -384,6 +390,9 @@ async fn auto_approve_policy_responds_without_tui() {
         mcp_servers: vec![],
         communication: Default::default(),
         lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -449,6 +458,9 @@ async fn auto_reject_policy_responds_without_tui() {
         mcp_servers: vec![],
         communication: Default::default(),
         lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -525,6 +537,9 @@ async fn propose_plan_end_to_end_unblocks_spawn_gate() {
         mcp_servers: vec![],
         communication: Default::default(),
         lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -555,6 +570,7 @@ async fn propose_plan_end_to_end_unblocks_spawn_gate() {
             tools: None,
             timeout_secs: None,
             model: None,
+            worker_type: None,
             meta: None,
         },
     )
@@ -660,6 +676,7 @@ async fn propose_plan_end_to_end_unblocks_spawn_gate() {
             tools: None,
             timeout_secs: None,
             model: None,
+            worker_type: None,
             meta: None,
         },
     )

--- a/crates/pitboss-cli/tests/dogfood_fake_flows.rs
+++ b/crates/pitboss-cli/tests/dogfood_fake_flows.rs
@@ -112,6 +112,9 @@ fn mk_state_with_subleads() -> (TempDir, Arc<DispatchState>) {
         mcp_servers: vec![],
         communication: Default::default(),
         lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();
@@ -1041,6 +1044,9 @@ async fn dogfood_envelope_cap_rejection() {
             mcp_servers: vec![],
             communication: Default::default(),
             lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/tests/e2e_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_flows.rs
@@ -82,6 +82,9 @@ fn mk_state(
         mcp_servers: vec![],
         communication: Default::default(),
         lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(run_dir.to_path_buf()));
     // Worker-side spawner: emits a complete stream-json run then exits 0.
@@ -392,6 +395,9 @@ async fn e2e_lead_cancels_worker_mid_flight() {
         mcp_servers: vec![],
         communication: Default::default(),
         lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let hold_script = FakeScript::new().hold_until_signal();
@@ -658,6 +664,9 @@ async fn e2e_lead_reprompts_running_worker() {
         mcp_servers: vec![],
         communication: Default::default(),
         lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     // Worker script emits init+result so session_id gets captured via the
@@ -862,6 +871,9 @@ async fn e2e_lead_propose_plan_gate_unblocks_spawn() {
         mcp_servers: vec![],
         communication: Default::default(),
         lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let worker_script = FakeScript::new()
@@ -1168,6 +1180,9 @@ async fn e2e_freeze_pause_and_continue_real_subprocess_worker() {
         mcp_servers: vec![],
         communication: Default::default(),
         lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(FakeClaudeWorkerSpawner {

--- a/crates/pitboss-cli/tests/e2e_sublead_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_sublead_flows.rs
@@ -97,6 +97,9 @@ fn mk_state(dir: &std::path::Path) -> (Uuid, Arc<DispatchState>) {
         mcp_servers: vec![],
         communication: Default::default(),
         lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.to_path_buf()));
     let worker_script = FakeScript::new()
@@ -171,6 +174,9 @@ fn mk_state_hold_workers(dir: &std::path::Path) -> (Uuid, Arc<DispatchState>) {
         mcp_servers: vec![],
         communication: Default::default(),
         lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.to_path_buf()));
     let hold_script = FakeScript::new().hold_until_signal();
@@ -228,6 +234,7 @@ async fn root_spawns_sublead_which_completes() {
         env: Default::default(),
         tools: Default::default(),
         resume_session_id: None,
+        sublead_type: None,
     };
     let sublead_id = spawn_sublead(&state, req)
         .await
@@ -322,6 +329,7 @@ async fn root_kill_cascades_to_sublead_workers() {
         env: Default::default(),
         tools: Default::default(),
         resume_session_id: None,
+        sublead_type: None,
     };
     let sublead_id = spawn_sublead(&state, req)
         .await
@@ -678,6 +686,7 @@ async fn budget_envelope_returns_to_root_pool() {
         env: Default::default(),
         tools: Default::default(),
         resume_session_id: None,
+        sublead_type: None,
     };
     let sublead_id = spawn_sublead(&state, req)
         .await
@@ -809,6 +818,9 @@ async fn sublead_session_spawns_runs_and_reconciles() {
         mcp_servers: vec![],
         communication: Default::default(),
         lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
     };
 
     let store: std::sync::Arc<dyn pitboss_core::store::SessionStore> = std::sync::Arc::new(
@@ -879,6 +891,7 @@ async fn sublead_session_spawns_runs_and_reconciles() {
         env: Default::default(),
         tools: Default::default(),
         resume_session_id: None,
+        sublead_type: None,
     };
     let sublead_id = spawn_sublead(&state, req)
         .await

--- a/crates/pitboss-cli/tests/hierarchical_flows.rs
+++ b/crates/pitboss-cli/tests/hierarchical_flows.rs
@@ -73,6 +73,9 @@ fn mk_state() -> (TempDir, Arc<DispatchState>) {
         mcp_servers: vec![],
         communication: Default::default(),
         lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();
@@ -312,6 +315,7 @@ async fn wait_actor_alias_resolves_worker_id() {
             model: None,
             failure_reason: None,
             cost_usd: None,
+            actor_type: None,
         };
         let mut w = state_clone.root.workers.write().await;
         w.insert(worker_id_clone.clone(), WorkerState::Done(rec));

--- a/crates/pitboss-cli/tests/notify_flows.rs
+++ b/crates/pitboss-cli/tests/notify_flows.rs
@@ -259,6 +259,9 @@ async fn approval_pending_notification_fires_on_enqueue() {
         mcp_servers: vec![],
         communication: Default::default(),
         lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());

--- a/crates/pitboss-cli/tests/shared_store_flows.rs
+++ b/crates/pitboss-cli/tests/shared_store_flows.rs
@@ -467,6 +467,9 @@ async fn lease_released_when_mcp_connection_drops() {
         mcp_servers: vec![],
         communication: Default::default(),
         lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
     };
     let store_trait: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().into()));
     let run_id = Uuid::now_v7();
@@ -615,6 +618,9 @@ async fn run_global_lease_released_when_mcp_connection_drops() {
         mcp_servers: vec![],
         communication: Default::default(),
         lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
     };
     let store_trait: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().into()));
     let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/tests/sublead_flows.rs
+++ b/crates/pitboss-cli/tests/sublead_flows.rs
@@ -81,6 +81,9 @@ fn mk_state_with_subleads() -> (TempDir, Arc<DispatchState>) {
         mcp_servers: vec![],
         communication: Default::default(),
         lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();
@@ -154,6 +157,9 @@ fn mk_state_without_subleads() -> (TempDir, Arc<DispatchState>) {
         mcp_servers: vec![],
         communication: Default::default(),
         lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();
@@ -225,6 +231,9 @@ fn mk_state_with_sublead_budget_cap(cap: f64) -> (TempDir, Arc<DispatchState>) {
         mcp_servers: vec![],
         communication: Default::default(),
         lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();
@@ -613,6 +622,7 @@ async fn unspent_sublead_envelope_returns_to_root_pool() {
         env: Default::default(),
         tools: Default::default(),
         resume_session_id: None,
+        sublead_type: None,
     };
     let sublead_id = pitboss_cli::dispatch::sublead::spawn_sublead(&state, req)
         .await
@@ -1226,6 +1236,7 @@ async fn wait_actor_returns_for_terminated_sublead() {
         env: Default::default(),
         tools: Default::default(),
         resume_session_id: None,
+        sublead_type: None,
     };
     let sublead_id = spawn_sublead(&state, req)
         .await
@@ -1287,6 +1298,7 @@ async fn wait_actor_blocks_then_wakes_on_sublead_termination() {
         env: Default::default(),
         tools: Default::default(),
         resume_session_id: None,
+        sublead_type: None,
     };
     let sublead_id = spawn_sublead(&state, req)
         .await
@@ -1369,6 +1381,7 @@ async fn wait_actor_still_handles_worker_back_compat() {
             model: None,
             failure_reason: None,
             cost_usd: None,
+            actor_type: None,
         };
         let mut w = state_clone.root.workers.write().await;
         w.insert(worker_id_clone.clone(), WorkerState::Done(rec));
@@ -1505,6 +1518,7 @@ async fn v0_5_back_compat_no_meta_routes_to_root() {
         tools: None,
         timeout_secs: None,
         model: None,
+        worker_type: None,
         meta: None, // Explicitly absent — the v0.5 compat path
     };
     let result = handle_spawn_worker(&state, args)
@@ -1708,6 +1722,7 @@ async fn kill_with_reason_skips_delivery_when_lead_already_terminated() {
             model: Some("claude-haiku-4-5".into()),
             failure_reason: None,
             cost_usd: None,
+            actor_type: None,
         };
         sub.workers.write().await.insert(
             s1.clone(),
@@ -1764,6 +1779,7 @@ async fn sublead_worker_budget_reserved_against_sublead_envelope() {
         env: Default::default(),
         tools: Default::default(),
         resume_session_id: None,
+        sublead_type: None,
     };
     let sublead_id = spawn_sublead(&state, req)
         .await
@@ -1781,6 +1797,7 @@ async fn sublead_worker_budget_reserved_against_sublead_envelope() {
         tools: None,
         timeout_secs: None,
         model: Some("claude-haiku-4-5".into()),
+        worker_type: None,
         meta: Some(MetaField {
             actor_id: sublead_id.clone(),
             actor_role: ActorRole::Sublead,

--- a/crates/pitboss-core/src/store/mod.rs
+++ b/crates/pitboss-core/src/store/mod.rs
@@ -56,6 +56,7 @@ mod integration_tests {
             model: None,
             failure_reason: None,
             cost_usd: None,
+            actor_type: None,
         }
     }
 

--- a/crates/pitboss-core/src/store/record.rs
+++ b/crates/pitboss-core/src/store/record.rs
@@ -107,6 +107,12 @@ pub struct TaskRecord {
     /// retroactively rewrite historical records.
     #[serde(default)]
     pub cost_usd: Option<f64>,
+    /// Resolved `[[worker_type]]` id at spawn time, or `None` when the
+    /// spawn was untyped or the record is from a pre-v0.12 run. Lets the
+    /// TUI / `pitboss status` / `pitboss-web` group workers by class
+    /// without re-deriving from the manifest snapshot. Added with #252.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor_type: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -182,6 +188,7 @@ mod tests {
             model: None,
             failure_reason: None,
             cost_usd: Some(0.0234),
+            actor_type: None,
         };
         let json = serde_json::to_string(&rec).unwrap();
         let back: TaskRecord = serde_json::from_str(&json).unwrap();
@@ -214,6 +221,7 @@ mod tests {
             model: None,
             failure_reason: None,
             cost_usd: None,
+            actor_type: None,
         };
         let json = serde_json::to_string(&rec).unwrap();
         assert!(json.contains("parent_task_id"));
@@ -277,6 +285,7 @@ mod tests {
             model: Some("claude-opus-4-7".into()),
             failure_reason: None,
             cost_usd: None,
+            actor_type: None,
         };
         let json = serde_json::to_string(&rec).unwrap();
         assert!(json.contains("claude-opus-4-7"));
@@ -395,6 +404,7 @@ mod tests {
             model: None,
             failure_reason: None,
             cost_usd: None,
+            actor_type: None,
         };
         let s = serde_json::to_string(&rec).unwrap();
         let back: TaskRecord = serde_json::from_str(&s).unwrap();
@@ -477,6 +487,7 @@ mod tests {
             model: None,
             failure_reason: None,
             cost_usd: None,
+            actor_type: None,
         };
         let s = serde_json::to_string(&rec).unwrap();
         let back: TaskRecord = serde_json::from_str(&s).unwrap();

--- a/crates/pitboss-core/src/store/sqlite.rs
+++ b/crates/pitboss-core/src/store/sqlite.rs
@@ -699,6 +699,7 @@ impl TaskRow {
                 .as_deref()
                 .and_then(|s| serde_json::from_str(s).ok()),
             cost_usd: self.cost_usd,
+            actor_type: None,
         })
     }
 }
@@ -1104,6 +1105,7 @@ mod sqlite_tests {
             model: None,
             failure_reason: None,
             cost_usd: None,
+            actor_type: None,
         }
     }
 

--- a/crates/pitboss-web/src/api/runs.rs
+++ b/crates/pitboss-web/src/api/runs.rs
@@ -349,6 +349,7 @@ mod tests {
             model: Some("claude-haiku-4-5".to_string()),
             failure_reason: None,
             cost_usd: None,
+            actor_type: None,
         };
         serde_json::to_string(&rec).unwrap()
     }

--- a/crates/pitboss-web/tests/insights_aggregator_integration.rs
+++ b/crates/pitboss-web/tests/insights_aggregator_integration.rs
@@ -72,6 +72,7 @@ fn task(id: &str, status: TaskStatus, reason: Option<FailureReason>) -> TaskReco
         model: None,
         failure_reason: reason,
         cost_usd: None,
+        actor_type: None,
     }
 }
 

--- a/docs/manifest-map.md
+++ b/docs/manifest-map.md
@@ -14,33 +14,34 @@ The annotated example lives at [`pitboss.example.toml`](../pitboss.example.toml)
 
 ## `[run]` — `RunConfig`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:439`](../crates/pitboss-cli/src/manifest/schema.rs#L439).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:452`](../crates/pitboss-cli/src/manifest/schema.rs#L452).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `name` | text | no | Human-readable label used to group related runs in the console (e.g. "build-db", "nightly-sync"). When unset, the manifest filename is used as fallback. | [`../crates/pitboss-cli/src/manifest/schema.rs#L450`](../crates/pitboss-cli/src/manifest/schema.rs#L450) |
-| `max_parallel_tasks` | integer | no | Flat-mode concurrency cap for [[task]] runs. Default 4. Overridden by ANTHROPIC_MAX_CONCURRENT. | [`../crates/pitboss-cli/src/manifest/schema.rs#L459`](../crates/pitboss-cli/src/manifest/schema.rs#L459) |
-| `halt_on_failure` | boolean | no | Stop remaining flat-mode tasks on first failure. | [`../crates/pitboss-cli/src/manifest/schema.rs#L466`](../crates/pitboss-cli/src/manifest/schema.rs#L466) |
-| `run_dir` | path | no | Where per-run artifacts land. Default ~/.local/share/pitboss/runs. | [`../crates/pitboss-cli/src/manifest/schema.rs#L472`](../crates/pitboss-cli/src/manifest/schema.rs#L472) |
-| `worktree_cleanup` | enum (`always` \| `on_success` \| `never`) | no | What to do with each worker's git worktree after it finishes. | [`../crates/pitboss-cli/src/manifest/schema.rs#L480`](../crates/pitboss-cli/src/manifest/schema.rs#L480) |
-| `emit_event_stream` | boolean | no | Write a JSONL event stream alongside summary.jsonl. | [`../crates/pitboss-cli/src/manifest/schema.rs#L487`](../crates/pitboss-cli/src/manifest/schema.rs#L487) |
-| `default_approval_policy` | enum (`block` \| `auto_approve` \| `auto_reject`) | no | Default action for request_approval / propose_plan when no rule matches. `auto_approve`/`auto_reject` are unconditional; `block` routes to the operator if attached, else queues. | [`../crates/pitboss-cli/src/manifest/schema.rs#L515`](../crates/pitboss-cli/src/manifest/schema.rs#L515) |
-| `denial_termination_policy` | enum (`adapt` \| `reclassify`) | no | How a denied permission_prompt affects the actor's terminal status. `adapt` (default) keeps the actor's exit code as-is; `reclassify` re-labels clean exits within 30s of a denial as ApprovalRejected. | [`../crates/pitboss-cli/src/manifest/schema.rs#L526`](../crates/pitboss-cli/src/manifest/schema.rs#L526) |
-| `dump_shared_store` | boolean | no | Write shared-store.json into the run directory on finalize. | [`../crates/pitboss-cli/src/manifest/schema.rs#L534`](../crates/pitboss-cli/src/manifest/schema.rs#L534) |
-| `require_plan_approval` | boolean | no | When true, spawn_worker is blocked until propose_plan has been approved. | [`../crates/pitboss-cli/src/manifest/schema.rs#L542`](../crates/pitboss-cli/src/manifest/schema.rs#L542) |
+| `name` | text | no | Human-readable label used to group related runs in the console (e.g. "build-db", "nightly-sync"). When unset, the manifest filename is used as fallback. | [`../crates/pitboss-cli/src/manifest/schema.rs#L463`](../crates/pitboss-cli/src/manifest/schema.rs#L463) |
+| `max_parallel_tasks` | integer | no | Flat-mode concurrency cap for [[task]] runs. Default 4. Overridden by ANTHROPIC_MAX_CONCURRENT. | [`../crates/pitboss-cli/src/manifest/schema.rs#L472`](../crates/pitboss-cli/src/manifest/schema.rs#L472) |
+| `halt_on_failure` | boolean | no | Stop remaining flat-mode tasks on first failure. | [`../crates/pitboss-cli/src/manifest/schema.rs#L479`](../crates/pitboss-cli/src/manifest/schema.rs#L479) |
+| `run_dir` | path | no | Where per-run artifacts land. Default ~/.local/share/pitboss/runs. | [`../crates/pitboss-cli/src/manifest/schema.rs#L485`](../crates/pitboss-cli/src/manifest/schema.rs#L485) |
+| `worktree_cleanup` | enum (`always` \| `on_success` \| `never`) | no | What to do with each worker's git worktree after it finishes. | [`../crates/pitboss-cli/src/manifest/schema.rs#L493`](../crates/pitboss-cli/src/manifest/schema.rs#L493) |
+| `emit_event_stream` | boolean | no | Write a JSONL event stream alongside summary.jsonl. | [`../crates/pitboss-cli/src/manifest/schema.rs#L500`](../crates/pitboss-cli/src/manifest/schema.rs#L500) |
+| `default_approval_policy` | enum (`block` \| `auto_approve` \| `auto_reject`) | no | Default action for request_approval / propose_plan when no rule matches. `auto_approve`/`auto_reject` are unconditional; `block` routes to the operator if attached, else queues. | [`../crates/pitboss-cli/src/manifest/schema.rs#L528`](../crates/pitboss-cli/src/manifest/schema.rs#L528) |
+| `denial_termination_policy` | enum (`adapt` \| `reclassify`) | no | How a denied permission_prompt affects the actor's terminal status. `adapt` (default) keeps the actor's exit code as-is; `reclassify` re-labels clean exits within 30s of a denial as ApprovalRejected. | [`../crates/pitboss-cli/src/manifest/schema.rs#L539`](../crates/pitboss-cli/src/manifest/schema.rs#L539) |
+| `dump_shared_store` | boolean | no | Write shared-store.json into the run directory on finalize. | [`../crates/pitboss-cli/src/manifest/schema.rs#L547`](../crates/pitboss-cli/src/manifest/schema.rs#L547) |
+| `require_plan_approval` | boolean | no | When true, spawn_worker is blocked until propose_plan has been approved. | [`../crates/pitboss-cli/src/manifest/schema.rs#L555`](../crates/pitboss-cli/src/manifest/schema.rs#L555) |
+| `require_actor_type` | boolean | no | When true, every spawn_worker and spawn_sublead call must name a declared [[worker_type]]/[[sublead_type]]. Default false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L566`](../crates/pitboss-cli/src/manifest/schema.rs#L566) |
 
 ## `[defaults]` — `Defaults`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:576`](../crates/pitboss-cli/src/manifest/schema.rs#L576).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:688`](../crates/pitboss-cli/src/manifest/schema.rs#L688).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `model` | text | no | Claude model id (e.g. claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-7). | [`../crates/pitboss-cli/src/manifest/schema.rs#L581`](../crates/pitboss-cli/src/manifest/schema.rs#L581) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Maps to the claude --effort flag. | [`../crates/pitboss-cli/src/manifest/schema.rs#L587`](../crates/pitboss-cli/src/manifest/schema.rs#L587) |
-| `tools` | string list | no | Allowed tool surface. Pitboss auto-appends its MCP tools for leads and workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L592`](../crates/pitboss-cli/src/manifest/schema.rs#L592) |
-| `timeout_secs` | integer | no | Per-task wall-clock cap. No default (no cap). | [`../crates/pitboss-cli/src/manifest/schema.rs#L597`](../crates/pitboss-cli/src/manifest/schema.rs#L597) |
-| `use_worktree` | boolean | no | Isolate each worker in a git worktree. Default true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L602`](../crates/pitboss-cli/src/manifest/schema.rs#L602) |
-| `env` | key-value map | no | Environment variables passed to the claude subprocess. | [`../crates/pitboss-cli/src/manifest/schema.rs#L608`](../crates/pitboss-cli/src/manifest/schema.rs#L608) |
+| `model` | text | no | Claude model id (e.g. claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-7). | [`../crates/pitboss-cli/src/manifest/schema.rs#L693`](../crates/pitboss-cli/src/manifest/schema.rs#L693) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Maps to the claude --effort flag. | [`../crates/pitboss-cli/src/manifest/schema.rs#L699`](../crates/pitboss-cli/src/manifest/schema.rs#L699) |
+| `tools` | string list | no | Allowed tool surface. Pitboss auto-appends its MCP tools for leads and workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L704`](../crates/pitboss-cli/src/manifest/schema.rs#L704) |
+| `timeout_secs` | integer | no | Per-task wall-clock cap. No default (no cap). | [`../crates/pitboss-cli/src/manifest/schema.rs#L709`](../crates/pitboss-cli/src/manifest/schema.rs#L709) |
+| `use_worktree` | boolean | no | Isolate each worker in a git worktree. Default true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L714`](../crates/pitboss-cli/src/manifest/schema.rs#L714) |
+| `env` | key-value map | no | Environment variables passed to the claude subprocess. | [`../crates/pitboss-cli/src/manifest/schema.rs#L720`](../crates/pitboss-cli/src/manifest/schema.rs#L720) |
 
 ## `[container]` — `ContainerConfig`
 
@@ -66,66 +67,66 @@ Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:138`](../crates/pitbos
 
 ## `[[task]]` — `Task`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:639`](../crates/pitboss-cli/src/manifest/schema.rs#L639).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:751`](../crates/pitboss-cli/src/manifest/schema.rs#L751).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique slug. Alphanumeric + _ + -. Used in logs and worktree names. | [`../crates/pitboss-cli/src/manifest/schema.rs#L644`](../crates/pitboss-cli/src/manifest/schema.rs#L644) |
-| `directory` | path | **yes** | Working directory. Must be inside a git repo if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L649`](../crates/pitboss-cli/src/manifest/schema.rs#L649) |
-| `prompt` | text (multi-line) | no | Prompt body sent to claude via -p. Mutually exclusive with `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L655`](../crates/pitboss-cli/src/manifest/schema.rs#L655) |
-| `template` | text | no | Reference to a [[template]] entry. Mutually exclusive with `prompt`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L660`](../crates/pitboss-cli/src/manifest/schema.rs#L660) |
-| `vars` | key-value map | no | Substitutions for {placeholders} when using `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L666`](../crates/pitboss-cli/src/manifest/schema.rs#L666) |
-| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L671`](../crates/pitboss-cli/src/manifest/schema.rs#L671) |
-| `model` | text | no | Per-task override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L673`](../crates/pitboss-cli/src/manifest/schema.rs#L673) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-task override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L679`](../crates/pitboss-cli/src/manifest/schema.rs#L679) |
-| `tools` | string list | no | Per-task override of [defaults].tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L681`](../crates/pitboss-cli/src/manifest/schema.rs#L681) |
-| `timeout_secs` | integer | no | Per-task wall-clock cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L683`](../crates/pitboss-cli/src/manifest/schema.rs#L683) |
-| `use_worktree` | boolean | no | Per-task override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L688`](../crates/pitboss-cli/src/manifest/schema.rs#L688) |
-| `env` | key-value map | no | Per-task env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L694`](../crates/pitboss-cli/src/manifest/schema.rs#L694) |
+| `id` | text | **yes** | Unique slug. Alphanumeric + _ + -. Used in logs and worktree names. | [`../crates/pitboss-cli/src/manifest/schema.rs#L756`](../crates/pitboss-cli/src/manifest/schema.rs#L756) |
+| `directory` | path | **yes** | Working directory. Must be inside a git repo if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L761`](../crates/pitboss-cli/src/manifest/schema.rs#L761) |
+| `prompt` | text (multi-line) | no | Prompt body sent to claude via -p. Mutually exclusive with `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L767`](../crates/pitboss-cli/src/manifest/schema.rs#L767) |
+| `template` | text | no | Reference to a [[template]] entry. Mutually exclusive with `prompt`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L772`](../crates/pitboss-cli/src/manifest/schema.rs#L772) |
+| `vars` | key-value map | no | Substitutions for {placeholders} when using `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L778`](../crates/pitboss-cli/src/manifest/schema.rs#L778) |
+| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L783`](../crates/pitboss-cli/src/manifest/schema.rs#L783) |
+| `model` | text | no | Per-task override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L785`](../crates/pitboss-cli/src/manifest/schema.rs#L785) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-task override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L791`](../crates/pitboss-cli/src/manifest/schema.rs#L791) |
+| `tools` | string list | no | Per-task override of [defaults].tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L793`](../crates/pitboss-cli/src/manifest/schema.rs#L793) |
+| `timeout_secs` | integer | no | Per-task wall-clock cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L795`](../crates/pitboss-cli/src/manifest/schema.rs#L795) |
+| `use_worktree` | boolean | no | Per-task override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L800`](../crates/pitboss-cli/src/manifest/schema.rs#L800) |
+| `env` | key-value map | no | Per-task env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L806`](../crates/pitboss-cli/src/manifest/schema.rs#L806) |
 
 ## `[lead]` — `Lead`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:704`](../crates/pitboss-cli/src/manifest/schema.rs#L704).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:816`](../crates/pitboss-cli/src/manifest/schema.rs#L816).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique slug used as the TUI tile label and in run artifact paths. | [`../crates/pitboss-cli/src/manifest/schema.rs#L711`](../crates/pitboss-cli/src/manifest/schema.rs#L711) |
-| `directory` | path | **yes** | Working directory for the lead's claude subprocess. Must be a git work-tree if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L718`](../crates/pitboss-cli/src/manifest/schema.rs#L718) |
-| `prompt` | text (multi-line) | **yes** | Operator instructions passed to claude via -p. Must appear before any [lead.X] subtable in the source. | [`../crates/pitboss-cli/src/manifest/schema.rs#L730`](../crates/pitboss-cli/src/manifest/schema.rs#L730) |
-| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L738`](../crates/pitboss-cli/src/manifest/schema.rs#L738) |
-| `model` | text | no | Per-lead override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L741`](../crates/pitboss-cli/src/manifest/schema.rs#L741) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-lead override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L748`](../crates/pitboss-cli/src/manifest/schema.rs#L748) |
-| `tools` | string list | no | Per-lead override of [defaults].tools. Pitboss auto-appends its MCP tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L754`](../crates/pitboss-cli/src/manifest/schema.rs#L754) |
-| `timeout_secs` | integer | no | Per-actor subprocess wall-clock cap (claude --timeout). | [`../crates/pitboss-cli/src/manifest/schema.rs#L760`](../crates/pitboss-cli/src/manifest/schema.rs#L760) |
-| `use_worktree` | boolean | no | Per-lead override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L766`](../crates/pitboss-cli/src/manifest/schema.rs#L766) |
-| `env` | key-value map | no | Per-lead env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L772`](../crates/pitboss-cli/src/manifest/schema.rs#L772) |
-| `max_workers` | integer | no | Hard cap on the lead's concurrent + queued worker pool (1–16). Required when the lead spawns workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L781`](../crates/pitboss-cli/src/manifest/schema.rs#L781) |
-| `budget_usd` | float | no | Soft cap on lead spend with reservation accounting. spawn_worker fails once spent + reserved + next_estimate > budget. | [`../crates/pitboss-cli/src/manifest/schema.rs#L790`](../crates/pitboss-cli/src/manifest/schema.rs#L790) |
-| `lead_timeout_secs` | integer | no | Wall-clock cap on the lead session. Default 3600. | [`../crates/pitboss-cli/src/manifest/schema.rs#L799`](../crates/pitboss-cli/src/manifest/schema.rs#L799) |
-| `permission_routing` | enum (`path_a` \| `path_b`) | no | path_a (default) makes pitboss the sole permission authority. path_b routes claude's gate through pitboss (rejected at validate time pending stabilization). | [`../crates/pitboss-cli/src/manifest/schema.rs#L812`](../crates/pitboss-cli/src/manifest/schema.rs#L812) |
-| `allow_subleads` | boolean | no | Expose spawn_sublead to the root lead. | [`../crates/pitboss-cli/src/manifest/schema.rs#L821`](../crates/pitboss-cli/src/manifest/schema.rs#L821) |
-| `max_subleads` | integer | no | Hard cap on total live sub-leads under this root. | [`../crates/pitboss-cli/src/manifest/schema.rs#L828`](../crates/pitboss-cli/src/manifest/schema.rs#L828) |
-| `max_sublead_budget_usd` | float | no | Cap on the per-sub-lead budget envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L835`](../crates/pitboss-cli/src/manifest/schema.rs#L835) |
-| `max_total_workers` | integer | no | Cap on total live workers across the entire tree (root + sub-trees). | [`../crates/pitboss-cli/src/manifest/schema.rs#L843`](../crates/pitboss-cli/src/manifest/schema.rs#L843) |
+| `id` | text | **yes** | Unique slug used as the TUI tile label and in run artifact paths. | [`../crates/pitboss-cli/src/manifest/schema.rs#L823`](../crates/pitboss-cli/src/manifest/schema.rs#L823) |
+| `directory` | path | **yes** | Working directory for the lead's claude subprocess. Must be a git work-tree if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L830`](../crates/pitboss-cli/src/manifest/schema.rs#L830) |
+| `prompt` | text (multi-line) | **yes** | Operator instructions passed to claude via -p. Must appear before any [lead.X] subtable in the source. | [`../crates/pitboss-cli/src/manifest/schema.rs#L842`](../crates/pitboss-cli/src/manifest/schema.rs#L842) |
+| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L850`](../crates/pitboss-cli/src/manifest/schema.rs#L850) |
+| `model` | text | no | Per-lead override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L853`](../crates/pitboss-cli/src/manifest/schema.rs#L853) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-lead override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L860`](../crates/pitboss-cli/src/manifest/schema.rs#L860) |
+| `tools` | string list | no | Per-lead override of [defaults].tools. Pitboss auto-appends its MCP tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L866`](../crates/pitboss-cli/src/manifest/schema.rs#L866) |
+| `timeout_secs` | integer | no | Per-actor subprocess wall-clock cap (claude --timeout). | [`../crates/pitboss-cli/src/manifest/schema.rs#L872`](../crates/pitboss-cli/src/manifest/schema.rs#L872) |
+| `use_worktree` | boolean | no | Per-lead override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L878`](../crates/pitboss-cli/src/manifest/schema.rs#L878) |
+| `env` | key-value map | no | Per-lead env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L884`](../crates/pitboss-cli/src/manifest/schema.rs#L884) |
+| `max_workers` | integer | no | Hard cap on the lead's concurrent + queued worker pool (1–16). Required when the lead spawns workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L893`](../crates/pitboss-cli/src/manifest/schema.rs#L893) |
+| `budget_usd` | float | no | Soft cap on lead spend with reservation accounting. spawn_worker fails once spent + reserved + next_estimate > budget. | [`../crates/pitboss-cli/src/manifest/schema.rs#L902`](../crates/pitboss-cli/src/manifest/schema.rs#L902) |
+| `lead_timeout_secs` | integer | no | Wall-clock cap on the lead session. Default 3600. | [`../crates/pitboss-cli/src/manifest/schema.rs#L911`](../crates/pitboss-cli/src/manifest/schema.rs#L911) |
+| `permission_routing` | enum (`path_a` \| `path_b`) | no | path_a (default) makes pitboss the sole permission authority. path_b routes claude's gate through pitboss (rejected at validate time pending stabilization). | [`../crates/pitboss-cli/src/manifest/schema.rs#L924`](../crates/pitboss-cli/src/manifest/schema.rs#L924) |
+| `allow_subleads` | boolean | no | Expose spawn_sublead to the root lead. | [`../crates/pitboss-cli/src/manifest/schema.rs#L933`](../crates/pitboss-cli/src/manifest/schema.rs#L933) |
+| `max_subleads` | integer | no | Hard cap on total live sub-leads under this root. | [`../crates/pitboss-cli/src/manifest/schema.rs#L940`](../crates/pitboss-cli/src/manifest/schema.rs#L940) |
+| `max_sublead_budget_usd` | float | no | Cap on the per-sub-lead budget envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L947`](../crates/pitboss-cli/src/manifest/schema.rs#L947) |
+| `max_total_workers` | integer | no | Cap on total live workers across the entire tree (root + sub-trees). | [`../crates/pitboss-cli/src/manifest/schema.rs#L955`](../crates/pitboss-cli/src/manifest/schema.rs#L955) |
 
 ## `[sublead_defaults]` — `SubleadDefaults`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:850`](../crates/pitboss-cli/src/manifest/schema.rs#L850).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:962`](../crates/pitboss-cli/src/manifest/schema.rs#L962).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `budget_usd` | float | no | Per-sub-lead envelope when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L855`](../crates/pitboss-cli/src/manifest/schema.rs#L855) |
-| `max_workers` | integer | no | Per-sub-lead worker pool when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L860`](../crates/pitboss-cli/src/manifest/schema.rs#L860) |
-| `lead_timeout_secs` | integer | no | Wall-clock cap for the sub-lead session. | [`../crates/pitboss-cli/src/manifest/schema.rs#L865`](../crates/pitboss-cli/src/manifest/schema.rs#L865) |
-| `read_down` | boolean | no | When true, sub-lead shares root's budget + worker pool instead of carving its own envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L871`](../crates/pitboss-cli/src/manifest/schema.rs#L871) |
+| `budget_usd` | float | no | Per-sub-lead envelope when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L967`](../crates/pitboss-cli/src/manifest/schema.rs#L967) |
+| `max_workers` | integer | no | Per-sub-lead worker pool when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L972`](../crates/pitboss-cli/src/manifest/schema.rs#L972) |
+| `lead_timeout_secs` | integer | no | Wall-clock cap for the sub-lead session. | [`../crates/pitboss-cli/src/manifest/schema.rs#L977`](../crates/pitboss-cli/src/manifest/schema.rs#L977) |
+| `read_down` | boolean | no | When true, sub-lead shares root's budget + worker pool instead of carving its own envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L983`](../crates/pitboss-cli/src/manifest/schema.rs#L983) |
 
 ## `[[approval_policy]]` — `ApprovalRuleSpec`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:389`](../crates/pitboss-cli/src/manifest/schema.rs#L389).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:402`](../crates/pitboss-cli/src/manifest/schema.rs#L402).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `action` | enum (`auto_approve` \| `auto_reject` \| `block`) | **yes** | Action when this rule matches. | [`../crates/pitboss-cli/src/manifest/schema.rs#L400`](../crates/pitboss-cli/src/manifest/schema.rs#L400) |
+| `action` | enum (`auto_approve` \| `auto_reject` \| `block`) | **yes** | Action when this rule matches. | [`../crates/pitboss-cli/src/manifest/schema.rs#L413`](../crates/pitboss-cli/src/manifest/schema.rs#L413) |
 
 ## `[[mcp_server]]` — `McpServerSpec`
 
@@ -137,6 +138,29 @@ Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:183`](../crates/pitbos
 | `command` | text | **yes** | Executable to launch (e.g. npx, uvx, or an absolute path). | [`../crates/pitboss-cli/src/manifest/schema.rs#L195`](../crates/pitboss-cli/src/manifest/schema.rs#L195) |
 | `args` | string list | no | Arguments passed to the command. | [`../crates/pitboss-cli/src/manifest/schema.rs#L199`](../crates/pitboss-cli/src/manifest/schema.rs#L199) |
 | `env` | key-value map | no | Environment variables injected into the MCP server process. | [`../crates/pitboss-cli/src/manifest/schema.rs#L206`](../crates/pitboss-cli/src/manifest/schema.rs#L206) |
+
+## `[[worker_type]]` — `WorkerType`
+
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:609`](../crates/pitboss-cli/src/manifest/schema.rs#L609).
+
+| Field | Type | Required | Help | Source |
+|---|---|---|---|---|
+| `id` | text | **yes** | Unique id used in spawn_worker(worker_type = "<id>"). Match: ^[A-Za-z0-9_-]+$. | [`../crates/pitboss-cli/src/manifest/schema.rs#L616`](../crates/pitboss-cli/src/manifest/schema.rs#L616) |
+| `tools` | string list | no | Allowed tool surface for this worker class. Lead's spawn_worker(tools=...) must be a subset; omit means "give me the whole allowlist." | [`../crates/pitboss-cli/src/manifest/schema.rs#L624`](../crates/pitboss-cli/src/manifest/schema.rs#L624) |
+| `allowed_models` | string list | no | When non-empty, spawn_worker(model=...) must be in this list. Empty means any model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L632`](../crates/pitboss-cli/src/manifest/schema.rs#L632) |
+| `max_timeout_secs` | integer | no | Hard cap on spawn_worker(timeout_secs=...). Lead values clamp DOWN; smaller values pass through. | [`../crates/pitboss-cli/src/manifest/schema.rs#L640`](../crates/pitboss-cli/src/manifest/schema.rs#L640) |
+
+## `[[sublead_type]]` — `SubleadType`
+
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:648`](../crates/pitboss-cli/src/manifest/schema.rs#L648).
+
+| Field | Type | Required | Help | Source |
+|---|---|---|---|---|
+| `id` | text | **yes** | Unique id used in spawn_sublead(sublead_type = "<id>"). Match: ^[A-Za-z0-9_-]+$. | [`../crates/pitboss-cli/src/manifest/schema.rs#L655`](../crates/pitboss-cli/src/manifest/schema.rs#L655) |
+| `tools` | string list | no | Allowed tool surface for this sub-lead class. spawn_sublead(tools=...) must be a subset; empty means "give me the whole allowlist." | [`../crates/pitboss-cli/src/manifest/schema.rs#L662`](../crates/pitboss-cli/src/manifest/schema.rs#L662) |
+| `allowed_models` | string list | no | When non-empty, spawn_sublead(model=...) must be in this list. | [`../crates/pitboss-cli/src/manifest/schema.rs#L669`](../crates/pitboss-cli/src/manifest/schema.rs#L669) |
+| `max_timeout_secs` | integer | no | Hard cap on spawn_sublead(lead_timeout_secs=...). Clamps DOWN. | [`../crates/pitboss-cli/src/manifest/schema.rs#L676`](../crates/pitboss-cli/src/manifest/schema.rs#L676) |
+| `max_budget_usd` | float | no | Hard cap on spawn_sublead(budget_usd=...). Clamps DOWN. | [`../crates/pitboss-cli/src/manifest/schema.rs#L683`](../crates/pitboss-cli/src/manifest/schema.rs#L683) |
 
 ## `[communication]` — `CommunicationConfig`
 
@@ -151,18 +175,18 @@ Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:243`](../crates/pitbos
 
 ## `[[template]]` — `Template`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:623`](../crates/pitboss-cli/src/manifest/schema.rs#L623).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:735`](../crates/pitboss-cli/src/manifest/schema.rs#L735).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Slug referenced from [[task]].template. | [`../crates/pitboss-cli/src/manifest/schema.rs#L628`](../crates/pitboss-cli/src/manifest/schema.rs#L628) |
-| `prompt` | text (multi-line) | **yes** | Prompt body. Supports {var} placeholders supplied by [[task]].vars. | [`../crates/pitboss-cli/src/manifest/schema.rs#L634`](../crates/pitboss-cli/src/manifest/schema.rs#L634) |
+| `id` | text | **yes** | Slug referenced from [[task]].template. | [`../crates/pitboss-cli/src/manifest/schema.rs#L740`](../crates/pitboss-cli/src/manifest/schema.rs#L740) |
+| `prompt` | text (multi-line) | **yes** | Prompt body. Supports {var} placeholders supplied by [[task]].vars. | [`../crates/pitboss-cli/src/manifest/schema.rs#L746`](../crates/pitboss-cli/src/manifest/schema.rs#L746) |
 
 ## `[lifecycle]` — `Lifecycle`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:366`](../crates/pitboss-cli/src/manifest/schema.rs#L366).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:379`](../crates/pitboss-cli/src/manifest/schema.rs#L379).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `survive_parent` | boolean | no | Allow this dispatch to outlive its parent process. Requires a notify target. | [`../crates/pitboss-cli/src/manifest/schema.rs#L377`](../crates/pitboss-cli/src/manifest/schema.rs#L377) |
+| `survive_parent` | boolean | no | Allow this dispatch to outlive its parent process. Requires a notify target. | [`../crates/pitboss-cli/src/manifest/schema.rs#L390`](../crates/pitboss-cli/src/manifest/schema.rs#L390) |
 

--- a/docs/manifest-reference.toml
+++ b/docs/manifest-reference.toml
@@ -31,6 +31,7 @@ default_approval_policy = "block"
 denial_termination_policy = "adapt"
 dump_shared_store = false
 require_plan_approval = false
+require_actor_type = false
 
 [defaults]
 model = "<value>"
@@ -104,6 +105,19 @@ id = "<value>"
 command = "<value>"
 args = []
 env = { EXAMPLE_KEY = "value" }
+
+[[worker_type]]
+id = "<value>"
+tools = []
+allowed_models = []
+max_timeout_secs = 0
+
+[[sublead_type]]
+id = "<value>"
+tools = []
+allowed_models = []
+max_timeout_secs = 0
+max_budget_usd = 0.0
 
 [communication]
 mode = "disabled"

--- a/examples/252-typed-actor-profiles-demo.toml
+++ b/examples/252-typed-actor-profiles-demo.toml
@@ -1,0 +1,187 @@
+# #252 — Typed worker/sublead profiles, dispatcher-enforced caps.
+#
+# This manifest exercises the v0.12 typed-actor-profile surface end-to-end:
+#
+# - `[run].require_actor_type = true` forces every spawn_worker /
+#   spawn_sublead call to name a profile. Type-less calls are rejected.
+# - Two `[[worker_type]]` profiles (`extraction`, `writer`) with
+#   different tools / allowed_models / max_timeout_secs caps.
+# - One `[[sublead_type]]` profile (`planner`) with tools, allowed
+#   models, and a max_budget_usd clamp.
+# - The lead is instructed to drive a depth-2 hierarchy that exercises
+#   subset-on-explicit-tools, omit-tools (gets profile's full allowlist),
+#   and nominally violates one cap to confirm the dispatcher rejects it.
+#
+# Cost: ~$0.20-$0.40 on Haiku/Sonnet. Run with:
+#
+#   mkdir -p /tmp/pitboss-252-demo && cd /tmp/pitboss-252-demo && git init -q
+#   pitboss validate examples/252-typed-actor-profiles-demo.toml
+#   pitboss dispatch examples/252-typed-actor-profiles-demo.toml
+#
+# Watch live:
+#   (terminal 2) pitboss-tui    # actor tiles surface .actor_type per tile
+#   (terminal 3) pitboss status <run-id>   # summary.json shows actor_type column
+
+[run]
+worktree_cleanup    = "never"
+dump_shared_store   = true
+# Force every spawn to name a profile. A bare spawn_worker without
+# `worker_type=...` is rejected at the dispatcher with a clear error
+# the lead can adapt to.
+require_actor_type  = true
+
+[defaults]
+model        = "claude-haiku-4-5"
+use_worktree = false
+
+# ---- Worker profiles -------------------------------------------------
+
+# Read-only investigator. Cannot Bash, Write, or Edit — even if the lead
+# tries, the spawn_worker call is rejected before the subprocess starts.
+[[worker_type]]
+id               = "extraction"
+tools            = ["Read", "Glob", "Grep"]
+allowed_models   = ["claude-haiku-4-5"]
+max_timeout_secs = 300
+
+# Writer can do everything `extraction` can plus Write. Still no Bash.
+# `allowed_models = []` (omitted) means any model the lead is allowed
+# to spend on.
+[[worker_type]]
+id               = "writer"
+tools            = ["Read", "Glob", "Grep", "Write"]
+max_timeout_secs = 600
+
+# ---- Sub-lead profile ------------------------------------------------
+
+# Planner sub-lead orchestrates investigation phases. Pinned to Haiku
+# (allowed_models has one entry); budget capped at $1.50 even if the
+# lead requests more.
+[[sublead_type]]
+id              = "planner"
+tools           = ["Read", "Glob", "Grep"]
+allowed_models  = ["claude-haiku-4-5"]
+max_budget_usd  = 1.50
+max_timeout_secs = 600
+
+# ---- Lead ------------------------------------------------------------
+
+[lead]
+id                       = "test-coordinator"
+directory                = "/tmp/pitboss-252-demo"
+model                    = "claude-haiku-4-5"
+budget_usd               = 3.00
+max_workers              = 4
+lead_timeout_secs        = 900
+allow_subleads           = true
+max_subleads             = 2
+max_sublead_budget_usd   = 2.00
+
+prompt = """
+You are testing pitboss's typed-actor-profile feature (#252). The
+manifest declares two `[[worker_type]]` profiles and one
+`[[sublead_type]]` profile. `[run].require_actor_type = true` means
+every spawn call MUST include a profile id; a bare spawn_worker is
+rejected.
+
+Run the following test sequence in order. Report PASS/FAIL for each
+step in your final summary.
+
+=== TEST 1 — typed spawn with omit-tools ===
+
+Call mcp__pitboss__spawn_worker with:
+  prompt      = "List the files under /tmp/pitboss-252-demo and report what you see."
+  worker_type = "extraction"
+  directory   = "/tmp/pitboss-252-demo"
+  model       = "claude-haiku-4-5"
+  (NO tools field — the worker must inherit the profile's full allowlist
+   verbatim: Read, Glob, Grep.)
+
+Wait for it via mcp__pitboss__wait_for_worker. Expect SUCCESS.
+
+=== TEST 2 — typed spawn with tools subset ===
+
+Call mcp__pitboss__spawn_worker with:
+  prompt      = "Read /etc/hostname and report the hostname."
+  worker_type = "extraction"
+  directory   = "/tmp/pitboss-252-demo"
+  model       = "claude-haiku-4-5"
+  tools       = ["Read"]    # strict subset of the extraction profile
+
+Wait for it. Expect SUCCESS.
+
+=== TEST 3 — typed spawn that violates the tool cap ===
+
+This call is EXPECTED TO BE REJECTED by the dispatcher. The error string
+will start with "spawn_worker rejected: tool 'Bash' is not in worker_type
+'extraction' allowlist".
+
+Call mcp__pitboss__spawn_worker with:
+  prompt      = "Run `uname -a`."
+  worker_type = "extraction"
+  directory   = "/tmp/pitboss-252-demo"
+  model       = "claude-haiku-4-5"
+  tools       = ["Read", "Bash"]    # Bash is NOT in extraction.tools
+
+You should observe the call returning an error, not a task_id. Record
+the error message verbatim. Do NOT retry. Move on to TEST 4.
+
+=== TEST 4 — typed spawn that violates the model cap ===
+
+This call is EXPECTED TO BE REJECTED. The extraction profile's
+allowed_models is ["claude-haiku-4-5"]; passing Sonnet must reject.
+
+Call mcp__pitboss__spawn_worker with:
+  prompt      = "Trivial."
+  worker_type = "extraction"
+  directory   = "/tmp/pitboss-252-demo"
+  model       = "claude-sonnet-4-6"   # NOT in allowed_models
+
+Record the error. Move on.
+
+=== TEST 5 — typeless spawn under require_actor_type ===
+
+This call is EXPECTED TO BE REJECTED with "[run].require_actor_type =
+true requires every spawn_worker call to name a worker_type".
+
+Call mcp__pitboss__spawn_worker with NO worker_type field:
+  prompt    = "Anything."
+  directory = "/tmp/pitboss-252-demo"
+  model     = "claude-haiku-4-5"
+
+Record the error. Move on.
+
+=== TEST 6 — sub-lead with sublead_type ===
+
+Call mcp__pitboss__spawn_sublead with:
+  prompt          = "You are a planner sub-lead. Spawn ONE worker of
+                    worker_type=writer that writes /tmp/pitboss-252-demo/plan.txt
+                    with the line 'plan complete'. Then exit."
+  sublead_type    = "planner"
+  model           = "claude-haiku-4-5"
+  budget_usd      = 1.00
+  max_workers     = 1
+  lead_timeout_secs = 300
+
+Wait for it via mcp__pitboss__wait_actor with the returned sublead_id.
+Expect SUCCESS.
+
+=== FINAL SUMMARY ===
+
+Print a single concise summary that lists each test 1-6 and PASS / FAIL.
+For tests 3, 4, 5 the expected outcome IS rejection — those PASS when
+the dispatcher rejects them with the documented error message and FAIL
+if the spawn unexpectedly succeeds.
+
+The summary.json from this run should show:
+  - 2 successful workers (tests 1 & 2) with actor_type = "extraction"
+  - 1 successful sublead (test 6) with actor_type = "planner"
+  - 1 successful worker spawned by the planner sublead with actor_type = "writer"
+"""
+
+# Optional sublead defaults — used when spawn_sublead doesn't override.
+[sublead_defaults]
+budget_usd        = 0.50
+max_workers       = 1
+lead_timeout_secs = 180
+read_down         = false


### PR DESCRIPTION
Closes the spawn-arg gate half of #252 — operators declare per-class
capability caps in the manifest and the dispatcher enforces them at
spawn time. The lead can never widen these caps, so a drifted prompt
or hostile upstream cannot silently widen a worker's capability
surface without the operator's knowledge.

## Summary

- New `[[worker_type]]` / `[[sublead_type]]` manifest sections plus
  `[run].require_actor_type` flag.
- New optional `worker_type` / `sublead_type` args on the `spawn_worker`
  and `spawn_sublead` MCP tools.
- Dispatcher-side enforcement: unknown-id reject, tools subset, model
  allowlist, downward-only clamps for `timeout_secs` and `budget_usd`.
- `TaskRecord.actor_type` persisted end-to-end through `summary.json` /
  `summary.jsonl` so the TUI, `pitboss-web`, and `pitboss status` can
  group actors by class without re-deriving from the manifest snapshot.
- AGENTS.md section, regenerated `docs/manifest-reference.toml` and
  `docs/manifest-map.md`.

## Behavior matrix

| `require_actor_type` | requested type | outcome                                  |
|----------------------|----------------|------------------------------------------|
| true                 | None           | reject (`require_actor_type` error)      |
| true                 | Some(unknown)  | reject (lists known ids)                 |
| true                 | Some(known)    | enforce caps                             |
| false                | None           | back-compat: legacy `[lead].tools` cascade |
| false                | Some(unknown)  | reject                                   |
| false                | Some(known)    | enforce caps                             |

When `tools` is omitted on a typed spawn, the worker gets the profile's
**full allowlist verbatim** — explicit consent signal, NOT the legacy
`[lead].tools` cascade. Untyped spawns continue to follow the cascade
unchanged.

## Tests

- 13 unit tests for `actor_type::resolve_*` / `check_*` / `clamp_*`
- 6 validate-time tests (id charset, duplicates, `require_actor_type`
  invariants)
- 5 handler tests for spawn rejection paths
- 1 end-to-end persistence test pinning the spawn → `run_worker` →
  `TaskRecord.actor_type` plumbing
- All 706 lib tests + every integration suite green
- `cargo lint` / `cargo tidy` / `scripts/smoke-part1.sh` clean

## Live validation

Ran `examples/252-typed-actor-profiles-demo.toml` against real
claude-haiku-4-5. All 6 in-prompt tests PASSED:

| # | Test                                                        | Result |
|---|-------------------------------------------------------------|--------|
| 1 | typed spawn, omit `tools` → inherits profile allowlist       | PASS   |
| 2 | typed spawn, strict tools subset                            | PASS   |
| 3 | tools cap violation (`Bash` not in profile) → reject         | PASS   |
| 4 | model cap violation (Sonnet not in `allowed_models`) → reject | PASS  |
| 5 | typeless spawn under `require_actor_type=true` → reject      | PASS   |
| 6 | sub-lead (`planner`) → worker (`writer`) → wrote `plan.txt`  | PASS   |

`summary.json` confirmed `actor_type` populated for all spawned
actors, including the depth-2 worker spawned by a sub-lead — proving
the run-global profile lookup works for sub-tree spawns.

Run economics: 59.7s, 5 tasks, 0 failed, \$0.16 total.

## Phase 1 limitations (follow-up tasks)

Tracked under #252; intentionally deferred to keep this PR
reviewable:

- Per-actor MCP server scoping (`[[mcp_server].scope = \"type:<id>\"`)
- Resumed workers (\`continue_worker\` / \`reprompt_worker\`) drop
  \`actor_type\` on the appended record; the original spawn record
  retains it.
- Synthesized cancellation records on lead-exit cleanup also drop
  \`actor_type\`.
- SQLite-backed runs lose \`actor_type\` on round-trip; JsonFileStore
  preserves it.

## Backwards compatibility

All new fields are additive with \`#[serde(default)]\`. Existing
manifests parse unchanged; existing dispatch behavior is unchanged
when no \`[[worker_type]]\` is declared and \`require_actor_type\`
is left at its default \`false\`. Resumed snapshots without the new
fields deserialize cleanly.

## Test plan

- [x] \`cargo test --workspace --features pitboss-core/test-support\`
- [x] \`cargo lint\` (clippy --workspace --all-targets --all-features -D warnings)
- [x] \`cargo tidy\` (fmt --check)
- [x] \`scripts/smoke-part1.sh\`
- [x] Live dispatch of \`examples/252-typed-actor-profiles-demo.toml\` against real claude-haiku-4-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)