### PR TITLE
feat(manifest): per-server tools allowlist on [[mcp_server]] (#397 slice)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -352,6 +352,7 @@ scope   = "type:writer"   # only injected into worker_type/sublead_type "writer"
 | `args` | no | Arguments passed to the command. Default `[]`. |
 | `env` | no | Environment variables injected into the server process. Default `{}`. |
 | `scope` | no | Optional injection scope. Form `"type:<id>"` references a `[[worker_type]]` or `[[sublead_type]]`. Validated at manifest load — unknown ids are rejected. Untyped actors (no `worker_type` / `sublead_type` arg on spawn) NEVER receive scoped servers. Unset (default) = inject into all actors. |
+| `tools` | no | Optional per-tool allowlist for THIS server. When set, validate rejects any actor surface (`[lead].tools`, `[[task]].tools`, `[[worker_type]].tools`, `[[sublead_type]].tools`) that references `mcp__<id>__X` for an `X` not in this list. `tools = []` is rejected as self-defeating (remove the `[[mcp_server]]` block instead). Unset (default) = no per-tool restriction. **Manifest-time enforcement only in v0.12** — runtime gating is a follow-up (#397). (#391 / #397) |
 
 **Tools from injected servers are available immediately** — no additional `--allowedTools` configuration is needed; claude's MCP client discovers the tools from the server at startup.
 

--- a/crates/pitboss-cli/src/capability_matrix.rs
+++ b/crates/pitboss-cli/src/capability_matrix.rs
@@ -217,6 +217,7 @@ mod tests {
             args: vec![],
             env: Default::default(),
             scope: scope.map(str::to_string),
+            tools: None,
         }
     }
 

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -1473,6 +1473,7 @@ mod mcp_scope_tests {
             args: vec![],
             env: Default::default(),
             scope: scope.map(str::to_string),
+            tools: None,
         }
     }
 

--- a/crates/pitboss-cli/src/manifest/schema.rs
+++ b/crates/pitboss-cli/src/manifest/schema.rs
@@ -226,6 +226,22 @@ pub struct McpServerSpec {
         help = "Optional injection scope. Form: \"type:<id>\" — narrows this server to actors spawned under that worker_type/sublead_type. Unset = inject into all actors."
     )]
     pub scope: Option<String>,
