### PR TITLE
feat(tui): surface capability matrix in Detail view (#391 slice)

### DIFF
--- a/crates/pitboss-cli/src/capability_matrix.rs
+++ b/crates/pitboss-cli/src/capability_matrix.rs
@@ -17,50 +17,129 @@
 use crate::dispatch::hierarchical::mcp_server_scope_admits;
 use crate::manifest::resolve::ResolvedManifest;
 
-/// Render the matrix as a multi-line string ending in `\n`.
+/// Which class of actor a [`MatrixRow`] represents.
+///
+/// The CLI text formatter prefixes each label with this kind
+/// (`worker_type:` / `sublead_type:`) and renders the untyped row as
+/// `(untyped / root)`. Programmatic consumers (TUI Detail view,
+/// `pitboss-web` manifest panel) use the kind directly to pick which
+/// row matches a focused tile's `actor_type`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RowKind {
+    /// Root lead and any un-profiled (`actor_type = None`) spawn.
+    Untyped,
+    /// A declared `[[worker_type]]`.
+    WorkerType,
+    /// A declared `[[sublead_type]]`.
+    SubleadType,
+}
+
+/// One row of the actor-type × MCP-server matrix.
+///
+/// `actor_type` is `None` for the untyped/root row and `Some(id)` for
+/// declared profiles; consumers that want to match a tile's
+/// `actor_type` directly check `row.actor_type.as_deref() ==
+/// tile.actor_type.as_deref()`.
+///
+/// `server_ids` is in manifest declaration order so two manifests
+/// producing the same matrix shape compare stable diff-wise.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MatrixRow {
+    /// Display label as the CLI formatter emits it (`(untyped / root)`,
+    /// `worker_type:writer`, `sublead_type:planner`).
+    pub label: String,
+    /// `None` for the untyped row, `Some(id)` for typed rows. Drives
+    /// matching against `TaskRecord.actor_type`.
+    pub actor_type: Option<String>,
+    pub kind: RowKind,
+    /// MCP server ids that scope-admit for this row, in manifest
+    /// declaration order.
+    pub server_ids: Vec<String>,
+}
+
+/// Compute matrix rows from a fully resolved manifest. Used by the CLI
+/// `--capability-matrix` formatter and any Rust consumer that already
+/// owns a `ResolvedManifest`.
 ///
 /// Row order:
-/// 1. `(untyped / root)` — what the root lead and any un-profiled
-///    spawn sees. Always first; operators reading the table want the
-///    "default" row anchored at the top.
+/// 1. Untyped (always first; the "default" anchor row).
 /// 2. One row per `[[worker_type]]`, in declaration order.
 /// 3. One row per `[[sublead_type]]`, in declaration order.
