### PR TITLE
feat(tui): surface Path-B tool-denial counter on each actor tile

### DIFF
--- a/crates/pitboss-tui/src/grouped_grid.rs
+++ b/crates/pitboss-tui/src/grouped_grid.rs
@@ -79,6 +79,7 @@ mod tests {
             parent_task_id: None,
             worktree_path: None,
             completed_at: None,
+            denials_count: 0,
         }
     }
 

--- a/crates/pitboss-tui/src/main.rs
+++ b/crates/pitboss-tui/src/main.rs
@@ -224,6 +224,7 @@ fn cmd_screenshot(run: Option<&str>, cols: u16, rows: u16) -> Result<()> {
 }
 
 /// Same shape as `watcher::build_snapshot` but synchronous and self-contained.
+#[allow(clippy::too_many_lines)] // mirror of watcher::build_snapshot; two fns share the schema
 fn build_one_shot_snapshot(run_dir: &std::path::Path) -> state::AppSnapshot {
     use pitboss_core::store::{TaskRecord, TaskStatus};
     use pitboss_tui::state::{AppSnapshot, TileState, TileStatus};
@@ -306,6 +307,7 @@ fn build_one_shot_snapshot(run_dir: &std::path::Path) -> state::AppSnapshot {
                 parent_task_id: rec.parent_task_id.clone(),
                 worktree_path: rec.worktree_path.clone(),
                 completed_at: Some(rec.ended_at),
+                denials_count: 0,
             });
         } else {
             tiles.push(TileState {
@@ -322,6 +324,7 @@ fn build_one_shot_snapshot(run_dir: &std::path::Path) -> state::AppSnapshot {
                 parent_task_id: None,
                 worktree_path: None,
                 completed_at: None,
+                denials_count: 0,
             });
         }
     }

--- a/crates/pitboss-tui/src/state.rs
+++ b/crates/pitboss-tui/src/state.rs
@@ -213,6 +213,12 @@ pub struct TileState {
     /// Used by `is_promoted` to decide when to move the tile to the Completed
     /// page.
     pub completed_at: Option<DateTime<Utc>>,
+    /// Count of `tool_denied` rows in this actor's `events.jsonl`. Surfaced
+    /// on the tile so an operator running under Path B sees the denial
+    /// volume at a glance — every row is a `permission_prompt` deny that
+    /// claude received and adapted to (#370). Read-side aggregation only;
+    /// the canonical per-row data lives in `events.jsonl`.
+    pub denials_count: u32,
 }
 
 /// Full application state updated each poll cycle.
@@ -1216,6 +1222,7 @@ mod tests {
             parent_task_id: None,
             worktree_path: None,
             completed_at: None,
+            denials_count: 0,
         }];
         state
     }
@@ -1773,6 +1780,7 @@ mod tests {
             parent_task_id: None,
             worktree_path: None,
             completed_at: Some(Utc::now() - chrono::Duration::seconds(ended_secs_ago)),
+            denials_count: 0,
         }
     }
 
@@ -1807,6 +1815,7 @@ mod tests {
             parent_task_id: None,
             worktree_path: None,
             completed_at: None, // running tiles never have completed_at
+            denials_count: 0,
         };
         assert!(!state.is_promoted(&tile));
     }
@@ -1831,6 +1840,7 @@ mod tests {
                 parent_task_id: None,
                 worktree_path: None,
                 completed_at: None,
+                denials_count: 0,
             },
             make_done_tile("fresh", 2), // done but within grace period
         ];
@@ -1889,6 +1899,7 @@ mod tests {
             parent_task_id: None,
             worktree_path: None,
             completed_at: None,
+            denials_count: 0,
         }
     }
 

--- a/crates/pitboss-tui/src/theme.rs
+++ b/crates/pitboss-tui/src/theme.rs
@@ -64,6 +64,13 @@ pub fn primary_style() -> Style {
     Style::default().fg(TEXT_PRIMARY)
 }
 
