### PR TITLE
feat(tui,cli): surface recent tool denials in TUI Detail and pitboss status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -666,6 +666,11 @@ Other low-level options:
 - `cat <run-dir>/summary.jsonl` — completed tasks (streamed append-only)
 - `cat <run-dir>/summary.json` — full summary on clean finalize
 - `ls <run-dir>/tasks/` — all spawned task directories
+- `cat <run-dir>/tasks/<actor-id>/events.jsonl` — Path-B `tool_denied`
+  rows (the per-actor audit trail). `pitboss status` adds a `DENIED`
+  column when any actor recorded a denial; the TUI's Detail view
+  surfaces the last 5 rows in a `RECENT DENIALS` section so an operator
+  can see what was blocked without grepping the file (#405).
 
 The root lead's logs live at `<run-dir>/tasks/<lead-id>/stdout.log`.
 Workers and sub-leads live at `<run-dir>/tasks/<task-id>/` and

--- a/crates/pitboss-cli/src/status.rs
+++ b/crates/pitboss-cli/src/status.rs
@@ -71,20 +71,77 @@ pub fn run(run_id_prefix: &str, json: bool, run_dir_override: Option<PathBuf>) -
         .file_name()
         .map(|n| n.to_string_lossy().into_owned())
         .unwrap_or_else(|| run_dir.display().to_string());
-    render_status(&mut stdout, &run_name, &records, notify_failures)?;
+    let denied_counts = count_denials_per_task(&run_dir, &records);
+    render_status(
+        &mut stdout,
+        &run_name,
+        &records,
+        notify_failures,
+        &denied_counts,
+    )?;
 
     Ok(0)
+}
+
+/// Count `tool_denied` rows in each task's `<run_dir>/tasks/<id>/events.jsonl`.
+/// Returns a map keyed by `task_id`. Tasks with no jsonl file (quiet
+/// actors, common case) are simply absent from the map. (#405)
+///
+/// The five-line `kind == "tool_denied"` discrimination is the stable
+/// wire contract — same logic lives in `pitboss-tui/src/watcher.rs`'s
+/// `read_denial_state`. Duplicated here rather than shared via
+/// `pitboss-core` because the helper is too small to justify an
+/// events-schema dep on core, and the wire-stable `kind` string is
+/// what protects against drift.
+fn count_denials_per_task(
+    run_dir: &Path,
+    records: &[pitboss_core::store::TaskRecord],
+) -> std::collections::HashMap<String, u32> {
+    use std::io::{BufRead, BufReader};
+    let mut out = std::collections::HashMap::new();
+    for rec in records {
+        let path = run_dir
+            .join("tasks")
+            .join(&rec.task_id)
+            .join("events.jsonl");
+        let Ok(file) = std::fs::File::open(&path) else {
+            continue;
+        };
+        let mut count: u32 = 0;
+        for line in BufReader::new(file).lines().map_while(Result::ok) {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let Ok(val) = serde_json::from_str::<serde_json::Value>(trimmed) else {
+                continue;
+            };
+            if val.get("kind").and_then(|v| v.as_str()) == Some("tool_denied") {
+                count = count.saturating_add(1);
+            }
+        }
+        if count > 0 {
+            out.insert(rec.task_id.clone(), count);
+        }
+    }
+    out
 }
 
 /// Pure rendering helper, separated from I/O setup so the table + footer
 /// can be exercised by tests without driving the binary or capturing
 /// stdout. The non-positive-failure path (no router OR `Some(0)`) must
 /// not emit a footer line — callers depend on the absence as a signal.
