### PR TITLE
feat(web): surface capability matrix on manifest detail page (#391 slice)

### DIFF
--- a/crates/pitboss-cli/src/capability_matrix.rs
+++ b/crates/pitboss-cli/src/capability_matrix.rs
@@ -16,6 +16,7 @@
 
 use crate::dispatch::hierarchical::mcp_server_scope_admits;
 use crate::manifest::resolve::ResolvedManifest;
+use serde::Serialize;
 
 /// Which class of actor a [`MatrixRow`] represents.
 ///
@@ -24,7 +25,12 @@ use crate::manifest::resolve::ResolvedManifest;
 /// `(untyped / root)`. Programmatic consumers (TUI Detail view,
 /// `pitboss-web` manifest panel) use the kind directly to pick which
 /// row matches a focused tile's `actor_type`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// Serialized as snake_case strings (`"untyped"` / `"worker_type"` /
+/// `"sublead_type"`) on the wire, so the SPA's TypeScript stays
+/// idiomatic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum RowKind {
     /// Root lead and any un-profiled (`actor_type = None`) spawn.
     Untyped,
@@ -43,7 +49,7 @@ pub enum RowKind {
 ///
 /// `server_ids` is in manifest declaration order so two manifests
 /// producing the same matrix shape compare stable diff-wise.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct MatrixRow {
     /// Display label as the CLI formatter emits it (`(untyped / root)`,
     /// `worker_type:writer`, `sublead_type:planner`).
@@ -357,6 +363,43 @@ mod tests {
 
         assert_eq!(rs[3].kind, RowKind::SubleadType);
         assert_eq!(rs[3].actor_type.as_deref(), Some("planner"));
+    }
+
+    /// `MatrixRow` ships over the `pitboss-web` validate endpoint's
+    /// JSON response. Pin the wire shape so the SPA's TypeScript
+    /// `MatrixRow` interface and any future external consumer don't
+    /// silently drift when fields are renamed or `RowKind` variants
+    /// are reshuffled. Snake-case `kind` discrimination is the
+    /// contract; flipping to PascalCase would break the SPA.
+    #[test]
+    fn matrix_row_serialises_with_stable_field_and_kind_names() {
+        let row = MatrixRow {
+            label: "worker_type:writer".to_string(),
+            actor_type: Some("writer".to_string()),
+            kind: RowKind::WorkerType,
+            server_ids: vec!["pitboss".to_string(), "fs-writer".to_string()],
+        };
+        let json = serde_json::to_value(&row).expect("serialise");
+        assert_eq!(json["label"], "worker_type:writer");
+        assert_eq!(json["actor_type"], "writer");
+        assert_eq!(json["kind"], "worker_type");
+        assert_eq!(
+            json["server_ids"],
+            serde_json::json!(["pitboss", "fs-writer"])
+        );
+
+        // Untyped row also pins the `null` shape for actor_type and the
+        // `"untyped"` kind discriminant so SPA TS code can branch on
+        // either field.
+        let untyped = MatrixRow {
+            label: "(untyped / root)".to_string(),
+            actor_type: None,
+            kind: RowKind::Untyped,
+            server_ids: vec![],
+        };
+        let json = serde_json::to_value(&untyped).expect("serialise untyped");
+        assert!(json["actor_type"].is_null());
+        assert_eq!(json["kind"], "untyped");
     }
 
     /// `rows_from_parts` lets the TUI compute the matrix from a

--- a/crates/pitboss-web/spa/src/lib/api.ts
+++ b/crates/pitboss-web/spa/src/lib/api.ts
@@ -268,9 +268,38 @@ export interface ManifestEntry {
   mtime_unix: number;
 }
 
+/**
+ * Mirror of `pitboss_cli::capability_matrix::RowKind`. Snake-case wire
+ * shape; the Rust `#[serde(rename_all = "snake_case")]` is the contract.
+ */
+export type RowKind = 'untyped' | 'worker_type' | 'sublead_type';
+
+/**
+ * Mirror of `pitboss_cli::capability_matrix::MatrixRow`. One row of the
+ * actor-type × MCP-server matrix returned by `validateManifest` when
+ * validation succeeds. Matches the wire shape pinned by
+ * `matrix_row_serialises_with_stable_field_and_kind_names` (#391 slice 3).
+ */
+export interface MatrixRow {
+  /** Display label as the CLI text formatter emits it. */
+  label: string;
+  /** `null` for the untyped row, the type id for declared profiles. */
+  actor_type: string | null;
+  kind: RowKind;
+  /** MCP server ids that scope-admit, in manifest declaration order. */
+  server_ids: string[];
+}
+
 export interface ValidateResult {
   ok: boolean;
   errors: string[];
+  /**
+   * Capability matrix rows when validation succeeds; absent on failure.
+   * Always populated on success — even for manifests with no
+   * `[[mcp_server]]` declarations, so the UI can render the untyped
+   * row's `(none)` cell rather than guess from a missing field.
+   */
+  capability_matrix?: MatrixRow[];
 }
 
 export interface DispatchDescriptor {

--- a/crates/pitboss-web/spa/src/routes/manifests/[name]/+page.svelte
+++ b/crates/pitboss-web/spa/src/routes/manifests/[name]/+page.svelte
@@ -214,39 +214,80 @@
       </CardContent>
     </Card>
 
-    <Card>
-      <CardHeader class="pb-2">
-        <CardTitle class="flex items-center gap-2 text-base">
-          Validation
-          {#if validating}
-            <Loader2 class="text-muted-foreground size-3.5 animate-spin" />
-          {:else if validation?.ok}
-            <CheckCircle2 class="size-4 text-emerald-600" />
-          {:else if validation && !validation.ok}
-            <AlertTriangle class="text-destructive size-4" />
+    <div class="space-y-4">
+      <Card>
+        <CardHeader class="pb-2">
+          <CardTitle class="flex items-center gap-2 text-base">
+            Validation
+            {#if validating}
+              <Loader2 class="text-muted-foreground size-3.5 animate-spin" />
+            {:else if validation?.ok}
+              <CheckCircle2 class="size-4 text-emerald-600" />
+            {:else if validation && !validation.ok}
+              <AlertTriangle class="text-destructive size-4" />
+            {/if}
+          </CardTitle>
+          <CardDescription class="text-xs">
+            Runs `validate_skip_dir_check` against the editor buffer.
+          </CardDescription>
+        </CardHeader>
+        <CardContent class="pt-0">
+          {#if !validation}
+            <p class="text-muted-foreground py-2 text-xs">Edit to validate.</p>
+          {:else if validation.ok}
+            <p class="text-xs text-emerald-700 dark:text-emerald-400">
+              Manifest validates cleanly. Ready to dispatch.
+            </p>
+          {:else}
+            <ul class="space-y-1.5">
+              {#each validation.errors as err, idx (idx)}
+                <li class="bg-destructive/5 text-destructive rounded border-l-2 border-current px-2 py-1.5 text-xs">
+                  {err}
+                </li>
+              {/each}
+            </ul>
           {/if}
-        </CardTitle>
-        <CardDescription class="text-xs">
-          Runs `validate_skip_dir_check` against the editor buffer.
-        </CardDescription>
-      </CardHeader>
-      <CardContent class="pt-0">
-        {#if !validation}
-          <p class="text-muted-foreground py-2 text-xs">Edit to validate.</p>
-        {:else if validation.ok}
-          <p class="text-xs text-emerald-700 dark:text-emerald-400">
-            Manifest validates cleanly. Ready to dispatch.
-          </p>
-        {:else}
-          <ul class="space-y-1.5">
-            {#each validation.errors as err, idx (idx)}
-              <li class="bg-destructive/5 text-destructive rounded border-l-2 border-current px-2 py-1.5 text-xs">
-                {err}
-              </li>
-            {/each}
-          </ul>
-        {/if}
-      </CardContent>
-    </Card>
+        </CardContent>
+      </Card>
+
+      {#if validation?.ok && validation.capability_matrix}
+        <Card>
+          <CardHeader class="pb-2">
+            <CardTitle class="text-base">Capability matrix</CardTitle>
+            <CardDescription class="text-xs">
+              Which MCP servers each actor type sees at dispatch.
+            </CardDescription>
+          </CardHeader>
+          <CardContent class="pt-0">
+            <table class="w-full text-xs">
+              <thead>
+                <tr class="text-muted-foreground border-b text-left">
+                  <th class="py-1.5 pr-3 font-medium">actor type</th>
+                  <th class="py-1.5 font-medium">mcp servers</th>
+                </tr>
+              </thead>
+              <tbody>
+                {#each validation.capability_matrix as row, idx (idx)}
+                  <tr class="border-b last:border-0 align-top">
+                    <td class="py-1.5 pr-3 font-mono">{row.label}</td>
+                    <td class="py-1.5">
+                      {#if row.server_ids.length === 0}
+                        <span class="text-muted-foreground italic">(none)</span>
+                      {:else}
+                        <div class="flex flex-wrap gap-1">
+                          {#each row.server_ids as id, sidx (sidx)}
+                            <code class="bg-muted rounded px-1.5 py-0.5">{id}</code>
+                          {/each}
+                        </div>
+                      {/if}
+                    </td>
+                  </tr>
+                {/each}
+              </tbody>
+            </table>
+          </CardContent>
+        </Card>
+      {/if}
+    </div>
   </div>
 {/if}

--- a/crates/pitboss-web/src/api/manifests.rs
+++ b/crates/pitboss-web/src/api/manifests.rs
@@ -21,6 +21,7 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use pitboss_cli::capability_matrix::MatrixRow;
 use pitboss_cli::manifest::{
     load::load_manifest_from_str, metadata::sections, validate::validate_skip_dir_check,
 };
@@ -189,6 +190,14 @@ pub struct ValidateBody {
 pub struct ValidateResult {
     pub ok: bool,
     pub errors: Vec<String>,
+    /// Capability matrix (actor-type × MCP-server) computed from the
+    /// resolved manifest. `None` when validation failed (no resolved
+    /// manifest to compute against). On success, always populated —
+    /// even for manifests with no `[[mcp_server]]` declarations, the
+    /// SPA renders an explicit "no MCP servers declared" hint rather
+    /// than guessing from a missing field. (#391 slice 3)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capability_matrix: Option<Vec<MatrixRow>>,
 }
 
 pub async fn validate(Json(body): Json<ValidateBody>) -> Json<ValidateResult> {
@@ -196,6 +205,7 @@ pub async fn validate(Json(body): Json<ValidateBody>) -> Json<ValidateResult> {
         return Json(ValidateResult {
             ok: false,
             errors: vec![format!("manifest exceeds {MAX_MANIFEST_BYTES} bytes")],
+            capability_matrix: None,
         });
     }
     let resolved = match load_manifest_from_str(&body.contents) {
@@ -204,6 +214,7 @@ pub async fn validate(Json(body): Json<ValidateBody>) -> Json<ValidateResult> {
             return Json(ValidateResult {
                 ok: false,
                 errors: chain_errors(&e),
+                capability_matrix: None,
             });
         }
     };
@@ -213,11 +224,13 @@ pub async fn validate(Json(body): Json<ValidateBody>) -> Json<ValidateResult> {
         return Json(ValidateResult {
             ok: false,
             errors: chain_errors(&e),
+            capability_matrix: None,
         });
     }
     Json(ValidateResult {
         ok: true,
         errors: Vec::new(),
+        capability_matrix: Some(pitboss_cli::capability_matrix::rows(&resolved)),
     })
 }
 

--- a/crates/pitboss-web/tests/validate_capability_matrix_integration.rs
+++ b/crates/pitboss-web/tests/validate_capability_matrix_integration.rs
@@ -1,0 +1,175 @@
+//! Verifies `POST /api/manifests/validate` returns the capability
+//! matrix in its JSON response when validation succeeds (#391 slice 3).
+//!
+//! Same `#[path]`-mount pattern as `manifests_download_integration.rs` —
+//! the full `api::router` drags sibling modules that don't resolve
+//! from a tests file, so we mount only what the validate handler
+//! needs.
+
+use axum::{
+    body::{to_bytes, Body},
+    http::{Request, StatusCode},
+    routing::post,
+    Router,
+};
+use tower::ServiceExt;
+
+#[allow(dead_code, unused_imports)]
+#[path = "../src/control_bridge.rs"]
+mod control_bridge;
+#[allow(dead_code, unused_imports)]
+#[path = "../src/error.rs"]
+mod error;
+#[allow(dead_code, unused_imports)]
+#[path = "../src/insights/mod.rs"]
+mod insights;
+#[allow(dead_code, unused_imports)]
+#[path = "../src/api/manifests.rs"]
+mod manifests;
+#[allow(dead_code, unused_imports)]
+#[path = "../src/state.rs"]
+mod state;
+
+use state::AppState;
+
+fn fixture_router() -> Router {
+    let runs = tempfile::tempdir().unwrap().keep();
+    let mans = tempfile::tempdir().unwrap().keep();
+    let st = AppState::new(runs, mans, None);
+    Router::new()
+        .route("/api/manifests/validate", post(manifests::validate))
+        .with_state(st)
+}
+
+async fn body_to_json(res: axum::http::Response<Body>) -> serde_json::Value {
+    let bytes = to_bytes(res.into_body(), 256 * 1024).await.unwrap();
+    serde_json::from_slice(&bytes).expect("body is valid JSON")
+}
+
+const TYPED_MANIFEST: &str = r#"
+[run]
+name = "typed-fixture"
+
+[lead]
+id = "lead"
+directory = "/tmp"
+prompt = "drive"
+model = "claude-haiku-4-5"
+
+[[mcp_server]]
+id = "pitboss"
+command = "/bin/true"
+
+[[mcp_server]]
+id = "fs-writer"
+command = "/bin/true"
+scope = "type:writer"
+
+[[worker_type]]
+id = "writer"
+tools = ["Read", "Write"]
+
+[[worker_type]]
+id = "reader"
+tools = ["Read"]
+"#;
+
+/// On a clean validate, the response includes a `capability_matrix`
+/// field with one row per declared profile (plus the untyped row).
+/// The SPA renders this as a table on the manifest detail page; if
+/// the field disappeared from the JSON shape, the table would
+/// silently render as empty.
+#[tokio::test]
+async fn validate_returns_capability_matrix_on_success() {
+    let app = fixture_router();
+    let payload = serde_json::json!({ "contents": TYPED_MANIFEST }).to_string();
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/manifests/validate")
+                .header("content-type", "application/json")
+                .body(Body::from(payload))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = body_to_json(res).await;
+    assert_eq!(body["ok"], true, "validate should succeed: {body:?}");
+
+    let matrix = body["capability_matrix"]
+        .as_array()
+        .expect("capability_matrix must be present and an array");
+    // Untyped + 2 worker_type rows = 3.
+    assert_eq!(
+        matrix.len(),
+        3,
+        "expected untyped + 2 worker rows, got: {matrix:?}"
+    );
+
+    // Untyped row anchors first; only sees the unscoped server.
+    assert_eq!(matrix[0]["kind"], "untyped");
+    assert!(matrix[0]["actor_type"].is_null());
+    let untyped_servers: Vec<&str> = matrix[0]["server_ids"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert_eq!(untyped_servers, vec!["pitboss"]);
+
+    // Writer row sees the writer-scoped server.
+    let writer = matrix
+        .iter()
+        .find(|r| r["actor_type"] == "writer")
+        .expect("writer row missing");
+    assert_eq!(writer["kind"], "worker_type");
+    let writer_servers: Vec<&str> = writer["server_ids"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(
+        writer_servers.contains(&"pitboss") && writer_servers.contains(&"fs-writer"),
+        "writer should see both servers, got: {writer_servers:?}"
+    );
+}
+
+/// Validation failure must omit the `capability_matrix` key entirely
+/// (the resolved manifest doesn't exist, so there's nothing to compute
+/// against). Pin absence-of-key, not just JSON-null — the
+/// `#[serde(skip_serializing_if = "Option::is_none")]` attribute on
+/// the Rust side is the contract, and a future refactor that drops
+/// the attribute would silently flip wire shape from "key absent" to
+/// "key present, value null" without breaking current TS consumers
+/// (both are falsy). This test catches that drift.
+#[tokio::test]
+async fn validate_omits_capability_matrix_on_failure() {
+    let app = fixture_router();
+    let payload = serde_json::json!({ "contents": "this is not toml :::" }).to_string();
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/manifests/validate")
+                .header("content-type", "application/json")
+                .body(Body::from(payload))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = body_to_json(res).await;
+    assert_eq!(body["ok"], false);
+    let obj = body.as_object().expect("response is a JSON object");
+    assert!(
+        !obj.contains_key("capability_matrix"),
+        "capability_matrix key must be omitted entirely on failure, got: {body:?}"
+    );
+}


### PR DESCRIPTION
Slice 3 of #391 — pitboss-web surfacing of the actor-type × MCP-server matrix on the manifest detail page. Slice 4 (per-tool granularity) is filed as #397; #391 stays open after merge.

## What changes for operators

Open the web console, navigate to **Manifests → \<name\>**, edit a manifest with declared profiles. When validation succeeds, a new **Capability matrix** card appears in the right column under Validation:

| actor type | mcp servers |
|---|---|
| (untyped / root) | \`pitboss\` |
| worker_type:writer | \`pitboss\` \`fs-writer\` |
| worker_type:reader | \`pitboss\` |
| sublead_type:planner | \`pitboss\` |

Empty cells render as italic *(none)* rather than blank so the table is readable on flat-mode manifests with no \`[[mcp_server]]\` declarations.

## Mechanics

- **\`pitboss-cli\`** — added \`Serialize\` to \`MatrixRow\` and \`RowKind\` with \`#[serde(rename_all = \"snake_case\")]\` on the kind enum so TS stays idiomatic. The TUI consumer (#396) doesn't depend on this; the wire-shape unit test pins it as the contract.
- **\`pitboss-web\` Rust API** — extended \`ValidateResult\` with an optional \`capability_matrix: Option<Vec<MatrixRow>>\` field, populated via \`pitboss_cli::capability_matrix::rows(&resolved)\` on success and omitted (\`skip_serializing_if\`) on failure.
- **SPA TS** — mirrored \`MatrixRow\` / \`RowKind\` in \`api.ts\`; added \`capability_matrix?: MatrixRow[]\` to \`ValidateResult\`.
- **SPA Svelte** — new \`<Card>\` rendering the matrix as a table on \`routes/manifests/[name]/+page.svelte\`, conditional on \`validation.ok && capability_matrix\`.

## Tests

- **\`pitboss-cli\` lib:** \`matrix_row_serialises_with_stable_field_and_kind_names\` pins the wire shape (key names + snake_case kind discriminant + null-on-untyped).
- **\`pitboss-web\` integration:** new \`validate_capability_matrix_integration.rs\` test file (same \`#[path]\`-mount pattern as the existing \`manifests_download_integration.rs\`).
  - \`validate_returns_capability_matrix_on_success\` — typed fixture manifest, asserts row count and per-row server admission.
  - \`validate_omits_capability_matrix_on_failure\` — pins **absence-of-key** on failure, not just JSON-null. Because \`skip_serializing_if\` and a literal \`null\` are both falsy in TS, a refactor that drops the attribute would silently flip wire shape without breaking any current consumer; this test catches that drift.

## Test plan

- [x] \`cargo test --workspace --features pitboss-core/test-support\` (all green, including the 3 new tests).
- [x] \`cargo lint\` — clean.
- [x] \`cargo tidy\` — clean.
- [x] \`npm run build\` (SPA) — clean, no TS errors.
- [ ] CI matrix passes on this PR (the SPA build + bake step is in CI; the integration test exercises the API).
- [ ] Manual visual check: spin up \`pitboss-web\` against a runs/manifests dir with a typed manifest, navigate to the manifest detail page, confirm the Capability matrix card renders with the expected rows.

## Out of scope

- Slice 4 — per-tool granularity within an MCP server. Filed as #397, committed to Path 2 (declarative \`[[mcp_server.tools]]\` allowlist + Path-B-routed enforcement). Should land after this slice so the matrix UI is wired before per-tool data is added to render.
- TUI parity for the wire-shape Serialize derive — the TUI uses the in-process \`MatrixRow\` directly, no JSON crossing involved, so the \`Serialize\` derive is dormant for that consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)