+/// Style for "something was blocked" annotations — Path-B denial counters
+/// and similar operator-attention strings. Reuses the failure red so the
+/// signal is visually consistent with `STATUS_FAILED` tiles.
+pub fn danger_style() -> Style {
+    Style::default().fg(STATUS_FAILED)
+}
+
 pub fn focused_border() -> Style {
     Style::default()
         .fg(BORDER_FOCUSED)

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -1220,6 +1220,17 @@ fn render_tile(frame: &mut Frame, area: Rect, state: &AppState, tile_idx: usize,
     if let Some(line) = activity_line {
         lines.push(line);
     }
+    // Path-B denial counter. Same conditional discipline as the activity
+    // line — only render when non-zero so quiet runs don't spend a row on
+    // a `denied: 0` line. Painted in the danger color so the operator's
+    // eye lands on it; per-row detail still lives in
+    // `<run_dir>/tasks/<id>/events.jsonl`.
+    if tile.denials_count > 0 {
+        lines.push(Line::from(Span::styled(
+            format!("denied: {}", tile.denials_count),
+            theme::danger_style(),
+        )));
+    }
 
     let para = Paragraph::new(lines).wrap(Wrap { trim: false });
     frame.render_widget(para, inner);
@@ -1265,18 +1276,29 @@ fn render_tile_compact(
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    // Two content lines: status + tokens.
+    // Two content lines: status + tokens. The compact tile only has two
+    // rows, so the denial counter (when present) is appended inline to
+    // the status line as a separate styled span instead of consuming a
+    // whole row.
     let tokens = format!(
         "{}↑ {}↓",
         fmt_tokens(tile.token_usage_input),
         fmt_tokens(tile.token_usage_output)
     );
+    let mut status_spans = vec![
+        Span::styled(icon, Style::default().fg(icon_color)),
+        Span::raw(" "),
+        Span::styled(status_label, Style::default().fg(icon_color)),
+    ];
+    if tile.denials_count > 0 {
+        status_spans.push(Span::raw(" "));
+        status_spans.push(Span::styled(
+            format!("⊘{}", tile.denials_count),
+            theme::danger_style(),
+        ));
+    }
     let lines = vec![
-        Line::from(vec![
-            Span::styled(icon, Style::default().fg(icon_color)),
-            Span::raw(" "),
-            Span::styled(status_label, Style::default().fg(icon_color)),
-        ]),
+        Line::from(status_spans),
         Line::from(Span::styled(tokens, theme::muted_style())),
     ];
     frame.render_widget(Paragraph::new(lines), inner);
@@ -2323,6 +2345,7 @@ mod tests {
             parent_task_id: None,
             worktree_path: None,
             completed_at: None,
+            denials_count: 0,
         }
     }
 
@@ -2732,6 +2755,62 @@ mod tests {
         assert!(
             rendered.contains("msg:5 art:1"),
             "tile should render comm counters; got snippet: {:?}",
+            &rendered[..rendered.len().min(400)]
+        );
+    }
+
+    /// Path-B denial counter must surface on the full tile when non-zero.
+    /// The label is intentionally stable (`"denied: <N>"`) — review tooling
+    /// and operators may grep buffer dumps for it.
+    #[test]
+    fn render_tile_shows_denials_counter_when_positive() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let mut s = state(vec![tile("worker-deny", TileStatus::Running, None, 0, 0)]);
+        s.tasks[0].denials_count = 4;
+
+        let backend = TestBackend::new(120, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|frame| render(frame, &s)).unwrap();
+
+        let buf = terminal.backend().buffer();
+        let rendered: String = (0..30)
+            .flat_map(|y| (0..120u16).map(move |x| (x, y)))
+            .map(|(x, y)| buf.cell((x, y)).unwrap().symbol().to_string())
+            .collect();
+
+        assert!(
+            rendered.contains("denied: 4"),
+            "tile should render denial counter; got snippet: {:?}",
+            &rendered[..rendered.len().min(400)]
+        );
+    }
+
+    /// Symmetric to the comm-counters case: zero denials must NOT spend
+    /// a row on a `denied: 0` line — the conditional render is the
+    /// difference between a clean tile and one full of zero-stat noise.
+    #[test]
+    fn render_tile_omits_denials_counter_when_zero() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let s = state(vec![tile("worker-quiet", TileStatus::Running, None, 0, 0)]);
+        // denials_count defaults to 0 via `tile()`.
+
+        let backend = TestBackend::new(120, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|frame| render(frame, &s)).unwrap();
+
+        let buf = terminal.backend().buffer();
+        let rendered: String = (0..30)
+            .flat_map(|y| (0..120u16).map(move |x| (x, y)))
+            .map(|(x, y)| buf.cell((x, y)).unwrap().symbol().to_string())
+            .collect();
+
+        assert!(
+            !rendered.contains("denied:"),
+            "tile rendered a stray denial line for a quiet actor; got snippet: {:?}",
             &rendered[..rendered.len().min(400)]
         );
     }