-///
-/// `[[mcp_server]]` ids inside each row are emitted in declaration
-/// order so two manifests producing the same matrix shape compare
-/// stable diff-wise.
-pub fn render(manifest: &ResolvedManifest) -> String {
-    let server_ids: Vec<&str> = manifest.mcp_servers.iter().map(|s| s.id.as_str()).collect();
-    let server_scopes: Vec<Option<&str>> = manifest
+pub fn rows(manifest: &ResolvedManifest) -> Vec<MatrixRow> {
+    let servers: Vec<(String, Option<String>)> = manifest
         .mcp_servers
         .iter()
-        .map(|s| s.scope.as_deref())
+        .map(|s| (s.id.clone(), s.scope.clone()))
         .collect();
+    let wt_ids: Vec<String> = manifest.worker_types.iter().map(|w| w.id.clone()).collect();
+    let st_ids: Vec<String> = manifest
+        .sublead_types
+        .iter()
+        .map(|s| s.id.clone())
+        .collect();
+    rows_from_parts(&servers, &wt_ids, &st_ids)
+}
 
-    // Pre-compute the matrix as Vec<(label, Vec<&str>)>. The widest
-    // label drives the first column's width so multi-row output stays
-    // aligned without an external table crate.
-    let mut rows: Vec<(String, Vec<&str>)> = Vec::new();
-    rows.push((
-        "(untyped / root)".to_string(),
-        admitted_servers(&server_ids, &server_scopes, None),
-    ));
-    for wt in &manifest.worker_types {
-        rows.push((
-            format!("worker_type:{}", wt.id),
-            admitted_servers(&server_ids, &server_scopes, Some(wt.id.as_str())),
-        ));
+/// Compute matrix rows from the minimal data the algorithm needs. The
+/// TUI deserializes a lightweight subset of `resolved.json` and feeds
+/// it in here without having to construct a full `ResolvedManifest` —
+/// keeps the matrix logic decoupled from the larger manifest type.
+pub fn rows_from_parts(
+    servers: &[(String, Option<String>)],
+    worker_type_ids: &[String],
+    sublead_type_ids: &[String],
+) -> Vec<MatrixRow> {
+    let mut out: Vec<MatrixRow> =
+        Vec::with_capacity(1 + worker_type_ids.len() + sublead_type_ids.len());
+    out.push(MatrixRow {
+        label: "(untyped / root)".to_string(),
+        actor_type: None,
+        kind: RowKind::Untyped,
+        server_ids: admitted_for(servers, None),
+    });
+    for id in worker_type_ids {
+        out.push(MatrixRow {
+            label: format!("worker_type:{id}"),
+            actor_type: Some(id.clone()),
+            kind: RowKind::WorkerType,
+            server_ids: admitted_for(servers, Some(id.as_str())),
+        });
     }
-    for st in &manifest.sublead_types {
-        rows.push((
-            format!("sublead_type:{}", st.id),
-            admitted_servers(&server_ids, &server_scopes, Some(st.id.as_str())),
-        ));
+    for id in sublead_type_ids {
+        out.push(MatrixRow {
+            label: format!("sublead_type:{id}"),
+            actor_type: Some(id.clone()),
+            kind: RowKind::SubleadType,
+            server_ids: admitted_for(servers, Some(id.as_str())),
+        });
     }
+    out
+}
+
+fn admitted_for(servers: &[(String, Option<String>)], actor_type: Option<&str>) -> Vec<String> {
+    servers
+        .iter()
+        .filter_map(|(id, scope)| {
+            if mcp_server_scope_admits(scope.as_deref(), actor_type) {
+                Some(id.clone())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Render the matrix as a multi-line string ending in `\n`.
+///
+/// Thin formatter on top of [`rows`]. The widest label drives the
+/// first column's width so multi-row output stays aligned without an
+/// external table crate.
+pub fn render(manifest: &ResolvedManifest) -> String {
+    let rows = rows(manifest);
 
     let label_width = rows
         .iter()
-        .map(|(l, _)| l.len())
+        .map(|r| r.label.len())
         .chain(std::iter::once("actor type".len()))
         .max()
         .unwrap_or(20);
@@ -75,36 +154,16 @@ pub fn render(manifest: &ResolvedManifest) -> String {
         "-".repeat(label_width),
         "-".repeat(36)
     ));
-    for (label, ids) in &rows {
-        let cell = if ids.is_empty() {
+    for row in &rows {
+        let cell = if row.server_ids.is_empty() {
             "(none)".to_string()
         } else {
-            ids.join(", ")
+            row.server_ids.join(", ")
         };
+        let label = &row.label;
         out.push_str(&format!("{label:<label_width$}  {cell}\n"));
     }
     out
-}
-
-/// Compute the subset of server ids that scope-admit for a given
-/// `actor_type` (`None` for the untyped / root row). Preserves
-/// declaration order — the upstream zip of ids with scopes is
-/// position-aligned by `render`'s caller.
-fn admitted_servers<'a>(
-    ids: &[&'a str],
-    scopes: &[Option<&str>],
-    actor_type: Option<&str>,
-) -> Vec<&'a str> {
-    ids.iter()
-        .zip(scopes.iter())
-        .filter_map(|(id, scope)| {
-            if mcp_server_scope_admits(*scope, actor_type) {
-                Some(*id)
-            } else {
-                None
-            }
-        })
-        .collect()
 }
 
 #[cfg(test)]
@@ -263,6 +322,64 @@ mod tests {
             !out.contains("worker_type:") && !out.contains("sublead_type:"),
             "must not emit profile rows when no profiles are declared: {out}"
         );
+    }
+
+    /// `rows()` exposes the structured matrix data the TUI Detail view
+    /// and `pitboss-web` manifest panel will consume. Pin the row
+    /// shape: untyped first, then declared profiles in declaration
+    /// order, with `actor_type` set so consumers can match a tile's
+    /// `TaskRecord.actor_type` directly.
+    #[test]
+    fn rows_emits_untyped_then_worker_then_sublead_in_declaration_order() {
+        let mut m = empty_manifest();
+        m.mcp_servers = vec![srv("pitboss", None), srv("fs-writer", Some("type:writer"))];
+        m.worker_types = vec![wt("writer"), wt("reader")];
+        m.sublead_types = vec![st("planner")];
+
+        let rs = rows(&m);
+        assert_eq!(rs.len(), 4, "expected 1 untyped + 2 worker + 1 sublead");
+
+        assert_eq!(rs[0].kind, RowKind::Untyped);
+        assert!(rs[0].actor_type.is_none());
+        assert_eq!(rs[0].server_ids, vec!["pitboss".to_string()]);
+
+        assert_eq!(rs[1].kind, RowKind::WorkerType);
+        assert_eq!(rs[1].actor_type.as_deref(), Some("writer"));
+        assert_eq!(rs[1].label, "worker_type:writer");
+        // writer-scoped server admits for writer.
+        assert_eq!(
+            rs[1].server_ids,
+            vec!["pitboss".to_string(), "fs-writer".to_string()]
+        );
+
+        assert_eq!(rs[2].kind, RowKind::WorkerType);
+        assert_eq!(rs[2].actor_type.as_deref(), Some("reader"));
+
+        assert_eq!(rs[3].kind, RowKind::SubleadType);
+        assert_eq!(rs[3].actor_type.as_deref(), Some("planner"));
+    }
+
+    /// `rows_from_parts` lets the TUI compute the matrix from a
+    /// lightweight resolved.json deserialization without pulling in
+    /// the full `ResolvedManifest` shape. Pin equivalence with the
+    /// `ResolvedManifest`-driven path so the two stay in sync.
+    #[test]
+    fn rows_from_parts_matches_full_manifest_path() {
+        let servers = vec![
+            ("pitboss".to_string(), None),
+            ("fs-writer".to_string(), Some("type:writer".to_string())),
+        ];
+        let workers = vec!["writer".to_string()];
+        let subleads: Vec<String> = vec![];
+
+        let parts_rows = rows_from_parts(&servers, &workers, &subleads);
+
+        let mut m = empty_manifest();
+        m.mcp_servers = vec![srv("pitboss", None), srv("fs-writer", Some("type:writer"))];
+        m.worker_types = vec![wt("writer")];
+        let manifest_rows = rows(&m);
+
+        assert_eq!(parts_rows, manifest_rows);
     }
 
     /// A scoped server must be excluded from the untyped row even

--- a/crates/pitboss-tui/src/grouped_grid.rs
+++ b/crates/pitboss-tui/src/grouped_grid.rs
@@ -80,6 +80,7 @@ mod tests {
             worktree_path: None,
             completed_at: None,
             denials_count: 0,
+            actor_type: None,
         }
     }
 

--- a/crates/pitboss-tui/src/main.rs
+++ b/crates/pitboss-tui/src/main.rs
@@ -308,6 +308,7 @@ fn build_one_shot_snapshot(run_dir: &std::path::Path) -> state::AppSnapshot {
                 worktree_path: rec.worktree_path.clone(),
                 completed_at: Some(rec.ended_at),
                 denials_count: 0,
+                actor_type: rec.actor_type.clone(),
             });
         } else {
             tiles.push(TileState {
@@ -325,6 +326,7 @@ fn build_one_shot_snapshot(run_dir: &std::path::Path) -> state::AppSnapshot {
                 worktree_path: None,
                 completed_at: None,
                 denials_count: 0,
+                actor_type: None,
             });
         }
     }
@@ -334,6 +336,7 @@ fn build_one_shot_snapshot(run_dir: &std::path::Path) -> state::AppSnapshot {
         focus_log: Vec::new(),
         failed_count,
         run_started_at,
+        matrix_rows: Vec::new(),
     }
 }
 

--- a/crates/pitboss-tui/src/state.rs
+++ b/crates/pitboss-tui/src/state.rs
@@ -219,6 +219,12 @@ pub struct TileState {
     /// claude received and adapted to (#370). Read-side aggregation only;
     /// the canonical per-row data lives in `events.jsonl`.
     pub denials_count: u32,
+    /// Resolved `[[worker_type]]` / `[[sublead_type]]` id at spawn time
+    /// (from `TaskRecord.actor_type`). `None` for the lead, for un-typed
+    /// spawns, and for in-flight tiles whose record hasn't settled. Drives
+    /// the Detail view's matrix-row lookup so the focused tile sees
+    /// "MCP servers visible to this actor" matching its profile (#391).
+    pub actor_type: Option<String>,
 }
 
 /// Full application state updated each poll cycle.
@@ -335,6 +341,12 @@ pub struct AppState {
     /// operator must explicitly acknowledge before issuing a command that
     /// would target the wrong tile. (#339)
     pub focus_lost_notice: Option<FocusLostNotice>,
+    /// Capability matrix derived from `resolved.json` and refreshed on
+    /// each watcher tick. Empty until the first snapshot lands. The
+    /// Detail view picks the row matching `focused_tile.actor_type` and
+    /// renders the MCP servers visible to that actor. See
+    /// [`pitboss_cli::capability_matrix`] for row semantics (#391).
+    pub matrix_rows: Vec<pitboss_cli::capability_matrix::MatrixRow>,
 }
 
 /// Surfaced in the status bar when the focused tile disappeared (was
@@ -414,6 +426,7 @@ impl AppState {
             completed_after_secs: COMPLETED_COOLDOWN_DEFAULT_SECS,
             compact_tiles: false,
             focus_lost_notice: None,
+            matrix_rows: Vec::new(),
         }
     }
 
@@ -909,6 +922,7 @@ impl AppState {
         self.tasks = snapshot.tasks;
         self.focus_log = snapshot.focus_log;
         self.failed_count = snapshot.failed_count;
+        self.matrix_rows = snapshot.matrix_rows;
         // Keep the earliest start time we've ever seen (monotonically non-increasing).
         match (self.run_started_at, snapshot.run_started_at) {
             (None, v) => self.run_started_at = v,
@@ -1056,6 +1070,12 @@ pub struct AppSnapshot {
     /// Earliest wall-clock start time across all completed tiles. `None` if no
     /// tiles have recorded a `started_at` yet.
     pub run_started_at: Option<DateTime<Utc>>,
+    /// Capability matrix derived from `resolved.json` once on snapshot
+    /// build. Empty when `resolved.json` has no MCP servers and no typed
+    /// profiles — the watcher still emits the untyped row so the Detail
+    /// view can render "(none)" rather than a missing section. See
+    /// [`pitboss_cli::capability_matrix`] for row semantics (#391).
+    pub matrix_rows: Vec<pitboss_cli::capability_matrix::MatrixRow>,
 }
 
 #[cfg(test)]
@@ -1223,6 +1243,7 @@ mod tests {
             worktree_path: None,
             completed_at: None,
             denials_count: 0,
+            actor_type: None,
         }];
         state
     }
@@ -1649,6 +1670,7 @@ mod tests {
             focus_log: Vec::new(),
             failed_count: 0,
             run_started_at: Some(t0),
+            matrix_rows: Vec::new(),
         };
         state.apply_snapshot(snapshot);
         assert_eq!(state.run_started_at, Some(t0));
@@ -1660,6 +1682,7 @@ mod tests {
             focus_log: Vec::new(),
             failed_count: 0,
             run_started_at: Some(t_earlier),
+            matrix_rows: Vec::new(),
         };
         state.apply_snapshot(snapshot2);
         assert_eq!(
@@ -1675,6 +1698,7 @@ mod tests {
             focus_log: Vec::new(),
             failed_count: 0,
             run_started_at: Some(t_later),
+            matrix_rows: Vec::new(),
         };
         state.apply_snapshot(snapshot3);
         assert_eq!(
@@ -1781,6 +1805,7 @@ mod tests {
             worktree_path: None,
             completed_at: Some(Utc::now() - chrono::Duration::seconds(ended_secs_ago)),
             denials_count: 0,
+            actor_type: None,
         }
     }
 
@@ -1816,6 +1841,7 @@ mod tests {
             worktree_path: None,
             completed_at: None, // running tiles never have completed_at
             denials_count: 0,
+            actor_type: None,
         };
         assert!(!state.is_promoted(&tile));
     }
@@ -1841,6 +1867,7 @@ mod tests {
                 worktree_path: None,
                 completed_at: None,
                 denials_count: 0,
+                actor_type: None,
             },
             make_done_tile("fresh", 2), // done but within grace period
         ];
