### PR TITLE
feat(matrix): surface per-server tool allowlists in capability matrix UI

### DIFF
--- a/crates/pitboss-cli/src/capability_matrix.rs
+++ b/crates/pitboss-cli/src/capability_matrix.rs
@@ -1,18 +1,37 @@
-//! `pitboss validate --capability-matrix` formatter (#385).
+//! `pitboss validate --capability-matrix` formatter (#385, #391).
 //!
 //! Walks the resolved manifest's `[[mcp_server]]` list and computes,
 //! for each declared `[[worker_type]]` / `[[sublead_type]]` (plus an
 //! "untyped / root" row representing the root lead and any
-//! pre-#252-style un-profiled spawns), the set of MCP server ids that
-//! pitboss would inject into actors of that class.
+//! pre-#252-style un-profiled spawns), the set of MCP servers — and
+//! their per-server tool allowlists — that pitboss would inject into
+//! actors of that class.
 //!
 //! Reuses the same admission helper as the runtime injection
 //! (`crate::dispatch::hierarchical::mcp_server_scope_admits`) so the
 //! report output and the live behavior cannot drift.
 //!
-//! The output is plain text — one row per actor class, server ids as
-//! a comma-joined list. No JSON output here yet; operators piping
-//! the table into grep/awk get a stable column structure.
+//! ## What this matrix means (and what it does not)
+//!
+//! The matrix shows the **server-side** allowlist as it applies on
+//! each row: which MCP servers admit, and the `[[mcp_server]].tools`
+//! filter pitboss enforces against `--allowedTools` and the
+//! `permission_prompt` short-circuit (#399).
+//!
+//! It is **not** an intersection with the actor-side
+//! `[[worker_type]].tools` / `[[sublead_type]].tools` profile
+//! allowlist — that orthogonal restriction is surfaced in the actor
+//! profile panel of the wizard. The matrix answers "what can the
+//! server admit for this row," not "what can this actor actually
+//! call."
+//!
+//! ## Wire-shape contract
+//!
+//! `MatrixRow` ships JSON over `pitboss-web`'s `validate` endpoint,
+//! is consumed by the SPA's TS `MatrixRow` interface, and is read
+//! by the TUI from `resolved.json`. Three consumers; one shape.
+//! Field names and the snake-case `kind` / `MatrixServerEntry`
+//! discriminants are pinned by tests in this module.
 
 use crate::dispatch::hierarchical::mcp_server_scope_admits;
 use crate::manifest::resolve::ResolvedManifest;
@@ -40,6 +59,28 @@ pub enum RowKind {
     SubleadType,
 }
 
+/// One MCP server admitted on a [`MatrixRow`], plus the per-server
+/// `[[mcp_server]].tools` allowlist as it applies to actors on that
+/// row.
+///
+/// `tools = None` means the server has no allowlist — every tool the
+/// server exports is admitted at the server gate. `tools = Some(list)`
+/// means pitboss enforces that allowlist at spawn-time
+/// (`--allowedTools` filter) and at runtime (`permission_prompt`
+/// short-circuit) — see #399.
+///
+/// `validate.rs` rejects `tools = Some([])` as self-defeating, so
+/// consumers can safely treat `Some(non_empty)` and `None` as the
+/// only two cases.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MatrixServerEntry {
+    pub server_id: String,
+    /// `None` = no per-server filter (all tools admitted).
+    /// `Some(non_empty)` = explicit allowlist enforced.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<String>>,
+}
+
 /// One row of the actor-type × MCP-server matrix.
 ///
 /// `actor_type` is `None` for the untyped/root row and `Some(id)` for
