### PR TITLE
feat(manifest): per-actor MCP scoping + actor_type persistence (#252 Phase 1.5)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -325,7 +325,7 @@ Pushes to main rebuild the image regardless of whether the commit touched code p
 
 ### `[[mcp_server]]` (v0.9+)
 
-Declare external MCP servers to inject into **every actor's** `--mcp-config` (lead, sub-leads, and workers). This is the native alternative to the KV-bridge workaround for giving all actors access to tools like context7.
+Declare external MCP servers to inject into actors' `--mcp-config`. By default servers are injected into **every actor** (lead, sub-leads, and workers); the optional `scope` field narrows injection to actors of a typed profile (#252 Phase 1.5, v0.12+).
 
 ```toml
 [[mcp_server]]
@@ -338,6 +338,11 @@ id      = "my-tool"
 command = "/usr/local/bin/my-mcp-server"
 args    = ["--port", "3000"]
 env     = { MY_TOKEN = "abc" }
+
+[[mcp_server]]
+id      = "fs-writer"
+command = "/usr/local/bin/fs-mcp"
+scope   = "type:writer"   # only injected into worker_type/sublead_type "writer"
 ```
 
 | Key | Required? | Notes |
@@ -346,8 +351,7 @@ env     = { MY_TOKEN = "abc" }
 | `command` | yes | Executable to launch (e.g. `"npx"`, `"uvx"`, absolute path). |
 | `args` | no | Arguments passed to the command. Default `[]`. |
 | `env` | no | Environment variables injected into the server process. Default `{}`. |
-
-All declared servers are injected into all actors (scope = all). Per-actor scoping is deferred — see roadmap.
+| `scope` | no | Optional injection scope. Form `"type:<id>"` references a `[[worker_type]]` or `[[sublead_type]]`. Validated at manifest load — unknown ids are rejected. Untyped actors (no `worker_type` / `sublead_type` arg on spawn) NEVER receive scoped servers. Unset (default) = inject into all actors. |
 
 **Tools from injected servers are available immediately** — no additional `--allowedTools` configuration is needed; claude's MCP client discovers the tools from the server at startup.
 
@@ -386,11 +390,11 @@ Set `[run].require_actor_type = true` to make every `spawn_worker` / `spawn_subl
 
 The resolved profile id is persisted to each `TaskRecord.actor_type`, surfaced in `summary.json` / `summary.jsonl` so the TUI, `pitboss-web`, and `pitboss status` can group actors by class without re-deriving from the manifest snapshot.
 
-**v0.12 limitations (Phase 1, follow-ups in #252 backlog):**
-- Per-actor MCP server scoping (`[[mcp_server].scope = "type:<id>"`) is deferred.
-- Resumed workers (`continue_worker` / `reprompt_worker`) drop `actor_type` on the appended record; the original spawn's record retains the type.
-- Synthesized cancellation records on lead-exit cleanup also drop `actor_type`.
-- SQLite-backed runs lose `actor_type` on round-trip (JsonFileStore preserves it).
+**Phase 1.5 (v0.12, landed):**
+- Per-actor MCP server scoping via `[[mcp_server]].scope = "type:<id>"` — see the `[[mcp_server]]` section above.
+- Resumed workers (`continue_worker` / `reprompt_worker`) preserve `actor_type` on the appended record via the in-memory `worker_actor_types` map populated at spawn.
+- Synthesized cancellation records on lead-exit cleanup keep `actor_type` from the same map.
+- SQLite-backed runs round-trip `actor_type` (migration v10 adds the column; both backends are now at parity with `JsonFileStore`).
 
 ### `[communication]` (v0.10+, opt-in)
 

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -264,6 +264,9 @@ pub async fn run_hierarchical(
         &socket,
         &lead.id,
         "lead",
+        // Root lead is never typed (no `[[lead_type]]` concept); scoped
+        // servers therefore never reach the root. (#252 Phase 1.5)
+        None,
         Some(&lead_token),
         &resolved.mcp_servers,
     )
@@ -605,42 +608,44 @@ pub async fn run_hierarchical(
     // would still see the worker as Running).
     let now = Utc::now();
     let mut cancelled_records: Vec<pitboss_core::store::TaskRecord> = Vec::new();
-    let make_cancelled = |id: &str, parent_id: &str, model: Option<String>| {
-        let token_usage = pitboss_core::parser::TokenUsage::default();
-        let cost_usd = pitboss_core::prices::cost_usd(model.as_deref().unwrap_or(""), &token_usage);
-        pitboss_core::store::TaskRecord {
-            task_id: id.to_string(),
-            status: pitboss_core::store::TaskStatus::Cancelled,
-            exit_code: None,
-            started_at: now,
-            ended_at: now,
-            duration_ms: 0,
-            worktree_path: None,
-            log_path: run_subdir.join("tasks").join(id).join("stdout.log"),
-            token_usage,
-            claude_session_id: None,
-            final_message_preview: Some("cancelled when lead exited".into()),
-            final_message: None,
-            parent_task_id: Some(parent_id.to_string()),
-            pause_count: 0,
-            reprompt_count: 0,
-            approvals_requested: 0,
-            approvals_approved: 0,
-            approvals_rejected: 0,
-            model,
-            failure_reason: None,
-            cost_usd,
-            // Cancellation records are synthesized post-hoc when the lead
-            // exits while workers are still running; the original spawn's
-            // actor_type was lost when the prior TaskRecord (if any) was
-            // overwritten. Phase 1.5 will preserve the attribution on this
-            // path by reading the prior record before synthesizing.
-            actor_type: None,
-        }
-    };
+    let make_cancelled =
+        |id: &str, parent_id: &str, model: Option<String>, actor_type: Option<String>| {
+            let token_usage = pitboss_core::parser::TokenUsage::default();
+            let cost_usd =
+                pitboss_core::prices::cost_usd(model.as_deref().unwrap_or(""), &token_usage);
+            pitboss_core::store::TaskRecord {
+                task_id: id.to_string(),
+                status: pitboss_core::store::TaskStatus::Cancelled,
+                exit_code: None,
+                started_at: now,
+                ended_at: now,
+                duration_ms: 0,
+                worktree_path: None,
+                log_path: run_subdir.join("tasks").join(id).join("stdout.log"),
+                token_usage,
+                claude_session_id: None,
+                final_message_preview: Some("cancelled when lead exited".into()),
+                final_message: None,
+                parent_task_id: Some(parent_id.to_string()),
+                pause_count: 0,
+                reprompt_count: 0,
+                approvals_requested: 0,
+                approvals_approved: 0,
+                approvals_rejected: 0,
+                model,
+                failure_reason: None,
+                cost_usd,
+                // Preserve the typed-profile attribution on synthesized
+                // cancellations: the in-memory `worker_actor_types` map
+                // still has the original spawn's id even though no
+                // TaskRecord was appended yet. (#252 Phase 1.5)
+                actor_type,
+            }
+        };
     {
         let workers = state.root.workers.read().await;
         let worker_models = state.root.worker_models.read().await;
+        let worker_actor_types = state.root.worker_actor_types.read().await;
         for (id, w) in workers.iter() {
             if id == &lead.id || existing_ids.contains(id) {
                 continue;
@@ -650,6 +655,7 @@ pub async fn run_hierarchical(
                     id,
                     &lead.id,
                     worker_models.get(id).cloned(),
+                    worker_actor_types.get(id).cloned(),
                 ));
             }
         }
@@ -659,6 +665,7 @@ pub async fn run_hierarchical(
         for (sublead_id, sub) in subleads.iter() {
             let workers = sub.workers.read().await;
             let worker_models = sub.worker_models.read().await;
+            let worker_actor_types = sub.worker_actor_types.read().await;
             for (id, w) in workers.iter() {
                 // Sub-lead layers register the sub-lead itself as a
                 // "worker" entry (the claude subprocess). Filter by the
@@ -673,6 +680,7 @@ pub async fn run_hierarchical(
                         id,
                         sublead_id,
                         worker_models.get(id).cloned(),
+                        worker_actor_types.get(id).cloned(),
                     ));
                 }
             }
@@ -885,11 +893,17 @@ async fn refresh_in_flight_from_maps(
 /// `DispatchState::mint_token`). When `Some`, it is appended as
 /// `--token <hex>` to the bridge args; the server then validates it and
 /// binds the connection identity. Closes #145.
+///
+/// `actor_type` is the actor's resolved typed profile id (worker_type or
+/// sublead_type) for #252 Phase 1.5 scoping. Servers with
+/// `scope = "type:<id>"` are injected only when `actor_type == Some(<id>)`.
+/// Untyped actors (`actor_type = None`) never receive scoped servers.
 fn build_mcp_servers_json(
     pitboss_exe: &std::path::Path,
     socket: &std::path::Path,
     actor_id: &str,
     actor_role: &str,
+    actor_type: Option<&str>,
     token: Option<&str>,
     extra_servers: &[crate::manifest::schema::McpServerSpec],
 ) -> serde_json::Map<String, serde_json::Value> {
@@ -914,6 +928,9 @@ fn build_mcp_servers_json(
         }),
     );
     for s in extra_servers {
+        if !mcp_server_scope_admits(s.scope.as_deref(), actor_type) {
+            continue;
+        }
         let mut entry = serde_json::Map::new();
         entry.insert("command".into(), s.command.clone().into());
         entry.insert(
@@ -933,11 +950,34 @@ fn build_mcp_servers_json(
     servers
 }
 
+/// Returns true when an MCP server with the given `scope` should be
+/// injected into an actor with the given `actor_type` (#252 Phase 1.5).
+///
+/// Rules:
+/// - `scope = None` → always inject (back-compat default).
+/// - `scope = Some("type:<id>")` and `actor_type = Some(<id>)` → inject.
+/// - Otherwise → exclude (untyped actor never gets scoped servers; a
+///   different type never gets a server scoped to a sibling type).
+///
+/// Validation rejects malformed `scope` strings at manifest load time, so
+/// here a value that doesn't parse as `type:<id>` simply excludes (defence
+/// in depth — should never happen on a validated manifest).
+fn mcp_server_scope_admits(scope: Option<&str>, actor_type: Option<&str>) -> bool {
+    let Some(raw) = scope else {
+        return true;
+    };
+    let Some(target) = raw.strip_prefix("type:") else {
+        return false;
+    };
+    actor_type == Some(target)
+}
+
 async fn write_mcp_config(
     path: &std::path::Path,
     socket: &std::path::Path,
     actor_id: &str,
     actor_role: &str, // "lead" or "worker"
+    actor_type: Option<&str>,
     token: Option<&str>,
     extra_servers: &[crate::manifest::schema::McpServerSpec],
 ) -> Result<()> {
@@ -950,6 +990,7 @@ async fn write_mcp_config(
         socket,
         actor_id,
         actor_role,
+        actor_type,
         token,
         extra_servers,
     );
@@ -979,6 +1020,7 @@ pub async fn write_worker_mcp_config(
     path: &std::path::Path,
     socket: &std::path::Path,
     worker_id: &str,
+    actor_type: Option<&str>,
     token: Option<&str>,
     extra_servers: &[crate::manifest::schema::McpServerSpec],
 ) -> Result<()> {
@@ -989,6 +1031,7 @@ pub async fn write_worker_mcp_config(
         socket,
         worker_id,
         "worker",
+        actor_type,
         token,
         extra_servers,
     );
@@ -1028,6 +1071,7 @@ pub async fn build_sublead_mcp_config(
     sublead_id: &str,
     socket: &std::path::Path,
     run_subdir: &std::path::Path,
+    actor_type: Option<&str>,
     token: Option<&str>,
     extra_servers: &[crate::manifest::schema::McpServerSpec],
     communication_mode: crate::manifest::schema::CommunicationMode,
@@ -1041,6 +1085,7 @@ pub async fn build_sublead_mcp_config(
         socket,
         sublead_id,
         "sublead",
+        actor_type,
         token,
         extra_servers,
     );
@@ -1411,5 +1456,80 @@ mod summary_jsonl_aggregation_tests {
             err.to_string().contains("read summary.jsonl"),
             "context attached: {err}"
         );
+    }
+}
+
+#[cfg(test)]
+mod mcp_scope_tests {
+    use super::*;
+    use crate::manifest::schema::McpServerSpec;
+    use std::path::PathBuf;
+
+    fn srv(id: &str, scope: Option<&str>) -> McpServerSpec {
+        McpServerSpec {
+            id: id.into(),
+            command: "/bin/true".into(),
+            args: vec![],
+            env: Default::default(),
+            scope: scope.map(str::to_string),
+        }
+    }
+
+    fn build(actor_type: Option<&str>, servers: &[McpServerSpec]) -> Vec<String> {
+        let json = build_mcp_servers_json(
+            &PathBuf::from("/usr/bin/pitboss"),
+            &PathBuf::from("/tmp/sock"),
+            "actor-1",
+            "worker",
+            actor_type,
+            None,
+            servers,
+        );
+        json.keys().cloned().collect()
+    }
+
+    #[test]
+    fn scope_admits_helper_matrix() {
+        // Unscoped: always admits.
+        assert!(mcp_server_scope_admits(None, None));
+        assert!(mcp_server_scope_admits(None, Some("writer")));
+        // Scoped + matching type: admits.
+        assert!(mcp_server_scope_admits(Some("type:writer"), Some("writer")));
+        // Scoped + mismatched type: rejects.
+        assert!(!mcp_server_scope_admits(
+            Some("type:writer"),
+            Some("reader")
+        ));
+        // Scoped + untyped actor: rejects (untyped never gets scoped servers).
+        assert!(!mcp_server_scope_admits(Some("type:writer"), None));
+        // Malformed scope: defence-in-depth, rejects.
+        assert!(!mcp_server_scope_admits(Some("role:lead"), Some("lead")));
+    }
+
+    #[test]
+    fn build_mcp_servers_json_excludes_scoped_for_untyped_actor() {
+        let servers = vec![srv("ctx7", None), srv("fs", Some("type:writer"))];
+        let mut keys = build(None, &servers);
+        keys.sort();
+        assert_eq!(keys, vec!["ctx7".to_string(), "pitboss".to_string()]);
+    }
+
+    #[test]
+    fn build_mcp_servers_json_includes_scoped_for_matching_actor() {
+        let servers = vec![srv("ctx7", None), srv("fs", Some("type:writer"))];
+        let mut keys = build(Some("writer"), &servers);
+        keys.sort();
+        assert_eq!(
+            keys,
+            vec!["ctx7".to_string(), "fs".to_string(), "pitboss".to_string()]
+        );
+    }
+
+    #[test]
+    fn build_mcp_servers_json_excludes_scoped_for_other_typed_actor() {
+        let servers = vec![srv("fs", Some("type:writer"))];
+        let mut keys = build(Some("reader"), &servers);
+        keys.sort();
+        assert_eq!(keys, vec!["pitboss".to_string()]);
     }
 }

--- a/crates/pitboss-cli/src/dispatch/layer.rs
+++ b/crates/pitboss-cli/src/dispatch/layer.rs
@@ -77,6 +77,13 @@ pub struct LayerState {
     pub worker_prompts: RwLock<HashMap<String, String>>,
     /// Per-worker resolved model, keyed by task_id.
     pub worker_models: RwLock<HashMap<String, String>>,
+    /// Per-worker resolved `actor_type` (matches a `[[worker_type]].id` from
+    /// the manifest), keyed by task_id. Populated at spawn time when the
+    /// caller resolves to `WorkerProfileResolution::Typed`. Read on resume
+    /// (continue/reprompt) so the rebuilt `mcp-config.json` can scope MCP
+    /// servers and the appended `TaskRecord` keeps its profile attribution.
+    /// (#252 Phase 1.5)
+    pub worker_actor_types: RwLock<HashMap<String, String>>,
     /// Per-worker reserved cost (USD) at spawn time.
     pub worker_reservations: RwLock<HashMap<String, f64>>,
     /// Dependencies needed to actually launch worker subprocesses.
@@ -209,6 +216,7 @@ impl LayerState {
             worker_cancels: RwLock::new(HashMap::new()),
             worker_prompts: RwLock::new(HashMap::new()),
             worker_models: RwLock::new(HashMap::new()),
+            worker_actor_types: RwLock::new(HashMap::new()),
             worker_reservations: RwLock::new(HashMap::new()),
             spawner,
             claude_binary,

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -497,6 +497,7 @@ async fn spawn_sublead_session(
         &sublead_id,
         &socket_path,
         &state.root.run_subdir,
+        sublead_type.as_deref(),
         Some(&sublead_token),
         &state.root.manifest.mcp_servers,
         communication_mode,

--- a/crates/pitboss-cli/src/manifest/schema.rs
+++ b/crates/pitboss-cli/src/manifest/schema.rs
@@ -165,11 +165,10 @@ pub struct CopySpec {
     pub container: PathBuf,
 }
 
-/// An external MCP server to inject into every actor's `--mcp-config`.
-/// Declared as `[[mcp_server]]` in the manifest. All actors (lead, sub-lead,
-/// and workers) receive the server so they can call its tools directly.
-///
-/// Per-actor scope granularity is deferred — see roadmap.
+/// An external MCP server to inject into actors' `--mcp-config`.
+/// Declared as `[[mcp_server]]` in the manifest. By default all actors
+/// (lead, sub-lead, and workers) receive the server. The optional `scope`
+/// narrows injection to actors of a given typed profile (#252 Phase 1.5).
 ///
 /// Example:
 /// ```toml
@@ -177,6 +176,11 @@ pub struct CopySpec {
 /// id      = "context7"
 /// command = "npx"
 /// args    = ["-y", "@upstash/context7-mcp"]
+///
+/// [[mcp_server]]
+/// id      = "fs-writer"
+/// command = "/usr/local/bin/fs-mcp"
+/// scope   = "type:writer"   # only injected into worker_type/sublead_type "writer"
 /// ```
 #[derive(Debug, Clone, Deserialize, Serialize, FieldMetadata)]
 #[serde(deny_unknown_fields)]
@@ -204,6 +208,19 @@ pub struct McpServerSpec {
         help = "Environment variables injected into the MCP server process."
     )]
     pub env: HashMap<String, String>,
+    /// Optional injection scope. Currently the only supported form is
+    /// `"type:<id>"`, where `<id>` references a `[[worker_type]]` or
+    /// `[[sublead_type]]`. When set, the server is injected ONLY into
+    /// actors spawned under that type — including untyped actors when
+    /// no profiles are required is NOT supported (`require_actor_type`
+    /// still respects its own gate). Unset means inject into all actors
+    /// (the v0.11 behaviour). (#252 Phase 1.5)
+    #[serde(default)]
+    #[field(
+        label = "Scope",
+        help = "Optional injection scope. Form: \"type:<id>\" — narrows this server to actors spawned under that worker_type/sublead_type. Unset = inject into all actors."
+    )]
+    pub scope: Option<String>,
 }
 
 /// Communication policy mode for the Pitboss-owned mailbox + artifact MCP

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -28,6 +28,7 @@ fn validate_inner(resolved: &ResolvedManifest, skip_dir_check: bool) -> Result<(
     validate_container(resolved)?;
     validate_communication(resolved)?;
     validate_actor_types(resolved)?;
+    validate_mcp_server_scopes(resolved)?;
     if resolved.lead.is_some() {
         validate_lead(resolved, skip_dir_check)?;
         validate_hierarchical_ranges(resolved)?;
@@ -119,6 +120,64 @@ fn validate_actor_types(r: &ResolvedManifest) -> Result<()> {
                  or `[[sublead_type]]` declared; the flag would reject every \
                  spawn call. Declare at least one profile or set \
                  require_actor_type = false."
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate `[[mcp_server]].scope` strings against the declared profile
+/// catalogue (#252 Phase 1.5).
+///
+/// - Unset → always valid (server injects into all actors, the legacy
+///   v0.11 default).
+/// - Set → must parse as `type:<id>` exactly. The `<id>` must reference
+///   either a `[[worker_type]]` or a `[[sublead_type]]`. Any other prefix
+///   form is reserved for future expansion (`role:`, `actor:`, ...) and
+///   rejected today.
+///
+/// We reject loudly at validate time because a typo here would silently
+/// strip the server from every typed actor (the runtime filter would
+/// fail-closed against an unknown id), and operators would see "MCP
+/// server X never injected" with no obvious cause.
+fn validate_mcp_server_scopes(r: &ResolvedManifest) -> Result<()> {
+    let mut known: HashSet<&str> = HashSet::new();
+    for wt in &r.worker_types {
+        known.insert(&wt.id);
+    }
+    for st in &r.sublead_types {
+        known.insert(&st.id);
+    }
+
+    for s in &r.mcp_servers {
+        let Some(raw) = s.scope.as_deref() else {
+            continue;
+        };
+        let Some(target) = raw.strip_prefix("type:") else {
+            bail!(
+                "[[mcp_server]].scope {:?} on server {:?}: only the \
+                 \"type:<id>\" form is currently supported",
+                raw,
+                s.id
+            );
+        };
+        if target.is_empty() {
+            bail!(
+                "[[mcp_server]].scope {:?} on server {:?}: empty id \
+                 after \"type:\" prefix",
+                raw,
+                s.id
+            );
+        }
+        if !known.contains(target) {
+            bail!(
+                "[[mcp_server]].scope {:?} on server {:?}: id {:?} does \
+                 not match any `[[worker_type]]` or `[[sublead_type]]`. \
+                 Declare the profile or fix the typo.",
+                raw,
+                s.id,
+                target
             );
         }
     }
@@ -1882,5 +1941,93 @@ mod tests {
             max_budget_usd: Some(2.0),
         }];
         validate(&m).expect("declared profiles without require flag must validate");
+    }
+
+    fn mcp(id: &str, scope: Option<&str>) -> crate::manifest::schema::McpServerSpec {
+        crate::manifest::schema::McpServerSpec {
+            id: id.into(),
+            command: "/bin/true".into(),
+            args: vec![],
+            env: Default::default(),
+            scope: scope.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn rejects_mcp_server_scope_with_unknown_prefix() {
+        let r = rm_with(|m| {
+            m.mcp_servers = vec![mcp("ctx", Some("role:lead"))];
+        });
+        let err = validate(&r).unwrap_err().to_string();
+        assert!(err.contains("type:<id>"), "{err}");
+        assert!(err.contains("ctx"), "{err}");
+    }
+
+    #[test]
+    fn rejects_mcp_server_scope_with_empty_id() {
+        let r = rm_with(|m| {
+            m.mcp_servers = vec![mcp("ctx", Some("type:"))];
+        });
+        let err = validate(&r).unwrap_err().to_string();
+        assert!(err.contains("empty id"), "{err}");
+    }
+
+    #[test]
+    fn rejects_mcp_server_scope_with_unknown_id() {
+        use crate::manifest::schema::WorkerType;
+        let r = rm_with(|m| {
+            m.worker_types = vec![WorkerType {
+                id: "writer".into(),
+                tools: vec!["Read".into()],
+                allowed_models: vec![],
+                max_timeout_secs: None,
+            }];
+            m.mcp_servers = vec![mcp("ctx", Some("type:rdr"))];
+        });
+        let err = validate(&r).unwrap_err().to_string();
+        assert!(err.contains("rdr"), "{err}");
+        assert!(err.contains("does not match"), "{err}");
+    }
+
+    #[test]
+    fn accepts_mcp_server_scope_referencing_worker_type() {
+        use crate::manifest::schema::WorkerType;
+        let r = rm_with(|m| {
+            m.worker_types = vec![WorkerType {
+                id: "writer".into(),
+                tools: vec!["Read".into(), "Write".into()],
+                allowed_models: vec![],
+                max_timeout_secs: None,
+            }];
+            m.mcp_servers = vec![mcp("ctx", Some("type:writer"))];
+        });
+        validate_skip_dir_check(&r)
+            .expect("scope referencing a declared worker_type must validate");
+    }
+
+    #[test]
+    fn accepts_mcp_server_scope_referencing_sublead_type() {
+        use crate::manifest::schema::SubleadType;
+        let r = rm_with(|m| {
+            m.sublead_types = vec![SubleadType {
+                id: "planner".into(),
+                tools: vec!["Read".into()],
+                allowed_models: vec![],
+                max_timeout_secs: None,
+                max_budget_usd: None,
+            }];
+            m.mcp_servers = vec![mcp("ctx", Some("type:planner"))];
+        });
+        validate_skip_dir_check(&r)
+            .expect("scope referencing a declared sublead_type must validate");
+    }
+
+    #[test]
+    fn accepts_unscoped_mcp_server_with_no_profiles() {
+        let r = rm_with(|m| {
+            m.mcp_servers = vec![mcp("ctx", None)];
+        });
+        validate_skip_dir_check(&r)
+            .expect("unscoped server is the legacy default and must validate");
     }
 }

--- a/crates/pitboss-cli/src/mcp/tools/spawn.rs
+++ b/crates/pitboss-cli/src/mcp/tools/spawn.rs
@@ -275,6 +275,17 @@ pub async fn handle_spawn_worker(
         .await
         .insert(task_id.clone(), worker_model.clone());
 
+    // Track the worker's resolved actor_type (typed-profile id) so
+    // resume paths can rebuild the scoped mcp-config.json correctly and
+    // reattach the type to appended TaskRecords. (#252 Phase 1.5)
+    if let Some(t) = resolved_worker_type_id.as_deref() {
+        target_layer
+            .worker_actor_types
+            .write()
+            .await
+            .insert(task_id.clone(), t.to_string());
+    }
+
     // Resolve the worker's directory and worktree-use, falling back through:
     //   1. `args.directory` / per-args overrides — operator's spawn_worker call
     //   2. target_layer's lead — set for root-lead callers, NOT for sub-leads
@@ -521,6 +532,7 @@ async fn run_worker(
         &worker_mcp_config,
         &socket_path,
         &task_id,
+        actor_type.as_deref(),
         Some(&worker_token),
         &layer.manifest.mcp_servers,
     )
@@ -939,6 +951,11 @@ pub async fn spawn_resume_worker(
         .get(&task_id)
         .cloned()
         .unwrap_or_else(|| "claude-haiku-4-5".to_string());
+    // Resolve the worker's typed-profile id (if any) so the rebuilt
+    // mcp-config.json scopes correctly and the appended TaskRecord
+    // keeps its profile attribution. (#252 Phase 1.5)
+    let resumed_actor_type: Option<String> =
+        layer.worker_actor_types.read().await.get(&task_id).cloned();
     let tools: Vec<String> = layer
         .manifest
         .lead
@@ -1011,6 +1028,7 @@ pub async fn spawn_resume_worker(
         &worker_mcp_config_path,
         &socket_path,
         &task_id,
+        resumed_actor_type.as_deref(),
         Some(&worker_token),
         &layer.manifest.mcp_servers,
     )
@@ -1079,6 +1097,7 @@ pub async fn spawn_resume_worker(
     let log_path = task_dir.join("stdout.log");
     let stderr_path = task_dir.join("stderr.log");
     let resume_model = model.clone();
+    let resumed_actor_type_bg = resumed_actor_type.clone();
     // Register a pid slot for the resumed subprocess too, so
     // freeze-pause works across continue_worker boundaries.
     let resume_pid_slot = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
@@ -1157,11 +1176,11 @@ pub async fn spawn_resume_worker(
                 Some(&stderr_path),
             ),
             cost_usd,
-            // TODO(#252 Phase 1.5): plumb actor_type through resume so a
-            // continue/reprompt of a typed worker keeps its profile
-            // attribution on the appended record. For now Phase 1 drops it
-            // on resume — the original spawn record retains the type.
-            actor_type: None,
+            // Preserve the typed-profile attribution across resume so the
+            // appended record carries the same `actor_type` as the original
+            // spawn — read from the in-memory `worker_actor_types` map at
+            // resume entry. (#252 Phase 1.5)
+            actor_type: resumed_actor_type_bg.clone(),
         };
         let _ = layer_bg.store.append_record(layer_bg.run_id, &rec).await;
         if let Some(reason) = rec.failure_reason.clone() {

--- a/crates/pitboss-core/src/store/sqlite.rs
+++ b/crates/pitboss-core/src/store/sqlite.rs
@@ -160,6 +160,11 @@ const MIGRATIONS: &[Migration] = &[
         name: "cost_usd",
         apply: migrate_cost_usd,
     },
+    Migration {
+        version: 10,
+        name: "actor_type",
+        apply: migrate_actor_type,
+    },
 ];
 
 /// Apply every entry in [`MIGRATIONS`] whose version is not yet
@@ -308,6 +313,15 @@ fn migrate_final_message(conn: &rusqlite::Connection) -> Result<(), StoreError> 
 /// keep `NULL` and consumers render "—".
 fn migrate_cost_usd(conn: &rusqlite::Connection) -> Result<(), StoreError> {
     add_column_if_missing(conn, "task_records", "cost_usd", "REAL NULL")
+}
+
+/// Idempotent migration: add the v0.12 `actor_type` column (#252 Phase 1.5).
+/// Stores the resolved `[[worker_type]]` / `[[sublead_type]]` id as `TEXT
+/// NULL` so untyped spawns and pre-Phase-1 records stay `NULL`. Round-trips
+/// through `JsonFileStore` were already wired in Phase 1; this brings the
+/// `SQLite` backend to parity.
+fn migrate_actor_type(conn: &rusqlite::Connection) -> Result<(), StoreError> {
+    add_column_if_missing(conn, "task_records", "actor_type", "TEXT NULL")
 }
 
 /// Idempotent migration: add v0.4 counter columns to `task_records` if missing.
@@ -526,6 +540,7 @@ fn init_schema(conn: &rusqlite::Connection) -> Result<(), StoreError> {
             failure_reason        TEXT NULL,
             final_message         TEXT NULL,
             cost_usd              REAL NULL,
+            actor_type            TEXT NULL,
             PRIMARY KEY (run_id, task_id)
         );
         ",
@@ -632,6 +647,7 @@ struct TaskRow {
     failure_reason: Option<String>,
     final_message: Option<String>,
     cost_usd: Option<f64>,
+    actor_type: Option<String>,
 }
 
 impl TaskRow {
@@ -661,6 +677,7 @@ impl TaskRow {
             failure_reason: row.get("failure_reason").unwrap_or(None),
             final_message: row.get("final_message").unwrap_or(None),
             cost_usd: row.get("cost_usd").unwrap_or(None),
+            actor_type: row.get("actor_type").unwrap_or(None),
         })
     }
 
@@ -699,7 +716,7 @@ impl TaskRow {
                 .as_deref()
                 .and_then(|s| serde_json::from_str(s).ok()),
             cost_usd: self.cost_usd,
-            actor_type: None,
+            actor_type: self.actor_type,
         })
     }
 }
@@ -738,7 +755,7 @@ fn fetch_task_records(
                   claude_session_id, final_message_preview, parent_task_id, \
                   pause_count, reprompt_count, approvals_requested, \
                   approvals_approved, approvals_rejected, model, failure_reason, \
-                  final_message, cost_usd \
+                  final_message, cost_usd, actor_type \
              FROM task_records WHERE run_id = ?1 ORDER BY rowid",
         )
         .map_err(|e| StoreError::Incomplete(format!("task query prepare: {e}")))?;
@@ -886,9 +903,9 @@ impl SessionStore for SqliteStore {
                       claude_session_id, final_message_preview, parent_task_id, \
                       pause_count, reprompt_count, approvals_requested, \
                       approvals_approved, approvals_rejected, model, failure_reason, \
-                      final_message, cost_usd) \
+                      final_message, cost_usd, actor_type) \
                      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, \