@@ -1900,6 +1927,7 @@ mod tests {
             worktree_path: None,
             completed_at: None,
             denials_count: 0,
+            actor_type: None,
         }
     }
 
@@ -1944,6 +1972,7 @@ mod tests {
             focus_log: Vec::new(),
             failed_count: 0,
             run_started_at: None,
+            matrix_rows: Vec::new(),
         };
         state.apply_snapshot(snapshot);
         let notice = state
@@ -1965,6 +1994,7 @@ mod tests {
             focus_log: Vec::new(),
             failed_count: 0,
             run_started_at: None,
+            matrix_rows: Vec::new(),
         };
         state.apply_snapshot(snapshot);
         assert_eq!(state.focus, 0, "focus must follow id, not index");
@@ -1992,6 +2022,7 @@ mod tests {
             focus_log: Vec::new(),
             failed_count: 0,
             run_started_at: None,
+            matrix_rows: Vec::new(),
         };
         state.apply_snapshot(snapshot);
         let notice = state

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -1726,9 +1726,69 @@ fn render_detail_metadata(
             theme::muted_style(),
         )));
     }
+    lines.push(Line::from(""));
+
+    // --- MCP servers (capability matrix row for this actor) ---
+    // Picks the row whose `actor_type` matches the focused tile and
+    // lists the MCP server ids pitboss would inject. Falls back to the
+    // untyped row when the tile has no actor_type yet (in-flight,
+    // pre-#252 record, or root lead). Nothing renders when
+    // `resolved.json` declared no MCP servers — common for flat-mode
+    // manifests, no value in showing an empty section. (#391)
+    let matrix_row = matrix_row_for_tile(&state.matrix_rows, tile);
+    if let Some(row) = matrix_row {
+        lines.push(Line::from(Span::styled(
+            "MCP SERVERS",
+            theme::secondary_style().add_modifier(Modifier::BOLD),
+        )));
+        let actor_label = match tile.actor_type.as_deref() {
+            Some(t) => format!("(profile: {t})"),
+            None => "(untyped / root)".to_string(),
+        };
+        lines.push(Line::from(Span::styled(
+            format!("  {actor_label}"),
+            theme::muted_style(),
+        )));
+        if row.server_ids.is_empty() {
+            lines.push(Line::from(Span::styled("  (none)", theme::muted_style())));
+        } else {
+            for id in &row.server_ids {
+                lines.push(Line::from(Span::styled(
+                    format!("  • {id}"),
+                    theme::muted_style(),
+                )));
+            }
+        }
+    }
 
     let para = Paragraph::new(lines).wrap(Wrap { trim: false });
     frame.render_widget(para, inner);
