### PR TITLE
fix(release): route breaking-marker commits to dedicated section

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -118,6 +118,22 @@ git cliff --unreleased            # what would land in [Unreleased]
 git cliff --tag vX.Y.Z --strip header  # what cliff would emit for this tag
 ```
 
+**Verify breaking changes routed correctly (#406).** When a release
+includes any commit with a `!:` marker (e.g. `feat(scope)!: …`) or a
+`BREAKING CHANGE:` footer, the regenerated changelog MUST emit a
+`### Breaking changes` section ABOVE `### Added` for that release.
+Sanity-check before tagging:
+
+```bash
+# Should print "### Breaking changes" ahead of "### Added" for any
+# release containing a breaking commit:
+awk '/^## \[X\.Y\.Z\]/,/^## \[/' CHANGELOG.md | grep -E '^### '
+```
+
+If the section is missing or out of order, the cliff config has
+regressed — see #406 for the parser-and-template setup that handles
+both the subject `!:` marker and the `BREAKING CHANGE:` footer.
+
 ### 4. README.md — replace the version-highlight paragraph
 
 README has one paragraph near the top that describes the current release.

--- a/cliff.toml
+++ b/cliff.toml
@@ -37,13 +37,31 @@ body = """
 {% else %}\
 ## [Unreleased]
 {% endif %}\
-{% for group, commits in commits | group_by(attribute="group") %}
+{# Emit Breaking changes first when present. Tera's group_by sorts groups
+   alphabetically, which puts "Added" above "Breaking changes" — wrong
+   for our convention (CLAUDE.md says breaking belongs above the others
+   so operators see the upgrade impact at the top of the section).
+   Two-pass: explicit Breaking block, then the rest with that group
+   filtered out. (#406) -#}
+{% for group, commits in commits | group_by(attribute="group") %}\
+{% if group == "Breaking changes" %}
 ### {{ group | upper_first }}
 
 {% for commit in commits %}\
 - {{ commit.message | upper_first }}\
 {% if commit.remote.pr_number %} ([#{{ commit.remote.pr_number }}](https://github.com/SDS-Mode/pitboss/pull/{{ commit.remote.pr_number }})){% endif %}
 {% endfor %}
+{% endif %}\
+{% endfor %}\
+{% for group, commits in commits | group_by(attribute="group") %}\
+{% if group != "Breaking changes" %}
+### {{ group | upper_first }}
+
+{% for commit in commits %}\
+- {{ commit.message | upper_first }}\
+{% if commit.remote.pr_number %} ([#{{ commit.remote.pr_number }}](https://github.com/SDS-Mode/pitboss/pull/{{ commit.remote.pr_number }})){% endif %}
+{% endfor %}
+{% endif %}\
 {% endfor %}\n
 """
 
@@ -78,9 +96,19 @@ commit_preprocessors = [
 # The wider community uses "Added/Fixed/Changed" from Keep-a-Changelog;
 # we keep that vocabulary so existing entries don't look out of place.
 commit_parsers = [
-    # Breaking changes (cliff sets `commit.breaking = true` when the
-    # subject has `!:` or the body has `BREAKING CHANGE:`). Promote
-    # those to a dedicated section regardless of type.
+    # Breaking changes — promote to a dedicated section regardless of
+    # commit type. cliff's `breaking = true` parser key alone does NOT
+    # reliably route conventionally-marked breaking commits to a custom
+    # group when they ALSO match a later type parser (`^feat` etc.) —
+    # observed during the v0.12 release where #393's
+    # `feat(dispatch)!: ...` subject + `BREAKING CHANGE:` footer landed
+    # in `### Added`. Belt-and-suspenders: explicit regex matchers on
+    # the subject's `!:` marker AND the body footer, ordered first so
+    # they win first-match-wins. (#406)
+    { message = "^[a-z]+(\\(.+\\))?!:", group = "Breaking changes" },
+    { body = ".*BREAKING CHANGE", group = "Breaking changes" },
+    # Kept as a backstop for any future cliff release where the
+    # `breaking = true` filter starts working as advertised.
     { breaking = true, group = "Breaking changes" },
 
     { message = "^feat", group = "Added" },


### PR DESCRIPTION
## Summary

Closes #406.

The v0.12 release surfaced a cliff config bug: commit #393 (`feat(dispatch)!: flip permission_routing default to path_b`) carried both the `!:` subject marker AND a `BREAKING CHANGE:` footer, but landed in `### Added` instead of `### Breaking changes`. CLAUDE.md's CHANGELOG conventions explicitly say *"Breaking changes use the `!:` marker (...) cliff promotes those to a dedicated `### Breaking changes` section above the others"* — both halves were broken.

### Repro (against v0.12.0, before this fix)

```bash
git checkout v0.12.0
git cliff --tag v0.12.0 -o /tmp/test.md
awk '/^## \[0\.12\.0\]/,/^## \[0\.11\.0\]/' /tmp/test.md | grep '^### '
# Output: ### Added, ### Fixed   ← no Breaking section, #393 buried in Added
```

### Two fixes in `cliff.toml`

**1. Explicit subject + body matchers** ahead of the type-specific parsers. cliff's `breaking = true` parser key alone was not routing conventionally-marked breaking commits to a custom group when the same commit also matched a later type parser (`^feat`). Belt-and-suspenders: add `message = "^[a-z]+(\\(.+\\))?!:"` and `body = ".*BREAKING CHANGE"` parsers ordered first so they win first-match-wins. Keep the `breaking = true` parser as a backstop in case a future cliff release fixes the filter.

**2. Two-pass body template** so Breaking changes renders ABOVE Added. Tera's `group_by` sorts groups alphabetically, which puts "Added" above "Breaking changes" — wrong for our convention. Restructure the body template to emit a Breaking-only block first, then iterate the remaining groups with that name filtered out.

### Verified

```bash
# After this PR's cliff.toml against v0.12.0:
git cliff --tag v0.12.0 -o /tmp/test.md
awk '/^## \[0\.12\.0\]/,/^## \[0\.11\.0\]/' /tmp/test.md | grep '^### '
# Output: ### Breaking changes, ### Added, ### Fixed   ✓
```

The `### Breaking changes` section now appears for v0.12, ABOVE `### Added`, listing #393 with its PR link. Unreleased mode and prior-release rendering both unaffected.

### `RELEASE.md` verification step

Added a sanity-check command the release driver runs before tagging:

```bash
awk '/^## \[X\.Y\.Z\]/,/^## \[/' CHANGELOG.md | grep -E '^### '
```

Catches regressions if a future cliff config tweak breaks the routing again. Operator-facing text points at this issue for the parser/template setup that handles both the `!:` marker AND the `BREAKING CHANGE:` footer.

## Test plan

- [x] Reproduced bug against v0.12.0 (no Breaking section, #393 in `### Added`)
- [x] Patched cliff.toml — verified Breaking section appears
- [x] Reordered body template — verified Breaking renders above Added
- [x] Unreleased mode (`git cliff --unreleased`) renders correctly post-fix
- [x] Prior releases (v0.11, v0.10, v0.9.x) still render correctly post-fix (no regressions visible in spot-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)