### PR TITLE
feat(mcp): synthetic-default profile for un-typed Path-B callers (#252)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -388,6 +388,8 @@ The `spawn_worker` and `spawn_sublead` MCP tools gain optional `worker_type` / `
 
 Set `[run].require_actor_type = true` to make every `spawn_worker` / `spawn_sublead` call REQUIRE a profile arg — type-less spawns are rejected. The flag is inert in flat mode (warning logged at validate time).
 
+**`[run].untyped_actor_policy`** (Path-B-only, default `"bridge"`) controls what happens when an un-typed Worker / Sublead reaches `permission_prompt`. `"bridge"` (default) routes to the operator approval bridge — pre-#252 behavior, preserved for back-compat. `"block"` synthesizes an empty profile so anything outside `--allowedTools` auto-denies via `denied_by_profile` with the sentinel `actor_type = "<synthetic>"` on the audit row — closes the un-typed escape hatch for headless production runs. Validate rejects `"block"` when no profiles are declared (every spawn would auto-deny → self-defeating manifest).
+
 The resolved profile id is persisted to each `TaskRecord.actor_type`, surfaced in `summary.json` / `summary.jsonl` so the TUI, `pitboss-web`, and `pitboss status` can group actors by class without re-deriving from the manifest snapshot.
 
 **Phase 1.5 (v0.12, landed):**

--- a/crates/pitboss-cli/src/capability_matrix.rs
+++ b/crates/pitboss-cli/src/capability_matrix.rs
@@ -141,6 +141,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         }
     }
 

--- a/crates/pitboss-cli/src/communication.rs
+++ b/crates/pitboss-cli/src/communication.rs
@@ -858,6 +858,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -1273,6 +1273,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -1755,6 +1756,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         let sub_layer = std::sync::Arc::new(LayerState::new(
             run_id,
@@ -2244,6 +2246,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         let sub_layer = std::sync::Arc::new(LayerState::new(
             run_id,
@@ -2357,6 +2360,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         let sub_layer = std::sync::Arc::new(LayerState::new(
             run_id,
@@ -2485,6 +2489,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         let sub_layer = std::sync::Arc::new(LayerState::new(
             run_id,
@@ -2626,6 +2631,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         let sub_layer = std::sync::Arc::new(LayerState::new(
             run_id,

--- a/crates/pitboss-cli/src/dispatch/failure_detection.rs
+++ b/crates/pitboss-cli/src/dispatch/failure_detection.rs
@@ -375,6 +375,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         let store: Arc<dyn pitboss_core::store::SessionStore> =
             Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
@@ -471,6 +472,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         let store: Arc<dyn pitboss_core::store::SessionStore> =
             Arc::new(JsonFileStore::new(dir.path().to_path_buf()));

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -1154,6 +1154,7 @@ mod await_drained_tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/src/dispatch/kill_resume.rs
+++ b/crates/pitboss-cli/src/dispatch/kill_resume.rs
@@ -293,6 +293,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         }
     }
 

--- a/crates/pitboss-cli/src/dispatch/layer.rs
+++ b/crates/pitboss-cli/src/dispatch/layer.rs
@@ -472,6 +472,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(FakeSpawner::new(FakeScript::new()));

--- a/crates/pitboss-cli/src/dispatch/resume.rs
+++ b/crates/pitboss-cli/src/dispatch/resume.rs
@@ -710,6 +710,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         std::fs::write(
             run_dir.join("resolved.json"),
@@ -830,6 +831,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         std::fs::write(
             run_dir.join("resolved.json"),
@@ -953,6 +955,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         std::fs::write(
             run_dir.join("resolved.json"),
@@ -1140,6 +1143,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         let json = serde_json::to_string(&m).unwrap();
         assert!(

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -1451,6 +1451,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         }
     }
 
@@ -1601,6 +1602,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
 
         // Script: first call succeeds, second call fails. FakeSpawner is single-shot,
@@ -1700,6 +1702,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
 
         let spawner = Arc::new(CyclingFake(
@@ -1812,6 +1815,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
 
         let spawner = Arc::new(CyclingFake(

--- a/crates/pitboss-cli/src/dispatch/signals.rs
+++ b/crates/pitboss-cli/src/dispatch/signals.rs
@@ -382,6 +382,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -475,6 +476,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -568,6 +570,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -663,6 +663,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/src/manifest/migration_doc.rs
+++ b/crates/pitboss-cli/src/manifest/migration_doc.rs
@@ -46,6 +46,11 @@ pub fn render() -> String {
 #      the caps at spawn; the lead can never widen them.
 #   4) Once every spawn site is typed, set
 #      `[run].require_actor_type = true` to lock out type-less spawns.
+#   5) For headless runs that must never round-trip to an operator,
+#      add `[run].untyped_actor_policy = "block"` so any un-typed call
+#      reaching permission_prompt auto-denies via `denied_by_profile`
+#      instead of routing through the bridge. Requires step 1+ —
+#      validate rejects `block` when no profiles are declared.
 
 [[worker_type]]
 id    = "default"

--- a/crates/pitboss-cli/src/manifest/resolve.rs
+++ b/crates/pitboss-cli/src/manifest/resolve.rs
@@ -204,6 +204,12 @@ pub struct ResolvedManifest {
     /// back-compat. (#252)
     #[serde(default)]
     pub require_actor_type: bool,
+    /// Path-B-only policy for un-typed actors reaching
+    /// `permission_prompt`. Default `Bridge` preserves pre-#252
+    /// behavior; `Block` synthesizes an empty profile so the call
+    /// auto-denies via `denied_by_profile`. (#252)
+    #[serde(default)]
+    pub untyped_actor_policy: crate::manifest::schema::UntypedActorPolicy,
 }
 
 const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
@@ -310,6 +316,7 @@ pub fn resolve(
         worker_types: manifest.worker_types,
         sublead_types: manifest.sublead_types,
         require_actor_type: manifest.run.require_actor_type,
+        untyped_actor_policy: manifest.run.untyped_actor_policy,
     })
 }
 

--- a/crates/pitboss-cli/src/manifest/schema.rs
+++ b/crates/pitboss-cli/src/manifest/schema.rs
@@ -581,6 +581,38 @@ pub struct RunConfig {
         help = "When true, every spawn_worker and spawn_sublead call must name a declared [[worker_type]]/[[sublead_type]]. Default false."
     )]
     pub require_actor_type: bool,
+    /// What happens when a `spawn_worker` / `spawn_sublead` call
+    /// reaches `permission_prompt` for an actor that has no declared
+    /// `[[worker_type]]` / `[[sublead_type]]`. Only meaningful under
+    /// `permission_routing = "path_b"`. Default `bridge` preserves
+    /// pre-#252 behavior (route to the operator approval bridge);
+    /// `block` synthesizes an empty profile so anything outside
+    /// `--allowedTools` auto-denies via `denied_by_profile` without
+    /// an operator round-trip — the strict counterpart to declaring
+    /// every actor's profile, useful for headless production runs
+    /// once the operator has migrated their manifests.
+    #[serde(default)]
+    #[field(
+        label = "Untyped actor policy",
+        help = "Path-B-only behavior for un-typed callers reaching permission_prompt. `bridge` (default) routes to the operator queue; `block` auto-denies via a synthesized empty profile.",
+        enum_values = ["bridge", "block"]
+    )]
+    pub untyped_actor_policy: UntypedActorPolicy,
+}
+
+/// What pitboss does when an un-typed Worker / Sublead reaches
+/// `permission_prompt` under Path B (#252). See the field doc on
+/// `RunConfig::untyped_actor_policy` for the full semantics.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UntypedActorPolicy {
+    /// Route to the operator approval bridge (pre-#252 behavior).
+    #[default]
+    Bridge,
+    /// Auto-deny via a synthesized empty profile so the model receives
+    /// `denied_by_profile` without an operator round-trip. Pairs with
+    /// declared profiles to make the manifest the consent signal.
+    Block,
 }
 
 impl Default for RunConfig {
@@ -597,6 +629,7 @@ impl Default for RunConfig {
             dump_shared_store: false,
             require_plan_approval: false,
             require_actor_type: false,
+            untyped_actor_policy: UntypedActorPolicy::Bridge,
         }
     }
 }

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -28,6 +28,7 @@ fn validate_inner(resolved: &ResolvedManifest, skip_dir_check: bool) -> Result<(
     validate_container(resolved)?;
     validate_communication(resolved)?;
     validate_actor_types(resolved)?;
+    validate_block_untyped_requires_profiles(resolved)?;
     validate_mcp_server_scopes(resolved)?;
     if resolved.lead.is_some() {
         validate_lead(resolved, skip_dir_check)?;
@@ -323,6 +324,32 @@ pub(crate) fn path_b_profile_migration_warning(r: &ResolvedManifest) -> Option<S
          Run `pitboss schema --format=migration` for a starter scaffold."
             .to_string(),
     )
+}
+
+/// Reject `[run].untyped_actor_policy = "block"` when no profiles are
+/// declared. The combination is self-defeating: every un-typed call
+/// site (which under `block` is also every spawn unless every spawn
+/// names a profile) would auto-deny via the synthetic empty profile,
+/// so the lead can spawn nothing useful. Bailing at validate time
+/// saves a confused operator from a dispatch that produces only
+/// `denied_by_profile` events.
+fn validate_block_untyped_requires_profiles(r: &ResolvedManifest) -> Result<()> {
+    use crate::manifest::schema::UntypedActorPolicy;
+    if !matches!(r.untyped_actor_policy, UntypedActorPolicy::Block) {
+        return Ok(());
+    }
+    if r.worker_types.is_empty() && r.sublead_types.is_empty() {
+        bail!(
+            "[run].untyped_actor_policy = \"block\" requires at least one \
+             `[[worker_type]]` or `[[sublead_type]]` profile to be declared. \
+             Without any profiles, every spawn_worker / spawn_sublead call \
+             would auto-deny via `denied_by_profile`. Either declare a \
+             profile (run `pitboss schema --format=migration` for a \
+             starter) or set `untyped_actor_policy = \"bridge\"` (the \
+             default) to keep the operator approval bridge in the loop."
+        );
+    }
+    Ok(())
 }
 
 fn validate_lead(r: &ResolvedManifest, skip_dir_check: bool) -> Result<()> {
@@ -812,6 +839,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         }
     }
 
@@ -846,6 +874,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         f(&mut m);
         m
@@ -936,6 +965,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         let err = validate(&r).unwrap_err().to_string();
         assert!(
@@ -973,6 +1003,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         assert!(validate(&r).is_err());
     }
@@ -1006,6 +1037,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         assert!(validate(&r).is_err());
     }
@@ -1053,6 +1085,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         }
     }
 
@@ -1152,6 +1185,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         (d, r)
     }
@@ -1271,6 +1305,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         let err = validate(&r).unwrap_err().to_string();
         assert!(err.contains("empty manifest"), "got: {err}");
@@ -1329,6 +1364,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         let err = validate(&r).unwrap_err().to_string();
         assert!(
@@ -1368,6 +1404,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         assert!(validate(&r).is_err());
     }
@@ -1578,6 +1615,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         // Sanity: with skip_dir_check=false the validator rejects (the
         // host-side path is bogus).
@@ -1770,6 +1808,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         validate(&r).expect("path_b must validate (in soak); pre-#368 this bailed");
     }
@@ -1806,6 +1845,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         validate(&r).expect("path_a is the default and must validate");
     }
