### PR TITLE
docs(schema): correct stale permission_routing field help text

### DIFF
--- a/crates/pitboss-cli/src/manifest/schema.rs
+++ b/crates/pitboss-cli/src/manifest/schema.rs
@@ -999,14 +999,19 @@ pub struct Lead {
     pub lead_timeout_secs: Option<u64>,
 
     // ── v0.8 permission routing ──────────────────────────────────────────
-    /// `"path_a"` (default): `CLAUDE_CODE_ENTRYPOINT=sdk-ts` bypasses claude's
-    /// built-in gate; pitboss is sole authority via its approval queue.
-    /// `"path_b"`: pitboss registers a `permission_prompt` MCP tool;
-    /// claude routes each permission check through it.
+    /// `"path_b"` (default since v0.12): pitboss registers a
+    /// `permission_prompt` MCP tool; claude routes each per-tool check
+    /// through it. Layered enforcement runs the per-server
+    /// `[[mcp_server]].tools` allowlist first, then operator
+    /// `[[approval_policy]]` rules, then the typed-profile gate.
+    /// `"path_a"`: `CLAUDE_CODE_ENTRYPOINT=sdk-ts` plus
+    /// `--dangerously-skip-permissions` bypasses claude's built-in gate;
+    /// pitboss becomes sole authority via the approval queue. Use only
+    /// for runs that want to opt out of per-tool gating entirely.
     #[serde(default)]
     #[field(
         label = "Permission routing",
-        help = "path_a (default) makes pitboss the sole permission authority. path_b routes claude's gate through pitboss (rejected at validate time pending stabilization).",
+        help = "path_b (default) routes claude's per-tool gate through pitboss's permission_prompt MCP tool — layered enforcement (mcp_server tools allowlist, operator policy, typed profile). path_a bypasses claude's gate via --dangerously-skip-permissions and makes pitboss the sole authority.",
         enum_values = ["path_a", "path_b"]
     )]
     pub permission_routing: PermissionRouting,