+}
+
+/// Pick the matrix row that applies to a given tile.
+///
+/// 1. If the tile has an `actor_type`, find the row whose
+///    `row.actor_type` matches.
+/// 2. Otherwise fall back to the untyped row (the root lead and any
+///    pre-#252 / in-flight tile).
+/// 3. Returns `None` when `matrix_rows` is empty — the caller skips the
+///    section so we don't paint a "(none)" row when the manifest had
+///    no MCP servers to begin with (would surprise operators reading
+///    Detail on a flat-mode run that never declared `[[mcp_server]]`).
+fn matrix_row_for_tile<'a>(
+    rows: &'a [pitboss_cli::capability_matrix::MatrixRow],
+    tile: &crate::state::TileState,
+) -> Option<&'a pitboss_cli::capability_matrix::MatrixRow> {
+    if rows.is_empty() {
+        return None;
+    }
+    if let Some(t) = tile.actor_type.as_deref() {
+        if let Some(row) = rows.iter().find(|r| r.actor_type.as_deref() == Some(t)) {
+            return Some(row);
+        }
+    }
+    rows.iter()
+        .find(|r| matches!(r.kind, pitboss_cli::capability_matrix::RowKind::Untyped))
 }
 
 /// Right-pane scrollable log. Scroll unit is VISUAL ROWS post-wrap, not
@@ -2346,6 +2406,7 @@ mod tests {
             worktree_path: None,
             completed_at: None,
             denials_count: 0,
+            actor_type: None,
         }
     }
 
@@ -2381,6 +2442,7 @@ mod tests {
             completed_after_secs: crate::state::COMPLETED_COOLDOWN_DEFAULT_SECS,
             compact_tiles: false,
             focus_lost_notice: None,
+            matrix_rows: Vec::new(),
         }
     }
 
