### PR TITLE
feat(validate): nudge Path-B operators toward typed profiles (#252)

### DIFF
--- a/crates/pitboss-cli/src/cli.rs
+++ b/crates/pitboss-cli/src/cli.rs
@@ -409,6 +409,12 @@ pub enum SchemaFormat {
     Map,
     /// Complete reference TOML — every field present as `key = placeholder`.
     Example,
+    /// Starter `[[worker_type]]` / `[[sublead_type]]` profile scaffold
+    /// for operators migrating onto Path B's typed-profile auto-approve
+    /// (#252). Emits a copy-paste TOML block with explanatory comments;
+    /// the operator customizes `tools`, `allowed_models`, and the
+    /// numeric caps to fit their run.
+    Migration,
 }
 
 /// Starter templates supported by `pitboss init`.

--- a/crates/pitboss-cli/src/main.rs
+++ b/crates/pitboss-cli/src/main.rs
@@ -242,6 +242,7 @@ fn run_schema(format: cli::SchemaFormat, check: Option<&std::path::Path>) -> i32
     let (generated, format_flag) = match format {
         cli::SchemaFormat::Map => (crate::manifest::map_doc::render(), "map"),
         cli::SchemaFormat::Example => (crate::manifest::example_doc::render(), "example"),
+        cli::SchemaFormat::Migration => (crate::manifest::migration_doc::render(), "migration"),
     };
     match check {
         None => {

--- a/crates/pitboss-cli/src/manifest/migration_doc.rs
+++ b/crates/pitboss-cli/src/manifest/migration_doc.rs
@@ -1,0 +1,117 @@
+//! Starter `[[worker_type]]` / `[[sublead_type]]` profile scaffold for
+//! `pitboss schema --format=migration` (#252). Operators selecting Path B
+//! without any profiles see a validate-time warning pointing them here;
+//! the output is a hand-editable TOML block with comments explaining
+//! each field's role.
+//!
+//! The output is deliberately STATIC — derived from neither the
+//! manifest under inspection nor any past `summary.jsonl`. A v2 could
+//! read the live manifest's `[lead].tools` cascade and produce a
+//! tailored scaffold; for now the static form is enough to give
+//! operators a copy-paste starting point with the right field names
+//! and a working example of every cap.
+
+/// Render the migration scaffold. Pure function — same output every
+/// call. The leading hash-banner names the command that produced it
+/// so a `--check`-style drift test (if added later) can ignore the
+/// header line; the trailing newline matches the `--format=example`
+/// convention.
+pub fn render() -> String {
+    String::from(
+        r#"# pitboss schema --format=migration
+#
+# Starter [[worker_type]] / [[sublead_type]] profiles. Drop these
+# blocks into your manifest to declare per-class capability caps that
+# pitboss enforces at spawn time AND auto-approves under Path B
+# (#252).
+#
+# How profiles compose with permission_routing:
+#
+#   [[approval_policy]] rules first  (operator override, cross-cutting)
+#   profile.tools allowlist          (this section — the manifest is
+#                                      the consent signal: tools in
+#                                      the list ⇒ auto-approve, tools
+#                                      not in the list ⇒ auto-deny via
+#                                      `denied_by_profile`)
+#   bridge fallback                  (un-typed callers; pre-#252
+#                                      behavior)
+#
+# Workflow:
+#
+#   1) Pick names that describe each class's job (`extraction`,
+#      `writer`, `planner`). `default` is fine for a single-class run.
+#   2) Copy the matching block into your manifest.
+#   3) Reference it: `spawn_worker(worker_type = "default", ...)` or
+#      `spawn_sublead(sublead_type = "planner", ...)`. Pitboss enforces
+#      the caps at spawn; the lead can never widen them.
+#   4) Once every spawn site is typed, set
+#      `[run].require_actor_type = true` to lock out type-less spawns.
+
+[[worker_type]]
+id    = "default"
+
+# Tools the worker may invoke. `--allowedTools` is set from this list;
+# under Path B, anything outside the list auto-denies via
+# `denied_by_profile` (the model receives a non-terminating
+# `{behavior: "deny", message: ...}` and adapts).
+tools = ["Read", "Glob", "Grep"]
+
+# Optional: pin the worker to specific models. `spawn_worker(model =
+# ...)` rejects values outside this list. Omit to inherit
+# `[defaults].model`.
+# allowed_models = ["claude-haiku-4-5", "claude-sonnet-4-6"]
+
+# Optional: cap wall-clock timeout. spawn_worker(timeout_secs = N)
+# clamps DOWN to this value; never up.
+# max_timeout_secs = 1800
+
+[[sublead_type]]
+id    = "planner"
+
+# Same shape as [[worker_type]], but applied to spawn_sublead. The
+# orchestration tools (mcp__pitboss__spawn_worker, etc.) are
+# auto-injected — list only the model-facing tools the sub-lead
+# needs to read context and propose plans.
+tools = ["Read", "Glob", "Grep"]
+
+# allowed_models = ["claude-opus-4-7"]
+
+# Optional: cap the sub-tree's USD budget. spawn_sublead(budget_usd
+# = X) clamps DOWN.
+# max_budget_usd = 5.0
+"#,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::render;
+
+    /// The output must include both profile sections and the workflow
+    /// header so operators can identify what they're looking at when
+    /// the validate-time warning sends them here.
+    #[test]
+    fn render_includes_profile_sections_and_header() {
+        let out = render();
+        assert!(
+            out.contains("[[worker_type]]"),
+            "missing worker_type:\n{out}"
+        );
+        assert!(
+            out.contains("[[sublead_type]]"),
+            "missing sublead_type:\n{out}"
+        );
+        assert!(
+            out.contains("pitboss schema --format=migration"),
+            "missing self-identifying header:\n{out}"
+        );
+    }
+
+    /// Stability — the function is pure and idempotent. A
+    /// `--format=migration --check` mode (if added later) and any
+    /// docs-snapshot test depends on this.
+    #[test]
+    fn render_is_pure() {
+        assert_eq!(render(), render());
+    }
+}

--- a/crates/pitboss-cli/src/manifest/mod.rs
+++ b/crates/pitboss-cli/src/manifest/mod.rs
@@ -5,6 +5,7 @@ pub mod init_template;
 pub mod load;
 pub mod map_doc;
 pub mod metadata;
+pub mod migration_doc;
 pub mod resolve;
 pub mod schema;
 pub mod validate;

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -294,6 +294,37 @@ fn validate_mode(r: &ResolvedManifest) -> Result<()> {
     Ok(())
 }
 
+/// Returns a one-line warning message when Path B is in effect but the
+/// manifest declares no `[[worker_type]]` / `[[sublead_type]]` profiles.
+///
+/// The runtime gate (#388) only fast-paths typed actors via their
+/// profile's `tools` allowlist; un-typed callers still bridge-route
+/// every `permission_prompt`. Operators who selected Path B without
+/// profiles are not getting the headline payoff of the routing change
+/// — they're just paying the bridge round-trip on every tool that
+/// claude can't pre-approve via `--allowedTools`. Pure nudge: returns
+/// `None` (no warn) when at least one profile is declared, so a
+/// partially-migrated manifest doesn't keep firing a stale advisory.
+///
+/// Returned as a string rather than emitted via `tracing::warn!` so
+/// unit tests can assert the trigger conditions without capturing a
+/// global subscriber. The validate-time caller logs it.
+pub(crate) fn path_b_profile_migration_warning(r: &ResolvedManifest) -> Option<String> {
+    if !r.worker_types.is_empty() || !r.sublead_types.is_empty() {
+        return None;
+    }
+    Some(
+        "`permission_routing = \"path_b\"` is selected but the manifest declares \
+         no `[[worker_type]]` / `[[sublead_type]]` profiles. Typed actors get a \
+         fast-path auto-approve via their `tools` allowlist (#388); un-typed \
+         actors route every per-tool check through the operator approval bridge \
+         on first use. Declare profiles to fast-path common tools and audit \
+         out-of-policy requests as `denied_by_profile`. \
+         Run `pitboss schema --format=migration` for a starter scaffold."
+            .to_string(),
+    )
+}
+
 fn validate_lead(r: &ResolvedManifest, skip_dir_check: bool) -> Result<()> {
     let lead = r.lead.as_ref().unwrap();
 
@@ -324,6 +355,9 @@ fn validate_lead(r: &ResolvedManifest, skip_dir_check: bool) -> Result<()> {
              <run_dir>/tasks/<actor>/events.jsonl. File issues at \
              https://github.com/SDS-Mode/pitboss/issues"
         );
+        if let Some(msg) = path_b_profile_migration_warning(r) {
+            tracing::warn!("{msg}");
+        }
     }
 
     // A lead with an empty prompt starts, receives no `-p` argument, and exits
@@ -2029,5 +2063,73 @@ mod tests {
         });
         validate_skip_dir_check(&r)
             .expect("unscoped server is the legacy default and must validate");
+    }
+
+    /// Path B + zero profiles ⇒ migration warning fires. Pure check on
+    /// the helper since the runtime caller logs via `tracing::warn!`,
+    /// which is awkward to capture without installing a global
+    /// subscriber. Operators see the message via `pitboss validate`'s
+    /// stderr.
+    #[test]
+    fn path_b_without_profiles_emits_migration_warning() {
+        let r = rm_with(|_| {
+            // Default rl() lead has worker_types/sublead_types empty
+            // and permission_routing defaults to PathA — bump it.
+        });
+        let mut r = r;
+        r.lead.as_mut().unwrap().permission_routing =
+            crate::manifest::schema::PermissionRouting::PathB;
+
+        let msg = path_b_profile_migration_warning(&r)
+            .expect("Path B + no profiles must produce a migration warning");
+        assert!(
+            msg.contains("`[[worker_type]]`"),
+            "warning must reference the missing profile section: {msg}"
+        );
+        assert!(
+            msg.contains("pitboss schema --format=migration"),
+            "warning must point operators at the scaffold command: {msg}"
+        );
+    }
+
+    /// Declaring at least one `[[worker_type]]` suppresses the
+    /// migration warning even if `[[sublead_type]]` is still empty
+    /// (and vice versa). A partially-migrated manifest mustn't keep
+    /// firing a stale advisory — once the operator has started
+    /// declaring profiles, they know the system exists.
+    #[test]
+    fn migration_warning_silenced_by_any_declared_profile() {
+        // worker_type-only.
+        let mut r = rm_with(|m| {
+            m.worker_types = vec![crate::manifest::schema::WorkerType {
+                id: "extraction".into(),
+                tools: vec!["Read".into()],
+                allowed_models: vec![],
+                max_timeout_secs: None,
+            }];
+        });
+        r.lead.as_mut().unwrap().permission_routing =
+            crate::manifest::schema::PermissionRouting::PathB;
+        assert!(
+            path_b_profile_migration_warning(&r).is_none(),
+            "worker_type alone must suppress the warning"
+        );
+
+        // sublead_type-only.
+        let mut r = rm_with(|m| {
+            m.sublead_types = vec![crate::manifest::schema::SubleadType {
+                id: "planner".into(),
+                tools: vec!["Read".into()],
+                allowed_models: vec![],
+                max_timeout_secs: None,
+                max_budget_usd: None,
+            }];
+        });
+        r.lead.as_mut().unwrap().permission_routing =
+            crate::manifest::schema::PermissionRouting::PathB;
+        assert!(
+            path_b_profile_migration_warning(&r).is_none(),
+            "sublead_type alone must suppress the warning"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Two coupled pieces aimed at adoption of the typed-profile machinery shipped in #382 / #384 / #388:

- **Validate-time warning.** When \`[lead].permission_routing = \"path_b\"\` and the manifest declares zero \`[[worker_type]]\` / \`[[sublead_type]]\` profiles, \`pitboss validate\` emits a one-line warn after the existing soak warning. Pointed at \`pitboss schema --format=migration\`. Suppressed as soon as either profile list is non-empty so partial migrations don't keep firing a stale advisory.
- **\`pitboss schema --format=migration\`.** New format variant emitting a static TOML scaffold: starter \`[[worker_type]]\` + \`[[sublead_type]]\` block, inline cheat-sheet for the rule → profile → bridge order-of-evaluation contract, four-step migration workflow. Generator is pure and idempotent — a future \`--check\` mode could pin docs against it.

## Why this isn't the synthetic-default profile

The wild-tinkering plan calls for a runtime baseline that auto-denies every undeclared tool when no profile is present. Per advisor (and an audit of how \`--allowedTools\` already filters Path-B traffic): that's a behavior change appropriate to the Path-B default-flip PR, where the breaking-change calculus is already on the table. This slice ships the soft nudge instead so operators have time to migrate before the runtime fallback lands.

## Test plan

- [x] \`cargo test --workspace --features pitboss-core/test-support\` — every suite green; pitboss-cli lib at 733/733
- [x] 4 new tests:
  - \`path_b_without_profiles_emits_migration_warning\` — trigger conditions + message references the scaffold command
  - \`migration_warning_silenced_by_any_declared_profile\` — partial migration (worker_type-only or sublead_type-only) suppresses the warn
  - \`migration_doc::render_includes_profile_sections_and_header\` — output identifies itself + has both profile blocks
  - \`migration_doc::render_is_pure\` — idempotence pin
- [x] Manual smoke: \`pitboss schema --format=migration\` renders 61 lines of TOML scaffold with \`[[worker_type]]\` + \`[[sublead_type]]\` blocks
- [x] \`cargo lint\` — clean
- [x] \`cargo tidy\` — clean

## Follow-ups parked

- **Synthetic-default runtime fallback** (auto-deny on undeclared tools) — bundled with the eventual default flip.
- **Dynamic migration scaffold** that derives \`tools\` from the manifest's \`[lead].tools\` cascade — the static form is enough for v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)