+///
+/// `denied_counts` is keyed by `task_id`; tasks absent from the map (or
+/// mapped to 0) carry no denials. When the map is empty across the
+/// whole run, the DENIED column is hidden entirely so the common-case
+/// output stays tight (#405).
 pub(crate) fn render_status<W: Write>(
     out: &mut W,
     run_name: &str,
     records: &[pitboss_core::store::TaskRecord],
     notify_failures: Option<u32>,
+    denied_counts: &std::collections::HashMap<String, u32>,
 ) -> Result<()> {
     writeln!(out, "Run: {run_name}")?;
 
@@ -99,13 +156,36 @@ pub(crate) fn render_status<W: Write>(
         .max()
         .unwrap_or(0);
     let task_id_width = observed_max.clamp(TASK_ID_MIN, TASK_ID_MAX);
-    let sep_width = task_id_width + 1 + 16 + 1 + 10 + 1 + 24 + 1 + 6;
 
-    writeln!(
-        out,
-        "{:<task_id_width$} {:<16} {:>10} {:<24} {:>6}",
-        "TASK_ID", "STATUS", "DURATION", "STARTED", "EXIT",
-    )?;
+    // Show the DENIED column only when at least one actor recorded a
+    // Path-B denial. Empty map => column hidden; same conditional
+    // discipline as the TUI tile counter (#405).
+    let show_denied = denied_counts.values().any(|n| *n > 0);
+    const DENIED_WIDTH: usize = 6;
+    let sep_width = task_id_width
+        + 1
+        + 16
+        + 1
+        + 10
+        + 1
+        + 24
+        + 1
+        + 6
+        + if show_denied { 1 + DENIED_WIDTH } else { 0 };
+
+    if show_denied {
+        writeln!(
+            out,
+            "{:<task_id_width$} {:<16} {:>10} {:<24} {:>6} {:>DENIED_WIDTH$}",
+            "TASK_ID", "STATUS", "DURATION", "STARTED", "EXIT", "DENIED",
+        )?;
+    } else {
+        writeln!(
+            out,
+            "{:<task_id_width$} {:<16} {:>10} {:<24} {:>6}",
+            "TASK_ID", "STATUS", "DURATION", "STARTED", "EXIT",
+        )?;
+    }
     writeln!(out, "{}", "-".repeat(sep_width))?;
 
     for rec in records {
@@ -117,10 +197,22 @@ pub(crate) fn render_status<W: Write>(
             .map(|c| c.to_string())
             .unwrap_or_else(|| "—".to_string());
         let task_id = pitboss_core::fmt::truncate_ellipsis(&rec.task_id, task_id_width);
-        writeln!(
-            out,
-            "{task_id:<task_id_width$} {status:<16} {duration:>10} {started:<24} {exit:>6}",
-        )?;
+        if show_denied {
+            // Render "0" for absent tasks rather than "—" — the count is
+            // an authoritative count, not an unknown value, and "0"
+            // visually contrasts against the populated rows so an
+            // operator sees which actors hit denials at a glance.
+            let denied = denied_counts.get(&rec.task_id).copied().unwrap_or(0);
+            writeln!(
+                out,
+                "{task_id:<task_id_width$} {status:<16} {duration:>10} {started:<24} {exit:>6} {denied:>DENIED_WIDTH$}",
+            )?;
+        } else {
+            writeln!(
+                out,
+                "{task_id:<task_id_width$} {status:<16} {duration:>10} {started:<24} {exit:>6}",
+            )?;
+        }
     }
 
     if records.is_empty() {
@@ -138,9 +230,10 @@ pub(crate) fn render_status<W: Write>(
     // Approvals aggregate. `approvals_rejected` covers both Path A
     // (`request_approval` denials) and Path B (`permission_prompt`
     // denials) — per #367 the Path-B handler bumps the same counter.
-    // Per-`DeniedReasonKind` breakdown lives on each actor's
-    // `events.jsonl::tool_denied` rows; surfacing that requires reading
-    // those files per-actor and is left for `--json` consumers / TUI.
+    // Per-actor Path-B denial counts surface in the DENIED column
+    // above (#405); per-`DeniedReasonKind` breakdown still lives on
+    // `events.jsonl::tool_denied` rows and is left for `--json`
+    // consumers / TUI Detail's RECENT DENIALS section.
     let approvals_requested: u32 = records.iter().map(|r| r.approvals_requested).sum();
     let approvals_approved: u32 = records.iter().map(|r| r.approvals_approved).sum();
     let approvals_rejected: u32 = records.iter().map(|r| r.approvals_rejected).sum();
@@ -283,7 +376,14 @@ mod tests {
     fn render_status_emits_notify_failures_footer_when_positive() {
         let recs = vec![make_record("w-1", TaskStatus::Success)];
         let mut buf = Vec::new();
-        render_status(&mut buf, "test-run", &recs, Some(3)).unwrap();
+        render_status(
+            &mut buf,
+            "test-run",
+            &recs,
+            Some(3),
+            &std::collections::HashMap::new(),
+        )
+        .unwrap();
         let out = String::from_utf8(buf).unwrap();
         assert!(
             out.contains("Notification failures: 3 (see notifications.jsonl)"),
@@ -298,7 +398,14 @@ mod tests {
     fn render_status_omits_notify_failures_footer_when_zero() {
         let recs = vec![make_record("w-1", TaskStatus::Success)];
         let mut buf = Vec::new();
-        render_status(&mut buf, "test-run", &recs, Some(0)).unwrap();
+        render_status(
+            &mut buf,
+            "test-run",
+            &recs,
+            Some(0),
+            &std::collections::HashMap::new(),
+        )
+        .unwrap();
         let out = String::from_utf8(buf).unwrap();
         assert!(
             !out.contains("Notification failures"),
@@ -313,7 +420,14 @@ mod tests {
     fn render_status_omits_notify_failures_footer_when_unknown() {
         let recs = vec![make_record("w-1", TaskStatus::Success)];
         let mut buf = Vec::new();
-        render_status(&mut buf, "test-run", &recs, None).unwrap();
+        render_status(
+            &mut buf,
+            "test-run",
+            &recs,
+            None,
+            &std::collections::HashMap::new(),
+        )
+        .unwrap();
         let out = String::from_utf8(buf).unwrap();
         assert!(
             !out.contains("Notification failures"),
@@ -345,7 +459,14 @@ mod tests {
             make_record_with_approvals("w-2", 3, 1, 2),
         ];
         let mut buf = Vec::new();
-        render_status(&mut buf, "test-run", &recs, None).unwrap();
+        render_status(
+            &mut buf,
+            "test-run",
+            &recs,
+            None,
+            &std::collections::HashMap::new(),
+        )
+        .unwrap();
         let out = String::from_utf8(buf).unwrap();
         assert!(
             out.contains("Approvals: 8 requested, 5 approved, 3 rejected"),
@@ -363,7 +484,14 @@ mod tests {
             make_record_with_approvals("w-2", 0, 0, 0),
         ];
         let mut buf = Vec::new();
-        render_status(&mut buf, "test-run", &recs, None).unwrap();
+        render_status(
+            &mut buf,
+            "test-run",
+            &recs,
+            None,
+            &std::collections::HashMap::new(),
+        )
+        .unwrap();
         let out = String::from_utf8(buf).unwrap();
         assert!(
             !out.contains("Approvals:"),
@@ -378,11 +506,140 @@ mod tests {
     fn render_status_emits_approvals_footer_when_only_rejected_positive() {
         let recs = vec![make_record_with_approvals("w-1", 4, 0, 4)];
         let mut buf = Vec::new();
-        render_status(&mut buf, "test-run", &recs, None).unwrap();
+        render_status(
+            &mut buf,
+            "test-run",
+            &recs,
+            None,
+            &std::collections::HashMap::new(),
+        )
+        .unwrap();
         let out = String::from_utf8(buf).unwrap();
         assert!(
             out.contains("Approvals: 4 requested, 0 approved, 4 rejected"),
             "approvals footer missing for rejection-only run in:\n{out}"
+        );
+    }
+
+    /// When no actor in the run has Path-B denials, the DENIED column is
+    /// hidden entirely so the common-case output stays unchanged. Pin
+    /// the absence so a future "always-show" refactor that breaks
+    /// downstream parsers gets caught. (#405)
+    #[test]
+    fn render_status_omits_denied_column_when_all_zero() {
+        let recs = vec![
+            make_record("w-1", TaskStatus::Success),
+            make_record("w-2", TaskStatus::Success),
+        ];
+        let mut buf = Vec::new();
+        render_status(
+            &mut buf,
+            "test-run",
+            &recs,
+            None,
+            &std::collections::HashMap::new(),
+        )
+        .unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(
+            !out.contains("DENIED"),
+            "DENIED column must be hidden when no actor has denials:\n{out}"
+        );
+    }
+
+    /// When at least one actor recorded a Path-B denial, the DENIED
+    /// column appears; absent tasks render as "0", populated tasks
+    /// render the count right-aligned. The signal is per-actor so an
+    /// operator can see at a glance which workers hit denials. (#405)
+    #[test]
+    fn render_status_emits_denied_column_when_any_positive() {
+        let recs = vec![
+            make_record("writer-1", TaskStatus::Success),
+            make_record("writer-2", TaskStatus::Failed),
+            make_record("reader-1", TaskStatus::Success),
+        ];
+        let mut counts = std::collections::HashMap::new();
+        counts.insert("writer-1".to_string(), 3);
+        counts.insert("writer-2".to_string(), 7);
+        // reader-1 has no denials — should render as "0", not be hidden.
+
+        let mut buf = Vec::new();
+        render_status(&mut buf, "test-run", &recs, None, &counts).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+
+        assert!(
+            out.contains("DENIED"),
+            "DENIED column heading missing in:\n{out}"
+        );
+        // Per-row counts. Right-aligned in 6-col field, so look for the
+        // task-id followed by the row content and a final "    3"
+        // (4 spaces padding + count).
+        let writer1_line = out
+            .lines()
+            .find(|l| l.starts_with("writer-1"))
+            .expect("writer-1 row missing");
+        assert!(
+            writer1_line.trim_end().ends_with("3"),
+            "writer-1 row should end with denied count 3, got: {writer1_line:?}"
+        );
+        let writer2_line = out
+            .lines()
+            .find(|l| l.starts_with("writer-2"))
+            .expect("writer-2 row missing");
+        assert!(
+            writer2_line.trim_end().ends_with("7"),
+            "writer-2 row should end with denied count 7, got: {writer2_line:?}"
+        );
+        let reader_line = out
+            .lines()
+            .find(|l| l.starts_with("reader-1"))
+            .expect("reader-1 row missing");
+        assert!(
+            reader_line.trim_end().ends_with("0"),
+            "reader-1 row (no denials) should render as 0, got: {reader_line:?}"
+        );
+    }
+
+    /// `count_denials_per_task` reads each task's events.jsonl and
+    /// counts only `kind == "tool_denied"` rows. Tasks with no jsonl
+    /// file (quiet actors) are absent from the result map; tasks with
+    /// jsonl but no denials don't appear either (the rendering helper
+    /// treats absent as zero).
+    #[test]
+    fn count_denials_per_task_reads_jsonl_per_task() {
+        let tmp = TempDir::new().unwrap();
+        let run_dir = tmp.path();
+        let mk = |id: &str, body: &str| {
+            let dir = run_dir.join("tasks").join(id);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("events.jsonl"), body).unwrap();
+        };
+        mk(
+            "noisy",
+            "{\"kind\":\"tool_denied\",\"at\":\"2026-05-08T00:00:00Z\",\"tool_name\":\"Bash\",\"actor_id\":\"noisy\",\"reason_kind\":\"denied_by_rule\",\"reason\":\"x\"}\n\
+             {\"kind\":\"pause\",\"at\":\"2026-05-08T00:00:01Z\"}\n\
+             {\"kind\":\"tool_denied\",\"at\":\"2026-05-08T00:00:02Z\",\"tool_name\":\"Write\",\"actor_id\":\"noisy\",\"reason_kind\":\"operator_rejected\",\"reason\":\"y\"}\n",
+        );
+        mk(
+            "approved-only",
+            "{\"kind\":\"approval_response\",\"at\":\"2026-05-08T00:00:00Z\",\"request_id\":\"r1\",\"approved\":true,\"edited\":false}\n",
+        );
+        // "quiet" has no events.jsonl at all.
+
+        let recs = vec![
+            make_record("noisy", TaskStatus::Success),
+            make_record("approved-only", TaskStatus::Success),
+            make_record("quiet", TaskStatus::Success),
+        ];
+        let counts = count_denials_per_task(run_dir, &recs);
+        assert_eq!(counts.get("noisy"), Some(&2));
+        assert!(
+            !counts.contains_key("approved-only"),
+            "task with jsonl but no tool_denied rows must be absent from map"
+        );
+        assert!(
+            !counts.contains_key("quiet"),
+            "task with no jsonl must be absent from map"
         );
     }
 }

--- a/crates/pitboss-tui/src/grouped_grid.rs
+++ b/crates/pitboss-tui/src/grouped_grid.rs
@@ -80,6 +80,7 @@ mod tests {
             worktree_path: None,
             completed_at: None,
             denials_count: 0,
+            recent_denials: Vec::new(),
             actor_type: None,
         }
     }

--- a/crates/pitboss-tui/src/main.rs
+++ b/crates/pitboss-tui/src/main.rs
@@ -308,6 +308,7 @@ fn build_one_shot_snapshot(run_dir: &std::path::Path) -> state::AppSnapshot {
                 worktree_path: rec.worktree_path.clone(),
                 completed_at: Some(rec.ended_at),
                 denials_count: 0,
+                recent_denials: Vec::new(),
                 actor_type: rec.actor_type.clone(),
             });
         } else {
@@ -326,6 +327,7 @@ fn build_one_shot_snapshot(run_dir: &std::path::Path) -> state::AppSnapshot {
                 worktree_path: None,
                 completed_at: None,
                 denials_count: 0,
+                recent_denials: Vec::new(),
                 actor_type: None,
             });
         }

--- a/crates/pitboss-tui/src/state.rs
+++ b/crates/pitboss-tui/src/state.rs
@@ -185,6 +185,26 @@ pub struct SubtreeView {
     pub read_down: bool,
 }
 
+/// One `tool_denied` row read from a per-actor `events.jsonl`. Lightweight
+/// TUI-local mirror of the canonical `pitboss_cli::dispatch::events::TaskEvent::ToolDenied`
+/// variant; carrying the typed enum here would force `pitboss-tui` to
+/// take a `pitboss-cli` dep just to read its own jsonl. The watcher
+/// extracts these fields via `serde_json::Value` discriminated on
+/// `kind == "tool_denied"` — same wire-stable contract as
+/// `count_tool_denials` already documents. (#405)
+///
+/// `at` and `reason_kind` are kept as strings since rendering doesn't
+/// need the typed forms — `reason_kind` is the `snake_case` enum
+/// discriminant (`denied_by_rule`, `denied_by_profile`, etc.) and `at`
+/// is rendered to clock time without parsing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DenialRow {
+    pub at: String,
+    pub tool_name: String,
+    pub reason_kind: String,
+    pub reason: String,
+}
+
 /// State for one task tile.
 #[derive(Debug, Clone)]
 pub struct TileState {
@@ -219,6 +239,13 @@ pub struct TileState {
     /// claude received and adapted to (#370). Read-side aggregation only;
     /// the canonical per-row data lives in `events.jsonl`.
     pub denials_count: u32,
+    /// Last `RECENT_DENIALS_CAP` (typically 5) `tool_denied` rows from
+    /// this actor's `events.jsonl`, in append order (oldest → newest).
+    /// Populated by the watcher in the same single pass as
+    /// [`Self::denials_count`]; the Detail view's `RECENT DENIALS`
+    /// section reads directly from this. Empty when no denials yet,
+    /// or when `denials_count == 0`. (#405)
+    pub recent_denials: Vec<DenialRow>,
     /// Resolved `[[worker_type]]` / `[[sublead_type]]` id at spawn time
     /// (from `TaskRecord.actor_type`). `None` for the lead, for un-typed
     /// spawns, and for in-flight tiles whose record hasn't settled. Drives
@@ -1243,6 +1270,7 @@ mod tests {
             worktree_path: None,
             completed_at: None,
             denials_count: 0,
+            recent_denials: Vec::new(),
             actor_type: None,
         }];
         state
@@ -1805,6 +1833,7 @@ mod tests {
             worktree_path: None,
             completed_at: Some(Utc::now() - chrono::Duration::seconds(ended_secs_ago)),
             denials_count: 0,
+            recent_denials: Vec::new(),
             actor_type: None,
         }
     }
@@ -1841,6 +1870,7 @@ mod tests {
             worktree_path: None,
             completed_at: None, // running tiles never have completed_at
             denials_count: 0,
+            recent_denials: Vec::new(),
             actor_type: None,
         };
         assert!(!state.is_promoted(&tile));
@@ -1867,6 +1897,7 @@ mod tests {
                 worktree_path: None,
                 completed_at: None,
                 denials_count: 0,
+                recent_denials: Vec::new(),
                 actor_type: None,
             },
             make_done_tile("fresh", 2), // done but within grace period
@@ -1927,6 +1958,7 @@ mod tests {
             worktree_path: None,
             completed_at: None,
             denials_count: 0,
+            recent_denials: Vec::new(),
             actor_type: None,
         }
     }

--- a/crates/pitboss-tui/src/tui.rs
+++ b/crates/pitboss-tui/src/tui.rs
@@ -1768,8 +1768,80 @@ fn render_detail_metadata(
         }
     }
 
+    // --- Recent denials (Path B `tool_denied` events) ---
+    // Surfaces the last N denial rows from this actor's events.jsonl so an
+    // operator running under Path B can see WHAT was denied, not just the
+    // count. Conditional on denials_count > 0 so quiet actors don't get
+    // an empty section. Counterpart to the static MCP SERVERS matrix
+    // above: the matrix shows what would admit; this shows what didn't.
+    // (#405)
+    if tile.denials_count > 0 {
+        lines.push(Line::from(Span::styled(
+            "RECENT DENIALS",
+            theme::secondary_style().add_modifier(Modifier::BOLD),
+        )));
+        if tile.recent_denials.is_empty() {
+            // Defensive: count > 0 but no rows captured (file shrank
+            // between watcher polls, or RECENT_DENIALS_CAP = 0). Keep
+            // the heading + count so the operator still sees the
+            // signal.
+            lines.push(Line::from(Span::styled(
+                format!("  ({} denied; rows unavailable)", tile.denials_count),
+                theme::muted_style(),
+            )));
+        } else {
+            // Render newest-last (append order). Show only the time-of-day
+            // portion of `at` (HH:MM:SS) — the date on a live-run jsonl is
+            // always today, and the column is narrow.
+            for row in &tile.recent_denials {
+                lines.push(Line::from(Span::styled(
+                    format!("  • {}", row.tool_name),
+                    theme::muted_style(),
+                )));
+                lines.push(Line::from(Span::styled(
+                    format!("      reason: {}", row.reason_kind),
+                    theme::muted_style(),
+                )));
+                if let Some(clock) = at_to_hhmmss(&row.at) {
+                    lines.push(Line::from(Span::styled(
+                        format!("      at: {clock}"),
+                        theme::muted_style(),
+                    )));
+                }
+            }
+            // If the buffer is capped, hint that older denials still exist
+            // in events.jsonl. Operator's path to the full history.
+            if (tile.denials_count as usize) > tile.recent_denials.len() {
+                let older = (tile.denials_count as usize) - tile.recent_denials.len();
+                lines.push(Line::from(Span::styled(
+                    format!("  (+{older} older in events.jsonl)"),
+                    theme::muted_style(),
+                )));
+            }
+        }
+    }
+
     let para = Paragraph::new(lines).wrap(Wrap { trim: false });
     frame.render_widget(para, inner);
+}
+
+/// Extract `HH:MM:SS` from an ISO-8601 `at` string. We render only the
+/// time-of-day portion in Detail view since the date is always today on
+/// a live run and the column is narrow. Returns `None` when the input
+/// doesn't match the expected RFC3339 prefix shape so the caller can
+/// fall back gracefully.
+fn at_to_hhmmss(at: &str) -> Option<String> {
+    // Cheap shape check: "YYYY-MM-DDTHH:MM:SS..." — pull the slice between
+    // 'T' and the next non-digit/colon. Avoids a chrono parse for what is
+    // a render-side cosmetic transformation.
+    let t_pos = at.find('T')?;
+    let after_t = &at[t_pos + 1..];
+    // Take HH:MM:SS = exactly 8 chars if available.
+    if after_t.len() >= 8 {
+        Some(after_t[..8].to_string())
+    } else {
+        None
+    }
 }
 
 /// Pick the matrix row that applies to a given tile.
@@ -2413,6 +2485,7 @@ mod tests {
             worktree_path: None,
             completed_at: None,
             denials_count: 0,
+            recent_denials: Vec::new(),
             actor_type: None,
         }
     }
@@ -2904,6 +2977,166 @@ mod tests {
             !rendered.contains("pitboss      tools:")
                 && !rendered.contains("• pitboss\n      tools:"),
             "pitboss has no allowlist; must not emit a tools continuation line"
+        );
+    }
+
+    /// `RECENT DENIALS` section appears on the Detail view when the
+    /// focused tile has at least one `tool_denied` row. Each row renders
+    /// as bullet (tool) + `reason_kind` + clock. Pin the layout so a
+    /// future refactor that drops one of the three lines per row gets
+    /// caught. (#405)
+    #[test]
+    fn detail_view_renders_recent_denials_section_when_present() {
+        use crate::state::{DenialRow, Mode};
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let task_id = "writer-1";
+        let mut t = tile(task_id, TileStatus::Running, None, 0, 0);
+        t.denials_count = 2;
+        t.recent_denials = vec![
+            DenialRow {
+                at: "2026-05-08T14:32:07Z".to_string(),
+                tool_name: "Bash".to_string(),
+                reason_kind: "denied_by_rule".to_string(),
+                reason: "denied: tool 'Bash' rejected by [[approval_policy]] rule".to_string(),
+            },
+            DenialRow {
+                at: "2026-05-08T14:33:12Z".to_string(),
+                tool_name: "mcp__fs-writer__delete_all".to_string(),
+                reason_kind: "denied_by_mcp_server_allowlist".to_string(),
+                reason: "denied: not in mcp_server allowlist".to_string(),
+            },
+        ];
+
+        let mut s = state(vec![t]);
+        s.mode = Mode::Detail {
+            task_id: task_id.to_string(),
+            scroll: 0,
+            at_bottom: true,
+            return_to: Box::new(Mode::Normal),
+        };
+
+        let backend = TestBackend::new(120, 60);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|frame| render(frame, &s)).unwrap();
+
+        let buf = terminal.backend().buffer();
+        let rendered: String = (0..60)
+            .flat_map(|y| (0..120u16).map(move |x| (x, y)))
+            .map(|(x, y)| buf.cell((x, y)).unwrap().symbol().to_string())
+            .collect();
+
+        assert!(
+            rendered.contains("RECENT DENIALS"),
+            "RECENT DENIALS heading should appear when recent_denials is non-empty"
+        );
+        assert!(rendered.contains("Bash"), "first row's tool_name");
+        assert!(
+            rendered.contains("reason: denied_by_rule"),
+            "reason_kind line for first row"
+        );
+        assert!(
+            rendered.contains("at: 14:32:07"),
+            "clock-only at: line for first row"
+        );
+        // The metadata pane is 40 cols wide and wraps long lines, so
+        // assert on substrings that fit. `mcp__fs-writer__delete_all`
+        // is 27 chars + `  • ` prefix = fits; the longer reason_kind
+        // wraps after 40 chars so we look for a unique sub-prefix.
+        assert!(
+            rendered.contains("mcp__fs-writer__delete_all"),
+            "second row's tool name"
+        );
+        assert!(
+            rendered.contains("denied_by_mcp_server_allow"),
+            "reason_kind prefix for the mcp-server-allowlist denial \
+             (full string wraps in the 40-col metadata pane)"
+        );
+    }
+
+    /// Quiet actor (no denials) must NOT emit a RECENT DENIALS heading —
+    /// keeps the Detail view tight on the common case. Counterpart to
+    /// the existing `render_tile_omits_denials_counter_when_zero` test
+    /// that pins the same conditional discipline on the tile counter.
+    #[test]
+    fn detail_view_omits_recent_denials_section_when_count_zero() {
+        use crate::state::Mode;
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let task_id = "quiet-1";
+        let t = tile(task_id, TileStatus::Running, None, 0, 0);
+        // denials_count defaults to 0, recent_denials defaults to empty.
+
+        let mut s = state(vec![t]);
+        s.mode = Mode::Detail {
+            task_id: task_id.to_string(),
+            scroll: 0,
+            at_bottom: true,
+            return_to: Box::new(Mode::Normal),
+        };
+
+        let backend = TestBackend::new(120, 60);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|frame| render(frame, &s)).unwrap();
+
+        let buf = terminal.backend().buffer();
+        let rendered: String = (0..60)
+            .flat_map(|y| (0..120u16).map(move |x| (x, y)))
+            .map(|(x, y)| buf.cell((x, y)).unwrap().symbol().to_string())
+            .collect();
+
+        assert!(
+            !rendered.contains("RECENT DENIALS"),
+            "quiet tile must not paint a RECENT DENIALS section"
+        );
+    }
+
+    /// When more denials exist than the cap captured, the Detail view
+    /// hints at the older history with `(+N older in events.jsonl)`.
+    /// Pin the exact phrasing — operators grep for it.
+    #[test]
+    fn detail_view_hints_at_older_denials_when_cap_exceeded() {
+        use crate::state::{DenialRow, Mode};
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let task_id = "noisy-1";
+        let mut t = tile(task_id, TileStatus::Running, None, 0, 0);
+        t.denials_count = 12;
+        t.recent_denials = (0..5)
+            .map(|i| DenialRow {
+                at: format!("2026-05-08T14:00:{i:02}Z"),
+                tool_name: format!("T{i}"),
+                reason_kind: "denied_by_rule".to_string(),
+                reason: "x".to_string(),
+            })
+            .collect();
+
+        let mut s = state(vec![t]);
+        s.mode = Mode::Detail {
+            task_id: task_id.to_string(),
+            scroll: 0,
+            at_bottom: true,
+            return_to: Box::new(Mode::Normal),
+        };
+
+        let backend = TestBackend::new(120, 60);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|frame| render(frame, &s)).unwrap();
+
+        let buf = terminal.backend().buffer();
+        let rendered: String = (0..60)
+            .flat_map(|y| (0..120u16).map(move |x| (x, y)))
+            .map(|(x, y)| buf.cell((x, y)).unwrap().symbol().to_string())
+            .collect();
+
+        assert!(
+            rendered.contains("(+7 older in events.jsonl)"),
+            "expected '(+7 older in events.jsonl)' hint when count exceeds buffer; \
+             rendered: {}",
+            &rendered[..rendered.len().min(800)]
         );
     }
 

--- a/crates/pitboss-tui/src/watcher.rs
+++ b/crates/pitboss-tui/src/watcher.rs
@@ -10,7 +10,13 @@ use pitboss_core::parser::{parse_line_all, Event};
 use pitboss_core::store::{TaskRecord, TaskStatus};
 use serde::Deserialize;
 
-use crate::state::{AppSnapshot, TileState, TileStatus};
+use crate::state::{AppSnapshot, DenialRow, TileState, TileStatus};
+
+/// Maximum number of recent `tool_denied` rows the watcher carries on each
+/// tile. The Detail view's `RECENT DENIALS` section renders from this
+/// buffer; older denials remain available in `events.jsonl` itself
+/// for post-mortem inspection. (#405)
+const RECENT_DENIALS_CAP: usize = 5;
 
 const POLL_INTERVAL_MS: u64 = 250;
 /// Number of parsed focus-pane lines to keep. Deep scroll-back on long
@@ -197,7 +203,7 @@ fn build_snapshot(run_dir: &Path, focused_id: Option<&str>) -> AppSnapshot {
     for id in &all_ids {
         let log_path = tasks_dir.join(id).join("stdout.log");
         let events_path = tasks_dir.join(id).join("events.jsonl");
-        let denials_count = count_tool_denials(&events_path);
+        let (denials_count, recent_denials) = read_denial_state(&events_path);
         let model = model_map.get(id).and_then(Option::clone);
         let is_dynamic = dynamic_ids.iter().any(|d| d == id);
         let tile = build_tile(
@@ -208,6 +214,7 @@ fn build_snapshot(run_dir: &Path, focused_id: Option<&str>) -> AppSnapshot {
             completed.get(id),
             parent_task_id_fallback.as_deref(),
             denials_count,
+            recent_denials,
             &mut failed_count,
             &mut run_started_at,
         );
@@ -348,6 +355,7 @@ fn build_tile(
     rec: Option<&TaskRecord>,
     parent_task_id_fallback: Option<&str>,
     denials_count: u32,
+    recent_denials: Vec<DenialRow>,
     failed_count: &mut usize,
     run_started_at: &mut Option<chrono::DateTime<chrono::Utc>>,
 ) -> TileState {
@@ -394,6 +402,7 @@ fn build_tile(
                 .or_else(|| log_path.parent().and_then(read_worktree_sidecar)),
             completed_at: Some(rec.ended_at),
             denials_count,
+            recent_denials,
             actor_type: rec.actor_type.clone(),
         }
     } else {
@@ -438,6 +447,7 @@ fn build_tile(
             },
             completed_at: None,
             denials_count,
+            recent_denials,
             // In-flight tiles haven't settled a `TaskRecord` yet, so we
             // don't know the resolved actor_type. Defaults to None →
             // Detail view falls back to the "(untyped / root)" matrix
@@ -451,10 +461,13 @@ fn build_tile(
     }
 }
 
-/// Count `tool_denied` rows in a per-actor `events.jsonl`. Cheap O(file)
-/// scan: lines parse as `serde_json::Value` and we discriminate on
-/// `kind == "tool_denied"`. The file is tiny vs `stdout.log` (one line
-/// per Path-B deny), so reparsing on every poll tick is negligible.
+/// Single-pass scan of a per-actor `events.jsonl` that returns both the
+/// total `tool_denied` count and the last [`RECENT_DENIALS_CAP`] rows
+/// (in append order, oldest → newest). Cheap O(file) scan: lines parse
+/// as `serde_json::Value` and we discriminate on `kind == "tool_denied"`.
+/// The file is tiny vs `stdout.log` (one line per Path-B deny), so
+/// reparsing on every poll tick is negligible. Denial volume is bounded
+/// by per-tool gate cardinality, not by stdout chatter.
 ///
 /// Decoupling from the canonical `TaskEvent` enum (defined in
 /// `pitboss-cli`) keeps `pitboss-tui` from taking a cli-crate dependency
@@ -462,12 +475,22 @@ fn build_tile(
 /// contract that the `#[serde(tag = "kind", rename_all = "snake_case")]`
 /// derive on `TaskEvent` produces — see
 /// `crates/pitboss-cli/src/dispatch/events.rs`.
-fn count_tool_denials(events_jsonl: &Path) -> u32 {
+///
+/// Returns `(count, recent_in_oldest_to_newest_order)`. Missing or
+/// malformed files yield `(0, vec![])`. Malformed individual rows are
+/// skipped silently — the watcher is read-side and must never panic
+/// over a corrupt audit log.
+fn read_denial_state(events_jsonl: &Path) -> (u32, Vec<DenialRow>) {
     let Ok(file) = std::fs::File::open(events_jsonl) else {
-        return 0;
+        return (0, Vec::new());
     };
     let reader = BufReader::new(file);
     let mut count: u32 = 0;
+    // Ring buffer: keep the last RECENT_DENIALS_CAP rows seen. We use a
+    // VecDeque so we can pop from the front when the cap is exceeded
+    // without shifting the whole buffer.
+    let mut recent: std::collections::VecDeque<DenialRow> =
+        std::collections::VecDeque::with_capacity(RECENT_DENIALS_CAP);
     for line in reader.lines().map_while(Result::ok) {
         let trimmed = line.trim();
         if trimmed.is_empty() {
@@ -476,11 +499,38 @@ fn count_tool_denials(events_jsonl: &Path) -> u32 {
         let Ok(val) = serde_json::from_str::<serde_json::Value>(trimmed) else {
             continue;
         };
-        if val.get("kind").and_then(|v| v.as_str()) == Some("tool_denied") {
-            count = count.saturating_add(1);
+        if val.get("kind").and_then(|v| v.as_str()) != Some("tool_denied") {
+            continue;
         }
+        count = count.saturating_add(1);
+        let row = DenialRow {
+            at: val
+                .get("at")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            tool_name: val
+                .get("tool_name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("?")
+                .to_string(),
+            reason_kind: val
+                .get("reason_kind")
+                .and_then(|v| v.as_str())
+                .unwrap_or("?")
+                .to_string(),
+            reason: val
+                .get("reason")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+        };
+        if recent.len() == RECENT_DENIALS_CAP {
+            recent.pop_front();
+        }
+        recent.push_back(row);
     }
-    count
+    (count, recent.into_iter().collect())
 }
 
 /// Read the `worktree.path` sidecar file written at spawn time.
@@ -1365,13 +1415,15 @@ mod tests {
         assert!(out.is_empty());
     }
 
-    /// `count_tool_denials` must count only `kind == "tool_denied"` rows
+    /// `read_denial_state` must count only `kind == "tool_denied"` rows
     /// while ignoring other event variants in the same `events.jsonl`
     /// (e.g. `pause`, `approval_response`). The discriminant is the
     /// stable wire contract — see `TaskEvent` in
-    /// `crates/pitboss-cli/src/dispatch/events.rs`.
+    /// `crates/pitboss-cli/src/dispatch/events.rs`. Recent rows must
+    /// arrive in append order (oldest → newest) so the Detail view
+    /// renders them top-down chronologically.
     #[test]
-    fn count_tool_denials_counts_only_tool_denied_rows() {
+    fn read_denial_state_counts_and_collects_only_tool_denied_rows() {
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join("events.jsonl");
         let lines = [
@@ -1384,18 +1436,66 @@ mod tests {
         let body = lines.join("\n");
         std::fs::write(&path, body).unwrap();
 
-        assert_eq!(count_tool_denials(&path), 3);
+        let (count, recent) = read_denial_state(&path);
+        assert_eq!(count, 3, "must count only the three tool_denied rows");
+        let tool_names: Vec<&str> = recent.iter().map(|r| r.tool_name.as_str()).collect();
+        assert_eq!(
+            tool_names,
+            vec!["Bash", "Write", "Edit"],
+            "recent rows must preserve append order (oldest first)"
+        );
+        assert_eq!(recent[0].reason_kind, "denied_by_rule");
+        assert_eq!(recent[1].reason_kind, "operator_rejected");
+        assert_eq!(recent[2].reason_kind, "ttl_expired");
+        assert_eq!(recent[0].at, "2026-05-07T00:00:01Z");
+    }
+
+    /// Once the file accumulates more than `RECENT_DENIALS_CAP` denied
+    /// rows, the watcher must keep the LAST N — the most recent are
+    /// what the Detail view's `RECENT DENIALS` section is meant to
+    /// surface. Older rows remain in `events.jsonl` for post-mortem
+    /// inspection. Pin the cap behavior so a future bump of the
+    /// constant stays explicit.
+    #[test]
+    fn read_denial_state_keeps_most_recent_when_over_cap() {
+        use std::fmt::Write as _;
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("events.jsonl");
+        // Write CAP + 3 denial rows with monotonically increasing tool
+        // names so we can assert which window survived.
+        let total = RECENT_DENIALS_CAP + 3;
+        let mut body = String::new();
+        for i in 0..total {
+            writeln!(
+                body,
+                r#"{{"kind":"tool_denied","at":"2026-05-07T00:00:{i:02}Z","tool_name":"T{i}","actor_id":"w-1","reason_kind":"denied_by_rule","reason":"x"}}"#
+            )
+            .unwrap();
+        }
+        std::fs::write(&path, body).unwrap();
+
+        let (count, recent) = read_denial_state(&path);
+        let total_u32 = u32::try_from(total).unwrap();
+        assert_eq!(count, total_u32, "count is total denials regardless of cap");
+        assert_eq!(recent.len(), RECENT_DENIALS_CAP, "recent buffer is capped");
+        // Last row should be T(total-1); first should be T(total-CAP).
+        let first_name = format!("T{}", total - RECENT_DENIALS_CAP);
+        let last_name = format!("T{}", total - 1);
+        assert_eq!(recent.first().unwrap().tool_name, first_name);
+        assert_eq!(recent.last().unwrap().tool_name, last_name);
     }
 
     /// Missing `events.jsonl` (the common quiet-actor case) and malformed
-    /// rows (truncated mid-write, partial flush) must both yield 0 rather
-    /// than panic — the watcher polls every 250ms and any I/O error here
-    /// would freeze the snapshot pipeline.
+    /// rows (truncated mid-write, partial flush) must both yield empty
+    /// state rather than panic — the watcher polls every 250ms and any
+    /// I/O error here would freeze the snapshot pipeline.
     #[test]
-    fn count_tool_denials_handles_missing_and_malformed() {
+    fn read_denial_state_handles_missing_and_malformed() {
         let dir = tempfile::TempDir::new().unwrap();
         // Missing file — quiet actor case.
-        assert_eq!(count_tool_denials(&dir.path().join("nope.jsonl")), 0);
+        let (count, recent) = read_denial_state(&dir.path().join("nope.jsonl"));
+        assert_eq!(count, 0);
+        assert!(recent.is_empty());
 
         // Malformed lines next to one valid denied row.
         let path = dir.path().join("events.jsonl");
@@ -1407,7 +1507,10 @@ mod tests {
         ]
         .join("\n");
         std::fs::write(&path, body).unwrap();
-        assert_eq!(count_tool_denials(&path), 1);
+        let (count, recent) = read_denial_state(&path);
+        assert_eq!(count, 1);
+        assert_eq!(recent.len(), 1);
+        assert_eq!(recent[0].tool_name, "Bash");
     }
 
     /// End-to-end: a dynamic worker with three `tool_denied` rows in its

--- a/crates/pitboss-tui/tests/tui_control.rs
+++ b/crates/pitboss-tui/tests/tui_control.rs
@@ -176,6 +176,7 @@ fn empty_grid_cells_are_cleared() {
             worktree_path: None,
             completed_at: None,
             denials_count: 0,
+            recent_denials: Vec::new(),
             actor_type: None,
         }
     }
@@ -245,6 +246,7 @@ fn focus_log_content_does_not_bleed_into_tile_grid() {
             worktree_path: None,
             completed_at: None,
             denials_count: 0,
+            recent_denials: Vec::new(),
             actor_type: None,
         }
     }


### PR DESCRIPTION
## Summary

Closes #405.

The capability matrix (#391, finalised in #402) shows operators *what each actor profile would admit*. This PR adds the live complement: *what actually got denied* during a run. Together they're defense-in-depth — a static cap declaration plus an audit trail of attempted-and-blocked calls.

### Three changes, one conceptual surface

**TUI Detail — `RECENT DENIALS` section.** When the focused tile has any `tool_denied` rows in its `events.jsonl`, the Detail view's metadata pane gains a section after `MCP SERVERS` listing the last 5 denials as `tool / reason / clock` triples. When more denials exist than the buffer captures, a `(+N older in events.jsonl)` line points operators at the full history. Conditional on `denials_count > 0` so quiet actors stay tight.

**Watcher refactor.** `count_tool_denials(events_jsonl) -> u32` becomes `read_denial_state(events_jsonl) -> (u32, Vec<DenialRow>)` — a single-pass scan that returns both the total count and the last `RECENT_DENIALS_CAP` rows (oldest → newest). `DenialRow` is a new TUI-local struct on `pitboss-tui::state` that mirrors `TaskEvent::ToolDenied` without taking a `pitboss-cli` dep — the wire-stable `kind == "tool_denied"` discriminator is the contract between them, the same boundary the existing watcher comment documents.

**`pitboss status` — `DENIED` column.** The per-task table grows a `DENIED` column when any actor recorded a Path-B denial. Tasks without denials render `0`; tasks without an `events.jsonl` are simply absent from the count map. When the whole run has zero denials, the column is hidden entirely (same conditional discipline as the TUI tile counter) — common-case output unchanged.

### Why this closes #391's loop

The matrix tells you what *would* admit. Without #405, an operator who sees a worker get denied a tool had to grep `events.jsonl` by hand to find out which call. Now: at-a-glance counter on the tile, last-5 in Detail, per-actor column in `pitboss status`. Three surfaces, one shape.

### Wire contract

The `kind == "tool_denied"` discriminator is the stable contract between `pitboss-cli`'s `TaskEvent` enum and these read-side scans. Duplicated locally in both watcher.rs and status.rs rather than shared via `pitboss-core` because each helper is ~15 lines and pulling the events schema into core would be load-bearing for one tiny field. The existing watcher comment already documents this boundary; the new `count_denials_per_task` helper in status.rs cites the same one.

### Out of scope

- Web tile rendering for live runs (the manifest detail page is design-time; live tile state lives in the run view, which would warrant its own slice — likely fold into #260)
- Cross-run aggregation (separate Insights slice; could fold into #257 or #260)
- Full audit log replay (#259 covers persistent control event stream)

## Test plan

- [x] `cargo lint` clean
- [x] `cargo tidy` clean
- [x] `cargo test --workspace --features pitboss-core/test-support` — all green; pitboss-cli 773 (was 770, +3 new); pitboss-tui 137 (was 134, +3 new). New tests pin:
  - `read_denial_state` counts + collects `tool_denied` rows in append order
  - Cap behavior: keeps the last N when over `RECENT_DENIALS_CAP`
  - Missing/malformed events.jsonl yields `(0, vec![])` without panicking
  - Detail view renders `RECENT DENIALS` section when present, omits when count is zero
  - Detail view emits `(+N older in events.jsonl)` hint when count exceeds buffer
  - `pitboss status` emits DENIED column when any actor positive; hides it when all zero
  - `count_denials_per_task` reads only `kind == "tool_denied"` rows; absent map keys for quiet/missing actors

🤖 Generated with [Claude Code](https://claude.com/claude-code)