@@ -2563,6 +2625,195 @@ mod tests {
             rendered.contains("first log line"),
             "rendered output should contain log content; got snippet: {:?}",
             &rendered[..rendered.len().min(200)]
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // capability matrix lookup + Detail rendering (#391)
+    // -----------------------------------------------------------------------
+
+    fn matrix_row(
+        label: &str,
+        actor_type: Option<&str>,
+        kind: pitboss_cli::capability_matrix::RowKind,
+        servers: &[&str],
+    ) -> pitboss_cli::capability_matrix::MatrixRow {
+        pitboss_cli::capability_matrix::MatrixRow {
+            label: label.to_string(),
+            actor_type: actor_type.map(str::to_string),
+            kind,
+            server_ids: servers.iter().map(|s| (*s).to_string()).collect(),
+        }
+    }
+
+    /// Tile with `actor_type = Some("writer")` selects the
+    /// `worker_type:writer` row over the untyped one. Pin this so the
+    /// Detail view never silently falls back to untyped when the typed
+    /// row exists.
+    #[test]
+    fn matrix_row_for_tile_picks_typed_row_when_actor_type_matches() {
+        use pitboss_cli::capability_matrix::RowKind;
+        let rows = vec![
+            matrix_row("(untyped / root)", None, RowKind::Untyped, &["pitboss"]),
+            matrix_row(
+                "worker_type:writer",
+                Some("writer"),
+                RowKind::WorkerType,
+                &["pitboss", "fs-writer"],
+            ),
+        ];
+        let mut t = tile("w1", TileStatus::Running, None, 0, 0);
+        t.actor_type = Some("writer".to_string());
+        let picked = matrix_row_for_tile(&rows, &t).expect("expected a row");
+        assert_eq!(picked.actor_type.as_deref(), Some("writer"));
+    }
+
+    /// In-flight tile (no `actor_type` yet) and the root lead both fall back
+    /// to the untyped row. Without this fallback, Detail would render an
+    /// empty MCP-SERVERS section for the lead, which is the operator's
+    /// most common focus.
+    #[test]
+    fn matrix_row_for_tile_falls_back_to_untyped_when_actor_type_is_none() {
+        use pitboss_cli::capability_matrix::RowKind;
+        let rows = vec![
+            matrix_row("(untyped / root)", None, RowKind::Untyped, &["pitboss"]),
+            matrix_row(
+                "worker_type:writer",
+                Some("writer"),
+                RowKind::WorkerType,
+                &["pitboss", "fs-writer"],
+            ),
+        ];
+        let t = tile("lead", TileStatus::Running, None, 0, 0);
+        let picked = matrix_row_for_tile(&rows, &t).expect("expected fallback");
+        assert!(matches!(picked.kind, RowKind::Untyped));
+    }
+
+    /// Empty matrix (resolved.json had no `[[mcp_server]]`) returns `None`
+    /// so the Detail-view caller skips rendering the section entirely.
+    /// Pinning this prevents an "(none)" row from appearing on flat-mode
+    /// runs that never declared MCP servers.
+    #[test]
+    fn matrix_row_for_tile_returns_none_when_matrix_is_empty() {
+        let rows: Vec<pitboss_cli::capability_matrix::MatrixRow> = Vec::new();
+        let t = tile("anything", TileStatus::Running, None, 0, 0);
+        assert!(matrix_row_for_tile(&rows, &t).is_none());
+    }
+
+    /// Detail view renders the MCP-SERVERS section with the focused
+    /// tile's profile label and its admitted server ids. The section
+    /// should be visible without scrolling on a normal-sized terminal.
+    #[test]
+    fn detail_view_renders_mcp_servers_section_for_typed_tile() {
+        use crate::state::Mode;
+        use pitboss_cli::capability_matrix::RowKind;
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let task_id = "writer-1";
+        let mut t = tile(task_id, TileStatus::Running, None, 0, 0);
+        t.actor_type = Some("writer".to_string());
+
+        let mut s = state(vec![t]);
+        s.matrix_rows = vec![
+            matrix_row("(untyped / root)", None, RowKind::Untyped, &["pitboss"]),
+            matrix_row(
+                "worker_type:writer",
+                Some("writer"),
+                RowKind::WorkerType,
+                &["pitboss", "fs-writer"],
+            ),
+        ];
+        s.mode = Mode::Detail {
+            task_id: task_id.to_string(),
+            scroll: 0,
+            at_bottom: true,
+            return_to: Box::new(Mode::Normal),
+        };
+
+        // Tall terminal so the MCP-SERVERS section lands within the
+        // metadata pane regardless of whether the tile renders all
+        // upstream sections.
+        let backend = TestBackend::new(120, 60);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|frame| render(frame, &s)).unwrap();
+
+        let buf = terminal.backend().buffer();
+        let rendered: String = (0..60)
+            .flat_map(|y| (0..120u16).map(move |x| (x, y)))
+            .map(|(x, y)| buf.cell((x, y)).unwrap().symbol().to_string())
+            .collect();
+
+        assert!(
+            rendered.contains("MCP SERVERS"),
+            "MCP SERVERS heading should be visible"
+        );
+        assert!(
+            rendered.contains("profile: writer"),
+            "should show profile label for typed tile"
+        );
+        assert!(
+            rendered.contains("fs-writer"),
+            "writer-scoped server should appear in the list"
+        );
+    }
+
+    /// Untyped path: the lead (and any in-flight tile whose record
+    /// hasn't settled) shows the `(untyped / root)` label and only the
+    /// unscoped servers — not the writer-scoped one. This is the most
+    /// common Detail view operators see in hierarchical runs (the lead
+    /// is the default focus), so pin the rendering separately from the
+    /// typed branch.
+    #[test]
+    fn detail_view_renders_mcp_servers_section_for_lead_under_untyped_row() {
+        use crate::state::Mode;
+        use pitboss_cli::capability_matrix::RowKind;
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let task_id = "lead";
+        // Lead tile has actor_type = None (it's the root, never typed).
+        let t = tile(task_id, TileStatus::Running, None, 0, 0);
+
+        let mut s = state(vec![t]);
+        s.matrix_rows = vec![
+            matrix_row("(untyped / root)", None, RowKind::Untyped, &["pitboss"]),
+            matrix_row(
+                "worker_type:writer",
+                Some("writer"),
+                RowKind::WorkerType,
+                &["pitboss", "fs-writer"],
+            ),
+        ];
+        s.mode = Mode::Detail {
+            task_id: task_id.to_string(),
+            scroll: 0,
+            at_bottom: true,
+            return_to: Box::new(Mode::Normal),
+        };
+
+        let backend = TestBackend::new(120, 60);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|frame| render(frame, &s)).unwrap();
+
+        let buf = terminal.backend().buffer();
+        let rendered: String = (0..60)
+            .flat_map(|y| (0..120u16).map(move |x| (x, y)))
+            .map(|(x, y)| buf.cell((x, y)).unwrap().symbol().to_string())
+            .collect();
+
+        assert!(rendered.contains("MCP SERVERS"), "heading should appear");
+        assert!(
+            rendered.contains("(untyped / root)"),
+            "lead should render the untyped fallback label"
+        );
+        assert!(
+            rendered.contains("pitboss"),
+            "unscoped server should appear in the list"
+        );
+        assert!(
+            !rendered.contains("fs-writer"),
+            "writer-scoped server must not appear under the untyped row"
         );
     }
 

--- a/crates/pitboss-tui/src/watcher.rs
+++ b/crates/pitboss-tui/src/watcher.rs
@@ -56,12 +56,38 @@ struct ResolvedLead {
     pub model: Option<String>,
 }
 