-                             ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25)",
+                             ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26)",
                     rusqlite::params![
                         run_id_str,
                         record.task_id,
@@ -921,6 +938,7 @@ impl SessionStore for SqliteStore {
                             .and_then(|fr| serde_json::to_string(fr).ok()),
                         record.final_message,
                         record.cost_usd,
+                        record.actor_type.as_deref(),
                     ],
                 )
                 .map_err(|e| StoreError::Incomplete(format!("append_record insert: {e}")))?;
@@ -1207,6 +1225,36 @@ mod sqlite_tests {
         );
         // Second append (Failed) wins since it was an OR REPLACE.
         assert!(matches!(loaded.tasks[0].status, TaskStatus::Failed));
+    }
+
+    #[tokio::test]
+    async fn sqlite_stores_actor_type() {
+        // #252 Phase 1.5: actor_type round-trips via INSERT and SELECT.
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("runs.db");
+        let store = SqliteStore::new(db_path.clone()).unwrap();
+
+        let run_id = Uuid::now_v7();
+        store.init_run(&meta(run_id, dir.path())).await.unwrap();
+
+        let mut typed = rec("worker-typed", TaskStatus::Success);
+        typed.actor_type = Some("writer".into());
+        store.append_record(run_id, &typed).await.unwrap();
+
+        let untyped = rec("worker-untyped", TaskStatus::Success);
+        store.append_record(run_id, &untyped).await.unwrap();
+
+        let back = store.load_run(run_id).await.unwrap();
+        let by_id: std::collections::HashMap<_, _> = back
+            .tasks
+            .iter()
+            .map(|t| (t.task_id.clone(), t.actor_type.clone()))
+            .collect();
+        assert_eq!(
+            by_id.get("worker-typed").unwrap().as_deref(),
+            Some("writer")
+        );
+        assert_eq!(by_id.get("worker-untyped").unwrap().as_deref(), None);
     }
 
     #[tokio::test]