+    /// Optional per-server tool allowlist. When set, any actor's
+    /// declared `tools` (in `[lead]`, `[[task]]`, `[[worker_type]]`,
+    /// `[[sublead_type]]`) referencing this server via the
+    /// `mcp__<id>__<tool>` form must list a `<tool>` that appears in
+    /// this allowlist; validate rejects mismatches loudly. Unset means
+    /// "no per-server restriction" (the v0.12 default). Empty list
+    /// (`tools = []`) is rejected as self-defeating — set
+    /// `mode = "disabled"` on `[communication]` or remove the
+    /// `[[mcp_server]]` block instead. (#391 / #397, slice 4 — schema
+    /// + validate-time enforcement; runtime gate is a follow-up.)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[field(
+        label = "Tools",
+        help = "Optional per-tool allowlist for this MCP server. Validate rejects any actor `tools` entry like `mcp__<id>__X` whose `X` is not in this list. Unset = no restriction."
+    )]
+    pub tools: Option<Vec<String>>,
 }
 
 /// Communication policy mode for the Pitboss-owned mailbox + artifact MCP

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -30,6 +30,8 @@ fn validate_inner(resolved: &ResolvedManifest, skip_dir_check: bool) -> Result<(
     validate_actor_types(resolved)?;
     validate_block_untyped_requires_profiles(resolved)?;
     validate_mcp_server_scopes(resolved)?;
+    validate_mcp_server_tools(resolved)?;
+    validate_mcp_tool_consistency(resolved)?;
     if resolved.lead.is_some() {
         validate_lead(resolved, skip_dir_check)?;
         validate_hierarchical_ranges(resolved)?;
@@ -183,6 +185,132 @@ fn validate_mcp_server_scopes(r: &ResolvedManifest) -> Result<()> {
         }
     }
 
+    Ok(())
+}
+
+/// Validate the per-server `[[mcp_server]].tools` allowlist shape
+/// (#391 slice 4 / #397 — Path 2). This is the manifest-time enforcement
+/// half: shape checks only. Runtime enforcement (intersecting with the
+/// actor's `--allowedTools` at spawn time, or denying through Path B's
+/// `permission_prompt`) is a follow-up — see #397.
+///
+/// - Unset → no restriction (the v0.12 default).
+/// - `Some([])` → reject as self-defeating: the operator declared the
+///   `[[mcp_server]]` block then declared zero tools, which is
+///   indistinguishable in intent from "remove the server entirely" but
+///   silent. Force the explicit form.
+/// - Empty / whitespace tool names → reject; would never match a real
+///   tool and likely indicates a typo'd quote pair.
+/// - Duplicate tool names within one server → reject; ambiguous intent
+///   ("did the operator mean to allowlist the tool twice or is one a
+///   typo?") and the dedup would silently lose information either way.
+fn validate_mcp_server_tools(r: &ResolvedManifest) -> Result<()> {
+    for s in &r.mcp_servers {
+        let Some(tools) = s.tools.as_ref() else {
+            continue;
+        };
+        if tools.is_empty() {
+            bail!(
+                "[[mcp_server]].tools on server {:?}: empty list is \
+                 self-defeating (allowlists no tools but keeps the server \
+                 declared). Either remove the [[mcp_server]] block or list \
+                 the tools you want to admit.",
+                s.id
+            );
+        }
+        let mut seen: HashSet<&str> = HashSet::new();
+        for tool in tools {
+            if tool.trim().is_empty() {
+                bail!(
+                    "[[mcp_server]].tools on server {:?}: empty / whitespace \
+                     tool name is not allowed (likely a typo'd quote pair).",
+                    s.id
+                );
+            }
+            if !seen.insert(tool.as_str()) {
+                bail!(
+                    "[[mcp_server]].tools on server {:?}: duplicate tool {:?} \
+                     in allowlist; remove the duplicate so the manifest's \
+                     intent is unambiguous.",
+                    s.id,
+                    tool
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Validate that every actor-declared MCP tool reference is consistent
+/// with the per-server `tools` allowlist (#391 slice 4).
+///
+/// Walks `[lead].tools`, `[[task]].tools`, `[[worker_type]].tools`, and
+/// `[[sublead_type]].tools`. For any entry of the form
+/// `mcp__<server>__<tool>`, if `<server>` is declared with a `tools`
+/// allowlist, `<tool>` must appear in that allowlist. Otherwise reject
+/// with a message naming both the actor surface and the offending
+/// allowlist — operators see exactly which line to fix.
+///
+/// Tool names that don't parse as `mcp__<known-server>__*` are skipped
+/// (they're top-level claude tools or references to undeclared servers,
+/// neither of which this gate constrains). Server-id matching uses
+/// longest-prefix-match so server ids containing underscores parse
+/// unambiguously.
+fn validate_mcp_tool_consistency(r: &ResolvedManifest) -> Result<()> {
+    // Collect (id, allowlist) pairs once. Sort by descending id length so
+    // longest-prefix-match resolves `mcp__some_server__some_tool` correctly
+    // when both `some` and `some_server` are declared servers.
+    let mut servers: Vec<(&str, Option<&[String]>)> = r
+        .mcp_servers
+        .iter()
+        .map(|s| (s.id.as_str(), s.tools.as_deref()))
+        .collect();
+    servers.sort_by_key(|(id, _)| std::cmp::Reverse(id.len()));
+
+    let mut surfaces: Vec<(String, &[String])> = Vec::new();
+    if let Some(lead) = &r.lead {
+        surfaces.push(("[lead].tools".to_string(), &lead.tools));
+    }
+    for t in &r.tasks {
+        surfaces.push((format!("[[task]] {:?}.tools", t.id), &t.tools));
+    }
+    for wt in &r.worker_types {
+        surfaces.push((format!("[[worker_type]] {:?}.tools", wt.id), &wt.tools));
+    }
+    for st in &r.sublead_types {
+        surfaces.push((format!("[[sublead_type]] {:?}.tools", st.id), &st.tools));
+    }
+
+    for (surface, tools) in surfaces {
+        for entry in tools {
+            let Some(rest) = entry.strip_prefix("mcp__") else {
+                continue;
+            };
+            // Find the longest declared server id that is a prefix of
+            // `rest` followed by `__`. Skips entries referencing
+            // undeclared servers — those don't match the gate by design.
+            let Some((server_id, allowlist)) = servers
+                .iter()
+                .find(|(id, _)| rest.starts_with(id) && rest[id.len()..].starts_with("__"))
+                .map(|(id, allow)| (*id, *allow))
+            else {
+                continue;
+            };
+            let Some(allow) = allowlist else {
+                continue;
+            };
+            let tool_name = &rest[server_id.len() + 2..];
+            if !allow.iter().any(|t| t == tool_name) {
+                bail!(
+                    "{surface}: tool {entry:?} references mcp_server {server_id:?} \
+                     which declares tools = {allow:?}. Tool {tool_name:?} is \
+                     not in that allowlist. Either add {tool_name:?} to the \
+                     server's `tools = […]`, remove the entry from {surface}, \
+                     or drop the server's `tools` allowlist."
+                );
+            }
+        }
+    }
     Ok(())
 }
 
@@ -2010,6 +2138,7 @@ mod tests {
             args: vec![],
             env: Default::default(),
             scope: scope.map(str::to_string),
+            tools: None,
         }
     }
 
@@ -2089,6 +2218,170 @@ mod tests {
         });
         validate_skip_dir_check(&r)
             .expect("unscoped server is the legacy default and must validate");
+    }
+
+    // ---- per-server [[mcp_server]].tools allowlist (#391 slice 4) -------
+
+    fn mcp_with_tools(id: &str, tools: Vec<&str>) -> crate::manifest::schema::McpServerSpec {
+        crate::manifest::schema::McpServerSpec {
+            id: id.into(),
+            command: "/bin/true".into(),
+            args: vec![],
+            env: Default::default(),
+            scope: None,
+            tools: Some(tools.into_iter().map(String::from).collect()),
+        }
+    }
+
+    /// `tools = []` is self-defeating: the operator declared the server
+    /// then forbade every tool. Force the explicit form (remove the
+    /// block) so the manifest's intent is unambiguous.
+    #[test]
+    fn rejects_mcp_server_tools_empty_list() {
+        let r = rm_with(|m| {
+            m.mcp_servers = vec![mcp_with_tools("ctx", vec![])];
+        });
+        let err = validate_skip_dir_check(&r).unwrap_err().to_string();
+        assert!(err.contains("self-defeating"), "{err}");
+        assert!(err.contains("ctx"), "{err}");
+    }
+
+    /// Empty / whitespace tool names are almost always typos and would
+    /// silently match nothing at runtime. Reject loudly.
+    #[test]
+    fn rejects_mcp_server_tools_blank_entry() {
+        let r = rm_with(|m| {
+            m.mcp_servers = vec![mcp_with_tools("ctx", vec!["read_file", "  "])];
+        });
+        let err = validate_skip_dir_check(&r).unwrap_err().to_string();
+        assert!(err.contains("empty / whitespace"), "{err}");
+    }
+
+    /// Duplicates in the allowlist mask intent: did the operator mean
+    /// to list the tool twice or is one a typo? Reject so they decide.
+    #[test]
+    fn rejects_mcp_server_tools_duplicate() {
+        let r = rm_with(|m| {
+            m.mcp_servers = vec![mcp_with_tools(
+                "ctx",
+                vec!["read_file", "write_file", "read_file"],
+            )];
+        });
+        let err = validate_skip_dir_check(&r).unwrap_err().to_string();
+        assert!(err.contains("duplicate"), "{err}");
+        assert!(err.contains("read_file"), "{err}");
+    }
+
+    /// A non-empty, distinct allowlist with no actor surfaces yet
+    /// referencing it must validate cleanly. Pin so the shape checks
+    /// don't accidentally over-reject the happy path.
+    #[test]
+    fn accepts_mcp_server_tools_well_formed() {
+        let r = rm_with(|m| {
+            m.mcp_servers = vec![mcp_with_tools("ctx", vec!["read_file", "write_file"])];
+        });
+        validate_skip_dir_check(&r).expect("declared, non-empty, distinct allowlist must validate");
+    }
+
+    /// Consistency check: when an actor surface declares
+    /// `mcp__<server>__<tool>` and the server has an allowlist, `<tool>`
+    /// must appear in it. This is the manifest-time enforcement Path 2
+    /// promises (#397). Tested via worker_type since it's the most
+    /// common case.
+    #[test]
+    fn rejects_worker_type_tool_not_in_mcp_server_allowlist() {
+        use crate::manifest::schema::WorkerType;
+        let r = rm_with(|m| {
+            m.mcp_servers = vec![mcp_with_tools("fs", vec!["read_file"])];
+            m.worker_types = vec![WorkerType {
+                id: "writer".into(),
+                tools: vec!["mcp__fs__write_file".into()],
+                allowed_models: vec![],
+                max_timeout_secs: None,
+            }];
+        });
+        let err = validate_skip_dir_check(&r).unwrap_err().to_string();
+        assert!(err.contains("write_file"), "{err}");
+        assert!(err.contains("worker_type"), "{err}");
+        assert!(err.contains("\"fs\""), "{err}");
+    }
+
+    /// Same gate, but matching: the worker_type's tool IS in the
+    /// allowlist. Validate must accept.
+    #[test]
+    fn accepts_worker_type_tool_in_mcp_server_allowlist() {
+        use crate::manifest::schema::WorkerType;
+        let r = rm_with(|m| {
+            m.mcp_servers = vec![mcp_with_tools("fs", vec!["read_file", "write_file"])];
+            m.worker_types = vec![WorkerType {
+                id: "writer".into(),
+                tools: vec!["mcp__fs__write_file".into(), "Read".into()],
+                allowed_models: vec![],
+                max_timeout_secs: None,
+            }];
+        });
+        validate_skip_dir_check(&r)
+            .expect("worker_type tool listed in mcp_server allowlist must validate");
+    }
+
+    /// Server ids with underscores parse correctly:
+    /// `mcp__fs_writer__read` must resolve to server `fs_writer` +
+    /// tool `read`, not server `fs` + tool `writer__read`.
+    /// Longest-prefix-match in the validator guards this.
+    #[test]
+    fn consistency_check_resolves_server_ids_with_underscores() {
+        use crate::manifest::schema::WorkerType;
+        let r = rm_with(|m| {
+            m.mcp_servers = vec![
+                mcp_with_tools("fs", vec!["never_called"]),
+                mcp_with_tools("fs_writer", vec!["read_file"]),
+            ];
+            m.worker_types = vec![WorkerType {
+                id: "writer".into(),
+                tools: vec!["mcp__fs_writer__read_file".into()],
+                allowed_models: vec![],
+                max_timeout_secs: None,
+            }];
+        });
+        validate_skip_dir_check(&r).expect(
+            "longest-prefix-match must resolve `mcp__fs_writer__read_file` to server `fs_writer`, \
+             not `fs`",
+        );
+    }
+
+    /// Tool entries referencing servers without an allowlist must NOT
+    /// trip the consistency check — the gate only constrains servers
+    /// that opted into the allowlist surface.
+    #[test]
+    fn consistency_check_skips_servers_without_allowlist() {
+        use crate::manifest::schema::WorkerType;
+        let r = rm_with(|m| {
+            m.mcp_servers = vec![mcp("fs", None)];
+            m.worker_types = vec![WorkerType {
+                id: "writer".into(),
+                tools: vec!["mcp__fs__anything".into()],
+                allowed_models: vec![],
+                max_timeout_secs: None,
+            }];
+        });
+        validate_skip_dir_check(&r)
+            .expect("servers without an allowlist must not constrain actor tool entries");
+    }
+
+    /// `[lead].tools` is also subject to the consistency check.
+    /// Operators using a typed lead with declared MCP servers expect
+    /// the same validate-time guarantee as workers/subleads.
+    #[test]
+    fn rejects_lead_tool_not_in_mcp_server_allowlist() {
+        let r = rm_with(|m| {
+            m.mcp_servers = vec![mcp_with_tools("fs", vec!["read_file"])];
+            if let Some(lead) = m.lead.as_mut() {
+                lead.tools = vec!["mcp__fs__write_file".into()];
+            }
+        });
+        let err = validate_skip_dir_check(&r).unwrap_err().to_string();
+        assert!(err.contains("write_file"), "{err}");
+        assert!(err.contains("[lead]"), "{err}");
     }
 
     /// Path B + zero profiles ⇒ migration warning fires. Pure check on

--- a/docs/manifest-map.md
+++ b/docs/manifest-map.md
@@ -14,35 +14,35 @@ The annotated example lives at [`pitboss.example.toml`](../pitboss.example.toml)
 
 ## `[run]` — `RunConfig`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:474`](../crates/pitboss-cli/src/manifest/schema.rs#L474).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:490`](../crates/pitboss-cli/src/manifest/schema.rs#L490).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `name` | text | no | Human-readable label used to group related runs in the console (e.g. "build-db", "nightly-sync"). When unset, the manifest filename is used as fallback. | [`../crates/pitboss-cli/src/manifest/schema.rs#L485`](../crates/pitboss-cli/src/manifest/schema.rs#L485) |
-| `max_parallel_tasks` | integer | no | Flat-mode concurrency cap for [[task]] runs. Default 4. Overridden by ANTHROPIC_MAX_CONCURRENT. | [`../crates/pitboss-cli/src/manifest/schema.rs#L494`](../crates/pitboss-cli/src/manifest/schema.rs#L494) |
-| `halt_on_failure` | boolean | no | Stop remaining flat-mode tasks on first failure. | [`../crates/pitboss-cli/src/manifest/schema.rs#L501`](../crates/pitboss-cli/src/manifest/schema.rs#L501) |
-| `run_dir` | path | no | Where per-run artifacts land. Default ~/.local/share/pitboss/runs. | [`../crates/pitboss-cli/src/manifest/schema.rs#L507`](../crates/pitboss-cli/src/manifest/schema.rs#L507) |
-| `worktree_cleanup` | enum (`always` \| `on_success` \| `never`) | no | What to do with each worker's git worktree after it finishes. | [`../crates/pitboss-cli/src/manifest/schema.rs#L515`](../crates/pitboss-cli/src/manifest/schema.rs#L515) |
-| `emit_event_stream` | boolean | no | Write a JSONL event stream alongside summary.jsonl. | [`../crates/pitboss-cli/src/manifest/schema.rs#L522`](../crates/pitboss-cli/src/manifest/schema.rs#L522) |
-| `default_approval_policy` | enum (`block` \| `auto_approve` \| `auto_reject`) | no | Default action for request_approval / propose_plan when no rule matches. `auto_approve`/`auto_reject` are unconditional; `block` routes to the operator if attached, else queues. | [`../crates/pitboss-cli/src/manifest/schema.rs#L550`](../crates/pitboss-cli/src/manifest/schema.rs#L550) |
-| `denial_termination_policy` | enum (`adapt` \| `reclassify`) | no | How a denied permission_prompt affects the actor's terminal status. `adapt` (default) keeps the actor's exit code as-is; `reclassify` re-labels clean exits within 30s of a denial as ApprovalRejected. | [`../crates/pitboss-cli/src/manifest/schema.rs#L561`](../crates/pitboss-cli/src/manifest/schema.rs#L561) |
-| `dump_shared_store` | boolean | no | Write shared-store.json into the run directory on finalize. | [`../crates/pitboss-cli/src/manifest/schema.rs#L569`](../crates/pitboss-cli/src/manifest/schema.rs#L569) |
-| `require_plan_approval` | boolean | no | When true, spawn_worker is blocked until propose_plan has been approved. | [`../crates/pitboss-cli/src/manifest/schema.rs#L577`](../crates/pitboss-cli/src/manifest/schema.rs#L577) |
-| `require_actor_type` | boolean | no | When true, every spawn_worker and spawn_sublead call must name a declared [[worker_type]]/[[sublead_type]]. Default false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L588`](../crates/pitboss-cli/src/manifest/schema.rs#L588) |
-| `untyped_actor_policy` | enum (`bridge` \| `block`) | no | Path-B-only behavior for un-typed callers reaching permission_prompt. `bridge` (default) routes to the operator queue; `block` auto-denies via a synthesized empty profile. | [`../crates/pitboss-cli/src/manifest/schema.rs#L605`](../crates/pitboss-cli/src/manifest/schema.rs#L605) |
+| `name` | text | no | Human-readable label used to group related runs in the console (e.g. "build-db", "nightly-sync"). When unset, the manifest filename is used as fallback. | [`../crates/pitboss-cli/src/manifest/schema.rs#L501`](../crates/pitboss-cli/src/manifest/schema.rs#L501) |
+| `max_parallel_tasks` | integer | no | Flat-mode concurrency cap for [[task]] runs. Default 4. Overridden by ANTHROPIC_MAX_CONCURRENT. | [`../crates/pitboss-cli/src/manifest/schema.rs#L510`](../crates/pitboss-cli/src/manifest/schema.rs#L510) |
+| `halt_on_failure` | boolean | no | Stop remaining flat-mode tasks on first failure. | [`../crates/pitboss-cli/src/manifest/schema.rs#L517`](../crates/pitboss-cli/src/manifest/schema.rs#L517) |
+| `run_dir` | path | no | Where per-run artifacts land. Default ~/.local/share/pitboss/runs. | [`../crates/pitboss-cli/src/manifest/schema.rs#L523`](../crates/pitboss-cli/src/manifest/schema.rs#L523) |
+| `worktree_cleanup` | enum (`always` \| `on_success` \| `never`) | no | What to do with each worker's git worktree after it finishes. | [`../crates/pitboss-cli/src/manifest/schema.rs#L531`](../crates/pitboss-cli/src/manifest/schema.rs#L531) |
+| `emit_event_stream` | boolean | no | Write a JSONL event stream alongside summary.jsonl. | [`../crates/pitboss-cli/src/manifest/schema.rs#L538`](../crates/pitboss-cli/src/manifest/schema.rs#L538) |
+| `default_approval_policy` | enum (`block` \| `auto_approve` \| `auto_reject`) | no | Default action for request_approval / propose_plan when no rule matches. `auto_approve`/`auto_reject` are unconditional; `block` routes to the operator if attached, else queues. | [`../crates/pitboss-cli/src/manifest/schema.rs#L566`](../crates/pitboss-cli/src/manifest/schema.rs#L566) |
+| `denial_termination_policy` | enum (`adapt` \| `reclassify`) | no | How a denied permission_prompt affects the actor's terminal status. `adapt` (default) keeps the actor's exit code as-is; `reclassify` re-labels clean exits within 30s of a denial as ApprovalRejected. | [`../crates/pitboss-cli/src/manifest/schema.rs#L577`](../crates/pitboss-cli/src/manifest/schema.rs#L577) |
+| `dump_shared_store` | boolean | no | Write shared-store.json into the run directory on finalize. | [`../crates/pitboss-cli/src/manifest/schema.rs#L585`](../crates/pitboss-cli/src/manifest/schema.rs#L585) |
+| `require_plan_approval` | boolean | no | When true, spawn_worker is blocked until propose_plan has been approved. | [`../crates/pitboss-cli/src/manifest/schema.rs#L593`](../crates/pitboss-cli/src/manifest/schema.rs#L593) |
+| `require_actor_type` | boolean | no | When true, every spawn_worker and spawn_sublead call must name a declared [[worker_type]]/[[sublead_type]]. Default false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L604`](../crates/pitboss-cli/src/manifest/schema.rs#L604) |
+| `untyped_actor_policy` | enum (`bridge` \| `block`) | no | Path-B-only behavior for un-typed callers reaching permission_prompt. `bridge` (default) routes to the operator queue; `block` auto-denies via a synthesized empty profile. | [`../crates/pitboss-cli/src/manifest/schema.rs#L621`](../crates/pitboss-cli/src/manifest/schema.rs#L621) |
 
 ## `[defaults]` — `Defaults`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:743`](../crates/pitboss-cli/src/manifest/schema.rs#L743).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:759`](../crates/pitboss-cli/src/manifest/schema.rs#L759).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `model` | text | no | Claude model id (e.g. claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-7). | [`../crates/pitboss-cli/src/manifest/schema.rs#L748`](../crates/pitboss-cli/src/manifest/schema.rs#L748) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Maps to the claude --effort flag. | [`../crates/pitboss-cli/src/manifest/schema.rs#L754`](../crates/pitboss-cli/src/manifest/schema.rs#L754) |
-| `tools` | string list | no | Allowed tool surface. Pitboss auto-appends its MCP tools for leads and workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L759`](../crates/pitboss-cli/src/manifest/schema.rs#L759) |
-| `timeout_secs` | integer | no | Per-task wall-clock cap. No default (no cap). | [`../crates/pitboss-cli/src/manifest/schema.rs#L764`](../crates/pitboss-cli/src/manifest/schema.rs#L764) |
-| `use_worktree` | boolean | no | Isolate each worker in a git worktree. Default true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L769`](../crates/pitboss-cli/src/manifest/schema.rs#L769) |
-| `env` | key-value map | no | Environment variables passed to the claude subprocess. | [`../crates/pitboss-cli/src/manifest/schema.rs#L775`](../crates/pitboss-cli/src/manifest/schema.rs#L775) |
+| `model` | text | no | Claude model id (e.g. claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-7). | [`../crates/pitboss-cli/src/manifest/schema.rs#L764`](../crates/pitboss-cli/src/manifest/schema.rs#L764) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Maps to the claude --effort flag. | [`../crates/pitboss-cli/src/manifest/schema.rs#L770`](../crates/pitboss-cli/src/manifest/schema.rs#L770) |
+| `tools` | string list | no | Allowed tool surface. Pitboss auto-appends its MCP tools for leads and workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L775`](../crates/pitboss-cli/src/manifest/schema.rs#L775) |
+| `timeout_secs` | integer | no | Per-task wall-clock cap. No default (no cap). | [`../crates/pitboss-cli/src/manifest/schema.rs#L780`](../crates/pitboss-cli/src/manifest/schema.rs#L780) |
+| `use_worktree` | boolean | no | Isolate each worker in a git worktree. Default true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L785`](../crates/pitboss-cli/src/manifest/schema.rs#L785) |
+| `env` | key-value map | no | Environment variables passed to the claude subprocess. | [`../crates/pitboss-cli/src/manifest/schema.rs#L791`](../crates/pitboss-cli/src/manifest/schema.rs#L791) |
 
 ## `[container]` — `ContainerConfig`
 
@@ -68,66 +68,66 @@ Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:143`](../crates/pitbos
 
 ## `[[task]]` — `Task`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:806`](../crates/pitboss-cli/src/manifest/schema.rs#L806).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:822`](../crates/pitboss-cli/src/manifest/schema.rs#L822).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique slug. Alphanumeric + _ + -. Used in logs and worktree names. | [`../crates/pitboss-cli/src/manifest/schema.rs#L811`](../crates/pitboss-cli/src/manifest/schema.rs#L811) |
-| `directory` | path | **yes** | Working directory. Must be inside a git repo if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L816`](../crates/pitboss-cli/src/manifest/schema.rs#L816) |
-| `prompt` | text (multi-line) | no | Prompt body sent to claude via -p. Mutually exclusive with `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L822`](../crates/pitboss-cli/src/manifest/schema.rs#L822) |
-| `template` | text | no | Reference to a [[template]] entry. Mutually exclusive with `prompt`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L827`](../crates/pitboss-cli/src/manifest/schema.rs#L827) |
-| `vars` | key-value map | no | Substitutions for {placeholders} when using `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L833`](../crates/pitboss-cli/src/manifest/schema.rs#L833) |
-| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L838`](../crates/pitboss-cli/src/manifest/schema.rs#L838) |
-| `model` | text | no | Per-task override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L840`](../crates/pitboss-cli/src/manifest/schema.rs#L840) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-task override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L846`](../crates/pitboss-cli/src/manifest/schema.rs#L846) |
-| `tools` | string list | no | Per-task override of [defaults].tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L848`](../crates/pitboss-cli/src/manifest/schema.rs#L848) |
-| `timeout_secs` | integer | no | Per-task wall-clock cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L850`](../crates/pitboss-cli/src/manifest/schema.rs#L850) |
-| `use_worktree` | boolean | no | Per-task override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L855`](../crates/pitboss-cli/src/manifest/schema.rs#L855) |
-| `env` | key-value map | no | Per-task env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L861`](../crates/pitboss-cli/src/manifest/schema.rs#L861) |
+| `id` | text | **yes** | Unique slug. Alphanumeric + _ + -. Used in logs and worktree names. | [`../crates/pitboss-cli/src/manifest/schema.rs#L827`](../crates/pitboss-cli/src/manifest/schema.rs#L827) |
+| `directory` | path | **yes** | Working directory. Must be inside a git repo if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L832`](../crates/pitboss-cli/src/manifest/schema.rs#L832) |
+| `prompt` | text (multi-line) | no | Prompt body sent to claude via -p. Mutually exclusive with `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L838`](../crates/pitboss-cli/src/manifest/schema.rs#L838) |
+| `template` | text | no | Reference to a [[template]] entry. Mutually exclusive with `prompt`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L843`](../crates/pitboss-cli/src/manifest/schema.rs#L843) |
+| `vars` | key-value map | no | Substitutions for {placeholders} when using `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L849`](../crates/pitboss-cli/src/manifest/schema.rs#L849) |
+| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L854`](../crates/pitboss-cli/src/manifest/schema.rs#L854) |
+| `model` | text | no | Per-task override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L856`](../crates/pitboss-cli/src/manifest/schema.rs#L856) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-task override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L862`](../crates/pitboss-cli/src/manifest/schema.rs#L862) |
+| `tools` | string list | no | Per-task override of [defaults].tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L864`](../crates/pitboss-cli/src/manifest/schema.rs#L864) |
+| `timeout_secs` | integer | no | Per-task wall-clock cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L866`](../crates/pitboss-cli/src/manifest/schema.rs#L866) |
+| `use_worktree` | boolean | no | Per-task override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L871`](../crates/pitboss-cli/src/manifest/schema.rs#L871) |
+| `env` | key-value map | no | Per-task env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L877`](../crates/pitboss-cli/src/manifest/schema.rs#L877) |
 
 ## `[lead]` — `Lead`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:871`](../crates/pitboss-cli/src/manifest/schema.rs#L871).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:887`](../crates/pitboss-cli/src/manifest/schema.rs#L887).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique slug used as the TUI tile label and in run artifact paths. | [`../crates/pitboss-cli/src/manifest/schema.rs#L878`](../crates/pitboss-cli/src/manifest/schema.rs#L878) |
-| `directory` | path | **yes** | Working directory for the lead's claude subprocess. Must be a git work-tree if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L885`](../crates/pitboss-cli/src/manifest/schema.rs#L885) |
-| `prompt` | text (multi-line) | **yes** | Operator instructions passed to claude via -p. Must appear before any [lead.X] subtable in the source. | [`../crates/pitboss-cli/src/manifest/schema.rs#L897`](../crates/pitboss-cli/src/manifest/schema.rs#L897) |
-| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L905`](../crates/pitboss-cli/src/manifest/schema.rs#L905) |
-| `model` | text | no | Per-lead override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L908`](../crates/pitboss-cli/src/manifest/schema.rs#L908) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-lead override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L915`](../crates/pitboss-cli/src/manifest/schema.rs#L915) |
-| `tools` | string list | no | Per-lead override of [defaults].tools. Pitboss auto-appends its MCP tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L921`](../crates/pitboss-cli/src/manifest/schema.rs#L921) |
-| `timeout_secs` | integer | no | Per-actor subprocess wall-clock cap (claude --timeout). | [`../crates/pitboss-cli/src/manifest/schema.rs#L927`](../crates/pitboss-cli/src/manifest/schema.rs#L927) |
-| `use_worktree` | boolean | no | Per-lead override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L933`](../crates/pitboss-cli/src/manifest/schema.rs#L933) |
-| `env` | key-value map | no | Per-lead env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L939`](../crates/pitboss-cli/src/manifest/schema.rs#L939) |
-| `max_workers` | integer | no | Hard cap on the lead's concurrent + queued worker pool (1–16). Required when the lead spawns workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L948`](../crates/pitboss-cli/src/manifest/schema.rs#L948) |
-| `budget_usd` | float | no | Soft cap on lead spend with reservation accounting. spawn_worker fails once spent + reserved + next_estimate > budget. | [`../crates/pitboss-cli/src/manifest/schema.rs#L957`](../crates/pitboss-cli/src/manifest/schema.rs#L957) |
-| `lead_timeout_secs` | integer | no | Wall-clock cap on the lead session. Default 3600. | [`../crates/pitboss-cli/src/manifest/schema.rs#L966`](../crates/pitboss-cli/src/manifest/schema.rs#L966) |
-| `permission_routing` | enum (`path_a` \| `path_b`) | no | path_a (default) makes pitboss the sole permission authority. path_b routes claude's gate through pitboss (rejected at validate time pending stabilization). | [`../crates/pitboss-cli/src/manifest/schema.rs#L979`](../crates/pitboss-cli/src/manifest/schema.rs#L979) |
-| `allow_subleads` | boolean | no | Expose spawn_sublead to the root lead. | [`../crates/pitboss-cli/src/manifest/schema.rs#L988`](../crates/pitboss-cli/src/manifest/schema.rs#L988) |
-| `max_subleads` | integer | no | Hard cap on total live sub-leads under this root. | [`../crates/pitboss-cli/src/manifest/schema.rs#L995`](../crates/pitboss-cli/src/manifest/schema.rs#L995) |
-| `max_sublead_budget_usd` | float | no | Cap on the per-sub-lead budget envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1002`](../crates/pitboss-cli/src/manifest/schema.rs#L1002) |
-| `max_total_workers` | integer | no | Cap on total live workers across the entire tree (root + sub-trees). | [`../crates/pitboss-cli/src/manifest/schema.rs#L1010`](../crates/pitboss-cli/src/manifest/schema.rs#L1010) |
+| `id` | text | **yes** | Unique slug used as the TUI tile label and in run artifact paths. | [`../crates/pitboss-cli/src/manifest/schema.rs#L894`](../crates/pitboss-cli/src/manifest/schema.rs#L894) |
+| `directory` | path | **yes** | Working directory for the lead's claude subprocess. Must be a git work-tree if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L901`](../crates/pitboss-cli/src/manifest/schema.rs#L901) |
+| `prompt` | text (multi-line) | **yes** | Operator instructions passed to claude via -p. Must appear before any [lead.X] subtable in the source. | [`../crates/pitboss-cli/src/manifest/schema.rs#L913`](../crates/pitboss-cli/src/manifest/schema.rs#L913) |
+| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L921`](../crates/pitboss-cli/src/manifest/schema.rs#L921) |
+| `model` | text | no | Per-lead override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L924`](../crates/pitboss-cli/src/manifest/schema.rs#L924) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-lead override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L931`](../crates/pitboss-cli/src/manifest/schema.rs#L931) |
+| `tools` | string list | no | Per-lead override of [defaults].tools. Pitboss auto-appends its MCP tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L937`](../crates/pitboss-cli/src/manifest/schema.rs#L937) |
+| `timeout_secs` | integer | no | Per-actor subprocess wall-clock cap (claude --timeout). | [`../crates/pitboss-cli/src/manifest/schema.rs#L943`](../crates/pitboss-cli/src/manifest/schema.rs#L943) |
+| `use_worktree` | boolean | no | Per-lead override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L949`](../crates/pitboss-cli/src/manifest/schema.rs#L949) |
+| `env` | key-value map | no | Per-lead env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L955`](../crates/pitboss-cli/src/manifest/schema.rs#L955) |
+| `max_workers` | integer | no | Hard cap on the lead's concurrent + queued worker pool (1–16). Required when the lead spawns workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L964`](../crates/pitboss-cli/src/manifest/schema.rs#L964) |
+| `budget_usd` | float | no | Soft cap on lead spend with reservation accounting. spawn_worker fails once spent + reserved + next_estimate > budget. | [`../crates/pitboss-cli/src/manifest/schema.rs#L973`](../crates/pitboss-cli/src/manifest/schema.rs#L973) |
+| `lead_timeout_secs` | integer | no | Wall-clock cap on the lead session. Default 3600. | [`../crates/pitboss-cli/src/manifest/schema.rs#L982`](../crates/pitboss-cli/src/manifest/schema.rs#L982) |
+| `permission_routing` | enum (`path_a` \| `path_b`) | no | path_a (default) makes pitboss the sole permission authority. path_b routes claude's gate through pitboss (rejected at validate time pending stabilization). | [`../crates/pitboss-cli/src/manifest/schema.rs#L995`](../crates/pitboss-cli/src/manifest/schema.rs#L995) |
+| `allow_subleads` | boolean | no | Expose spawn_sublead to the root lead. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1004`](../crates/pitboss-cli/src/manifest/schema.rs#L1004) |
+| `max_subleads` | integer | no | Hard cap on total live sub-leads under this root. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1011`](../crates/pitboss-cli/src/manifest/schema.rs#L1011) |
+| `max_sublead_budget_usd` | float | no | Cap on the per-sub-lead budget envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1018`](../crates/pitboss-cli/src/manifest/schema.rs#L1018) |
+| `max_total_workers` | integer | no | Cap on total live workers across the entire tree (root + sub-trees). | [`../crates/pitboss-cli/src/manifest/schema.rs#L1026`](../crates/pitboss-cli/src/manifest/schema.rs#L1026) |
 
 ## `[sublead_defaults]` — `SubleadDefaults`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:1017`](../crates/pitboss-cli/src/manifest/schema.rs#L1017).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:1033`](../crates/pitboss-cli/src/manifest/schema.rs#L1033).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `budget_usd` | float | no | Per-sub-lead envelope when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1022`](../crates/pitboss-cli/src/manifest/schema.rs#L1022) |
-| `max_workers` | integer | no | Per-sub-lead worker pool when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1027`](../crates/pitboss-cli/src/manifest/schema.rs#L1027) |
-| `lead_timeout_secs` | integer | no | Wall-clock cap for the sub-lead session. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1032`](../crates/pitboss-cli/src/manifest/schema.rs#L1032) |
-| `read_down` | boolean | no | When true, sub-lead shares root's budget + worker pool instead of carving its own envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1038`](../crates/pitboss-cli/src/manifest/schema.rs#L1038) |
+| `budget_usd` | float | no | Per-sub-lead envelope when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1038`](../crates/pitboss-cli/src/manifest/schema.rs#L1038) |
+| `max_workers` | integer | no | Per-sub-lead worker pool when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1043`](../crates/pitboss-cli/src/manifest/schema.rs#L1043) |
+| `lead_timeout_secs` | integer | no | Wall-clock cap for the sub-lead session. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1048`](../crates/pitboss-cli/src/manifest/schema.rs#L1048) |
+| `read_down` | boolean | no | When true, sub-lead shares root's budget + worker pool instead of carving its own envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1054`](../crates/pitboss-cli/src/manifest/schema.rs#L1054) |
 
 ## `[[approval_policy]]` — `ApprovalRuleSpec`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:424`](../crates/pitboss-cli/src/manifest/schema.rs#L424).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:440`](../crates/pitboss-cli/src/manifest/schema.rs#L440).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `action` | enum (`auto_approve` \| `auto_reject` \| `block`) | **yes** | Action when this rule matches. | [`../crates/pitboss-cli/src/manifest/schema.rs#L435`](../crates/pitboss-cli/src/manifest/schema.rs#L435) |
+| `action` | enum (`auto_approve` \| `auto_reject` \| `block`) | **yes** | Action when this rule matches. | [`../crates/pitboss-cli/src/manifest/schema.rs#L451`](../crates/pitboss-cli/src/manifest/schema.rs#L451) |
 
 ## `[[mcp_server]]` — `McpServerSpec`
 
@@ -140,55 +140,56 @@ Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:192`](../crates/pitbos
 | `args` | string list | no | Arguments passed to the command. | [`../crates/pitboss-cli/src/manifest/schema.rs#L208`](../crates/pitboss-cli/src/manifest/schema.rs#L208) |
 | `env` | key-value map | no | Environment variables injected into the MCP server process. | [`../crates/pitboss-cli/src/manifest/schema.rs#L215`](../crates/pitboss-cli/src/manifest/schema.rs#L215) |
 | `scope` | text | no | Optional injection scope. Form: "type:<id>" — narrows this server to actors spawned under that worker_type/sublead_type. Unset = inject into all actors. | [`../crates/pitboss-cli/src/manifest/schema.rs#L228`](../crates/pitboss-cli/src/manifest/schema.rs#L228) |
+| `tools` | string list | no | Optional per-tool allowlist for this MCP server. Validate rejects any actor `tools` entry like `mcp__<id>__X` whose `X` is not in this list. Unset = no restriction. | [`../crates/pitboss-cli/src/manifest/schema.rs#L244`](../crates/pitboss-cli/src/manifest/schema.rs#L244) |
 
 ## `[[worker_type]]` — `WorkerType`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:664`](../crates/pitboss-cli/src/manifest/schema.rs#L664).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:680`](../crates/pitboss-cli/src/manifest/schema.rs#L680).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique id used in spawn_worker(worker_type = "<id>"). Match: ^[A-Za-z0-9_-]+$. | [`../crates/pitboss-cli/src/manifest/schema.rs#L671`](../crates/pitboss-cli/src/manifest/schema.rs#L671) |
-| `tools` | string list | no | Allowed tool surface for this worker class. Lead's spawn_worker(tools=...) must be a subset; omit means "give me the whole allowlist." | [`../crates/pitboss-cli/src/manifest/schema.rs#L679`](../crates/pitboss-cli/src/manifest/schema.rs#L679) |
-| `allowed_models` | string list | no | When non-empty, spawn_worker(model=...) must be in this list. Empty means any model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L687`](../crates/pitboss-cli/src/manifest/schema.rs#L687) |
-| `max_timeout_secs` | integer | no | Hard cap on spawn_worker(timeout_secs=...). Lead values clamp DOWN; smaller values pass through. | [`../crates/pitboss-cli/src/manifest/schema.rs#L695`](../crates/pitboss-cli/src/manifest/schema.rs#L695) |
+| `id` | text | **yes** | Unique id used in spawn_worker(worker_type = "<id>"). Match: ^[A-Za-z0-9_-]+$. | [`../crates/pitboss-cli/src/manifest/schema.rs#L687`](../crates/pitboss-cli/src/manifest/schema.rs#L687) |
+| `tools` | string list | no | Allowed tool surface for this worker class. Lead's spawn_worker(tools=...) must be a subset; omit means "give me the whole allowlist." | [`../crates/pitboss-cli/src/manifest/schema.rs#L695`](../crates/pitboss-cli/src/manifest/schema.rs#L695) |
+| `allowed_models` | string list | no | When non-empty, spawn_worker(model=...) must be in this list. Empty means any model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L703`](../crates/pitboss-cli/src/manifest/schema.rs#L703) |
+| `max_timeout_secs` | integer | no | Hard cap on spawn_worker(timeout_secs=...). Lead values clamp DOWN; smaller values pass through. | [`../crates/pitboss-cli/src/manifest/schema.rs#L711`](../crates/pitboss-cli/src/manifest/schema.rs#L711) |
 
 ## `[[sublead_type]]` — `SubleadType`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:703`](../crates/pitboss-cli/src/manifest/schema.rs#L703).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:719`](../crates/pitboss-cli/src/manifest/schema.rs#L719).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique id used in spawn_sublead(sublead_type = "<id>"). Match: ^[A-Za-z0-9_-]+$. | [`../crates/pitboss-cli/src/manifest/schema.rs#L710`](../crates/pitboss-cli/src/manifest/schema.rs#L710) |
-| `tools` | string list | no | Allowed tool surface for this sub-lead class. spawn_sublead(tools=...) must be a subset; empty means "give me the whole allowlist." | [`../crates/pitboss-cli/src/manifest/schema.rs#L717`](../crates/pitboss-cli/src/manifest/schema.rs#L717) |
-| `allowed_models` | string list | no | When non-empty, spawn_sublead(model=...) must be in this list. | [`../crates/pitboss-cli/src/manifest/schema.rs#L724`](../crates/pitboss-cli/src/manifest/schema.rs#L724) |
-| `max_timeout_secs` | integer | no | Hard cap on spawn_sublead(lead_timeout_secs=...). Clamps DOWN. | [`../crates/pitboss-cli/src/manifest/schema.rs#L731`](../crates/pitboss-cli/src/manifest/schema.rs#L731) |
-| `max_budget_usd` | float | no | Hard cap on spawn_sublead(budget_usd=...). Clamps DOWN. | [`../crates/pitboss-cli/src/manifest/schema.rs#L738`](../crates/pitboss-cli/src/manifest/schema.rs#L738) |
+| `id` | text | **yes** | Unique id used in spawn_sublead(sublead_type = "<id>"). Match: ^[A-Za-z0-9_-]+$. | [`../crates/pitboss-cli/src/manifest/schema.rs#L726`](../crates/pitboss-cli/src/manifest/schema.rs#L726) |
+| `tools` | string list | no | Allowed tool surface for this sub-lead class. spawn_sublead(tools=...) must be a subset; empty means "give me the whole allowlist." | [`../crates/pitboss-cli/src/manifest/schema.rs#L733`](../crates/pitboss-cli/src/manifest/schema.rs#L733) |
+| `allowed_models` | string list | no | When non-empty, spawn_sublead(model=...) must be in this list. | [`../crates/pitboss-cli/src/manifest/schema.rs#L740`](../crates/pitboss-cli/src/manifest/schema.rs#L740) |
+| `max_timeout_secs` | integer | no | Hard cap on spawn_sublead(lead_timeout_secs=...). Clamps DOWN. | [`../crates/pitboss-cli/src/manifest/schema.rs#L747`](../crates/pitboss-cli/src/manifest/schema.rs#L747) |
+| `max_budget_usd` | float | no | Hard cap on spawn_sublead(budget_usd=...). Clamps DOWN. | [`../crates/pitboss-cli/src/manifest/schema.rs#L754`](../crates/pitboss-cli/src/manifest/schema.rs#L754) |
 
 ## `[communication]` — `CommunicationConfig`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:265`](../crates/pitboss-cli/src/manifest/schema.rs#L265).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:281`](../crates/pitboss-cli/src/manifest/schema.rs#L281).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `mode` | enum (`disabled` \| `parent_child`) | no | Actor communication policy mode. "disabled" hides the message_* and artifact_* tools (conservative default). "parent_child" enables them with parent/sublead/worker authz. | [`../crates/pitboss-cli/src/manifest/schema.rs#L272`](../crates/pitboss-cli/src/manifest/schema.rs#L272) |
-| `max_message_bytes` | integer | no | Maximum UTF-8 body size accepted by message_send. | [`../crates/pitboss-cli/src/manifest/schema.rs#L278`](../crates/pitboss-cli/src/manifest/schema.rs#L278) |
-| `max_artifact_bytes` | integer | no | Maximum decoded artifact payload size accepted by artifact_put. | [`../crates/pitboss-cli/src/manifest/schema.rs#L284`](../crates/pitboss-cli/src/manifest/schema.rs#L284) |
-| `max_artifacts_per_actor` | integer | no | Maximum artifacts one actor may publish in a single run. | [`../crates/pitboss-cli/src/manifest/schema.rs#L290`](../crates/pitboss-cli/src/manifest/schema.rs#L290) |
+| `mode` | enum (`disabled` \| `parent_child`) | no | Actor communication policy mode. "disabled" hides the message_* and artifact_* tools (conservative default). "parent_child" enables them with parent/sublead/worker authz. | [`../crates/pitboss-cli/src/manifest/schema.rs#L288`](../crates/pitboss-cli/src/manifest/schema.rs#L288) |
+| `max_message_bytes` | integer | no | Maximum UTF-8 body size accepted by message_send. | [`../crates/pitboss-cli/src/manifest/schema.rs#L294`](../crates/pitboss-cli/src/manifest/schema.rs#L294) |
+| `max_artifact_bytes` | integer | no | Maximum decoded artifact payload size accepted by artifact_put. | [`../crates/pitboss-cli/src/manifest/schema.rs#L300`](../crates/pitboss-cli/src/manifest/schema.rs#L300) |
+| `max_artifacts_per_actor` | integer | no | Maximum artifacts one actor may publish in a single run. | [`../crates/pitboss-cli/src/manifest/schema.rs#L306`](../crates/pitboss-cli/src/manifest/schema.rs#L306) |
 
 ## `[[template]]` — `Template`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:790`](../crates/pitboss-cli/src/manifest/schema.rs#L790).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:806`](../crates/pitboss-cli/src/manifest/schema.rs#L806).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Slug referenced from [[task]].template. | [`../crates/pitboss-cli/src/manifest/schema.rs#L795`](../crates/pitboss-cli/src/manifest/schema.rs#L795) |
-| `prompt` | text (multi-line) | **yes** | Prompt body. Supports {var} placeholders supplied by [[task]].vars. | [`../crates/pitboss-cli/src/manifest/schema.rs#L801`](../crates/pitboss-cli/src/manifest/schema.rs#L801) |
+| `id` | text | **yes** | Slug referenced from [[task]].template. | [`../crates/pitboss-cli/src/manifest/schema.rs#L811`](../crates/pitboss-cli/src/manifest/schema.rs#L811) |
+| `prompt` | text (multi-line) | **yes** | Prompt body. Supports {var} placeholders supplied by [[task]].vars. | [`../crates/pitboss-cli/src/manifest/schema.rs#L817`](../crates/pitboss-cli/src/manifest/schema.rs#L817) |
 
 ## `[lifecycle]` — `Lifecycle`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:401`](../crates/pitboss-cli/src/manifest/schema.rs#L401).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:417`](../crates/pitboss-cli/src/manifest/schema.rs#L417).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `survive_parent` | boolean | no | Allow this dispatch to outlive its parent process. Requires a notify target. | [`../crates/pitboss-cli/src/manifest/schema.rs#L412`](../crates/pitboss-cli/src/manifest/schema.rs#L412) |
+| `survive_parent` | boolean | no | Allow this dispatch to outlive its parent process. Requires a notify target. | [`../crates/pitboss-cli/src/manifest/schema.rs#L428`](../crates/pitboss-cli/src/manifest/schema.rs#L428) |
 

--- a/docs/manifest-reference.toml
+++ b/docs/manifest-reference.toml
@@ -107,6 +107,7 @@ command = "<value>"
 args = []
 env = { EXAMPLE_KEY = "value" }
 scope = "<value>"
+tools = []
 
 [[worker_type]]
 id = "<value>"


### PR DESCRIPTION
First half of #397 (which is slice 4 of #391). Adds the optional \`[[mcp_server]].tools\` allowlist and validates manifest consistency across actor surfaces. Manifest-time enforcement only — runtime gating filed as #399, see "Why decompose" below.

## What changes for operators

Declare a per-tool allowlist on any \`[[mcp_server]]\`:

\`\`\`toml
[[mcp_server]]
id      = "fs-writer"
command = "/usr/local/bin/fs-mcp"
scope   = "type:writer"
tools   = ["read_file", "write_file"]    # NEW: optional allowlist

[[worker_type]]
id    = "writer"
tools = ["mcp__fs-writer__write_file", "Read"]   # OK — in allowlist

[[worker_type]]
id    = "reader"
tools = ["mcp__fs-writer__delete_all"]   # validate REJECTS
\`\`\`

Validate refuses to load the second worker_type with:

> \`[[worker_type]] "reader".tools: tool "mcp__fs-writer__delete_all" references mcp_server "fs-writer" which declares tools = ["read_file", "write_file"]. Tool "delete_all" is not in that allowlist. Either add "delete_all" to the server's \`tools = […]\`, remove the entry from [[worker_type]] "reader".tools, or drop the server's \`tools\` allowlist.

## Mechanics

- **\`pitboss-cli/src/manifest/schema.rs\`** — added \`tools: Option<Vec<String>>\` field on \`McpServerSpec\` with \`#[field(label, help)]\` so \`pitboss schema\` and the web wizard render tooltips automatically.
- **\`pitboss-cli/src/manifest/validate.rs\`** — two new validators wired into \`validate_inner\`:
  - \`validate_mcp_server_tools\` — shape check: empty list, blank/whitespace entries, duplicates within one server.
  - \`validate_mcp_tool_consistency\` — cross-cut: walks \`[lead].tools\`, \`[[task]].tools\`, \`[[worker_type]].tools\`, \`[[sublead_type]].tools\`. For any \`mcp__<server>__<tool>\` entry where \`<server>\` has an allowlist, \`<tool>\` must be in it. Server-id matching uses longest-prefix-match so server ids containing underscores resolve unambiguously.
- **\`AGENTS.md\`** — added the \`tools\` row to the \`[[mcp_server]]\` table with the manifest-time-only caveat.
- **\`docs/manifest-map.md\`** + **\`docs/manifest-reference.toml\`** — regenerated.

## Why decompose

#397 originally proposed Path B's \`permission_prompt\` as the runtime gate. Implementation review caught a bypass: \`--allowedTools\` short-circuits \`--permission-prompt-tool\` for any tool in the list, so an actor's \`tools = ["mcp__<server>__<tool>"]\` flowing into \`--allowedTools\` makes \`permission_prompt\` never fire and the per-server allowlist would be silently ineffective.

The right runtime enforcement is at the place that computes \`--allowedTools\` (intersect server allowlist with actor tools at spawn time). But that depends on a Path A semantic question I haven't verified (\`--dangerously-skip-permissions\` interaction with \`--allowedTools\`), so the runtime work is filed separately as **#399**.

The manifest-time enforcement here doesn't depend on that fork — it's pure validate-time. For a clean manifest where no actor surface declares an out-of-allowlist MCP tool, validate accepts and runtime is unconstrained (since there's nothing to constrain). The runtime gate becomes a defense-in-depth backstop for programmatic spawns or env-default tool sets that bypass validate.

## Tests (9 new)

\`pitboss-cli\` lib unit tests on \`validate_skip_dir_check\`:

- \`rejects_mcp_server_tools_empty_list\`
- \`rejects_mcp_server_tools_blank_entry\`
- \`rejects_mcp_server_tools_duplicate\`
- \`accepts_mcp_server_tools_well_formed\`
- \`rejects_worker_type_tool_not_in_mcp_server_allowlist\`
- \`accepts_worker_type_tool_in_mcp_server_allowlist\`
- \`consistency_check_resolves_server_ids_with_underscores\` — pins longest-prefix-match resolution
- \`consistency_check_skips_servers_without_allowlist\` — pins the opt-in semantic
- \`rejects_lead_tool_not_in_mcp_server_allowlist\` — pins lead surface coverage

## Test plan

- [x] \`cargo test --workspace --features pitboss-core/test-support\` — all green (including 9 new tests).
- [x] \`cargo lint\` — clean.
- [x] \`cargo tidy\` — clean.
- [x] \`docs/manifest-map.md\` and \`docs/manifest-reference.toml\` regenerated.
- [x] CI matrix passes on this PR.

## Out of scope

- **Runtime enforcement** — filed as #399. Includes Path A semantic verification + spawn-time \`--allowedTools\` filter + optional defense-in-depth \`permission_prompt\` short-circuit.
- **Capability matrix UI extension** to render per-server tool lists in the CLI \`--capability-matrix\` table, TUI Detail view, and web matrix table. Separate PR — touches three surfaces and benefits from being its own change.
- **Discovery probe** at lead startup (fetch \`tools/list\` from each MCP server, log diagnostics) — requires a new MCP client (pitboss is currently a server only); separate scoping.

## State of #391 after merge

- ✓ Slice 1-3 (capability matrix structured data + TUI + web)
- ⏳ Slice 4: schema + validate (this PR) → runtime (#399) → matrix UI extension (TBD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)