--- a/crates/pitboss-tui/src/watcher.rs
+++ b/crates/pitboss-tui/src/watcher.rs
@@ -155,6 +155,8 @@ fn build_snapshot(run_dir: &Path, focused_id: Option<&str>) -> AppSnapshot {
 
     for id in &all_ids {
         let log_path = tasks_dir.join(id).join("stdout.log");
+        let events_path = tasks_dir.join(id).join("events.jsonl");
+        let denials_count = count_tool_denials(&events_path);
         let model = model_map.get(id).and_then(Option::clone);
         let is_dynamic = dynamic_ids.iter().any(|d| d == id);
         let tile = build_tile(
@@ -164,6 +166,7 @@ fn build_snapshot(run_dir: &Path, focused_id: Option<&str>) -> AppSnapshot {
             is_dynamic,
             completed.get(id),
             parent_task_id_fallback.as_deref(),
+            denials_count,
             &mut failed_count,
             &mut run_started_at,
         );
@@ -268,6 +271,7 @@ fn build_tile(
     is_dynamic: bool,
     rec: Option<&TaskRecord>,
     parent_task_id_fallback: Option<&str>,
+    denials_count: u32,
     failed_count: &mut usize,
     run_started_at: &mut Option<chrono::DateTime<chrono::Utc>>,
 ) -> TileState {
@@ -313,6 +317,7 @@ fn build_tile(
                 .clone()
                 .or_else(|| log_path.parent().and_then(read_worktree_sidecar)),
             completed_at: Some(rec.ended_at),
+            denials_count,
         }
     } else {
         // Decide between Pending and Running by checking log freshness.
@@ -355,8 +360,41 @@ fn build_tile(
                 None
             },
             completed_at: None,
+            denials_count,
         }
     }
+}
+
+/// Count `tool_denied` rows in a per-actor `events.jsonl`. Cheap O(file)
+/// scan: lines parse as `serde_json::Value` and we discriminate on
+/// `kind == "tool_denied"`. The file is tiny vs `stdout.log` (one line
+/// per Path-B deny), so reparsing on every poll tick is negligible.
+///
+/// Decoupling from the canonical `TaskEvent` enum (defined in
+/// `pitboss-cli`) keeps `pitboss-tui` from taking a cli-crate dependency
+/// just to read its own jsonl. The `kind` field name is the stable wire
+/// contract that the `#[serde(tag = "kind", rename_all = "snake_case")]`
+/// derive on `TaskEvent` produces — see
+/// `crates/pitboss-cli/src/dispatch/events.rs`.
+fn count_tool_denials(events_jsonl: &Path) -> u32 {
+    let Ok(file) = std::fs::File::open(events_jsonl) else {
+        return 0;
+    };
+    let reader = BufReader::new(file);
+    let mut count: u32 = 0;
+    for line in reader.lines().map_while(Result::ok) {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Ok(val) = serde_json::from_str::<serde_json::Value>(trimmed) else {
+            continue;
+        };
+        if val.get("kind").and_then(|v| v.as_str()) == Some("tool_denied") {
+            count = count.saturating_add(1);
+        }
+    }
+    count
 }
 
 /// Read the `worktree.path` sidecar file written at spawn time.
@@ -1080,5 +1118,97 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let out = tail_log(&dir.path().join("does-not-exist.log"), 40);
         assert!(out.is_empty());
+    }
+
+    /// `count_tool_denials` must count only `kind == "tool_denied"` rows
+    /// while ignoring other event variants in the same `events.jsonl`
+    /// (e.g. `pause`, `approval_response`). The discriminant is the
+    /// stable wire contract — see `TaskEvent` in
+    /// `crates/pitboss-cli/src/dispatch/events.rs`.
+    #[test]
+    fn count_tool_denials_counts_only_tool_denied_rows() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("events.jsonl");
+        let lines = [
+            r#"{"kind":"pause","at":"2026-05-07T00:00:00Z"}"#,
+            r#"{"kind":"tool_denied","at":"2026-05-07T00:00:01Z","tool_name":"Bash","actor_id":"w-1","reason_kind":"denied_by_rule","reason":"denied: tool 'Bash' rejected by [[approval_policy]] rule"}"#,
+            r#"{"kind":"approval_response","at":"2026-05-07T00:00:02Z","request_id":"r1","approved":true,"edited":false}"#,
+            r#"{"kind":"tool_denied","at":"2026-05-07T00:00:03Z","tool_name":"Write","actor_id":"w-1","reason_kind":"operator_rejected","reason":"denied: tool 'Write' rejected by operator"}"#,
+            r#"{"kind":"tool_denied","at":"2026-05-07T00:00:04Z","tool_name":"Edit","actor_id":"w-1","reason_kind":"ttl_expired","reason":"denied: tool 'Edit' approval timed out before operator response"}"#,
+        ];
+        let body = lines.join("\n");
+        std::fs::write(&path, body).unwrap();
+
+        assert_eq!(count_tool_denials(&path), 3);
+    }
+
+    /// Missing `events.jsonl` (the common quiet-actor case) and malformed
+    /// rows (truncated mid-write, partial flush) must both yield 0 rather
+    /// than panic — the watcher polls every 250ms and any I/O error here
+    /// would freeze the snapshot pipeline.
+    #[test]
+    fn count_tool_denials_handles_missing_and_malformed() {
+        let dir = tempfile::TempDir::new().unwrap();
+        // Missing file — quiet actor case.
+        assert_eq!(count_tool_denials(&dir.path().join("nope.jsonl")), 0);
+
+        // Malformed lines next to one valid denied row.
+        let path = dir.path().join("events.jsonl");
+        let body = [
+            "not-json-at-all",
+            "",
+            r#"{"kind":"tool_denied","at":"2026-05-07T00:00:00Z","tool_name":"Bash","actor_id":"w-1","reason_kind":"denied_by_policy","reason":"x"}"#,
+            r#"{"kind":""#,
+        ]
+        .join("\n");
+        std::fs::write(&path, body).unwrap();
+        assert_eq!(count_tool_denials(&path), 1);
+    }
+
+    /// End-to-end: a dynamic worker with three `tool_denied` rows in its
+    /// `events.jsonl` must surface as `denials_count = 3` on its tile so
+    /// the TUI render path picks it up.
+    #[test]
+    fn build_snapshot_populates_denials_count_per_actor() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let run_dir = dir.path().to_path_buf();
+
+        let resolved = serde_json::json!({
+            "max_parallel": 4,
+            "halt_on_failure": false,
+            "run_dir": run_dir.to_str(),
+            "worktree_cleanup": "OnSuccess",
+            "emit_event_stream": false,
+            "tasks": [],
+            "lead": {"id": "lead", "model": "claude-haiku-4-5"},
+            "max_workers": 4,
+            "budget_usd": 5.0,
+            "lead_timeout_secs": 900
+        });
+        std::fs::write(
+            run_dir.join("resolved.json"),
+            serde_json::to_vec(&resolved).unwrap(),
+        )
+        .unwrap();
+
+        // Live worker subdir (no summary record yet) with two denials.
+        let worker_dir = run_dir.join("tasks").join("worker-noisy");
+        std::fs::create_dir_all(&worker_dir).unwrap();
+        std::fs::write(
+            worker_dir.join("events.jsonl"),
+            [
+                r#"{"kind":"tool_denied","at":"2026-05-07T00:00:00Z","tool_name":"Bash","actor_id":"worker-noisy","reason_kind":"denied_by_rule","reason":"x"}"#,
+                r#"{"kind":"tool_denied","at":"2026-05-07T00:00:01Z","tool_name":"Write","actor_id":"worker-noisy","reason_kind":"denied_by_rule","reason":"x"}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        // Lead has no events.jsonl — must default to 0 denials.
+        let snap = build_snapshot(&run_dir, None);
+        let lead_tile = snap.tasks.iter().find(|t| t.id == "lead").unwrap();
+        let worker_tile = snap.tasks.iter().find(|t| t.id == "worker-noisy").unwrap();
+        assert_eq!(lead_tile.denials_count, 0);
+        assert_eq!(worker_tile.denials_count, 2);
     }
 }