+/// Minimal MCP server shape — we only need id + scope for the
+/// capability matrix. The full `[[mcp_server]]` schema (command, args,
+/// env) lives in `pitboss-cli`'s `ResolvedManifest`; deserializing
+/// only what we render here keeps the TUI's resolved.json parser
+/// independent of full-schema churn.
+#[derive(Debug, Deserialize)]
+struct ResolvedMcpServer {
+    pub id: String,
+    #[serde(default)]
+    pub scope: Option<String>,
+}
+
+/// Minimal `[[worker_type]]` / `[[sublead_type]]` shape — only the id
+/// drives the matrix. Other fields (`tools`, `allowed_models`, caps)
+/// are enforced upstream by the dispatcher.
+#[derive(Debug, Deserialize)]
+struct ResolvedActorType {
+    pub id: String,
+}
+
 #[derive(Debug, Deserialize)]
 struct ResolvedManifest {
     #[serde(default)]
     pub tasks: Vec<ResolvedTask>,
     #[serde(default)]
     pub lead: Option<ResolvedLead>,
+    #[serde(default)]
+    pub mcp_servers: Vec<ResolvedMcpServer>,
+    #[serde(default)]
+    pub worker_types: Vec<ResolvedActorType>,
+    #[serde(default)]
+    pub sublead_types: Vec<ResolvedActorType>,
 }
 
 // ---------------------------------------------------------------------------
@@ -113,10 +139,18 @@ pub fn watch(
 // ---------------------------------------------------------------------------
 
 fn build_snapshot(run_dir: &Path, focused_id: Option<&str>) -> AppSnapshot {
-    // 1. Read resolved.json → get static task ids, models, and lead (if any).
-    let (resolved_tasks, resolved_lead) = read_resolved_manifest(run_dir);
-    let model_map = build_model_map(&resolved_tasks, resolved_lead.as_ref());
-    let static_ids = collect_static_ids(&resolved_tasks, resolved_lead.as_ref());
+    // 1. Read resolved.json → get static task ids, models, lead (if any),
+    //    plus the MCP servers + actor-type ids needed for the capability
+    //    matrix shown in Detail view.
+    let resolved = read_resolved_manifest(run_dir);
+    let model_map = build_model_map(&resolved.tasks, resolved.lead.as_ref());
+    let static_ids = collect_static_ids(&resolved.tasks, resolved.lead.as_ref());
+    let resolved_lead = resolved.lead;
+    let matrix_rows = build_matrix_rows(
+        &resolved.mcp_servers,
+        &resolved.worker_types,
+        &resolved.sublead_types,
+    );
 
     // 2. Gather completed task records. Prefer summary.json (written on clean
     //    finalize) since summary.jsonl may be empty or truncated after
@@ -192,20 +226,51 @@ fn build_snapshot(run_dir: &Path, focused_id: Option<&str>) -> AppSnapshot {
         focus_log,
         failed_count,
         run_started_at,
+        matrix_rows,
     }
 }
 
-/// Read and parse `resolved.json`, returning the static tasks and optional
-/// lead. Missing or malformed files yield empty values.
-fn read_resolved_manifest(run_dir: &Path) -> (Vec<ResolvedTask>, Option<ResolvedLead>) {
+/// Read and parse `resolved.json` into the lightweight TUI subset.
+/// Missing or malformed files yield an empty manifest so the TUI keeps
+/// rendering against an in-flight or partially-written run.
+fn read_resolved_manifest(run_dir: &Path) -> ResolvedManifest {
     let resolved_path = run_dir.join("resolved.json");
     match std::fs::read(&resolved_path) {
-        Ok(bytes) => match serde_json::from_slice::<ResolvedManifest>(&bytes) {
-            Ok(m) => (m.tasks, m.lead),
-            Err(_) => (Vec::new(), None),
+        Ok(bytes) => serde_json::from_slice::<ResolvedManifest>(&bytes).unwrap_or_else(|_| {
+            ResolvedManifest {
+                tasks: Vec::new(),
+                lead: None,
+                mcp_servers: Vec::new(),
+                worker_types: Vec::new(),
+                sublead_types: Vec::new(),
+            }
+        }),
+        Err(_) => ResolvedManifest {
+            tasks: Vec::new(),
+            lead: None,
+            mcp_servers: Vec::new(),
+            worker_types: Vec::new(),
+            sublead_types: Vec::new(),
         },
-        Err(_) => (Vec::new(), None),
     }
+}
+
+/// Build the capability matrix from the parsed resolved.json subset.
+/// Delegates to `pitboss_cli::capability_matrix::rows_from_parts` so the
+/// TUI and the CLI `--capability-matrix` formatter cannot disagree on
+/// row shape (#391).
+fn build_matrix_rows(
+    servers: &[ResolvedMcpServer],
+    worker_types: &[ResolvedActorType],
+    sublead_types: &[ResolvedActorType],
+) -> Vec<pitboss_cli::capability_matrix::MatrixRow> {
+    let server_parts: Vec<(String, Option<String>)> = servers
+        .iter()
+        .map(|s| (s.id.clone(), s.scope.clone()))
+        .collect();
+    let wt_ids: Vec<String> = worker_types.iter().map(|w| w.id.clone()).collect();
+    let st_ids: Vec<String> = sublead_types.iter().map(|s| s.id.clone()).collect();
+    pitboss_cli::capability_matrix::rows_from_parts(&server_parts, &wt_ids, &st_ids)
 }
 
 /// Build a map from task/lead id → model for quick lookup when constructing
@@ -318,6 +383,7 @@ fn build_tile(
                 .or_else(|| log_path.parent().and_then(read_worktree_sidecar)),
             completed_at: Some(rec.ended_at),
             denials_count,
+            actor_type: rec.actor_type.clone(),
         }
     } else {
         // Decide between Pending and Running by checking log freshness.
@@ -361,6 +427,15 @@ fn build_tile(
             },
             completed_at: None,
             denials_count,
+            // In-flight tiles haven't settled a `TaskRecord` yet, so we
+            // don't know the resolved actor_type. Defaults to None →
+            // Detail view falls back to the "(untyped / root)" matrix
+            // row. A typed worker therefore shows the untyped row mid-
+            // flight, then flips to its typed row once its record
+            // lands. TODO(#391-followup): plumb actor_type through an
+            // events.jsonl spawn event so the typed row appears
+            // immediately on spawn instead of on settle.
+            actor_type: None,
         }
     }
 }