--- a/docs/manifest-map.md
+++ b/docs/manifest-map.md
@@ -104,22 +104,22 @@ Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:904`](../crates/pitbos
 | `max_workers` | integer | no | Hard cap on the lead's concurrent + queued worker pool (1–16). Required when the lead spawns workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L981`](../crates/pitboss-cli/src/manifest/schema.rs#L981) |
 | `budget_usd` | float | no | Soft cap on lead spend with reservation accounting. spawn_worker fails once spent + reserved + next_estimate > budget. | [`../crates/pitboss-cli/src/manifest/schema.rs#L990`](../crates/pitboss-cli/src/manifest/schema.rs#L990) |
 | `lead_timeout_secs` | integer | no | Wall-clock cap on the lead session. Default 3600. | [`../crates/pitboss-cli/src/manifest/schema.rs#L999`](../crates/pitboss-cli/src/manifest/schema.rs#L999) |
-| `permission_routing` | enum (`path_a` \| `path_b`) | no | path_a (default) makes pitboss the sole permission authority. path_b routes claude's gate through pitboss (rejected at validate time pending stabilization). | [`../crates/pitboss-cli/src/manifest/schema.rs#L1012`](../crates/pitboss-cli/src/manifest/schema.rs#L1012) |
-| `allow_subleads` | boolean | no | Expose spawn_sublead to the root lead. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1021`](../crates/pitboss-cli/src/manifest/schema.rs#L1021) |
-| `max_subleads` | integer | no | Hard cap on total live sub-leads under this root. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1028`](../crates/pitboss-cli/src/manifest/schema.rs#L1028) |
-| `max_sublead_budget_usd` | float | no | Cap on the per-sub-lead budget envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1035`](../crates/pitboss-cli/src/manifest/schema.rs#L1035) |
-| `max_total_workers` | integer | no | Cap on total live workers across the entire tree (root + sub-trees). | [`../crates/pitboss-cli/src/manifest/schema.rs#L1043`](../crates/pitboss-cli/src/manifest/schema.rs#L1043) |
+| `permission_routing` | enum (`path_a` \| `path_b`) | no | path_b (default) routes claude's per-tool gate through pitboss's permission_prompt MCP tool — layered enforcement (mcp_server tools allowlist, operator policy, typed profile). path_a bypasses claude's gate via --dangerously-skip-permissions and makes pitboss the sole authority. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1017`](../crates/pitboss-cli/src/manifest/schema.rs#L1017) |
+| `allow_subleads` | boolean | no | Expose spawn_sublead to the root lead. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1026`](../crates/pitboss-cli/src/manifest/schema.rs#L1026) |
+| `max_subleads` | integer | no | Hard cap on total live sub-leads under this root. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1033`](../crates/pitboss-cli/src/manifest/schema.rs#L1033) |
+| `max_sublead_budget_usd` | float | no | Cap on the per-sub-lead budget envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1040`](../crates/pitboss-cli/src/manifest/schema.rs#L1040) |
+| `max_total_workers` | integer | no | Cap on total live workers across the entire tree (root + sub-trees). | [`../crates/pitboss-cli/src/manifest/schema.rs#L1048`](../crates/pitboss-cli/src/manifest/schema.rs#L1048) |
 
 ## `[sublead_defaults]` — `SubleadDefaults`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:1050`](../crates/pitboss-cli/src/manifest/schema.rs#L1050).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:1055`](../crates/pitboss-cli/src/manifest/schema.rs#L1055).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `budget_usd` | float | no | Per-sub-lead envelope when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1055`](../crates/pitboss-cli/src/manifest/schema.rs#L1055) |
-| `max_workers` | integer | no | Per-sub-lead worker pool when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1060`](../crates/pitboss-cli/src/manifest/schema.rs#L1060) |
-| `lead_timeout_secs` | integer | no | Wall-clock cap for the sub-lead session. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1065`](../crates/pitboss-cli/src/manifest/schema.rs#L1065) |
-| `read_down` | boolean | no | When true, sub-lead shares root's budget + worker pool instead of carving its own envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1071`](../crates/pitboss-cli/src/manifest/schema.rs#L1071) |
+| `budget_usd` | float | no | Per-sub-lead envelope when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1060`](../crates/pitboss-cli/src/manifest/schema.rs#L1060) |
+| `max_workers` | integer | no | Per-sub-lead worker pool when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1065`](../crates/pitboss-cli/src/manifest/schema.rs#L1065) |
+| `lead_timeout_secs` | integer | no | Wall-clock cap for the sub-lead session. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1070`](../crates/pitboss-cli/src/manifest/schema.rs#L1070) |
+| `read_down` | boolean | no | When true, sub-lead shares root's budget + worker pool instead of carving its own envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1076`](../crates/pitboss-cli/src/manifest/schema.rs#L1076) |
 
 ## `[[approval_policy]]` — `ApprovalRuleSpec`
 


### PR DESCRIPTION
## Summary

The `#[field(help = ...)]` annotation on `[lead].permission_routing` at `crates/pitboss-cli/src/manifest/schema.rs:1009` still claimed:

> path_a (default) makes pitboss the sole permission authority. path_b routes claude's gate through pitboss (rejected at validate time pending stabilization).

Both halves have been wrong since v0.12 promoted Path B to default:

- `PermissionRouting::PathB` carries `#[default]` (schema.rs:67)
- `validate.rs` has no `bail!` against `path_b` — the only `path_b`-specific path is the soft `path_b_profile_migration_warning` advisory
- The schema-level docstring (line 49) and `dispatch/runner.rs` comments already correctly say "default since v0.12"

The field help text was the lone holdout, and it feeds three operator-facing surfaces:

1. The `pitboss-web` manifest wizard tooltip
2. `pitboss schema --format=map` output
3. `docs/manifest-map.md` (the checked-in version of the map)

So operators were being told the opposite of what the code does, in three places at once.

This PR rewrites the help text to describe current behavior — Path B (default) layered enforcement, Path A as the opt-out — and regenerates `docs/manifest-map.md` so the `checked_in_doc_matches_generator` test passes.

## Test plan

- [x] `cargo test -p pitboss-cli --features pitboss-core/test-support` — all 769 unit + integration tests pass; the `checked_in_doc_matches_generator` test that caught the stale doc on first run now passes after regeneration.
- [x] `cargo lint` clean
- [x] `cargo tidy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)