--- a/crates/pitboss-tui/tests/tui_control.rs
+++ b/crates/pitboss-tui/tests/tui_control.rs
@@ -175,6 +175,7 @@ fn empty_grid_cells_are_cleared() {
             parent_task_id: None,
             worktree_path: None,
             completed_at: None,
+            denials_count: 0,
         }
     }
 
@@ -242,6 +243,7 @@ fn focus_log_content_does_not_bleed_into_tile_grid() {
             parent_task_id: None,
             worktree_path: None,
             completed_at: None,
+            denials_count: 0,
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds a per-actor \`denials_count\` to \`TileState\`, populated by the watcher on every poll tick from \`<run_dir>/tasks/<actor>/events.jsonl\`.
- Renders \`denied: N\` (failure-red) on the full tile when N > 0, mirroring the existing conditional-render discipline of the activity-counter line.
- Renders an inline \`⊘N\` span on the dense (compact) tile so it surfaces in the \`v\`-toggled grid without crowding out tokens.

## Why

Pitboss already writes \`TaskEvent::ToolDenied\` rows to \`events.jsonl\` on every Path-B \`permission_prompt\` deny (#370 item 4 unified the reason-kind enum). \`pitboss status\` now surfaces aggregate approvals (#386), but the live TUI was silent on Path-B activity. With the counter on tile, an operator running a Path-B lead sees denial volume at a glance and can drop into \`events.jsonl\` for the per-row breakdown by \`DeniedReasonKind\`.

## Design notes

- **Why a discriminant-string parse instead of \`serde_derive\` deserializing \`TaskEvent\`?** \`TaskEvent\` lives in \`pitboss-cli\`; making \`pitboss-tui\` deserialize it would mean a cli-crate dependency just to read a jsonl file the TUI already understands the layout of. The \`kind\` tag is the stable wire contract (documented on \`TaskEvent\` itself and in AGENTS.md), so a cheap \`serde_json::Value\` lookup is the right tool.
- **Decoupling from #252:** This slice is read-side only — no profile machinery, no default-flip. It works under any \`permission_routing\` (Path A's \`request_approval\` denials don't write \`tool_denied\` rows, so the counter stays at 0 for Path-A runs).

## Test plan

- [x] \`cargo test -p pitboss-tui\` — 124 lib + 7 integration + 1 doc, all pass
- [x] 5 new tests:
  - \`count_tool_denials_counts_only_tool_denied_rows\` — discriminant filter (mixed event kinds)
  - \`count_tool_denials_handles_missing_and_malformed\` — robustness: missing file + bad JSON lines
  - \`build_snapshot_populates_denials_count_per_actor\` — end-to-end via \`build_snapshot\`
  - \`render_tile_shows_denials_counter_when_positive\` — render scrape asserts \`denied: 4\`
  - \`render_tile_omits_denials_counter_when_zero\` — quiet-actor case
- [x] \`cargo lint\` — clean
- [x] \`cargo tidy\` — clean

## Follow-ups parked

- Per-\`DeniedReasonKind\` breakdown (pie chart of \`denied_by_rule\` / \`denied_by_policy\` / \`operator_rejected\` / \`ttl_expired\`) — natural when the tile expands into a Detail view.
- Default flip from \`PathA\` → \`PathB\` — still blocked on #252 full profile machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)