@@ -1919,6 +1959,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         m.require_actor_type = true;
         m.worker_types = vec![WorkerType {
@@ -1960,6 +2001,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         m.worker_types = vec![WorkerType {
             id: "extraction".into(),
@@ -2131,5 +2173,71 @@ mod tests {
             path_b_profile_migration_warning(&r).is_none(),
             "sublead_type alone must suppress the warning"
         );
+    }
+
+    /// `untyped_actor_policy = "block"` with no profiles is
+    /// self-defeating: every spawn would auto-deny via the synthetic
+    /// empty profile. Validate must reject the manifest before
+    /// dispatch so a confused operator doesn't run a session that
+    /// produces only `denied_by_profile` events.
+    #[test]
+    fn validate_rejects_block_untyped_when_no_profiles() {
+        let mut r = rm_with(|_| {});
+        r.untyped_actor_policy = crate::manifest::schema::UntypedActorPolicy::Block;
+
+        let err = validate_skip_dir_check(&r)
+            .expect_err("block policy without any profiles must fail validate");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("untyped_actor_policy = \"block\""),
+            "error must name the offending field: {msg}"
+        );
+        assert!(
+            msg.contains("[[worker_type]]") || msg.contains("[[sublead_type]]"),
+            "error must point operators at the missing profile section: {msg}"
+        );
+    }
+
+    /// One profile is enough — block + any declared profile is a
+    /// coherent manifest. Mirrors the migration-warning test's
+    /// "either profile suffices" property; this one is stricter
+    /// because it checks both arms of the OR.
+    #[test]
+    fn validate_accepts_block_untyped_with_at_least_one_profile() {
+        // worker_type only.
+        let mut r = rm_with(|m| {
+            m.worker_types = vec![crate::manifest::schema::WorkerType {
+                id: "extraction".into(),
+                tools: vec!["Read".into()],
+                allowed_models: vec![],
+                max_timeout_secs: None,
+            }];
+        });
+        r.untyped_actor_policy = crate::manifest::schema::UntypedActorPolicy::Block;
+        validate_skip_dir_check(&r)
+            .expect("worker_type alone must satisfy block-policy validation");
+
+        // sublead_type only.
+        let mut r = rm_with(|m| {
+            m.sublead_types = vec![crate::manifest::schema::SubleadType {
+                id: "planner".into(),
+                tools: vec!["Read".into()],
+                allowed_models: vec![],
+                max_timeout_secs: None,
+                max_budget_usd: None,
+            }];
+        });
+        r.untyped_actor_policy = crate::manifest::schema::UntypedActorPolicy::Block;
+        validate_skip_dir_check(&r)
+            .expect("sublead_type alone must satisfy block-policy validation");
+    }
+
+    /// `bridge` (default) without profiles is fine — that's pre-#252
+    /// behavior and the migration warning is the only signal.
+    #[test]
+    fn validate_accepts_bridge_policy_without_profiles() {
+        let r = rm_with(|_| {});
+        // Default `untyped_actor_policy = Bridge`; no profiles declared.
+        validate_skip_dir_check(&r).expect("bridge policy without profiles must pass validate");
     }
 }

--- a/crates/pitboss-cli/src/mcp/approval.rs
+++ b/crates/pitboss-cli/src/mcp/approval.rs
@@ -478,6 +478,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -1705,6 +1705,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();
@@ -1795,6 +1796,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();
@@ -1879,6 +1881,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();
@@ -2030,6 +2033,7 @@ mod tests {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/src/mcp/tools/approval.rs
+++ b/crates/pitboss-cli/src/mcp/tools/approval.rs
@@ -716,14 +716,31 @@ async fn record_permission_auto_approved(
     }
 }
 
+/// Sentinel `type_id` returned by [`caller_profile`] when the synthetic-
+/// default fallback fires (i.e. an un-typed Worker / Sublead under
+/// `untyped_actor_policy = "block"`). Audit consumers reading
+/// `events.jsonl` see this string in `tool_denied.actor_type` and
+/// `tool_auto_approved.actor_type` and can distinguish synthesized
+/// denials from declared-profile denials. Kept as a `<...>` token so
+/// it can never collide with a valid manifest profile id (validate
+/// rejects `<` in ids).
+const SYNTHETIC_PROFILE_ID: &str = "<synthetic>";
+
 /// Resolve a permission_prompt caller to its `(type_id, role_label,
 /// profile_tools)` triple, looking up the profile from the manifest.
 ///
-/// Returns `None` for the lead (root lead is never typed), for untyped
-/// callers (no entry in the per-layer / sublead actor-type maps), and
-/// when a typed caller's id is unknown to the manifest's profile list
-/// (shouldn't happen post-spawn; rejected by `actor_type::resolve_*`
+/// Returns `None` for the lead (root lead is never typed), for the
+/// pre-#252 un-typed bridge fallback (when
+/// `[run].untyped_actor_policy = "bridge"`, which is the default),
+/// and when a typed caller's id is unknown to the manifest's profile
+/// list (shouldn't happen post-spawn; rejected by `actor_type::resolve_*`
 /// at spawn time, but defensive against state corruption).
+///
+/// When `[run].untyped_actor_policy = "block"`, an un-typed caller
+/// receives a SYNTHESIZED profile with [`SYNTHETIC_PROFILE_ID`] and an
+/// empty `tools` list. The downstream short-circuit then auto-denies
+/// every call (because no tool is in the empty allowlist) — the
+/// "manifest is the consent signal" policy enacted at runtime.
 ///
 /// `role_label` is the lowercase string `"worker"` or `"sublead"` used
 /// to format the `not in <role>_type '<id>' allowlist` model-facing
@@ -734,10 +751,12 @@ async fn caller_profile(
     caller_id: &str,
     meta: Option<&crate::shared_store::tools::MetaField>,
 ) -> Option<(String, &'static str, Vec<String>)> {
+    use crate::manifest::schema::UntypedActorPolicy;
     use crate::shared_store::ActorRole;
 
     let m = meta?;
     let manifest = &state.root.manifest;
+    let block_untyped = matches!(manifest.untyped_actor_policy, UntypedActorPolicy::Block);
     match m.actor_role {
         ActorRole::Lead => None,
         ActorRole::Sublead => {
@@ -746,9 +765,17 @@ async fn caller_profile(
                 .read()
                 .await
                 .get(caller_id)
-                .cloned()?;
-            let profile = manifest.sublead_types.iter().find(|st| st.id == type_id)?;
-            Some((type_id, "sublead", profile.tools.clone()))
+                .cloned();
+            match type_id {
+                Some(id) => {
+                    let profile = manifest.sublead_types.iter().find(|st| st.id == id)?;
+                    Some((id, "sublead", profile.tools.clone()))
+                }
+                None if block_untyped => {
+                    Some((SYNTHETIC_PROFILE_ID.to_string(), "sublead", Vec::new()))
+                }
+                None => None,
+            }
         }
         ActorRole::Worker => {
             // Same dispatch as `build_caller_identity`: which sub-tree
@@ -760,14 +787,14 @@ async fn caller_profile(
                 .await
                 .get(caller_id)
                 .cloned();
-            let type_id = match layer_opt {
+            let type_id_opt: Option<String> = match layer_opt {
                 None | Some(None) => state
                     .root
                     .worker_actor_types
                     .read()
                     .await
                     .get(caller_id)
-                    .cloned()?,
+                    .cloned(),
                 Some(Some(sublead_id)) => {
                     // Clone the sub-layer Arc out before awaiting on its
                     // own RwLock — holding `subs` (a guard on
@@ -776,14 +803,27 @@ async fn caller_profile(
                     // read.
                     let sub = {
                         let subs = state.subleads.read().await;
-                        subs.get(&sublead_id).cloned()?
+                        subs.get(&sublead_id).cloned()
                     };
-                    let map = sub.worker_actor_types.read().await;
-                    map.get(caller_id).cloned()?
+                    match sub {
+                        Some(sub) => {
+                            let map = sub.worker_actor_types.read().await;
+                            map.get(caller_id).cloned()
+                        }
+                        None => None,
+                    }
                 }
             };
-            let profile = manifest.worker_types.iter().find(|wt| wt.id == type_id)?;
-            Some((type_id, "worker", profile.tools.clone()))
+            match type_id_opt {
+                Some(type_id) => {
+                    let profile = manifest.worker_types.iter().find(|wt| wt.id == type_id)?;
+                    Some((type_id, "worker", profile.tools.clone()))
+                }
+                None if block_untyped => {
+                    Some((SYNTHETIC_PROFILE_ID.to_string(), "worker", Vec::new()))
+                }
+                None => None,
+            }
         }
     }
 }

--- a/crates/pitboss-cli/src/mcp/tools/tests.rs
+++ b/crates/pitboss-cli/src/mcp/tools/tests.rs
@@ -101,6 +101,7 @@ async fn test_state_with_budget(budget: f64) -> Arc<DispatchState> {
         worker_types: vec![],
         sublead_types: vec![],
         require_actor_type: false,
+        untyped_actor_policy: Default::default(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();
@@ -765,6 +766,7 @@ async fn completing_test_state_with_budget(budget: Option<f64>) -> Arc<DispatchS
         worker_types: vec![],
         sublead_types: vec![],
         require_actor_type: false,
+        untyped_actor_policy: Default::default(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();
@@ -1622,6 +1624,7 @@ async fn handle_request_approval_auto_approves() {
         worker_types: vec![],
         sublead_types: vec![],
         require_actor_type: false,
+        untyped_actor_policy: Default::default(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let script = FakeScript::new().hold_until_signal();
@@ -1721,6 +1724,7 @@ async fn permission_prompt_auto_approves_and_returns_gate_response() {
         worker_types: vec![],
         sublead_types: vec![],
         require_actor_type: false,
+        untyped_actor_policy: Default::default(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let script = FakeScript::new().hold_until_signal();
@@ -1846,6 +1850,7 @@ async fn mk_plan_state_with_termination_policy(
         worker_types: vec![],
         sublead_types: vec![],
         require_actor_type: false,
+        untyped_actor_policy: Default::default(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let script = FakeScript::new().hold_until_signal();
@@ -2762,14 +2767,34 @@ async fn test_state_with_worker_types(
     worker_types: Vec<crate::manifest::schema::WorkerType>,
     require_actor_type: bool,
 ) -> Arc<DispatchState> {
-    test_state_with_worker_types_and_policy(worker_types, require_actor_type, ApprovalPolicy::Block)
-        .await
+    test_state_with_worker_types_full(
+        worker_types,
+        require_actor_type,
+        ApprovalPolicy::Block,
+        crate::manifest::schema::UntypedActorPolicy::Bridge,
+    )
+    .await
 }
 
 async fn test_state_with_worker_types_and_policy(
     worker_types: Vec<crate::manifest::schema::WorkerType>,
     require_actor_type: bool,
     approval_policy: ApprovalPolicy,
+) -> Arc<DispatchState> {
+    test_state_with_worker_types_full(
+        worker_types,
+        require_actor_type,
+        approval_policy,
+        crate::manifest::schema::UntypedActorPolicy::Bridge,
+    )
+    .await
+}
+
+async fn test_state_with_worker_types_full(
+    worker_types: Vec<crate::manifest::schema::WorkerType>,
+    require_actor_type: bool,
+    approval_policy: ApprovalPolicy,
+    untyped_actor_policy: crate::manifest::schema::UntypedActorPolicy,
 ) -> Arc<DispatchState> {
     use crate::manifest::resolve::{ResolvedLead, ResolvedManifest};
     use crate::manifest::schema::{Effort, WorktreeCleanup};
@@ -2828,6 +2853,7 @@ async fn test_state_with_worker_types_and_policy(
         worker_types,
         sublead_types: vec![],
         require_actor_type,
+        untyped_actor_policy,
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();
@@ -3263,5 +3289,141 @@ async fn permission_prompt_rule_auto_approve_beats_profile_deny() {
     assert!(
         matches!(resp, PermissionPromptResponse::Allow { .. }),
         "rule auto-approve must beat profile deny: {resp:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Synthetic-default profile under [run].untyped_actor_policy = "block".
+// ---------------------------------------------------------------------------
+//
+// The block policy converts the un-typed bridge fallback (today's
+// pre-#252 default) into auto-deny via a synthesized empty profile.
+// Behavior matrix:
+//
+//   actor typed?  policy=bridge  policy=block
+//   ------------  -------------  ----------------
+//   yes           profile fires  profile fires
+//   no            bridge         synthetic deny
+
+/// Helper for `block`-policy tests. Mirrors
+/// `test_state_with_worker_types` but pivots the manifest's
+/// `untyped_actor_policy` to `Block`. Validate-time rejects the
+/// empty-profiles + block combination, so every test reaching this
+/// helper declares at least one profile.
+async fn test_state_block_untyped(
+    worker_types: Vec<crate::manifest::schema::WorkerType>,
+) -> Arc<DispatchState> {
+    test_state_with_worker_types_full(
+        worker_types,
+        false,
+        ApprovalPolicy::Block,
+        crate::manifest::schema::UntypedActorPolicy::Block,
+    )
+    .await
+}
+
+#[tokio::test]
+async fn permission_prompt_synthetic_default_blocks_untyped_worker() {
+    let state = test_state_block_untyped(vec![extraction_profile()]).await;
+    // No `insert_typed_worker` call — the worker is un-typed, so the
+    // synthetic empty profile must fire.
+    state
+        .worker_layer_index
+        .write()
+        .await
+        .insert("worker-untyped".into(), None);
+
+    let resp = handle_permission_prompt(
+        &state,
+        PermissionPromptArgs {
+            tool_name: "Read".into(),
+            tool_input: None,
+            cost_estimate: None,
+            meta: Some(worker_meta("worker-untyped")),
+        },
+    )
+    .await
+    .unwrap();
+    let PermissionPromptResponse::Deny { message, .. } = resp else {
+        panic!("untyped worker under block policy must auto-deny: {resp:?}");
+    };
+    // The sentinel id `<synthetic>` shows up in the message so an
+    // operator reading the model-facing reason knows this denial
+    // came from the synthesized profile, not a declared one.
+    assert!(
+        message.contains("worker_type '<synthetic>'"),
+        "synthetic denial must name the sentinel profile id: {message}"
+    );
+
+    let counters = state.root.worker_counters.read().await;
+    let entry = counters
+        .get("worker-untyped")
+        .expect("synthetic auto-deny must bump approval counters");
+    assert_eq!(entry.approvals_requested, 1);
+    assert_eq!(entry.approvals_rejected, 1);
+}
+
+/// Declared profiles still win under `block`. Strict mode is meant to
+/// close the un-typed escape hatch — it must not perturb the typed
+/// fast-path that #388 shipped.
+#[tokio::test]
+async fn permission_prompt_synthetic_default_does_not_override_declared_profile() {
+    let state = test_state_block_untyped(vec![extraction_profile()]).await;
+    insert_typed_worker(&state, "worker-typed", "extraction").await;
+
+    // `Read` is in `extraction_profile()` → Allow via declared profile,
+    // not the synthetic empty one.
+    let resp = handle_permission_prompt(
+        &state,
+        PermissionPromptArgs {
+            tool_name: "Read".into(),
+            tool_input: None,
+            cost_estimate: None,
+            meta: Some(worker_meta("worker-typed")),
+        },
+    )
+    .await
+    .unwrap();
+    assert!(
+        matches!(resp, PermissionPromptResponse::Allow { .. }),
+        "declared profile's allowlist must still fire under block: {resp:?}"
+    );
+}
+
+/// Bridge policy (the default) preserves the pre-#252 un-typed fallback
+/// — un-typed callers route through the bridge instead of auto-denying.
+/// Symmetric with `permission_prompt_untyped_worker_falls_through_to_bridge`,
+/// but anchored in the synthetic-default test block so a future
+/// refactor that flips the default catches the regression.
+#[tokio::test]
+async fn permission_prompt_bridge_policy_keeps_untyped_bridge_fallback() {
+    let state = test_state_with_worker_types_and_policy(
+        vec![extraction_profile()],
+        false,
+        ApprovalPolicy::AutoApprove,
+    )
+    .await;
+    // Default `untyped_actor_policy = Bridge` — the helper does NOT
+    // patch it.
+    state
+        .worker_layer_index
+        .write()
+        .await
+        .insert("worker-untyped".into(), None);
+
+    let resp = handle_permission_prompt(
+        &state,
+        PermissionPromptArgs {
+            tool_name: "Read".into(),
+            tool_input: None,
+            cost_estimate: None,
+            meta: Some(worker_meta("worker-untyped")),
+        },
+    )
+    .await
+    .unwrap();
+    assert!(
+        matches!(resp, PermissionPromptResponse::Allow { .. }),
+        "bridge policy must still route un-typed callers to the bridge: {resp:?}"
     );
 }

--- a/crates/pitboss-cli/tests/cancel_cascade_flows.rs
+++ b/crates/pitboss-cli/tests/cancel_cascade_flows.rs
@@ -123,6 +123,7 @@ fn mk_state() -> (TempDir, Arc<DispatchState>) {
         worker_types: vec![],
         sublead_types: vec![],
         require_actor_type: false,
+        untyped_actor_policy: Default::default(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/tests/control_flows.rs
+++ b/crates/pitboss-cli/tests/control_flows.rs
@@ -60,6 +60,7 @@ async fn pause_op_writes_events_jsonl() {
         worker_types: vec![],
         sublead_types: vec![],
         require_actor_type: false,
+        untyped_actor_policy: Default::default(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -272,6 +273,7 @@ async fn block_policy_queue_drains_on_tui_connect() {
         worker_types: vec![],
         sublead_types: vec![],
         require_actor_type: false,
+        untyped_actor_policy: Default::default(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -393,6 +395,7 @@ async fn auto_approve_policy_responds_without_tui() {
         worker_types: vec![],
         sublead_types: vec![],
         require_actor_type: false,
+        untyped_actor_policy: Default::default(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -461,6 +464,7 @@ async fn auto_reject_policy_responds_without_tui() {
         worker_types: vec![],
         sublead_types: vec![],
         require_actor_type: false,
+        untyped_actor_policy: Default::default(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -540,6 +544,7 @@ async fn propose_plan_end_to_end_unblocks_spawn_gate() {
         worker_types: vec![],
         sublead_types: vec![],
         require_actor_type: false,
+        untyped_actor_policy: Default::default(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());

--- a/crates/pitboss-cli/tests/dogfood_fake_flows.rs
+++ b/crates/pitboss-cli/tests/dogfood_fake_flows.rs
@@ -115,6 +115,7 @@ fn mk_state_with_subleads() -> (TempDir, Arc<DispatchState>) {
         worker_types: vec![],
         sublead_types: vec![],
         require_actor_type: false,
+        untyped_actor_policy: Default::default(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();
@@ -1047,6 +1048,7 @@ async fn dogfood_envelope_cap_rejection() {
             worker_types: vec![],
             sublead_types: vec![],
             require_actor_type: false,
+            untyped_actor_policy: Default::default(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/tests/e2e_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_flows.rs
@@ -85,6 +85,7 @@ fn mk_state(
         worker_types: vec![],
         sublead_types: vec![],
         require_actor_type: false,
+        untyped_actor_policy: Default::default(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(run_dir.to_path_buf()));
     // Worker-side spawner: emits a complete stream-json run then exits 0.
@@ -398,6 +399,7 @@ async fn e2e_lead_cancels_worker_mid_flight() {
         worker_types: vec![],
         sublead_types: vec![],
         require_actor_type: false,
+        untyped_actor_policy: Default::default(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let hold_script = FakeScript::new().hold_until_signal();
@@ -667,6 +669,7 @@ async fn e2e_lead_reprompts_running_worker() {
         worker_types: vec![],
         sublead_types: vec![],
         require_actor_type: false,
+        untyped_actor_policy: Default::default(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     // Worker script emits init+result so session_id gets captured via the
@@ -874,6 +877,7 @@ async fn e2e_lead_propose_plan_gate_unblocks_spawn() {
         worker_types: vec![],
         sublead_types: vec![],
         require_actor_type: false,
+        untyped_actor_policy: Default::default(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let worker_script = FakeScript::new()
@@ -1183,6 +1187,7 @@ async fn e2e_freeze_pause_and_continue_real_subprocess_worker() {
         worker_types: vec![],
         sublead_types: vec![],
         require_actor_type: false,
+        untyped_actor_policy: Default::default(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(FakeClaudeWorkerSpawner {

--- a/crates/pitboss-cli/tests/e2e_sublead_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_sublead_flows.rs
@@ -100,6 +100,7 @@ fn mk_state(dir: &std::path::Path) -> (Uuid, Arc<DispatchState>) {
         worker_types: vec![],
         sublead_types: vec![],
         require_actor_type: false,
+        untyped_actor_policy: Default::default(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.to_path_buf()));
     let worker_script = FakeScript::new()
@@ -177,6 +178,7 @@ fn mk_state_hold_workers(dir: &std::path::Path) -> (Uuid, Arc<DispatchState>) {
         worker_types: vec![],
         sublead_types: vec![],
         require_actor_type: false,
+        untyped_actor_policy: Default::default(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.to_path_buf()));
     let hold_script = FakeScript::new().hold_until_signal();
@@ -821,6 +823,7 @@ async fn sublead_session_spawns_runs_and_reconciles() {
         worker_types: vec![],
         sublead_types: vec![],
         require_actor_type: false,
+        untyped_actor_policy: Default::default(),
     };
 
     let store: std::sync::Arc<dyn pitboss_core::store::SessionStore> = std::sync::Arc::new(

--- a/crates/pitboss-cli/tests/hierarchical_flows.rs
+++ b/crates/pitboss-cli/tests/hierarchical_flows.rs
@@ -76,6 +76,7 @@ fn mk_state() -> (TempDir, Arc<DispatchState>) {
         worker_types: vec![],
         sublead_types: vec![],
         require_actor_type: false,
+        untyped_actor_policy: Default::default(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/tests/notify_flows.rs
+++ b/crates/pitboss-cli/tests/notify_flows.rs
@@ -262,6 +262,7 @@ async fn approval_pending_notification_fires_on_enqueue() {
         worker_types: vec![],
         sublead_types: vec![],
         require_actor_type: false,
+        untyped_actor_policy: Default::default(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());

--- a/crates/pitboss-cli/tests/shared_store_flows.rs
+++ b/crates/pitboss-cli/tests/shared_store_flows.rs
@@ -470,6 +470,7 @@ async fn lease_released_when_mcp_connection_drops() {
         worker_types: vec![],
         sublead_types: vec![],
         require_actor_type: false,
+        untyped_actor_policy: Default::default(),
     };
     let store_trait: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().into()));
     let run_id = Uuid::now_v7();
@@ -621,6 +622,7 @@ async fn run_global_lease_released_when_mcp_connection_drops() {
         worker_types: vec![],
         sublead_types: vec![],
         require_actor_type: false,
+        untyped_actor_policy: Default::default(),
     };
     let store_trait: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().into()));
     let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/tests/sublead_flows.rs
+++ b/crates/pitboss-cli/tests/sublead_flows.rs
@@ -84,6 +84,7 @@ fn mk_state_with_subleads() -> (TempDir, Arc<DispatchState>) {
         worker_types: vec![],
         sublead_types: vec![],
         require_actor_type: false,
+        untyped_actor_policy: Default::default(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();
@@ -160,6 +161,7 @@ fn mk_state_without_subleads() -> (TempDir, Arc<DispatchState>) {
         worker_types: vec![],
         sublead_types: vec![],
         require_actor_type: false,
+        untyped_actor_policy: Default::default(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();
@@ -234,6 +236,7 @@ fn mk_state_with_sublead_budget_cap(cap: f64) -> (TempDir, Arc<DispatchState>) {
         worker_types: vec![],
         sublead_types: vec![],
         require_actor_type: false,
+        untyped_actor_policy: Default::default(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();

--- a/docs/manifest-map.md
+++ b/docs/manifest-map.md
@@ -29,19 +29,20 @@ Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:469`](../crates/pitbos
 | `dump_shared_store` | boolean | no | Write shared-store.json into the run directory on finalize. | [`../crates/pitboss-cli/src/manifest/schema.rs#L564`](../crates/pitboss-cli/src/manifest/schema.rs#L564) |
 | `require_plan_approval` | boolean | no | When true, spawn_worker is blocked until propose_plan has been approved. | [`../crates/pitboss-cli/src/manifest/schema.rs#L572`](../crates/pitboss-cli/src/manifest/schema.rs#L572) |
 | `require_actor_type` | boolean | no | When true, every spawn_worker and spawn_sublead call must name a declared [[worker_type]]/[[sublead_type]]. Default false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L583`](../crates/pitboss-cli/src/manifest/schema.rs#L583) |
+| `untyped_actor_policy` | enum (`bridge` \| `block`) | no | Path-B-only behavior for un-typed callers reaching permission_prompt. `bridge` (default) routes to the operator queue; `block` auto-denies via a synthesized empty profile. | [`../crates/pitboss-cli/src/manifest/schema.rs#L600`](../crates/pitboss-cli/src/manifest/schema.rs#L600) |
 
 ## `[defaults]` — `Defaults`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:705`](../crates/pitboss-cli/src/manifest/schema.rs#L705).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:738`](../crates/pitboss-cli/src/manifest/schema.rs#L738).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `model` | text | no | Claude model id (e.g. claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-7). | [`../crates/pitboss-cli/src/manifest/schema.rs#L710`](../crates/pitboss-cli/src/manifest/schema.rs#L710) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Maps to the claude --effort flag. | [`../crates/pitboss-cli/src/manifest/schema.rs#L716`](../crates/pitboss-cli/src/manifest/schema.rs#L716) |
-| `tools` | string list | no | Allowed tool surface. Pitboss auto-appends its MCP tools for leads and workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L721`](../crates/pitboss-cli/src/manifest/schema.rs#L721) |
-| `timeout_secs` | integer | no | Per-task wall-clock cap. No default (no cap). | [`../crates/pitboss-cli/src/manifest/schema.rs#L726`](../crates/pitboss-cli/src/manifest/schema.rs#L726) |
-| `use_worktree` | boolean | no | Isolate each worker in a git worktree. Default true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L731`](../crates/pitboss-cli/src/manifest/schema.rs#L731) |
-| `env` | key-value map | no | Environment variables passed to the claude subprocess. | [`../crates/pitboss-cli/src/manifest/schema.rs#L737`](../crates/pitboss-cli/src/manifest/schema.rs#L737) |
+| `model` | text | no | Claude model id (e.g. claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-7). | [`../crates/pitboss-cli/src/manifest/schema.rs#L743`](../crates/pitboss-cli/src/manifest/schema.rs#L743) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Maps to the claude --effort flag. | [`../crates/pitboss-cli/src/manifest/schema.rs#L749`](../crates/pitboss-cli/src/manifest/schema.rs#L749) |
+| `tools` | string list | no | Allowed tool surface. Pitboss auto-appends its MCP tools for leads and workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L754`](../crates/pitboss-cli/src/manifest/schema.rs#L754) |
+| `timeout_secs` | integer | no | Per-task wall-clock cap. No default (no cap). | [`../crates/pitboss-cli/src/manifest/schema.rs#L759`](../crates/pitboss-cli/src/manifest/schema.rs#L759) |
+| `use_worktree` | boolean | no | Isolate each worker in a git worktree. Default true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L764`](../crates/pitboss-cli/src/manifest/schema.rs#L764) |
+| `env` | key-value map | no | Environment variables passed to the claude subprocess. | [`../crates/pitboss-cli/src/manifest/schema.rs#L770`](../crates/pitboss-cli/src/manifest/schema.rs#L770) |
 
 ## `[container]` — `ContainerConfig`
 
@@ -67,58 +68,58 @@ Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:138`](../crates/pitbos
 
 ## `[[task]]` — `Task`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:768`](../crates/pitboss-cli/src/manifest/schema.rs#L768).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:801`](../crates/pitboss-cli/src/manifest/schema.rs#L801).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique slug. Alphanumeric + _ + -. Used in logs and worktree names. | [`../crates/pitboss-cli/src/manifest/schema.rs#L773`](../crates/pitboss-cli/src/manifest/schema.rs#L773) |
-| `directory` | path | **yes** | Working directory. Must be inside a git repo if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L778`](../crates/pitboss-cli/src/manifest/schema.rs#L778) |
-| `prompt` | text (multi-line) | no | Prompt body sent to claude via -p. Mutually exclusive with `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L784`](../crates/pitboss-cli/src/manifest/schema.rs#L784) |
-| `template` | text | no | Reference to a [[template]] entry. Mutually exclusive with `prompt`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L789`](../crates/pitboss-cli/src/manifest/schema.rs#L789) |
-| `vars` | key-value map | no | Substitutions for {placeholders} when using `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L795`](../crates/pitboss-cli/src/manifest/schema.rs#L795) |
-| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L800`](../crates/pitboss-cli/src/manifest/schema.rs#L800) |
-| `model` | text | no | Per-task override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L802`](../crates/pitboss-cli/src/manifest/schema.rs#L802) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-task override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L808`](../crates/pitboss-cli/src/manifest/schema.rs#L808) |
-| `tools` | string list | no | Per-task override of [defaults].tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L810`](../crates/pitboss-cli/src/manifest/schema.rs#L810) |
-| `timeout_secs` | integer | no | Per-task wall-clock cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L812`](../crates/pitboss-cli/src/manifest/schema.rs#L812) |
-| `use_worktree` | boolean | no | Per-task override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L817`](../crates/pitboss-cli/src/manifest/schema.rs#L817) |
-| `env` | key-value map | no | Per-task env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L823`](../crates/pitboss-cli/src/manifest/schema.rs#L823) |
+| `id` | text | **yes** | Unique slug. Alphanumeric + _ + -. Used in logs and worktree names. | [`../crates/pitboss-cli/src/manifest/schema.rs#L806`](../crates/pitboss-cli/src/manifest/schema.rs#L806) |
+| `directory` | path | **yes** | Working directory. Must be inside a git repo if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L811`](../crates/pitboss-cli/src/manifest/schema.rs#L811) |
+| `prompt` | text (multi-line) | no | Prompt body sent to claude via -p. Mutually exclusive with `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L817`](../crates/pitboss-cli/src/manifest/schema.rs#L817) |
+| `template` | text | no | Reference to a [[template]] entry. Mutually exclusive with `prompt`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L822`](../crates/pitboss-cli/src/manifest/schema.rs#L822) |
+| `vars` | key-value map | no | Substitutions for {placeholders} when using `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L828`](../crates/pitboss-cli/src/manifest/schema.rs#L828) |
+| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L833`](../crates/pitboss-cli/src/manifest/schema.rs#L833) |
+| `model` | text | no | Per-task override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L835`](../crates/pitboss-cli/src/manifest/schema.rs#L835) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-task override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L841`](../crates/pitboss-cli/src/manifest/schema.rs#L841) |
+| `tools` | string list | no | Per-task override of [defaults].tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L843`](../crates/pitboss-cli/src/manifest/schema.rs#L843) |
+| `timeout_secs` | integer | no | Per-task wall-clock cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L845`](../crates/pitboss-cli/src/manifest/schema.rs#L845) |
+| `use_worktree` | boolean | no | Per-task override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L850`](../crates/pitboss-cli/src/manifest/schema.rs#L850) |
+| `env` | key-value map | no | Per-task env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L856`](../crates/pitboss-cli/src/manifest/schema.rs#L856) |
 
 ## `[lead]` — `Lead`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:833`](../crates/pitboss-cli/src/manifest/schema.rs#L833).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:866`](../crates/pitboss-cli/src/manifest/schema.rs#L866).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique slug used as the TUI tile label and in run artifact paths. | [`../crates/pitboss-cli/src/manifest/schema.rs#L840`](../crates/pitboss-cli/src/manifest/schema.rs#L840) |
-| `directory` | path | **yes** | Working directory for the lead's claude subprocess. Must be a git work-tree if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L847`](../crates/pitboss-cli/src/manifest/schema.rs#L847) |
-| `prompt` | text (multi-line) | **yes** | Operator instructions passed to claude via -p. Must appear before any [lead.X] subtable in the source. | [`../crates/pitboss-cli/src/manifest/schema.rs#L859`](../crates/pitboss-cli/src/manifest/schema.rs#L859) |
-| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L867`](../crates/pitboss-cli/src/manifest/schema.rs#L867) |
-| `model` | text | no | Per-lead override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L870`](../crates/pitboss-cli/src/manifest/schema.rs#L870) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-lead override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L877`](../crates/pitboss-cli/src/manifest/schema.rs#L877) |
-| `tools` | string list | no | Per-lead override of [defaults].tools. Pitboss auto-appends its MCP tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L883`](../crates/pitboss-cli/src/manifest/schema.rs#L883) |
-| `timeout_secs` | integer | no | Per-actor subprocess wall-clock cap (claude --timeout). | [`../crates/pitboss-cli/src/manifest/schema.rs#L889`](../crates/pitboss-cli/src/manifest/schema.rs#L889) |
-| `use_worktree` | boolean | no | Per-lead override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L895`](../crates/pitboss-cli/src/manifest/schema.rs#L895) |
-| `env` | key-value map | no | Per-lead env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L901`](../crates/pitboss-cli/src/manifest/schema.rs#L901) |
-| `max_workers` | integer | no | Hard cap on the lead's concurrent + queued worker pool (1–16). Required when the lead spawns workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L910`](../crates/pitboss-cli/src/manifest/schema.rs#L910) |
-| `budget_usd` | float | no | Soft cap on lead spend with reservation accounting. spawn_worker fails once spent + reserved + next_estimate > budget. | [`../crates/pitboss-cli/src/manifest/schema.rs#L919`](../crates/pitboss-cli/src/manifest/schema.rs#L919) |
-| `lead_timeout_secs` | integer | no | Wall-clock cap on the lead session. Default 3600. | [`../crates/pitboss-cli/src/manifest/schema.rs#L928`](../crates/pitboss-cli/src/manifest/schema.rs#L928) |
-| `permission_routing` | enum (`path_a` \| `path_b`) | no | path_a (default) makes pitboss the sole permission authority. path_b routes claude's gate through pitboss (rejected at validate time pending stabilization). | [`../crates/pitboss-cli/src/manifest/schema.rs#L941`](../crates/pitboss-cli/src/manifest/schema.rs#L941) |
-| `allow_subleads` | boolean | no | Expose spawn_sublead to the root lead. | [`../crates/pitboss-cli/src/manifest/schema.rs#L950`](../crates/pitboss-cli/src/manifest/schema.rs#L950) |
-| `max_subleads` | integer | no | Hard cap on total live sub-leads under this root. | [`../crates/pitboss-cli/src/manifest/schema.rs#L957`](../crates/pitboss-cli/src/manifest/schema.rs#L957) |
-| `max_sublead_budget_usd` | float | no | Cap on the per-sub-lead budget envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L964`](../crates/pitboss-cli/src/manifest/schema.rs#L964) |
-| `max_total_workers` | integer | no | Cap on total live workers across the entire tree (root + sub-trees). | [`../crates/pitboss-cli/src/manifest/schema.rs#L972`](../crates/pitboss-cli/src/manifest/schema.rs#L972) |
+| `id` | text | **yes** | Unique slug used as the TUI tile label and in run artifact paths. | [`../crates/pitboss-cli/src/manifest/schema.rs#L873`](../crates/pitboss-cli/src/manifest/schema.rs#L873) |
+| `directory` | path | **yes** | Working directory for the lead's claude subprocess. Must be a git work-tree if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L880`](../crates/pitboss-cli/src/manifest/schema.rs#L880) |
+| `prompt` | text (multi-line) | **yes** | Operator instructions passed to claude via -p. Must appear before any [lead.X] subtable in the source. | [`../crates/pitboss-cli/src/manifest/schema.rs#L892`](../crates/pitboss-cli/src/manifest/schema.rs#L892) |
+| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L900`](../crates/pitboss-cli/src/manifest/schema.rs#L900) |
+| `model` | text | no | Per-lead override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L903`](../crates/pitboss-cli/src/manifest/schema.rs#L903) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-lead override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L910`](../crates/pitboss-cli/src/manifest/schema.rs#L910) |
+| `tools` | string list | no | Per-lead override of [defaults].tools. Pitboss auto-appends its MCP tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L916`](../crates/pitboss-cli/src/manifest/schema.rs#L916) |
+| `timeout_secs` | integer | no | Per-actor subprocess wall-clock cap (claude --timeout). | [`../crates/pitboss-cli/src/manifest/schema.rs#L922`](../crates/pitboss-cli/src/manifest/schema.rs#L922) |
+| `use_worktree` | boolean | no | Per-lead override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L928`](../crates/pitboss-cli/src/manifest/schema.rs#L928) |
+| `env` | key-value map | no | Per-lead env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L934`](../crates/pitboss-cli/src/manifest/schema.rs#L934) |
+| `max_workers` | integer | no | Hard cap on the lead's concurrent + queued worker pool (1–16). Required when the lead spawns workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L943`](../crates/pitboss-cli/src/manifest/schema.rs#L943) |
+| `budget_usd` | float | no | Soft cap on lead spend with reservation accounting. spawn_worker fails once spent + reserved + next_estimate > budget. | [`../crates/pitboss-cli/src/manifest/schema.rs#L952`](../crates/pitboss-cli/src/manifest/schema.rs#L952) |
+| `lead_timeout_secs` | integer | no | Wall-clock cap on the lead session. Default 3600. | [`../crates/pitboss-cli/src/manifest/schema.rs#L961`](../crates/pitboss-cli/src/manifest/schema.rs#L961) |
+| `permission_routing` | enum (`path_a` \| `path_b`) | no | path_a (default) makes pitboss the sole permission authority. path_b routes claude's gate through pitboss (rejected at validate time pending stabilization). | [`../crates/pitboss-cli/src/manifest/schema.rs#L974`](../crates/pitboss-cli/src/manifest/schema.rs#L974) |
+| `allow_subleads` | boolean | no | Expose spawn_sublead to the root lead. | [`../crates/pitboss-cli/src/manifest/schema.rs#L983`](../crates/pitboss-cli/src/manifest/schema.rs#L983) |
+| `max_subleads` | integer | no | Hard cap on total live sub-leads under this root. | [`../crates/pitboss-cli/src/manifest/schema.rs#L990`](../crates/pitboss-cli/src/manifest/schema.rs#L990) |
+| `max_sublead_budget_usd` | float | no | Cap on the per-sub-lead budget envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L997`](../crates/pitboss-cli/src/manifest/schema.rs#L997) |
+| `max_total_workers` | integer | no | Cap on total live workers across the entire tree (root + sub-trees). | [`../crates/pitboss-cli/src/manifest/schema.rs#L1005`](../crates/pitboss-cli/src/manifest/schema.rs#L1005) |
 
 ## `[sublead_defaults]` — `SubleadDefaults`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:979`](../crates/pitboss-cli/src/manifest/schema.rs#L979).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:1012`](../crates/pitboss-cli/src/manifest/schema.rs#L1012).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `budget_usd` | float | no | Per-sub-lead envelope when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L984`](../crates/pitboss-cli/src/manifest/schema.rs#L984) |
-| `max_workers` | integer | no | Per-sub-lead worker pool when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L989`](../crates/pitboss-cli/src/manifest/schema.rs#L989) |
-| `lead_timeout_secs` | integer | no | Wall-clock cap for the sub-lead session. | [`../crates/pitboss-cli/src/manifest/schema.rs#L994`](../crates/pitboss-cli/src/manifest/schema.rs#L994) |
-| `read_down` | boolean | no | When true, sub-lead shares root's budget + worker pool instead of carving its own envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1000`](../crates/pitboss-cli/src/manifest/schema.rs#L1000) |
+| `budget_usd` | float | no | Per-sub-lead envelope when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1017`](../crates/pitboss-cli/src/manifest/schema.rs#L1017) |
+| `max_workers` | integer | no | Per-sub-lead worker pool when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1022`](../crates/pitboss-cli/src/manifest/schema.rs#L1022) |
+| `lead_timeout_secs` | integer | no | Wall-clock cap for the sub-lead session. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1027`](../crates/pitboss-cli/src/manifest/schema.rs#L1027) |
+| `read_down` | boolean | no | When true, sub-lead shares root's budget + worker pool instead of carving its own envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1033`](../crates/pitboss-cli/src/manifest/schema.rs#L1033) |
 
 ## `[[approval_policy]]` — `ApprovalRuleSpec`
 
@@ -142,26 +143,26 @@ Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:187`](../crates/pitbos
 
 ## `[[worker_type]]` — `WorkerType`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:626`](../crates/pitboss-cli/src/manifest/schema.rs#L626).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:659`](../crates/pitboss-cli/src/manifest/schema.rs#L659).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique id used in spawn_worker(worker_type = "<id>"). Match: ^[A-Za-z0-9_-]+$. | [`../crates/pitboss-cli/src/manifest/schema.rs#L633`](../crates/pitboss-cli/src/manifest/schema.rs#L633) |
-| `tools` | string list | no | Allowed tool surface for this worker class. Lead's spawn_worker(tools=...) must be a subset; omit means "give me the whole allowlist." | [`../crates/pitboss-cli/src/manifest/schema.rs#L641`](../crates/pitboss-cli/src/manifest/schema.rs#L641) |
-| `allowed_models` | string list | no | When non-empty, spawn_worker(model=...) must be in this list. Empty means any model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L649`](../crates/pitboss-cli/src/manifest/schema.rs#L649) |
-| `max_timeout_secs` | integer | no | Hard cap on spawn_worker(timeout_secs=...). Lead values clamp DOWN; smaller values pass through. | [`../crates/pitboss-cli/src/manifest/schema.rs#L657`](../crates/pitboss-cli/src/manifest/schema.rs#L657) |
+| `id` | text | **yes** | Unique id used in spawn_worker(worker_type = "<id>"). Match: ^[A-Za-z0-9_-]+$. | [`../crates/pitboss-cli/src/manifest/schema.rs#L666`](../crates/pitboss-cli/src/manifest/schema.rs#L666) |
+| `tools` | string list | no | Allowed tool surface for this worker class. Lead's spawn_worker(tools=...) must be a subset; omit means "give me the whole allowlist." | [`../crates/pitboss-cli/src/manifest/schema.rs#L674`](../crates/pitboss-cli/src/manifest/schema.rs#L674) |
+| `allowed_models` | string list | no | When non-empty, spawn_worker(model=...) must be in this list. Empty means any model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L682`](../crates/pitboss-cli/src/manifest/schema.rs#L682) |
+| `max_timeout_secs` | integer | no | Hard cap on spawn_worker(timeout_secs=...). Lead values clamp DOWN; smaller values pass through. | [`../crates/pitboss-cli/src/manifest/schema.rs#L690`](../crates/pitboss-cli/src/manifest/schema.rs#L690) |
 
 ## `[[sublead_type]]` — `SubleadType`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:665`](../crates/pitboss-cli/src/manifest/schema.rs#L665).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:698`](../crates/pitboss-cli/src/manifest/schema.rs#L698).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique id used in spawn_sublead(sublead_type = "<id>"). Match: ^[A-Za-z0-9_-]+$. | [`../crates/pitboss-cli/src/manifest/schema.rs#L672`](../crates/pitboss-cli/src/manifest/schema.rs#L672) |
-| `tools` | string list | no | Allowed tool surface for this sub-lead class. spawn_sublead(tools=...) must be a subset; empty means "give me the whole allowlist." | [`../crates/pitboss-cli/src/manifest/schema.rs#L679`](../crates/pitboss-cli/src/manifest/schema.rs#L679) |
-| `allowed_models` | string list | no | When non-empty, spawn_sublead(model=...) must be in this list. | [`../crates/pitboss-cli/src/manifest/schema.rs#L686`](../crates/pitboss-cli/src/manifest/schema.rs#L686) |
-| `max_timeout_secs` | integer | no | Hard cap on spawn_sublead(lead_timeout_secs=...). Clamps DOWN. | [`../crates/pitboss-cli/src/manifest/schema.rs#L693`](../crates/pitboss-cli/src/manifest/schema.rs#L693) |
-| `max_budget_usd` | float | no | Hard cap on spawn_sublead(budget_usd=...). Clamps DOWN. | [`../crates/pitboss-cli/src/manifest/schema.rs#L700`](../crates/pitboss-cli/src/manifest/schema.rs#L700) |
+| `id` | text | **yes** | Unique id used in spawn_sublead(sublead_type = "<id>"). Match: ^[A-Za-z0-9_-]+$. | [`../crates/pitboss-cli/src/manifest/schema.rs#L705`](../crates/pitboss-cli/src/manifest/schema.rs#L705) |
+| `tools` | string list | no | Allowed tool surface for this sub-lead class. spawn_sublead(tools=...) must be a subset; empty means "give me the whole allowlist." | [`../crates/pitboss-cli/src/manifest/schema.rs#L712`](../crates/pitboss-cli/src/manifest/schema.rs#L712) |
+| `allowed_models` | string list | no | When non-empty, spawn_sublead(model=...) must be in this list. | [`../crates/pitboss-cli/src/manifest/schema.rs#L719`](../crates/pitboss-cli/src/manifest/schema.rs#L719) |
+| `max_timeout_secs` | integer | no | Hard cap on spawn_sublead(lead_timeout_secs=...). Clamps DOWN. | [`../crates/pitboss-cli/src/manifest/schema.rs#L726`](../crates/pitboss-cli/src/manifest/schema.rs#L726) |
+| `max_budget_usd` | float | no | Hard cap on spawn_sublead(budget_usd=...). Clamps DOWN. | [`../crates/pitboss-cli/src/manifest/schema.rs#L733`](../crates/pitboss-cli/src/manifest/schema.rs#L733) |
 
 ## `[communication]` — `CommunicationConfig`
 
@@ -176,12 +177,12 @@ Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:260`](../crates/pitbos
 
 ## `[[template]]` — `Template`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:752`](../crates/pitboss-cli/src/manifest/schema.rs#L752).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:785`](../crates/pitboss-cli/src/manifest/schema.rs#L785).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Slug referenced from [[task]].template. | [`../crates/pitboss-cli/src/manifest/schema.rs#L757`](../crates/pitboss-cli/src/manifest/schema.rs#L757) |
-| `prompt` | text (multi-line) | **yes** | Prompt body. Supports {var} placeholders supplied by [[task]].vars. | [`../crates/pitboss-cli/src/manifest/schema.rs#L763`](../crates/pitboss-cli/src/manifest/schema.rs#L763) |
+| `id` | text | **yes** | Slug referenced from [[task]].template. | [`../crates/pitboss-cli/src/manifest/schema.rs#L790`](../crates/pitboss-cli/src/manifest/schema.rs#L790) |
+| `prompt` | text (multi-line) | **yes** | Prompt body. Supports {var} placeholders supplied by [[task]].vars. | [`../crates/pitboss-cli/src/manifest/schema.rs#L796`](../crates/pitboss-cli/src/manifest/schema.rs#L796) |
 
 ## `[lifecycle]` — `Lifecycle`
 

--- a/docs/manifest-reference.toml
+++ b/docs/manifest-reference.toml
@@ -32,6 +32,7 @@ denial_termination_policy = "adapt"
 dump_shared_store = false
 require_plan_approval = false
 require_actor_type = false
+untyped_actor_policy = "bridge"
 
 [defaults]
 model = "<value>"


### PR DESCRIPTION
## Summary

New \`[run].untyped_actor_policy = \"bridge\" | \"block\"\` field. Default \`\"bridge\"\` preserves pre-#252 behavior (route to the operator approval bridge). \`\"block\"\` synthesizes an empty profile so the profile-driven short-circuit landed in #388 fires with a Deny on every un-typed call that reaches \`permission_prompt\` — the \"manifest is the consent signal\" policy enacted at runtime.

This is the runtime fallback the wild-tinkering plan called for. Useful for headless production runs once the operator has migrated their manifests.

## Behavior matrix

| actor typed?  | policy = bridge | policy = block |
|---------------|-----------------|------------------|
| yes (declared profile) | profile fires (#388) | profile fires (#388) |
| no            | bridge fallback (pre-#252) | **synthetic deny** ← new |

## Synthetic profile audit shape

Auto-deny rows on \`events.jsonl\` carry \`actor_type = \"<synthetic>\"\` so consumers can distinguish synthesized denials from declared-profile denials. The sentinel can never collide with a real profile id (validate rejects \`<\` in ids).

The model-facing reason names the sentinel: \`denied: tool 'Read' not in worker_type '<synthetic>' allowlist\`. Claude can pattern-match on it the same way it pattern-matches declared-profile denials.

## Validate-time guard

\`untyped_actor_policy = \"block\"\` with no profiles declared is a hard error — every spawn would auto-deny via the synthetic empty profile, so the lead can spawn nothing useful. Operators are pointed at \`pitboss schema --format=migration\` for a starter scaffold.

## Why not flip the default?

Flipping \`PermissionRouting::default()\` to Path B is a separate decision with its own breaking-change calculus (versioning, migration comms, CHANGELOG framing). Bundling it here would inflate the PR. The runtime mechanism lands now so opt-in Path B users can adopt strict mode today; the default flip is a small follow-up that just sets two manifest defaults.

## Test plan

- [x] \`cargo test --workspace --features pitboss-core/test-support\` — every suite green; pitboss-cli lib at 743/743
- [x] 5 new tests:
  - \`permission_prompt_synthetic_default_blocks_untyped_worker\`
  - \`permission_prompt_synthetic_default_does_not_override_declared_profile\`
  - \`permission_prompt_bridge_policy_keeps_untyped_bridge_fallback\`
  - \`validate_rejects_block_untyped_when_no_profiles\`
  - \`validate_accepts_block_untyped_with_at_least_one_profile\` (worker_type-only AND sublead_type-only branches)
  - \`validate_accepts_bridge_policy_without_profiles\`
- [x] Updated AGENTS.md \`[run]\` section with the new field.
- [x] Updated \`pitboss schema --format=migration\` scaffold with the new step 5 covering \`untyped_actor_policy = \"block\"\`.
- [x] Regenerated \`docs/manifest-reference.toml\` and \`docs/manifest-map.md\` via \`pitboss schema\`.
- [x] \`cargo lint\` — clean
- [x] \`cargo tidy\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)