--- a/docs/manifest-map.md
+++ b/docs/manifest-map.md
@@ -14,34 +14,34 @@ The annotated example lives at [`pitboss.example.toml`](../pitboss.example.toml)
 
 ## `[run]` — `RunConfig`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:452`](../crates/pitboss-cli/src/manifest/schema.rs#L452).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:469`](../crates/pitboss-cli/src/manifest/schema.rs#L469).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `name` | text | no | Human-readable label used to group related runs in the console (e.g. "build-db", "nightly-sync"). When unset, the manifest filename is used as fallback. | [`../crates/pitboss-cli/src/manifest/schema.rs#L463`](../crates/pitboss-cli/src/manifest/schema.rs#L463) |
-| `max_parallel_tasks` | integer | no | Flat-mode concurrency cap for [[task]] runs. Default 4. Overridden by ANTHROPIC_MAX_CONCURRENT. | [`../crates/pitboss-cli/src/manifest/schema.rs#L472`](../crates/pitboss-cli/src/manifest/schema.rs#L472) |
-| `halt_on_failure` | boolean | no | Stop remaining flat-mode tasks on first failure. | [`../crates/pitboss-cli/src/manifest/schema.rs#L479`](../crates/pitboss-cli/src/manifest/schema.rs#L479) |
-| `run_dir` | path | no | Where per-run artifacts land. Default ~/.local/share/pitboss/runs. | [`../crates/pitboss-cli/src/manifest/schema.rs#L485`](../crates/pitboss-cli/src/manifest/schema.rs#L485) |
-| `worktree_cleanup` | enum (`always` \| `on_success` \| `never`) | no | What to do with each worker's git worktree after it finishes. | [`../crates/pitboss-cli/src/manifest/schema.rs#L493`](../crates/pitboss-cli/src/manifest/schema.rs#L493) |
-| `emit_event_stream` | boolean | no | Write a JSONL event stream alongside summary.jsonl. | [`../crates/pitboss-cli/src/manifest/schema.rs#L500`](../crates/pitboss-cli/src/manifest/schema.rs#L500) |
-| `default_approval_policy` | enum (`block` \| `auto_approve` \| `auto_reject`) | no | Default action for request_approval / propose_plan when no rule matches. `auto_approve`/`auto_reject` are unconditional; `block` routes to the operator if attached, else queues. | [`../crates/pitboss-cli/src/manifest/schema.rs#L528`](../crates/pitboss-cli/src/manifest/schema.rs#L528) |
-| `denial_termination_policy` | enum (`adapt` \| `reclassify`) | no | How a denied permission_prompt affects the actor's terminal status. `adapt` (default) keeps the actor's exit code as-is; `reclassify` re-labels clean exits within 30s of a denial as ApprovalRejected. | [`../crates/pitboss-cli/src/manifest/schema.rs#L539`](../crates/pitboss-cli/src/manifest/schema.rs#L539) |
-| `dump_shared_store` | boolean | no | Write shared-store.json into the run directory on finalize. | [`../crates/pitboss-cli/src/manifest/schema.rs#L547`](../crates/pitboss-cli/src/manifest/schema.rs#L547) |
-| `require_plan_approval` | boolean | no | When true, spawn_worker is blocked until propose_plan has been approved. | [`../crates/pitboss-cli/src/manifest/schema.rs#L555`](../crates/pitboss-cli/src/manifest/schema.rs#L555) |
-| `require_actor_type` | boolean | no | When true, every spawn_worker and spawn_sublead call must name a declared [[worker_type]]/[[sublead_type]]. Default false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L566`](../crates/pitboss-cli/src/manifest/schema.rs#L566) |
+| `name` | text | no | Human-readable label used to group related runs in the console (e.g. "build-db", "nightly-sync"). When unset, the manifest filename is used as fallback. | [`../crates/pitboss-cli/src/manifest/schema.rs#L480`](../crates/pitboss-cli/src/manifest/schema.rs#L480) |
+| `max_parallel_tasks` | integer | no | Flat-mode concurrency cap for [[task]] runs. Default 4. Overridden by ANTHROPIC_MAX_CONCURRENT. | [`../crates/pitboss-cli/src/manifest/schema.rs#L489`](../crates/pitboss-cli/src/manifest/schema.rs#L489) |
+| `halt_on_failure` | boolean | no | Stop remaining flat-mode tasks on first failure. | [`../crates/pitboss-cli/src/manifest/schema.rs#L496`](../crates/pitboss-cli/src/manifest/schema.rs#L496) |
+| `run_dir` | path | no | Where per-run artifacts land. Default ~/.local/share/pitboss/runs. | [`../crates/pitboss-cli/src/manifest/schema.rs#L502`](../crates/pitboss-cli/src/manifest/schema.rs#L502) |
+| `worktree_cleanup` | enum (`always` \| `on_success` \| `never`) | no | What to do with each worker's git worktree after it finishes. | [`../crates/pitboss-cli/src/manifest/schema.rs#L510`](../crates/pitboss-cli/src/manifest/schema.rs#L510) |
+| `emit_event_stream` | boolean | no | Write a JSONL event stream alongside summary.jsonl. | [`../crates/pitboss-cli/src/manifest/schema.rs#L517`](../crates/pitboss-cli/src/manifest/schema.rs#L517) |
+| `default_approval_policy` | enum (`block` \| `auto_approve` \| `auto_reject`) | no | Default action for request_approval / propose_plan when no rule matches. `auto_approve`/`auto_reject` are unconditional; `block` routes to the operator if attached, else queues. | [`../crates/pitboss-cli/src/manifest/schema.rs#L545`](../crates/pitboss-cli/src/manifest/schema.rs#L545) |
+| `denial_termination_policy` | enum (`adapt` \| `reclassify`) | no | How a denied permission_prompt affects the actor's terminal status. `adapt` (default) keeps the actor's exit code as-is; `reclassify` re-labels clean exits within 30s of a denial as ApprovalRejected. | [`../crates/pitboss-cli/src/manifest/schema.rs#L556`](../crates/pitboss-cli/src/manifest/schema.rs#L556) |
+| `dump_shared_store` | boolean | no | Write shared-store.json into the run directory on finalize. | [`../crates/pitboss-cli/src/manifest/schema.rs#L564`](../crates/pitboss-cli/src/manifest/schema.rs#L564) |
+| `require_plan_approval` | boolean | no | When true, spawn_worker is blocked until propose_plan has been approved. | [`../crates/pitboss-cli/src/manifest/schema.rs#L572`](../crates/pitboss-cli/src/manifest/schema.rs#L572) |
+| `require_actor_type` | boolean | no | When true, every spawn_worker and spawn_sublead call must name a declared [[worker_type]]/[[sublead_type]]. Default false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L583`](../crates/pitboss-cli/src/manifest/schema.rs#L583) |
 
 ## `[defaults]` — `Defaults`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:688`](../crates/pitboss-cli/src/manifest/schema.rs#L688).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:705`](../crates/pitboss-cli/src/manifest/schema.rs#L705).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `model` | text | no | Claude model id (e.g. claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-7). | [`../crates/pitboss-cli/src/manifest/schema.rs#L693`](../crates/pitboss-cli/src/manifest/schema.rs#L693) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Maps to the claude --effort flag. | [`../crates/pitboss-cli/src/manifest/schema.rs#L699`](../crates/pitboss-cli/src/manifest/schema.rs#L699) |
-| `tools` | string list | no | Allowed tool surface. Pitboss auto-appends its MCP tools for leads and workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L704`](../crates/pitboss-cli/src/manifest/schema.rs#L704) |
-| `timeout_secs` | integer | no | Per-task wall-clock cap. No default (no cap). | [`../crates/pitboss-cli/src/manifest/schema.rs#L709`](../crates/pitboss-cli/src/manifest/schema.rs#L709) |
-| `use_worktree` | boolean | no | Isolate each worker in a git worktree. Default true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L714`](../crates/pitboss-cli/src/manifest/schema.rs#L714) |
-| `env` | key-value map | no | Environment variables passed to the claude subprocess. | [`../crates/pitboss-cli/src/manifest/schema.rs#L720`](../crates/pitboss-cli/src/manifest/schema.rs#L720) |
+| `model` | text | no | Claude model id (e.g. claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-7). | [`../crates/pitboss-cli/src/manifest/schema.rs#L710`](../crates/pitboss-cli/src/manifest/schema.rs#L710) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Maps to the claude --effort flag. | [`../crates/pitboss-cli/src/manifest/schema.rs#L716`](../crates/pitboss-cli/src/manifest/schema.rs#L716) |
+| `tools` | string list | no | Allowed tool surface. Pitboss auto-appends its MCP tools for leads and workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L721`](../crates/pitboss-cli/src/manifest/schema.rs#L721) |
+| `timeout_secs` | integer | no | Per-task wall-clock cap. No default (no cap). | [`../crates/pitboss-cli/src/manifest/schema.rs#L726`](../crates/pitboss-cli/src/manifest/schema.rs#L726) |
+| `use_worktree` | boolean | no | Isolate each worker in a git worktree. Default true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L731`](../crates/pitboss-cli/src/manifest/schema.rs#L731) |
+| `env` | key-value map | no | Environment variables passed to the claude subprocess. | [`../crates/pitboss-cli/src/manifest/schema.rs#L737`](../crates/pitboss-cli/src/manifest/schema.rs#L737) |
 
 ## `[container]` — `ContainerConfig`
 
@@ -67,126 +67,127 @@ Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:138`](../crates/pitbos
 
 ## `[[task]]` — `Task`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:751`](../crates/pitboss-cli/src/manifest/schema.rs#L751).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:768`](../crates/pitboss-cli/src/manifest/schema.rs#L768).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique slug. Alphanumeric + _ + -. Used in logs and worktree names. | [`../crates/pitboss-cli/src/manifest/schema.rs#L756`](../crates/pitboss-cli/src/manifest/schema.rs#L756) |
-| `directory` | path | **yes** | Working directory. Must be inside a git repo if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L761`](../crates/pitboss-cli/src/manifest/schema.rs#L761) |
-| `prompt` | text (multi-line) | no | Prompt body sent to claude via -p. Mutually exclusive with `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L767`](../crates/pitboss-cli/src/manifest/schema.rs#L767) |
-| `template` | text | no | Reference to a [[template]] entry. Mutually exclusive with `prompt`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L772`](../crates/pitboss-cli/src/manifest/schema.rs#L772) |
-| `vars` | key-value map | no | Substitutions for {placeholders} when using `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L778`](../crates/pitboss-cli/src/manifest/schema.rs#L778) |
-| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L783`](../crates/pitboss-cli/src/manifest/schema.rs#L783) |
-| `model` | text | no | Per-task override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L785`](../crates/pitboss-cli/src/manifest/schema.rs#L785) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-task override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L791`](../crates/pitboss-cli/src/manifest/schema.rs#L791) |
-| `tools` | string list | no | Per-task override of [defaults].tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L793`](../crates/pitboss-cli/src/manifest/schema.rs#L793) |
-| `timeout_secs` | integer | no | Per-task wall-clock cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L795`](../crates/pitboss-cli/src/manifest/schema.rs#L795) |
-| `use_worktree` | boolean | no | Per-task override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L800`](../crates/pitboss-cli/src/manifest/schema.rs#L800) |
-| `env` | key-value map | no | Per-task env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L806`](../crates/pitboss-cli/src/manifest/schema.rs#L806) |
+| `id` | text | **yes** | Unique slug. Alphanumeric + _ + -. Used in logs and worktree names. | [`../crates/pitboss-cli/src/manifest/schema.rs#L773`](../crates/pitboss-cli/src/manifest/schema.rs#L773) |
+| `directory` | path | **yes** | Working directory. Must be inside a git repo if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L778`](../crates/pitboss-cli/src/manifest/schema.rs#L778) |
+| `prompt` | text (multi-line) | no | Prompt body sent to claude via -p. Mutually exclusive with `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L784`](../crates/pitboss-cli/src/manifest/schema.rs#L784) |
+| `template` | text | no | Reference to a [[template]] entry. Mutually exclusive with `prompt`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L789`](../crates/pitboss-cli/src/manifest/schema.rs#L789) |
+| `vars` | key-value map | no | Substitutions for {placeholders} when using `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L795`](../crates/pitboss-cli/src/manifest/schema.rs#L795) |
+| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L800`](../crates/pitboss-cli/src/manifest/schema.rs#L800) |
+| `model` | text | no | Per-task override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L802`](../crates/pitboss-cli/src/manifest/schema.rs#L802) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-task override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L808`](../crates/pitboss-cli/src/manifest/schema.rs#L808) |
+| `tools` | string list | no | Per-task override of [defaults].tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L810`](../crates/pitboss-cli/src/manifest/schema.rs#L810) |
+| `timeout_secs` | integer | no | Per-task wall-clock cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L812`](../crates/pitboss-cli/src/manifest/schema.rs#L812) |
+| `use_worktree` | boolean | no | Per-task override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L817`](../crates/pitboss-cli/src/manifest/schema.rs#L817) |
+| `env` | key-value map | no | Per-task env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L823`](../crates/pitboss-cli/src/manifest/schema.rs#L823) |
 
 ## `[lead]` — `Lead`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:816`](../crates/pitboss-cli/src/manifest/schema.rs#L816).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:833`](../crates/pitboss-cli/src/manifest/schema.rs#L833).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique slug used as the TUI tile label and in run artifact paths. | [`../crates/pitboss-cli/src/manifest/schema.rs#L823`](../crates/pitboss-cli/src/manifest/schema.rs#L823) |
-| `directory` | path | **yes** | Working directory for the lead's claude subprocess. Must be a git work-tree if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L830`](../crates/pitboss-cli/src/manifest/schema.rs#L830) |
-| `prompt` | text (multi-line) | **yes** | Operator instructions passed to claude via -p. Must appear before any [lead.X] subtable in the source. | [`../crates/pitboss-cli/src/manifest/schema.rs#L842`](../crates/pitboss-cli/src/manifest/schema.rs#L842) |
-| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L850`](../crates/pitboss-cli/src/manifest/schema.rs#L850) |
-| `model` | text | no | Per-lead override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L853`](../crates/pitboss-cli/src/manifest/schema.rs#L853) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-lead override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L860`](../crates/pitboss-cli/src/manifest/schema.rs#L860) |
-| `tools` | string list | no | Per-lead override of [defaults].tools. Pitboss auto-appends its MCP tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L866`](../crates/pitboss-cli/src/manifest/schema.rs#L866) |
-| `timeout_secs` | integer | no | Per-actor subprocess wall-clock cap (claude --timeout). | [`../crates/pitboss-cli/src/manifest/schema.rs#L872`](../crates/pitboss-cli/src/manifest/schema.rs#L872) |
-| `use_worktree` | boolean | no | Per-lead override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L878`](../crates/pitboss-cli/src/manifest/schema.rs#L878) |
-| `env` | key-value map | no | Per-lead env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L884`](../crates/pitboss-cli/src/manifest/schema.rs#L884) |
-| `max_workers` | integer | no | Hard cap on the lead's concurrent + queued worker pool (1–16). Required when the lead spawns workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L893`](../crates/pitboss-cli/src/manifest/schema.rs#L893) |
-| `budget_usd` | float | no | Soft cap on lead spend with reservation accounting. spawn_worker fails once spent + reserved + next_estimate > budget. | [`../crates/pitboss-cli/src/manifest/schema.rs#L902`](../crates/pitboss-cli/src/manifest/schema.rs#L902) |
-| `lead_timeout_secs` | integer | no | Wall-clock cap on the lead session. Default 3600. | [`../crates/pitboss-cli/src/manifest/schema.rs#L911`](../crates/pitboss-cli/src/manifest/schema.rs#L911) |
-| `permission_routing` | enum (`path_a` \| `path_b`) | no | path_a (default) makes pitboss the sole permission authority. path_b routes claude's gate through pitboss (rejected at validate time pending stabilization). | [`../crates/pitboss-cli/src/manifest/schema.rs#L924`](../crates/pitboss-cli/src/manifest/schema.rs#L924) |
-| `allow_subleads` | boolean | no | Expose spawn_sublead to the root lead. | [`../crates/pitboss-cli/src/manifest/schema.rs#L933`](../crates/pitboss-cli/src/manifest/schema.rs#L933) |
-| `max_subleads` | integer | no | Hard cap on total live sub-leads under this root. | [`../crates/pitboss-cli/src/manifest/schema.rs#L940`](../crates/pitboss-cli/src/manifest/schema.rs#L940) |
-| `max_sublead_budget_usd` | float | no | Cap on the per-sub-lead budget envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L947`](../crates/pitboss-cli/src/manifest/schema.rs#L947) |
-| `max_total_workers` | integer | no | Cap on total live workers across the entire tree (root + sub-trees). | [`../crates/pitboss-cli/src/manifest/schema.rs#L955`](../crates/pitboss-cli/src/manifest/schema.rs#L955) |
+| `id` | text | **yes** | Unique slug used as the TUI tile label and in run artifact paths. | [`../crates/pitboss-cli/src/manifest/schema.rs#L840`](../crates/pitboss-cli/src/manifest/schema.rs#L840) |
+| `directory` | path | **yes** | Working directory for the lead's claude subprocess. Must be a git work-tree if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L847`](../crates/pitboss-cli/src/manifest/schema.rs#L847) |
+| `prompt` | text (multi-line) | **yes** | Operator instructions passed to claude via -p. Must appear before any [lead.X] subtable in the source. | [`../crates/pitboss-cli/src/manifest/schema.rs#L859`](../crates/pitboss-cli/src/manifest/schema.rs#L859) |
+| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L867`](../crates/pitboss-cli/src/manifest/schema.rs#L867) |
+| `model` | text | no | Per-lead override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L870`](../crates/pitboss-cli/src/manifest/schema.rs#L870) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-lead override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L877`](../crates/pitboss-cli/src/manifest/schema.rs#L877) |
+| `tools` | string list | no | Per-lead override of [defaults].tools. Pitboss auto-appends its MCP tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L883`](../crates/pitboss-cli/src/manifest/schema.rs#L883) |
+| `timeout_secs` | integer | no | Per-actor subprocess wall-clock cap (claude --timeout). | [`../crates/pitboss-cli/src/manifest/schema.rs#L889`](../crates/pitboss-cli/src/manifest/schema.rs#L889) |
+| `use_worktree` | boolean | no | Per-lead override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L895`](../crates/pitboss-cli/src/manifest/schema.rs#L895) |
+| `env` | key-value map | no | Per-lead env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L901`](../crates/pitboss-cli/src/manifest/schema.rs#L901) |
+| `max_workers` | integer | no | Hard cap on the lead's concurrent + queued worker pool (1–16). Required when the lead spawns workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L910`](../crates/pitboss-cli/src/manifest/schema.rs#L910) |
+| `budget_usd` | float | no | Soft cap on lead spend with reservation accounting. spawn_worker fails once spent + reserved + next_estimate > budget. | [`../crates/pitboss-cli/src/manifest/schema.rs#L919`](../crates/pitboss-cli/src/manifest/schema.rs#L919) |
+| `lead_timeout_secs` | integer | no | Wall-clock cap on the lead session. Default 3600. | [`../crates/pitboss-cli/src/manifest/schema.rs#L928`](../crates/pitboss-cli/src/manifest/schema.rs#L928) |
+| `permission_routing` | enum (`path_a` \| `path_b`) | no | path_a (default) makes pitboss the sole permission authority. path_b routes claude's gate through pitboss (rejected at validate time pending stabilization). | [`../crates/pitboss-cli/src/manifest/schema.rs#L941`](../crates/pitboss-cli/src/manifest/schema.rs#L941) |
+| `allow_subleads` | boolean | no | Expose spawn_sublead to the root lead. | [`../crates/pitboss-cli/src/manifest/schema.rs#L950`](../crates/pitboss-cli/src/manifest/schema.rs#L950) |
+| `max_subleads` | integer | no | Hard cap on total live sub-leads under this root. | [`../crates/pitboss-cli/src/manifest/schema.rs#L957`](../crates/pitboss-cli/src/manifest/schema.rs#L957) |
+| `max_sublead_budget_usd` | float | no | Cap on the per-sub-lead budget envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L964`](../crates/pitboss-cli/src/manifest/schema.rs#L964) |
+| `max_total_workers` | integer | no | Cap on total live workers across the entire tree (root + sub-trees). | [`../crates/pitboss-cli/src/manifest/schema.rs#L972`](../crates/pitboss-cli/src/manifest/schema.rs#L972) |
 
 ## `[sublead_defaults]` — `SubleadDefaults`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:962`](../crates/pitboss-cli/src/manifest/schema.rs#L962).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:979`](../crates/pitboss-cli/src/manifest/schema.rs#L979).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `budget_usd` | float | no | Per-sub-lead envelope when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L967`](../crates/pitboss-cli/src/manifest/schema.rs#L967) |
-| `max_workers` | integer | no | Per-sub-lead worker pool when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L972`](../crates/pitboss-cli/src/manifest/schema.rs#L972) |
-| `lead_timeout_secs` | integer | no | Wall-clock cap for the sub-lead session. | [`../crates/pitboss-cli/src/manifest/schema.rs#L977`](../crates/pitboss-cli/src/manifest/schema.rs#L977) |
-| `read_down` | boolean | no | When true, sub-lead shares root's budget + worker pool instead of carving its own envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L983`](../crates/pitboss-cli/src/manifest/schema.rs#L983) |
+| `budget_usd` | float | no | Per-sub-lead envelope when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L984`](../crates/pitboss-cli/src/manifest/schema.rs#L984) |
+| `max_workers` | integer | no | Per-sub-lead worker pool when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L989`](../crates/pitboss-cli/src/manifest/schema.rs#L989) |
+| `lead_timeout_secs` | integer | no | Wall-clock cap for the sub-lead session. | [`../crates/pitboss-cli/src/manifest/schema.rs#L994`](../crates/pitboss-cli/src/manifest/schema.rs#L994) |
+| `read_down` | boolean | no | When true, sub-lead shares root's budget + worker pool instead of carving its own envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1000`](../crates/pitboss-cli/src/manifest/schema.rs#L1000) |
 
 ## `[[approval_policy]]` — `ApprovalRuleSpec`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:402`](../crates/pitboss-cli/src/manifest/schema.rs#L402).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:419`](../crates/pitboss-cli/src/manifest/schema.rs#L419).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `action` | enum (`auto_approve` \| `auto_reject` \| `block`) | **yes** | Action when this rule matches. | [`../crates/pitboss-cli/src/manifest/schema.rs#L413`](../crates/pitboss-cli/src/manifest/schema.rs#L413) |
+| `action` | enum (`auto_approve` \| `auto_reject` \| `block`) | **yes** | Action when this rule matches. | [`../crates/pitboss-cli/src/manifest/schema.rs#L430`](../crates/pitboss-cli/src/manifest/schema.rs#L430) |
 
 ## `[[mcp_server]]` — `McpServerSpec`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:183`](../crates/pitboss-cli/src/manifest/schema.rs#L183).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:187`](../crates/pitboss-cli/src/manifest/schema.rs#L187).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Key under mcpServers in the generated config. | [`../crates/pitboss-cli/src/manifest/schema.rs#L189`](../crates/pitboss-cli/src/manifest/schema.rs#L189) |
-| `command` | text | **yes** | Executable to launch (e.g. npx, uvx, or an absolute path). | [`../crates/pitboss-cli/src/manifest/schema.rs#L195`](../crates/pitboss-cli/src/manifest/schema.rs#L195) |
-| `args` | string list | no | Arguments passed to the command. | [`../crates/pitboss-cli/src/manifest/schema.rs#L199`](../crates/pitboss-cli/src/manifest/schema.rs#L199) |
-| `env` | key-value map | no | Environment variables injected into the MCP server process. | [`../crates/pitboss-cli/src/manifest/schema.rs#L206`](../crates/pitboss-cli/src/manifest/schema.rs#L206) |
+| `id` | text | **yes** | Key under mcpServers in the generated config. | [`../crates/pitboss-cli/src/manifest/schema.rs#L193`](../crates/pitboss-cli/src/manifest/schema.rs#L193) |
+| `command` | text | **yes** | Executable to launch (e.g. npx, uvx, or an absolute path). | [`../crates/pitboss-cli/src/manifest/schema.rs#L199`](../crates/pitboss-cli/src/manifest/schema.rs#L199) |
+| `args` | string list | no | Arguments passed to the command. | [`../crates/pitboss-cli/src/manifest/schema.rs#L203`](../crates/pitboss-cli/src/manifest/schema.rs#L203) |
+| `env` | key-value map | no | Environment variables injected into the MCP server process. | [`../crates/pitboss-cli/src/manifest/schema.rs#L210`](../crates/pitboss-cli/src/manifest/schema.rs#L210) |
+| `scope` | text | no | Optional injection scope. Form: "type:<id>" — narrows this server to actors spawned under that worker_type/sublead_type. Unset = inject into all actors. | [`../crates/pitboss-cli/src/manifest/schema.rs#L223`](../crates/pitboss-cli/src/manifest/schema.rs#L223) |
 
 ## `[[worker_type]]` — `WorkerType`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:609`](../crates/pitboss-cli/src/manifest/schema.rs#L609).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:626`](../crates/pitboss-cli/src/manifest/schema.rs#L626).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique id used in spawn_worker(worker_type = "<id>"). Match: ^[A-Za-z0-9_-]+$. | [`../crates/pitboss-cli/src/manifest/schema.rs#L616`](../crates/pitboss-cli/src/manifest/schema.rs#L616) |
-| `tools` | string list | no | Allowed tool surface for this worker class. Lead's spawn_worker(tools=...) must be a subset; omit means "give me the whole allowlist." | [`../crates/pitboss-cli/src/manifest/schema.rs#L624`](../crates/pitboss-cli/src/manifest/schema.rs#L624) |
-| `allowed_models` | string list | no | When non-empty, spawn_worker(model=...) must be in this list. Empty means any model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L632`](../crates/pitboss-cli/src/manifest/schema.rs#L632) |
-| `max_timeout_secs` | integer | no | Hard cap on spawn_worker(timeout_secs=...). Lead values clamp DOWN; smaller values pass through. | [`../crates/pitboss-cli/src/manifest/schema.rs#L640`](../crates/pitboss-cli/src/manifest/schema.rs#L640) |
+| `id` | text | **yes** | Unique id used in spawn_worker(worker_type = "<id>"). Match: ^[A-Za-z0-9_-]+$. | [`../crates/pitboss-cli/src/manifest/schema.rs#L633`](../crates/pitboss-cli/src/manifest/schema.rs#L633) |
+| `tools` | string list | no | Allowed tool surface for this worker class. Lead's spawn_worker(tools=...) must be a subset; omit means "give me the whole allowlist." | [`../crates/pitboss-cli/src/manifest/schema.rs#L641`](../crates/pitboss-cli/src/manifest/schema.rs#L641) |
+| `allowed_models` | string list | no | When non-empty, spawn_worker(model=...) must be in this list. Empty means any model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L649`](../crates/pitboss-cli/src/manifest/schema.rs#L649) |
+| `max_timeout_secs` | integer | no | Hard cap on spawn_worker(timeout_secs=...). Lead values clamp DOWN; smaller values pass through. | [`../crates/pitboss-cli/src/manifest/schema.rs#L657`](../crates/pitboss-cli/src/manifest/schema.rs#L657) |
 
 ## `[[sublead_type]]` — `SubleadType`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:648`](../crates/pitboss-cli/src/manifest/schema.rs#L648).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:665`](../crates/pitboss-cli/src/manifest/schema.rs#L665).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique id used in spawn_sublead(sublead_type = "<id>"). Match: ^[A-Za-z0-9_-]+$. | [`../crates/pitboss-cli/src/manifest/schema.rs#L655`](../crates/pitboss-cli/src/manifest/schema.rs#L655) |
-| `tools` | string list | no | Allowed tool surface for this sub-lead class. spawn_sublead(tools=...) must be a subset; empty means "give me the whole allowlist." | [`../crates/pitboss-cli/src/manifest/schema.rs#L662`](../crates/pitboss-cli/src/manifest/schema.rs#L662) |
-| `allowed_models` | string list | no | When non-empty, spawn_sublead(model=...) must be in this list. | [`../crates/pitboss-cli/src/manifest/schema.rs#L669`](../crates/pitboss-cli/src/manifest/schema.rs#L669) |
-| `max_timeout_secs` | integer | no | Hard cap on spawn_sublead(lead_timeout_secs=...). Clamps DOWN. | [`../crates/pitboss-cli/src/manifest/schema.rs#L676`](../crates/pitboss-cli/src/manifest/schema.rs#L676) |
-| `max_budget_usd` | float | no | Hard cap on spawn_sublead(budget_usd=...). Clamps DOWN. | [`../crates/pitboss-cli/src/manifest/schema.rs#L683`](../crates/pitboss-cli/src/manifest/schema.rs#L683) |
+| `id` | text | **yes** | Unique id used in spawn_sublead(sublead_type = "<id>"). Match: ^[A-Za-z0-9_-]+$. | [`../crates/pitboss-cli/src/manifest/schema.rs#L672`](../crates/pitboss-cli/src/manifest/schema.rs#L672) |
+| `tools` | string list | no | Allowed tool surface for this sub-lead class. spawn_sublead(tools=...) must be a subset; empty means "give me the whole allowlist." | [`../crates/pitboss-cli/src/manifest/schema.rs#L679`](../crates/pitboss-cli/src/manifest/schema.rs#L679) |
+| `allowed_models` | string list | no | When non-empty, spawn_sublead(model=...) must be in this list. | [`../crates/pitboss-cli/src/manifest/schema.rs#L686`](../crates/pitboss-cli/src/manifest/schema.rs#L686) |
+| `max_timeout_secs` | integer | no | Hard cap on spawn_sublead(lead_timeout_secs=...). Clamps DOWN. | [`../crates/pitboss-cli/src/manifest/schema.rs#L693`](../crates/pitboss-cli/src/manifest/schema.rs#L693) |
+| `max_budget_usd` | float | no | Hard cap on spawn_sublead(budget_usd=...). Clamps DOWN. | [`../crates/pitboss-cli/src/manifest/schema.rs#L700`](../crates/pitboss-cli/src/manifest/schema.rs#L700) |
 
 ## `[communication]` — `CommunicationConfig`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:243`](../crates/pitboss-cli/src/manifest/schema.rs#L243).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:260`](../crates/pitboss-cli/src/manifest/schema.rs#L260).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `mode` | enum (`disabled` \| `parent_child`) | no | Actor communication policy mode. "disabled" hides the message_* and artifact_* tools (conservative default). "parent_child" enables them with parent/sublead/worker authz. | [`../crates/pitboss-cli/src/manifest/schema.rs#L250`](../crates/pitboss-cli/src/manifest/schema.rs#L250) |
-| `max_message_bytes` | integer | no | Maximum UTF-8 body size accepted by message_send. | [`../crates/pitboss-cli/src/manifest/schema.rs#L256`](../crates/pitboss-cli/src/manifest/schema.rs#L256) |
-| `max_artifact_bytes` | integer | no | Maximum decoded artifact payload size accepted by artifact_put. | [`../crates/pitboss-cli/src/manifest/schema.rs#L262`](../crates/pitboss-cli/src/manifest/schema.rs#L262) |
-| `max_artifacts_per_actor` | integer | no | Maximum artifacts one actor may publish in a single run. | [`../crates/pitboss-cli/src/manifest/schema.rs#L268`](../crates/pitboss-cli/src/manifest/schema.rs#L268) |
+| `mode` | enum (`disabled` \| `parent_child`) | no | Actor communication policy mode. "disabled" hides the message_* and artifact_* tools (conservative default). "parent_child" enables them with parent/sublead/worker authz. | [`../crates/pitboss-cli/src/manifest/schema.rs#L267`](../crates/pitboss-cli/src/manifest/schema.rs#L267) |
+| `max_message_bytes` | integer | no | Maximum UTF-8 body size accepted by message_send. | [`../crates/pitboss-cli/src/manifest/schema.rs#L273`](../crates/pitboss-cli/src/manifest/schema.rs#L273) |
+| `max_artifact_bytes` | integer | no | Maximum decoded artifact payload size accepted by artifact_put. | [`../crates/pitboss-cli/src/manifest/schema.rs#L279`](../crates/pitboss-cli/src/manifest/schema.rs#L279) |
+| `max_artifacts_per_actor` | integer | no | Maximum artifacts one actor may publish in a single run. | [`../crates/pitboss-cli/src/manifest/schema.rs#L285`](../crates/pitboss-cli/src/manifest/schema.rs#L285) |
 
 ## `[[template]]` — `Template`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:735`](../crates/pitboss-cli/src/manifest/schema.rs#L735).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:752`](../crates/pitboss-cli/src/manifest/schema.rs#L752).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Slug referenced from [[task]].template. | [`../crates/pitboss-cli/src/manifest/schema.rs#L740`](../crates/pitboss-cli/src/manifest/schema.rs#L740) |
-| `prompt` | text (multi-line) | **yes** | Prompt body. Supports {var} placeholders supplied by [[task]].vars. | [`../crates/pitboss-cli/src/manifest/schema.rs#L746`](../crates/pitboss-cli/src/manifest/schema.rs#L746) |
+| `id` | text | **yes** | Slug referenced from [[task]].template. | [`../crates/pitboss-cli/src/manifest/schema.rs#L757`](../crates/pitboss-cli/src/manifest/schema.rs#L757) |
+| `prompt` | text (multi-line) | **yes** | Prompt body. Supports {var} placeholders supplied by [[task]].vars. | [`../crates/pitboss-cli/src/manifest/schema.rs#L763`](../crates/pitboss-cli/src/manifest/schema.rs#L763) |
 
 ## `[lifecycle]` — `Lifecycle`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:379`](../crates/pitboss-cli/src/manifest/schema.rs#L379).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:396`](../crates/pitboss-cli/src/manifest/schema.rs#L396).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `survive_parent` | boolean | no | Allow this dispatch to outlive its parent process. Requires a notify target. | [`../crates/pitboss-cli/src/manifest/schema.rs#L390`](../crates/pitboss-cli/src/manifest/schema.rs#L390) |
+| `survive_parent` | boolean | no | Allow this dispatch to outlive its parent process. Requires a notify target. | [`../crates/pitboss-cli/src/manifest/schema.rs#L407`](../crates/pitboss-cli/src/manifest/schema.rs#L407) |
 

--- a/docs/manifest-reference.toml
+++ b/docs/manifest-reference.toml
@@ -105,6 +105,7 @@ id = "<value>"
 command = "<value>"
 args = []
 env = { EXAMPLE_KEY = "value" }
+scope = "<value>"
 
 [[worker_type]]
 id = "<value>"


### PR DESCRIPTION
## Summary

Phase 1.5 of #252 — three coupled pieces:

- **`[[mcp_server]].scope = "type:<id>"`**: narrows server injection to actors spawned under a matching `[[worker_type]]` / `[[sublead_type]]`. Filter lives in `build_mcp_servers_json` so all three writers (lead, worker, sublead) honor it consistently. Untyped actors never receive scoped servers; root lead is never typed and documented at the call site.
- **Resume preservation of `actor_type`**: `worker_actor_types` map on `LayerState` mirrors `worker_models`; populated at `handle_spawn_worker`, read in `spawn_resume_worker` to rebuild the scoped mcp-config + attach the type to the resumed `TaskRecord`. Cancel-synth at `hierarchical.rs:633` now reads the same map so synthesized cancellations keep attribution.
- **SQLite migration v10** adds `actor_type` to `task_records`. SQLite backend now at parity with `JsonFileStore` (which already round-tripped via serde).

Validate-time check (`validate_mcp_server_scopes`) rejects malformed scope (`role:lead`, `type:`, unknown id) — a typo would otherwise silently strip the server from every typed actor.

## Test plan

- [x] `cargo test --workspace --features pitboss-core/test-support` — 720+ tests, all pass
- [x] `cargo lint` — clean
- [x] `cargo tidy` — clean
- [x] New unit tests:
  - [x] `mcp_scope_tests::scope_admits_helper_matrix` (5 cases incl. malformed)
  - [x] `mcp_scope_tests::build_mcp_servers_json_excludes_scoped_for_untyped_actor`
  - [x] `mcp_scope_tests::build_mcp_servers_json_includes_scoped_for_matching_actor`
  - [x] `mcp_scope_tests::build_mcp_servers_json_excludes_scoped_for_other_typed_actor`
  - [x] 6 validator tests (rejects unknown prefix / empty id / unknown id; accepts worker_type / sublead_type / unscoped)
  - [x] `sqlite_stores_actor_type` round-trip (typed + untyped record)
- [x] AGENTS.md `[[mcp_server]]` table includes `scope` row; Phase 1.5 limitations section flipped to "landed"
- [x] `docs/manifest-reference.toml` + `docs/manifest-map.md` regenerated via `pitboss schema`

## Follow-ups (not in scope)

- `pitboss validate` (actor-type → MCP servers) capability matrix output (issue body's last unchecked box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)