@@ -948,6 +1023,165 @@ mod tests {
         );
         let live_tile = snap.tasks.iter().find(|t| t.id == "worker-live").unwrap();
         assert_eq!(live_tile.parent_task_id.as_deref(), Some("lead"));
+    }
+
+    /// resolved.json's `mcp_servers` + `worker_types` + `sublead_types`
+    /// flow through to the snapshot's `matrix_rows`. The Detail view
+    /// picks rows from this list to populate the MCP-SERVERS section,
+    /// so a missing or mis-shaped `matrix_rows` would silently drop the
+    /// section regardless of how `resolved.json` was authored. (#391)
+    #[test]
+    fn watcher_emits_capability_matrix_rows_from_resolved_json() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let run_dir = dir.path().to_path_buf();
+
+        let resolved = serde_json::json!({
+            "max_parallel": 4,
+            "halt_on_failure": false,
+            "run_dir": run_dir.to_str(),
+            "worktree_cleanup": "OnSuccess",
+            "emit_event_stream": false,
+            "tasks": [],
+            "lead": {"id": "lead", "model": "claude-haiku-4-5"},
+            "max_workers": 4,
+            "budget_usd": 5.0,
+            "lead_timeout_secs": 900,
+            "mcp_servers": [
+                {"id": "pitboss", "command": "/bin/true", "args": [], "env": {}},
+                {"id": "fs-writer", "command": "/bin/true", "args": [], "env": {}, "scope": "type:writer"}
+            ],
+            "worker_types": [
+                {"id": "writer", "tools": [], "allowed_models": []}
+            ],
+            "sublead_types": []
+        });
+        std::fs::write(
+            run_dir.join("resolved.json"),
+            serde_json::to_vec(&resolved).unwrap(),
+        )
+        .unwrap();
+
+        let snap = build_snapshot(&run_dir, None);
+        // Untyped row + worker_type:writer = 2 rows.
+        assert_eq!(snap.matrix_rows.len(), 2, "expected untyped + writer rows");
+        let writer = snap
+            .matrix_rows
+            .iter()
+            .find(|r| r.actor_type.as_deref() == Some("writer"))
+            .expect("writer row missing");
+        assert!(
+            writer.server_ids.iter().any(|s| s == "fs-writer"),
+            "writer row should admit fs-writer (scope=type:writer)"
+        );
+    }
+
+    /// `TaskRecord.actor_type` (Phase 1.5 #384) flows onto the tile so
+    /// the Detail view can pick the matching matrix row. Without this,
+    /// even a fully-resolved manifest would always render the untyped
+    /// fallback row for every settled worker tile. (#391)
+    #[test]
+    fn watcher_propagates_actor_type_from_task_record_to_tile() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let run_dir = dir.path().to_path_buf();
+
+        let resolved = serde_json::json!({
+            "max_parallel": 4,
+            "halt_on_failure": false,
+            "run_dir": run_dir.to_str(),
+            "worktree_cleanup": "OnSuccess",
+            "emit_event_stream": false,
+            "tasks": [],
+            "lead": {"id": "lead", "model": "claude-haiku-4-5"},
+            "max_workers": 4,
+            "budget_usd": 5.0,
+            "lead_timeout_secs": 900
+        });
+        std::fs::write(
+            run_dir.join("resolved.json"),
+            serde_json::to_vec(&resolved).unwrap(),
+        )
+        .unwrap();
+
+        let worker_rec = serde_json::json!({
+            "task_id": "worker-typed",
+            "status": "Success",
+            "exit_code": 0,
+            "started_at": "2026-04-17T00:00:00Z",
+            "ended_at": "2026-04-17T00:00:30Z",
+            "duration_ms": 30000,
+            "worktree_path": null,
+            "log_path": run_dir.join("tasks/worker-typed/stdout.log").to_str(),
+            "token_usage": {"input": 0, "output": 0, "cache_read": 0, "cache_creation": 0},
+            "claude_session_id": null,
+            "final_message_preview": null,
+            "parent_task_id": "lead",
+            "actor_type": "writer"
+        });
+        let mut jsonl_line = serde_json::to_vec(&worker_rec).unwrap();
+        jsonl_line.push(b'\n');
+        std::fs::write(run_dir.join("summary.jsonl"), jsonl_line).unwrap();
+
+        let snap = build_snapshot(&run_dir, None);
+        let tile = snap
+            .tasks
+            .iter()
+            .find(|t| t.id == "worker-typed")
+            .expect("typed worker tile missing");
+        assert_eq!(tile.actor_type.as_deref(), Some("writer"));
+    }
+
+    /// Sub-lead tiles flow through the same `TaskRecord.actor_type`
+    /// path. Pin parity with the worker case so a future refactor that
+    /// special-cased one but not the other would fail loudly. (#391)
+    #[test]
+    fn watcher_propagates_sublead_actor_type_from_task_record() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let run_dir = dir.path().to_path_buf();
+
+        let resolved = serde_json::json!({
+            "max_parallel": 4,
+            "halt_on_failure": false,
+            "run_dir": run_dir.to_str(),
+            "worktree_cleanup": "OnSuccess",
+            "emit_event_stream": false,
+            "tasks": [],
+            "lead": {"id": "lead", "model": "claude-haiku-4-5"},
+            "max_workers": 4,
+            "budget_usd": 5.0,
+            "lead_timeout_secs": 900
+        });
+        std::fs::write(
+            run_dir.join("resolved.json"),
+            serde_json::to_vec(&resolved).unwrap(),
+        )
+        .unwrap();
+
+        let sublead_rec = serde_json::json!({
+            "task_id": "sublead-planner",
+            "status": "Success",
+            "exit_code": 0,
+            "started_at": "2026-04-17T00:00:00Z",
+            "ended_at": "2026-04-17T00:01:00Z",
+            "duration_ms": 60000,
+            "worktree_path": null,
+            "log_path": run_dir.join("tasks/sublead-planner/stdout.log").to_str(),
+            "token_usage": {"input": 0, "output": 0, "cache_read": 0, "cache_creation": 0},
+            "claude_session_id": null,
+            "final_message_preview": null,
+            "parent_task_id": "lead",
+            "actor_type": "planner"
+        });
+        let mut jsonl_line = serde_json::to_vec(&sublead_rec).unwrap();
+        jsonl_line.push(b'\n');
+        std::fs::write(run_dir.join("summary.jsonl"), jsonl_line).unwrap();
+
+        let snap = build_snapshot(&run_dir, None);
+        let tile = snap
+            .tasks
+            .iter()
+            .find(|t| t.id == "sublead-planner")
+            .expect("sublead tile missing");
+        assert_eq!(tile.actor_type.as_deref(), Some("planner"));
     }
 
     #[test]