@@ -47,7 +88,7 @@ pub enum RowKind {
 /// `actor_type` directly check `row.actor_type.as_deref() ==
 /// tile.actor_type.as_deref()`.
 ///
-/// `server_ids` is in manifest declaration order so two manifests
+/// `servers` is in manifest declaration order so two manifests
 /// producing the same matrix shape compare stable diff-wise.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct MatrixRow {
@@ -58,9 +99,19 @@ pub struct MatrixRow {
     /// matching against `TaskRecord.actor_type`.
     pub actor_type: Option<String>,
     pub kind: RowKind,
-    /// MCP server ids that scope-admit for this row, in manifest
-    /// declaration order.
-    pub server_ids: Vec<String>,
+    /// MCP servers (with their per-server tool allowlists) that
+    /// scope-admit for this row, in manifest declaration order.
+    pub servers: Vec<MatrixServerEntry>,
+}
+
+/// Lightweight server descriptor for [`rows_from_parts`]. The TUI
+/// deserializes a subset of `resolved.json` and feeds these in
+/// without having to construct a full `ResolvedManifest`.
+#[derive(Debug, Clone)]
+pub struct MatrixServerSpec {
+    pub id: String,
+    pub scope: Option<String>,
+    pub tools: Option<Vec<String>>,
 }
 
 /// Compute matrix rows from a fully resolved manifest. Used by the CLI
@@ -72,10 +123,14 @@ pub struct MatrixRow {
 /// 2. One row per `[[worker_type]]`, in declaration order.
 /// 3. One row per `[[sublead_type]]`, in declaration order.
 pub fn rows(manifest: &ResolvedManifest) -> Vec<MatrixRow> {
-    let servers: Vec<(String, Option<String>)> = manifest
+    let servers: Vec<MatrixServerSpec> = manifest
         .mcp_servers
         .iter()
-        .map(|s| (s.id.clone(), s.scope.clone()))
+        .map(|s| MatrixServerSpec {
+            id: s.id.clone(),
+            scope: s.scope.clone(),
+            tools: s.tools.clone(),
+        })
         .collect();
     let wt_ids: Vec<String> = manifest.worker_types.iter().map(|w| w.id.clone()).collect();
     let st_ids: Vec<String> = manifest
@@ -86,12 +141,10 @@ pub fn rows(manifest: &ResolvedManifest) -> Vec<MatrixRow> {
     rows_from_parts(&servers, &wt_ids, &st_ids)
 }
 
-/// Compute matrix rows from the minimal data the algorithm needs. The
-/// TUI deserializes a lightweight subset of `resolved.json` and feeds
-/// it in here without having to construct a full `ResolvedManifest` —
-/// keeps the matrix logic decoupled from the larger manifest type.
+/// Compute matrix rows from the minimal data the algorithm needs.
+/// Keeps the matrix logic decoupled from the larger manifest type.
 pub fn rows_from_parts(
-    servers: &[(String, Option<String>)],
+    servers: &[MatrixServerSpec],
     worker_type_ids: &[String],
     sublead_type_ids: &[String],
 ) -> Vec<MatrixRow> {
@@ -101,14 +154,14 @@ pub fn rows_from_parts(
         label: "(untyped / root)".to_string(),
         actor_type: None,
         kind: RowKind::Untyped,
-        server_ids: admitted_for(servers, None),
+        servers: admitted_for(servers, None),
     });
     for id in worker_type_ids {
         out.push(MatrixRow {
             label: format!("worker_type:{id}"),
             actor_type: Some(id.clone()),
             kind: RowKind::WorkerType,
-            server_ids: admitted_for(servers, Some(id.as_str())),
+            servers: admitted_for(servers, Some(id.as_str())),
         });
     }
     for id in sublead_type_ids {
@@ -116,18 +169,21 @@ pub fn rows_from_parts(
             label: format!("sublead_type:{id}"),
             actor_type: Some(id.clone()),
             kind: RowKind::SubleadType,
-            server_ids: admitted_for(servers, Some(id.as_str())),
+            servers: admitted_for(servers, Some(id.as_str())),
         });
     }
     out
 }
 
-fn admitted_for(servers: &[(String, Option<String>)], actor_type: Option<&str>) -> Vec<String> {
+fn admitted_for(servers: &[MatrixServerSpec], actor_type: Option<&str>) -> Vec<MatrixServerEntry> {
     servers
         .iter()
-        .filter_map(|(id, scope)| {
-            if mcp_server_scope_admits(scope.as_deref(), actor_type) {
-                Some(id.clone())
+        .filter_map(|s| {
+            if mcp_server_scope_admits(s.scope.as_deref(), actor_type) {
+                Some(MatrixServerEntry {
+                    server_id: s.id.clone(),
+                    tools: s.tools.clone(),
+                })
             } else {
                 None
             }
@@ -137,9 +193,12 @@ fn admitted_for(servers: &[(String, Option<String>)], actor_type: Option<&str>) 
 
 /// Render the matrix as a multi-line string ending in `\n`.
 ///
-/// Thin formatter on top of [`rows`]. The widest label drives the
-/// first column's width so multi-row output stays aligned without an
-/// external table crate.
+/// Servers admitted on a row print as a comma-joined list. Each
+/// server with a `[[mcp_server]].tools` allowlist gets a continuation
+/// line listing those tools, indented under its server. Servers with
+/// no allowlist render bare — absence is implicit "all tools" and
+/// printing every per-server `(all)` annotation would clutter the
+/// common case.
 pub fn render(manifest: &ResolvedManifest) -> String {
     let rows = rows(manifest);
 
@@ -160,14 +219,27 @@ pub fn render(manifest: &ResolvedManifest) -> String {
         "-".repeat(label_width),
         "-".repeat(36)
     ));
+    let indent = " ".repeat(label_width + 2);
     for row in &rows {
-        let cell = if row.server_ids.is_empty() {
-            "(none)".to_string()
-        } else {
-            row.server_ids.join(", ")
-        };
         let label = &row.label;
-        out.push_str(&format!("{label:<label_width$}  {cell}\n"));
+        if row.servers.is_empty() {
+            out.push_str(&format!("{label:<label_width$}  (none)\n"));
+            continue;
+        }
+        let ids = row
+            .servers
+            .iter()
+            .map(|s| s.server_id.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        out.push_str(&format!("{label:<label_width$}  {ids}\n"));
+        for s in &row.servers {
+            if let Some(tools) = &s.tools {
+                let joined = tools.join(", ");
+                let server_id = &s.server_id;
+                out.push_str(&format!("{indent}  {server_id} tools: {joined}\n"));
+            }
+        }
     }
     out
 }
@@ -221,6 +293,17 @@ mod tests {
         }
     }
 
+    fn srv_with_tools(id: &str, scope: Option<&str>, tools: &[&str]) -> McpServerSpec {
+        McpServerSpec {
+            id: id.to_string(),
+            command: "/bin/true".into(),
+            args: vec![],
+            env: Default::default(),
+            scope: scope.map(str::to_string),
+            tools: Some(tools.iter().map(|t| (*t).to_string()).collect()),
+        }
+    }
+
     fn wt(id: &str) -> WorkerType {
         WorkerType {
             id: id.to_string(),
@@ -253,10 +336,6 @@ mod tests {
         m.sublead_types = vec![st("planner")];
 
         let out = render(&m);
-        // Anchor row: contains pitboss (unscoped) but not the
-        // writer-scoped server. Asserting on substring rather than the
-        // full padded prefix because the label column width is driven
-        // by the widest label in the matrix.
         let untyped_line = out
             .lines()
             .find(|l| l.starts_with("(untyped / root)"))
@@ -265,7 +344,6 @@ mod tests {
             untyped_line.contains("pitboss") && !untyped_line.contains("fs-writer"),
             "untyped row must list only the unscoped server: {untyped_line}"
         );
-        // Scoped server appears only on the matching row.
         let writer_line = out
             .lines()
             .find(|l| l.starts_with("worker_type:writer"))
@@ -314,9 +392,7 @@ mod tests {
     }
 
     /// An unscoped manifest (no `[[worker_type]]`/`[[sublead_type]]`)
-    /// renders just the untyped row. Verifies the helper's edge case:
-    /// the matrix is still useful for un-migrated manifests, even
-    /// though it collapses to a single row.
+    /// renders just the untyped row.
     #[test]
     fn renders_single_untyped_row_when_no_profiles_declared() {
         let mut m = empty_manifest();
@@ -324,7 +400,6 @@ mod tests {
 
         let out = render(&m);
         assert!(out.contains("(untyped / root)"));
-        // No worker_type or sublead_type rows.
         assert!(
             !out.contains("worker_type:") && !out.contains("sublead_type:"),
             "must not emit profile rows when no profiles are declared: {out}"
@@ -348,16 +423,14 @@ mod tests {
 
         assert_eq!(rs[0].kind, RowKind::Untyped);
         assert!(rs[0].actor_type.is_none());
-        assert_eq!(rs[0].server_ids, vec!["pitboss".to_string()]);
+        let untyped_ids: Vec<&str> = rs[0].servers.iter().map(|s| s.server_id.as_str()).collect();
+        assert_eq!(untyped_ids, vec!["pitboss"]);
 
         assert_eq!(rs[1].kind, RowKind::WorkerType);
         assert_eq!(rs[1].actor_type.as_deref(), Some("writer"));
         assert_eq!(rs[1].label, "worker_type:writer");
-        // writer-scoped server admits for writer.
-        assert_eq!(
-            rs[1].server_ids,
-            vec!["pitboss".to_string(), "fs-writer".to_string()]
-        );
+        let writer_ids: Vec<&str> = rs[1].servers.iter().map(|s| s.server_id.as_str()).collect();
+        assert_eq!(writer_ids, vec!["pitboss", "fs-writer"]);
 
         assert_eq!(rs[2].kind, RowKind::WorkerType);
         assert_eq!(rs[2].actor_type.as_deref(), Some("reader"));
@@ -378,29 +451,48 @@ mod tests {
             label: "worker_type:writer".to_string(),
             actor_type: Some("writer".to_string()),
             kind: RowKind::WorkerType,
-            server_ids: vec!["pitboss".to_string(), "fs-writer".to_string()],
+            servers: vec![
+                MatrixServerEntry {
+                    server_id: "pitboss".to_string(),
+                    tools: None,
+                },
+                MatrixServerEntry {
+                    server_id: "fs-writer".to_string(),
+                    tools: Some(vec!["Read".to_string(), "Write".to_string()]),
+                },
+            ],
         };
         let json = serde_json::to_value(&row).expect("serialise");
         assert_eq!(json["label"], "worker_type:writer");
         assert_eq!(json["actor_type"], "writer");
         assert_eq!(json["kind"], "worker_type");
+        assert_eq!(json["servers"][0]["server_id"], "pitboss");
+        // `tools = None` must be omitted (not serialised as
+        // `null`) so the SPA can branch on key-presence and keep its
+        // TS shape `tools?: string[]` clean.
+        assert!(
+            !json["servers"][0]
+                .as_object()
+                .unwrap()
+                .contains_key("tools"),
+            "absent tools must be omitted from JSON, not null: {json}"
+        );
+        assert_eq!(json["servers"][1]["server_id"], "fs-writer");
         assert_eq!(
-            json["server_ids"],
-            serde_json::json!(["pitboss", "fs-writer"])
+            json["servers"][1]["tools"],
+            serde_json::json!(["Read", "Write"])
         );
 
-        // Untyped row also pins the `null` shape for actor_type and the
-        // `"untyped"` kind discriminant so SPA TS code can branch on
-        // either field.
         let untyped = MatrixRow {
             label: "(untyped / root)".to_string(),
             actor_type: None,
             kind: RowKind::Untyped,
-            server_ids: vec![],
+            servers: vec![],
         };
         let json = serde_json::to_value(&untyped).expect("serialise untyped");
         assert!(json["actor_type"].is_null());
         assert_eq!(json["kind"], "untyped");
+        assert_eq!(json["servers"], serde_json::json!([]));
     }
 
     /// `rows_from_parts` lets the TUI compute the matrix from a
@@ -410,8 +502,16 @@ mod tests {
     #[test]
     fn rows_from_parts_matches_full_manifest_path() {
         let servers = vec![
-            ("pitboss".to_string(), None),
-            ("fs-writer".to_string(), Some("type:writer".to_string())),
+            MatrixServerSpec {
+                id: "pitboss".to_string(),
+                scope: None,
+                tools: None,
+            },
+            MatrixServerSpec {
+                id: "fs-writer".to_string(),
+                scope: Some("type:writer".to_string()),
+                tools: Some(vec!["Read".to_string(), "Write".to_string()]),
+            },
         ];
         let workers = vec!["writer".to_string()];
         let subleads: Vec<String> = vec![];
@@ -419,7 +519,10 @@ mod tests {
         let parts_rows = rows_from_parts(&servers, &workers, &subleads);
 
         let mut m = empty_manifest();
-        m.mcp_servers = vec![srv("pitboss", None), srv("fs-writer", Some("type:writer"))];
+        m.mcp_servers = vec![
+            srv("pitboss", None),
+            srv_with_tools("fs-writer", Some("type:writer"), &["Read", "Write"]),
+        ];
         m.worker_types = vec![wt("writer")];
         let manifest_rows = rows(&m);
 
@@ -443,6 +546,47 @@ mod tests {
         assert!(
             !untyped_line.contains("orphan"),
             "untyped row must not list orphaned scoped servers: {untyped_line}"
+        );
+    }
+
+    /// A `[[mcp_server]]` with a `tools = […]` allowlist renders the
+    /// tools on a continuation line under the server. Servers with no
+    /// allowlist render bare on the same line. Pins the layout the
+    /// CLI text formatter ships so operators piping the table into
+    /// grep/awk get a stable two-section output.
+    #[test]
+    fn render_emits_per_server_tool_lists_on_continuation_lines() {
+        let mut m = empty_manifest();
+        m.mcp_servers = vec![
+            srv("pitboss", None),
+            srv_with_tools("fs-writer", Some("type:writer"), &["Read", "Write", "Edit"]),
+        ];
+        m.worker_types = vec![wt("writer")];
+
+        let out = render(&m);
+        // Writer row lists both servers comma-joined.
+        let writer_line = out
+            .lines()
+            .find(|l| l.starts_with("worker_type:writer"))
+            .expect("writer row missing");
+        assert!(writer_line.contains("pitboss") && writer_line.contains("fs-writer"));
+
+        // The tools continuation line lists the allowlist for fs-writer.
+        let tools_line = out
+            .lines()
+            .find(|l| l.contains("fs-writer tools:"))
+            .expect("fs-writer tools continuation line missing");
+        assert!(
+            tools_line.contains("Read")
+                && tools_line.contains("Write")
+                && tools_line.contains("Edit"),
+            "expected continuation line listing fs-writer's tools allowlist: {tools_line}"
+        );
+
+        // Servers without an allowlist must not emit a continuation line.
+        assert!(
+            !out.contains("pitboss tools:"),
+            "pitboss has no allowlist; must not render a 'tools:' continuation line: {out}"
         );
     }
 }

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -1749,14 +1749,21 @@ fn render_detail_metadata(
             format!("  {actor_label}"),
             theme::muted_style(),
         )));
-        if row.server_ids.is_empty() {
+        if row.servers.is_empty() {
             lines.push(Line::from(Span::styled("  (none)", theme::muted_style())));
         } else {
-            for id in &row.server_ids {
+            for s in &row.servers {
                 lines.push(Line::from(Span::styled(
-                    format!("  • {id}"),
+                    format!("  • {}", s.server_id),
                     theme::muted_style(),
                 )));
+                if let Some(tools) = &s.tools {
+                    let joined = tools.join(", ");
+                    lines.push(Line::from(Span::styled(
+                        format!("      tools: {joined}"),
+                        theme::muted_style(),
+                    )));
+                }
             }
         }
     }
@@ -2642,7 +2649,13 @@ mod tests {
             label: label.to_string(),
             actor_type: actor_type.map(str::to_string),
             kind,
-            server_ids: servers.iter().map(|s| (*s).to_string()).collect(),
+            servers: servers
+                .iter()
+                .map(|s| pitboss_cli::capability_matrix::MatrixServerEntry {
+                    server_id: (*s).to_string(),
+                    tools: None,
+                })
+                .collect(),
         }
     }
 
@@ -2814,6 +2827,83 @@ mod tests {
         assert!(
             !rendered.contains("fs-writer"),
             "writer-scoped server must not appear under the untyped row"
+        );
+    }
+
+    /// A `[[mcp_server]].tools = [...]` allowlist surfaces in the
+    /// MCP-SERVERS section as an indented `tools:` continuation line
+    /// under the server bullet. Operators should be able to read the
+    /// per-server cap directly from the Detail view without re-opening
+    /// the manifest. (#391)
+    #[test]
+    fn detail_view_renders_per_server_tools_continuation_line() {
+        use crate::state::Mode;
+        use pitboss_cli::capability_matrix::{MatrixRow, MatrixServerEntry, RowKind};
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let task_id = "writer-1";
+        let mut t = tile(task_id, TileStatus::Running, None, 0, 0);
+        t.actor_type = Some("writer".to_string());
+
+        let mut s = state(vec![t]);
+        s.matrix_rows = vec![
+            matrix_row("(untyped / root)", None, RowKind::Untyped, &["pitboss"]),
+            // Hand-build the writer row so we can attach a per-server
+            // `tools` allowlist to fs-writer; the `matrix_row` helper
+            // produces only `tools = None` entries.
+            MatrixRow {
+                label: "worker_type:writer".to_string(),
+                actor_type: Some("writer".to_string()),
+                kind: RowKind::WorkerType,
+                servers: vec![
+                    MatrixServerEntry {
+                        server_id: "pitboss".to_string(),
+                        tools: None,
+                    },
+                    MatrixServerEntry {
+                        server_id: "fs-writer".to_string(),
+                        tools: Some(vec![
+                            "Read".to_string(),
+                            "Write".to_string(),
+                            "Edit".to_string(),
+                        ]),
+                    },
+                ],
+            },
+        ];
+        s.mode = Mode::Detail {
+            task_id: task_id.to_string(),
+            scroll: 0,
+            at_bottom: true,
+            return_to: Box::new(Mode::Normal),
+        };
+
+        let backend = TestBackend::new(120, 60);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|frame| render(frame, &s)).unwrap();
+
+        let buf = terminal.backend().buffer();
+        let rendered: String = (0..60)
+            .flat_map(|y| (0..120u16).map(move |x| (x, y)))
+            .map(|(x, y)| buf.cell((x, y)).unwrap().symbol().to_string())
+            .collect();
+
+        // The continuation line lists the allowlist verbatim — pin the
+        // exact tools so a future refactor that drops/replaces the
+        // line gets caught.
+        assert!(
+            rendered.contains("tools: Read, Write, Edit"),
+            "fs-writer's per-server tools allowlist must render as a continuation line"
+        );
+        // pitboss has no allowlist; assert no `pitboss tools:`-style
+        // line was emitted. Tying the negative assertion to the
+        // server prefix keeps it stable against unrelated
+        // `tools:`-substring uses elsewhere in the rendered buffer.
+        assert!(
+            !rendered.contains("pitboss      tools:")
+                && !rendered.contains("• pitboss\n      tools:"),
+            "pitboss has no allowlist; must not emit a tools continuation line"
         );
     }
 

--- a/crates/pitboss-tui/src/watcher.rs
+++ b/crates/pitboss-tui/src/watcher.rs
@@ -66,6 +66,13 @@ struct ResolvedMcpServer {
     pub id: String,
     #[serde(default)]
     pub scope: Option<String>,
+    /// Per-server `[[mcp_server]].tools` allowlist. `None` = unrestricted;
+    /// `Some(list)` is enforced at spawn-time and at runtime via the
+    /// `permission_prompt` short-circuit (#399). Surfaced in the Detail
+    /// view's MCP SERVERS section so operators can see the cap without
+    /// re-reading the manifest.
+    #[serde(default)]
+    pub tools: Option<Vec<String>>,
 }
 
 /// Minimal `[[worker_type]]` / `[[sublead_type]]` shape — only the id
@@ -264,9 +271,13 @@ fn build_matrix_rows(
     worker_types: &[ResolvedActorType],
     sublead_types: &[ResolvedActorType],
 ) -> Vec<pitboss_cli::capability_matrix::MatrixRow> {
-    let server_parts: Vec<(String, Option<String>)> = servers
+    let server_parts: Vec<pitboss_cli::capability_matrix::MatrixServerSpec> = servers
         .iter()
-        .map(|s| (s.id.clone(), s.scope.clone()))
+        .map(|s| pitboss_cli::capability_matrix::MatrixServerSpec {
+            id: s.id.clone(),
+            scope: s.scope.clone(),
+            tools: s.tools.clone(),
+        })
         .collect();
     let wt_ids: Vec<String> = worker_types.iter().map(|w| w.id.clone()).collect();
     let st_ids: Vec<String> = sublead_types.iter().map(|s| s.id.clone()).collect();
@@ -1070,7 +1081,7 @@ mod tests {
             .find(|r| r.actor_type.as_deref() == Some("writer"))
             .expect("writer row missing");
         assert!(
-            writer.server_ids.iter().any(|s| s == "fs-writer"),
+            writer.servers.iter().any(|s| s.server_id == "fs-writer"),
             "writer row should admit fs-writer (scope=type:writer)"
         );
     }

--- a/crates/pitboss-web/spa/src/lib/api.ts
+++ b/crates/pitboss-web/spa/src/lib/api.ts
@@ -280,14 +280,32 @@ export type RowKind = 'untyped' | 'worker_type' | 'sublead_type';
  * validation succeeds. Matches the wire shape pinned by
  * `matrix_row_serialises_with_stable_field_and_kind_names` (#391 slice 3).
  */
+/**
+ * Mirror of `pitboss_cli::capability_matrix::MatrixServerEntry`.
+ * One server admitted on a `MatrixRow`, plus the per-server
+ * `[[mcp_server]].tools` allowlist as it applies on that row.
+ *
+ * `tools` is omitted (not `null`) when the server has no allowlist —
+ * the Rust struct uses `#[serde(skip_serializing_if = "Option::is_none")]`
+ * so the SPA branches on key-presence, not on a sentinel. (#391)
+ */
+export interface MatrixServerEntry {
+  server_id: string;
+  /** Absent => unrestricted. Present => explicit allowlist. */
+  tools?: string[];
+}
+
 export interface MatrixRow {
   /** Display label as the CLI text formatter emits it. */
   label: string;
   /** `null` for the untyped row, the type id for declared profiles. */
   actor_type: string | null;
   kind: RowKind;
-  /** MCP server ids that scope-admit, in manifest declaration order. */
-  server_ids: string[];
+  /**
+   * MCP servers (with their per-server tool allowlists) that scope-admit,
+   * in manifest declaration order.
+   */
+  servers: MatrixServerEntry[];
 }
 
 export interface ValidateResult {

--- a/crates/pitboss-web/spa/src/routes/manifests/[name]/+page.svelte
+++ b/crates/pitboss-web/spa/src/routes/manifests/[name]/+page.svelte
@@ -271,14 +271,24 @@
                   <tr class="border-b last:border-0 align-top">
                     <td class="py-1.5 pr-3 font-mono">{row.label}</td>
                     <td class="py-1.5">
-                      {#if row.server_ids.length === 0}
+                      {#if row.servers.length === 0}
                         <span class="text-muted-foreground italic">(none)</span>
                       {:else}
-                        <div class="flex flex-wrap gap-1">
-                          {#each row.server_ids as id, sidx (sidx)}
-                            <code class="bg-muted rounded px-1.5 py-0.5">{id}</code>
+                        <ul class="space-y-1">
+                          {#each row.servers as srv, sidx (sidx)}
+                            <li>
+                              <code class="bg-muted rounded px-1.5 py-0.5">{srv.server_id}</code>
+                              {#if srv.tools && srv.tools.length > 0}
+                                <span class="text-muted-foreground ml-2">tools:</span>
+                                <span class="ml-1 inline-flex flex-wrap gap-1 align-middle">
+                                  {#each srv.tools as tool, tidx (tidx)}
+                                    <code class="bg-muted/60 rounded px-1 py-0.5">{tool}</code>
+                                  {/each}
+                                </span>
+                              {/if}
+                            </li>
                           {/each}
-                        </div>
+                        </ul>
                       {/if}
                     </td>
                   </tr>

--- a/crates/pitboss-web/tests/validate_capability_matrix_integration.rs
+++ b/crates/pitboss-web/tests/validate_capability_matrix_integration.rs
@@ -64,6 +64,7 @@ command = "/bin/true"
 id = "fs-writer"
 command = "/bin/true"
 scope = "type:writer"
+tools = ["Read", "Write"]
 
 [[worker_type]]
 id = "writer"
@@ -113,29 +114,56 @@ async fn validate_returns_capability_matrix_on_success() {
     // Untyped row anchors first; only sees the unscoped server.
     assert_eq!(matrix[0]["kind"], "untyped");
     assert!(matrix[0]["actor_type"].is_null());
-    let untyped_servers: Vec<&str> = matrix[0]["server_ids"]
+    let untyped_servers: Vec<&str> = matrix[0]["servers"]
         .as_array()
         .unwrap()
         .iter()
-        .map(|v| v.as_str().unwrap())
+        .map(|v| v["server_id"].as_str().unwrap())
         .collect();
     assert_eq!(untyped_servers, vec!["pitboss"]);
+    // pitboss has no per-server `tools` allowlist; the field must be
+    // omitted from the JSON entirely (not serialised as `null`) so the
+    // SPA can branch on key-presence and keep its TS shape clean.
+    assert!(
+        !matrix[0]["servers"][0]
+            .as_object()
+            .unwrap()
+            .contains_key("tools"),
+        "pitboss has no allowlist; tools key must be omitted, got: {:?}",
+        matrix[0]["servers"][0]
+    );
 
-    // Writer row sees the writer-scoped server.
+    // Writer row sees the writer-scoped server, AND fs-writer's
+    // per-server tools allowlist surfaces in the JSON so the SPA can
+    // render the per-tool gate without a second API round-trip.
     let writer = matrix
         .iter()
         .find(|r| r["actor_type"] == "writer")
         .expect("writer row missing");
     assert_eq!(writer["kind"], "worker_type");
-    let writer_servers: Vec<&str> = writer["server_ids"]
+    let writer_entries = writer["servers"].as_array().unwrap();
+    let writer_server_ids: Vec<&str> = writer_entries
+        .iter()
+        .map(|v| v["server_id"].as_str().unwrap())
+        .collect();
+    assert!(
+        writer_server_ids.contains(&"pitboss") && writer_server_ids.contains(&"fs-writer"),
+        "writer should see both servers, got: {writer_server_ids:?}"
+    );
+    let fs_writer_entry = writer_entries
+        .iter()
+        .find(|v| v["server_id"] == "fs-writer")
+        .expect("fs-writer entry missing");
+    let tools: Vec<&str> = fs_writer_entry["tools"]
         .as_array()
-        .unwrap()
+        .expect("fs-writer.tools must be present (allowlist declared)")
         .iter()
         .map(|v| v.as_str().unwrap())
         .collect();
-    assert!(
-        writer_servers.contains(&"pitboss") && writer_servers.contains(&"fs-writer"),
-        "writer should see both servers, got: {writer_servers:?}"
+    assert_eq!(
+        tools,
+        vec!["Read", "Write"],
+        "fs-writer's per-server allowlist should round-trip exactly"
     );
 }
 


### PR DESCRIPTION
## Summary

- Extend `MatrixRow.servers[]` (was `server_ids: string[]`) so each entry carries the optional `[[mcp_server]].tools` allowlist alongside the server id.
- **CLI** `pitboss validate --capability-matrix`: per-server tools printed on a continuation line under the server bullet; servers without an allowlist render bare.
- **TUI** Detail view: MCP SERVERS section adds an indented `tools:` line under each server when the allowlist is set.
- **pitboss-web** manifest panel: renders each server with optional inline tool chips next to the server id.

`tools` is omitted on the wire (via `#[serde(skip_serializing_if = "Option::is_none")]`) when the server has no allowlist — the SPA's TS interface uses `tools?: string[]` and branches on key-presence. The explicit gate itself was already enforced at spawn time and at runtime via `permission_prompt` (#399); this PR is **purely visualization**.

Closes #391.

### State of #391 after merge

- ✓ Slice 1 (structured matrix data) — #396
- ✓ Slice 2 (TUI Detail) — #396
- ✓ Slice 3 (web manifest panel) — #398
- ✓ Slice 4 (per-tool granularity, Path 2) — #400 (manifest schema + validate) → #401 (runtime enforcement)
- ✓ **Matrix UI extension** — this PR

### Wire shape break

`server_ids: string[]` → `servers: MatrixServerEntry[]` is a clean break in the JSON contract. Both consumers updated in this PR (Rust integration test + SPA TS interface). The SPA bundle is baked into the `pitboss-web` binary via `rust-embed`, so version skew is impossible.

### Parked complement

The runtime-side complement of this visualization — surfacing the `DeniedReasonKind::DeniedByMcpServerAllowlist` audit events on the TUI tile (per-actor denied counter, recent denials sub-panel) — is parked as a follow-on. The matrix view shows what *would* admit; the tile counter would show what *did* get denied.

## Test plan

- [x] `cargo lint` clean
- [x] `cargo tidy` clean
- [x] `cargo test --workspace --features pitboss-core/test-support` — all green; new module-level test pins per-server tools render in CLI text formatter; new TUI Detail test pins the indented `tools:` continuation line; web integration test asserts `servers[].tools` round-trips through validate.
- [x] Headless browser smoke (Playwright Chromium) against `pitboss-web` with a fixture manifest declaring `[[mcp_server]] tools = ["Read", "Write", "Edit"]` — confirmed the manifest detail page renders the matrix card with `fs-writer tools: Read Write Edit` and unrestricted servers render bare.
- [x] `pitboss-web` validate JSON inspected end-to-end via curl — `servers[].tools` only present for servers with declared allowlists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)