--- a/crates/pitboss-tui/tests/tui_control.rs
+++ b/crates/pitboss-tui/tests/tui_control.rs
@@ -176,6 +176,7 @@ fn empty_grid_cells_are_cleared() {
             worktree_path: None,
             completed_at: None,
             denials_count: 0,
+            actor_type: None,
         }
     }
 
@@ -244,6 +245,7 @@ fn focus_log_content_does_not_bleed_into_tile_grid() {
             worktree_path: None,
             completed_at: None,
             denials_count: 0,
+            actor_type: None,
         }
     }
 


### PR DESCRIPTION
Slice 2 of #391 — TUI surfacing of the actor-type × MCP-server matrix in the per-actor Detail view. Web (slice 3) and per-tool granularity (slice 4) remain open; the issue stays open after merge.

## What changes for operators

Open the Detail view on any tile (Enter on a tile in the grid). Below GIT DIFF, a new **MCP SERVERS** section lists the MCP server ids pitboss would inject for that actor:

```
MCP SERVERS
  (profile: writer)
  • pitboss
  • fs-writer
```

For the lead, an in-flight worker, or any tile whose `TaskRecord.actor_type` hasn't landed yet, the section shows the untyped fallback row:

```
MCP SERVERS
  (untyped / root)
  • pitboss
```

Manifests with no `[[mcp_server]]` entries don't render the section at all (avoids painting "(none)" on flat-mode runs that never declared any).

## How it's wired

- **`crates/pitboss-cli/src/capability_matrix.rs`** — refactored to expose structured `MatrixRow { label, actor_type, kind, server_ids }` + `rows()` / `rows_from_parts()`. The CLI `--capability-matrix` flag's text formatter is now a thin wrapper on top of `rows()` so the CLI table and the TUI rendering can't disagree.
- **`crates/pitboss-tui/src/watcher.rs`** — extended the lightweight `resolved.json` deserializer with `mcp_servers` (id + scope), `worker_types`, and `sublead_types` ids; computes the matrix once per snapshot via `rows_from_parts`.
- **`crates/pitboss-tui/src/state.rs`** — added `actor_type: Option<String>` to `TileState` and `matrix_rows: Vec<MatrixRow>` to `AppSnapshot` / `AppState`. `actor_type` is populated from `TaskRecord.actor_type` (#384 Phase 1.5 already persists it).
- **`crates/pitboss-tui/src/tui.rs`** — new `matrix_row_for_tile` picker (typed match → untyped fallback → None) and a render block in `render_detail_metadata` for the new section.

## Known trade-off (documented inline + flagged for follow-up)

A typed worker shows the **untyped** row mid-flight, then **flips** to its typed row when its `TaskRecord` settles — because `actor_type` arrives via the settle-time record, not the spawn event. Tagged with `// TODO(#391-followup)` on `crates/pitboss-tui/src/watcher.rs` to plumb actor_type through an events.jsonl spawn event in a later pass. Out of scope for this slice.

## Tests

All new (10 total):

**capability_matrix:**
- `rows_emits_untyped_then_worker_then_sublead_in_declaration_order` — pins row shape + ordering + `actor_type` wiring.
- `rows_from_parts_matches_full_manifest_path` — parity between the lightweight TUI path and the full-manifest CLI path.

**watcher:**
- `watcher_emits_capability_matrix_rows_from_resolved_json` — matrix flows through from `resolved.json` (`mcp_servers` + `worker_types` + `sublead_types`).
- `watcher_propagates_actor_type_from_task_record_to_tile` — worker actor_type propagates.
- `watcher_propagates_sublead_actor_type_from_task_record` — sub-lead parity.

**tui:**
- `matrix_row_for_tile_picks_typed_row_when_actor_type_matches` — typed branch.
- `matrix_row_for_tile_falls_back_to_untyped_when_actor_type_is_none` — fallback.
- `matrix_row_for_tile_returns_none_when_matrix_is_empty` — empty-matrix guard.
- `detail_view_renders_mcp_servers_section_for_typed_tile` — typed render.
- `detail_view_renders_mcp_servers_section_for_lead_under_untyped_row` — untyped render (the most common Detail focus in hierarchical runs).

## Test plan

- [x] `cargo test --workspace --features pitboss-core/test-support` (all green, including the 10 new tests).
- [x] `cargo lint` (`clippy --workspace --all-targets --all-features -D warnings`) — clean.
- [x] `cargo tidy` (`fmt --all -- --check`) — clean.
- [ ] CI matrix passes on this PR.
- [ ] Manual: open the TUI against a hierarchical run with declared `[[worker_type]]` profiles + a scoped `[[mcp_server]]`, focus the lead and a typed worker tile, confirm the section renders the expected ids on each.

## Out of scope for this PR

- Slice 3 — pitboss-web manifest panel matrix (separate PR).
- Slice 4 — per-tool granularity within an MCP server (Path 1 vs Path 2 design fork; needs operator decision).
- Plumbing actor_type through an events.jsonl spawn event so typed workers don't flip from untyped to typed mid-flight (TODO marker in `watcher.rs`; smaller follow-up issue if it ever bites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)