### PR TITLE
fix(runs,web): cancelled runs render distinctly in overview and detail

### DIFF
--- a/crates/pitboss-cli/src/prune.rs
+++ b/crates/pitboss-cli/src/prune.rs
@@ -171,8 +171,11 @@ fn matches_status(s: RunStatus, include_aborted: bool) -> bool {
     match s {
         RunStatus::Stale => true,
         RunStatus::Aborted => include_aborted,
-        // Never sweep live or finalized runs.
-        RunStatus::Running | RunStatus::Complete => false,
+        // Never sweep live or finalized runs. `Cancelled` is finalized
+        // (summary.json exists, was_interrupted=true) — operators who
+        // cancelled deliberately may still want the run dir for
+        // post-mortem; treat it like `Complete` for prune purposes. (#365)
+        RunStatus::Running | RunStatus::Complete | RunStatus::Cancelled => false,
     }
 }
 

--- a/crates/pitboss-cli/src/runs.rs
+++ b/crates/pitboss-cli/src/runs.rs
@@ -55,8 +55,17 @@ pub const STALENESS_THRESHOLD: Duration = Duration::from_secs(4 * 3600);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum RunStatus {
-    /// `summary.json` exists and parsed — run finalized cleanly.
+    /// `summary.json` exists, parsed, and `was_interrupted = false` —
+    /// run finalized cleanly.
     Complete,
+    /// `summary.json` exists, parsed, and `was_interrupted = true` —
+    /// run finalized but was cancelled (`cancel_run` op) or aborted
+    /// by Ctrl-C / TUI quit while still in flight. Distinguished
+    /// from [`Self::Complete`] so the operational console can colour
+    /// it differently and from [`Self::Aborted`] (which is a
+    /// dispatcher crash before any output) so operators can tell
+    /// "we asked it to stop" from "it died on us." (#365)
+    Cancelled,
     /// Live dispatcher (control socket accepts a connection) OR
     /// `summary.jsonl` was written recently (within
     /// [`STALENESS_THRESHOLD`]) so the dispatcher might still come
@@ -78,6 +87,7 @@ impl RunStatus {
     pub fn label(self) -> &'static str {
         match self {
             Self::Complete => "complete",
+            Self::Cancelled => "cancelled",
             Self::Running => "running",
             Self::Stale => "stale",
             Self::Aborted => "aborted",
@@ -92,7 +102,10 @@ impl RunStatus {
     /// to come back. Used by the prune sweep to decide whether a run
     /// is a candidate for cleanup.
     pub fn is_terminal(self) -> bool {
-        matches!(self, Self::Complete | Self::Stale | Self::Aborted)
+        matches!(
+            self,
+            Self::Complete | Self::Cancelled | Self::Stale | Self::Aborted
+        )
     }
 }
 
@@ -222,13 +235,24 @@ pub fn collect_run_entry(run_dir: &Path, run_id: String, mtime: SystemTime) -> R
     let summary_json_state = match std::fs::read(&summary_json) {
         Ok(bytes) => match serde_json::from_slice::<pitboss_core::store::RunSummary>(&bytes) {
             Ok(s) => {
+                // `was_interrupted = true` means the dispatcher
+                // finalized in response to `cancel_run` (or a Ctrl-C /
+                // TUI quit). The summary is canonical; the run did
+                // produce output up until the cancel signal. Surface
+                // as `Cancelled` so the operational console renders
+                // it visually distinct from a clean Complete (#365).
+                let status = if s.was_interrupted {
+                    RunStatus::Cancelled
+                } else {
+                    RunStatus::Complete
+                };
                 return RunEntry {
                     run_id,
                     run_dir: run_dir.to_path_buf(),
                     mtime,
                     tasks_total: s.tasks_total,
                     tasks_failed: s.tasks_failed,
-                    status: RunStatus::Complete,
+                    status,
                 };
             }
             Err(e) => {
@@ -560,14 +584,99 @@ mod tests {
     #[test]
     fn run_status_terminal_helpers() {
         assert!(RunStatus::Complete.is_terminal());
+        assert!(RunStatus::Cancelled.is_terminal());
         assert!(RunStatus::Stale.is_terminal());
         assert!(RunStatus::Aborted.is_terminal());
         assert!(!RunStatus::Running.is_terminal());
 
         assert!(RunStatus::Complete.is_complete());
+        // Cancelled is a TERMINAL state but not a CLEAN completion —
+        // operators querying `is_complete()` to mean "succeeded" should
+        // get false. (#365)
+        assert!(!RunStatus::Cancelled.is_complete());
         assert!(!RunStatus::Stale.is_complete());
         assert!(!RunStatus::Aborted.is_complete());
         assert!(!RunStatus::Running.is_complete());
+    }
+
+    /// Wire-shape pin: `RunStatus::Cancelled` must serialize as the
+    /// lowercase string `"cancelled"` so the SPA's TS `RunStatus` type
+    /// can match on it directly. Same enforcement discipline as the
+    /// other lowercase variants. (#365)
+    #[test]
+    fn run_status_cancelled_serializes_lowercase() {
+        let s = serde_json::to_string(&RunStatus::Cancelled).unwrap();
+        assert_eq!(s, "\"cancelled\"");
+        assert_eq!(RunStatus::Cancelled.label(), "cancelled");
+    }
+
+    /// Acceptance scenario from #365: a cancelled run finalizes its
+    /// `summary.json` with `was_interrupted = true`. The classifier
+    /// must surface this as `Cancelled`, NOT `Complete` — operators
+    /// need to tell "we asked it to stop" from "it finished cleanly"
+    /// at a glance in the run list. Pin the mapping so a future
+    /// schema tweak that drops `was_interrupted` from the path gets
+    /// caught.
+    #[test]
+    fn collect_run_entry_with_was_interrupted_summary_is_cancelled() {
+        let tmp = TempDir::new().unwrap();
+        let run_dir = make_run_dir(tmp.path(), "run-cancelled");
+        let run_id_uuid = "019dface-cafe-feed-c0de-deadbeef1234";
+        let summary = serde_json::json!({
+            "run_id": run_id_uuid,
+            "manifest_path": "/tmp/repro.toml",
+            "manifest_name": "repro-cancel",
+            "pitboss_version": "0.12.0",
+            "claude_version": null,
+            "started_at": "2026-05-08T01:00:00Z",
+            "ended_at": "2026-05-08T01:01:00Z",
+            "total_duration_ms": 60000,
+            "tasks_total": 3,
+            "tasks_failed": 2,
+            "was_interrupted": true,
+            "tasks": [],
+        });
+        fs::write(run_dir.join("summary.json"), summary.to_string()).unwrap();
+
+        let entry = collect_run_entry(&run_dir, "run-cancelled".to_string(), SystemTime::now());
+        assert_eq!(
+            entry.status,
+            RunStatus::Cancelled,
+            "summary.json with was_interrupted=true must classify as Cancelled, not Complete"
+        );
+        // Counts still flow through from the parsed summary — the
+        // operational console renders them in the same column.
+        assert_eq!(entry.tasks_total, 3);
+        assert_eq!(entry.tasks_failed, 2);
+    }
+
+    /// Counterpart to the cancelled test: a clean finalize
+    /// (`was_interrupted = false`) still classifies as `Complete`.
+    /// Without this companion test, the cancelled-mapping change
+    /// could silently flip every parseable summary to Cancelled.
+    #[test]
+    fn collect_run_entry_with_clean_summary_is_complete() {
+        let tmp = TempDir::new().unwrap();
+        let run_dir = make_run_dir(tmp.path(), "run-clean");
+        let run_id_uuid = "019dface-cafe-feed-c0de-deadbeef5678";
+        let summary = serde_json::json!({
+            "run_id": run_id_uuid,
+            "manifest_path": "/tmp/repro.toml",
+            "manifest_name": "clean",
+            "pitboss_version": "0.12.0",
+            "claude_version": null,
+            "started_at": "2026-05-08T01:00:00Z",
+            "ended_at": "2026-05-08T01:01:00Z",
+            "total_duration_ms": 60000,
+            "tasks_total": 3,
+            "tasks_failed": 0,
+            "was_interrupted": false,
+            "tasks": [],
+        });
+        fs::write(run_dir.join("summary.json"), summary.to_string()).unwrap();
+
+        let entry = collect_run_entry(&run_dir, "run-clean".to_string(), SystemTime::now());
+        assert_eq!(entry.status, RunStatus::Complete);
     }
 
     // ── #141: socket-path resolution doesn't double-nest the run id ─────

--- a/crates/pitboss-web/spa/src/lib/api.ts
+++ b/crates/pitboss-web/spa/src/lib/api.ts
@@ -4,7 +4,11 @@
 
 import { browser } from '$app/environment';
 
-export type RunStatus = 'complete' | 'running' | 'stale' | 'aborted';
+// Mirror of `pitboss_cli::runs::RunStatus`. `'cancelled'` was added in
+// the #365 fix: previously a `cancel_run`-finalized run rendered as
+// `'complete'` (green), which conflated user-initiated stops with clean
+// success. The status-badge component maps `'cancelled'` to red.
+export type RunStatus = 'complete' | 'cancelled' | 'running' | 'stale' | 'aborted';
 
 export interface RunDto {
   run_id: string;

--- a/crates/pitboss-web/spa/src/lib/components/status-badge.svelte
+++ b/crates/pitboss-web/spa/src/lib/components/status-badge.svelte
@@ -4,6 +4,10 @@
 
   let { status, label }: { status: RunStatus; label?: string } = $props();
 
+  // `cancelled` (user-initiated stop) and `aborted` (dispatcher
+  // crashed) both render in the destructive/red bucket — operators
+  // see at a glance that the run did not complete cleanly. The label
+  // text stays distinct so the difference is still readable. (#365)
   const variant = $derived(
     status === 'complete'
       ? 'default'

--- a/crates/pitboss-web/spa/src/routes/runs/[id]/+page.svelte
+++ b/crates/pitboss-web/spa/src/routes/runs/[id]/+page.svelte
@@ -73,9 +73,28 @@
   const inProgress = $derived(Boolean(r?.in_progress));
   const summary = $derived(inProgress ? null : r);
   const stub = $derived(inProgress ? (r?.run as Record<string, any> | null) : null);
+  // Run status derivation (#365):
+  //   - in-progress: defer to `stub.status`, which the API returns from
+  //     `pitboss_cli::runs::RunStatus` (the canonical classifier shared
+  //     with the overview list — single source of truth).
+  //   - finalized: read `was_interrupted` directly from `summary.json`.
+  //     `was_interrupted = true` means the run was cancelled (cancel_run
+  //     op or Ctrl-C / TUI quit); render as 'cancelled' so the badge
+  //     goes red and matches the overview's RunStatus::Cancelled.
+  //   - degenerate (no stub, no summary): 'aborted'. This fallback
+  //     should be unreachable in practice — the API always returns one
+  //     or the other — but keeps the type total.
+  //
+  // Replaces a pre-#365 derivation that read `summary.run_meta.outcome`,
+  // a field that has never existed on `RunSummary`, so cancelled runs
+  // silently rendered as 'complete' (green).
   const status = $derived<RunStatus>(
     (stub?.status as RunStatus | undefined) ??
-      (summary?.run_meta?.outcome === 'success' ? 'complete' : summary ? 'complete' : 'aborted')
+      (summary
+        ? summary.was_interrupted === true
+          ? 'cancelled'
+          : 'complete'
+        : 'aborted')
   );
   const taskList = $derived<Array<Record<string, any>>>(
     (summary?.tasks as Array<Record<string, any>> | undefined) ?? []

--- a/crates/pitboss-web/src/insights/aggregator.rs
+++ b/crates/pitboss-web/src/insights/aggregator.rs
@@ -232,6 +232,10 @@ fn compute_outcome(status: &RunStatus, failed: usize, total: usize) -> String {
         RunStatus::Running => "running".into(),
         RunStatus::Stale => "stale".into(),
         RunStatus::Aborted => "aborted".into(),
+        // Cancelled is its own bucket — operators looking at the
+        // failures dashboard want to distinguish "we cancelled it"
+        // from clean success / partial / total failure. (#365)
+        RunStatus::Cancelled => "cancelled".into(),
         RunStatus::Complete => {
             if failed == 0 {
                 "success".into()


### PR DESCRIPTION
## Summary

Closes #365.

Two related bugs conspired to make cancelled runs hard to spot in the operational console:

### 1. `RunStatus` had no `Cancelled` variant

A run finalized via `cancel_run` op (or Ctrl-C / TUI quit) wrote `summary.json` with `was_interrupted = true`, but `collect_run_entry` mapped any parseable summary to `RunStatus::Complete`. Overview's run list rendered cancel identically to clean success — same green badge, same column.

### 2. SPA detail view's status derivation read a non-existent field

At `+page.svelte:76-79` the derivation was:

```ts
summary?.run_meta?.outcome === 'success' ? 'complete' : summary ? 'complete' : 'aborted'
```

`RunSummary` (in `pitboss-core/src/store/record.rs`) has neither `run_meta` nor `outcome` — it has `was_interrupted: bool`. The expression always fell through to `summary ? 'complete' : 'aborted'`, so cancelled runs showed green there too.

The two views weren't really diverging; both were silently agreeing on the wrong answer. The empirical repro (fake run dir with `was_interrupted: true`) confirmed: overview returned `status: "complete"`, detail derived `'complete'`. Both green.

## Fix

- **Add `RunStatus::Cancelled`** between `Complete` and `Running`. `is_terminal()` includes it; `is_complete()` does not (operators querying "succeeded" should get false). Wire-shape is the lowercase string `"cancelled"`.
- **`collect_run_entry`** reads `was_interrupted` on the parseable-summary path: `true` ⇒ `Cancelled`, `false` ⇒ `Complete`. The corrupt-summary fallback (#157) and missing-summary heuristics (`classify_status`) are unaffected.
- **Three downstream match sites** updated to handle the new variant:
  - `prune::matches_status` — treat like Complete; never sweep user-cancelled runs (operators may want the run dir for post-mortem)
  - `insights::aggregator::compute_outcome` — own bucket so the failures dashboard distinguishes user-stopped from partial/total failure
  - SPA's TS `RunStatus` union
- **Replace the SPA detail view's dead-code derivation** with an explicit `summary.was_interrupted` read.
- **Status-badge component** renders both `cancelled` and `aborted` in the destructive/red bucket; the label text stays distinct so operators can tell them apart at a glance.

## Verification

End-to-end via headless browser (Playwright Chromium) against a fixture run with `was_interrupted: true`:

```
overview badge class: bg-red-500/15 text-red-700 ... border-red-500/30
detail   badge class: bg-red-500/15 text-red-700 ... border-red-500/30
```

Identical red rendering on both views; label "CANCELLED" on both. The pre-fix repro showed overview "complete" (green), detail "complete" (green via dead-code fallthrough).

## Test plan

- [x] `cargo lint` clean
- [x] `cargo tidy` clean
- [x] `cargo test --workspace --features pitboss-core/test-support` — all green; pitboss-cli 776 (was 773; +3 new). New tests pin:
  - `RunStatus::Cancelled` serializes lowercase `"cancelled"`
  - `is_terminal` includes it, `is_complete` does not
  - `collect_run_entry` maps `was_interrupted: true` → `Cancelled`
  - `was_interrupted: false` still maps to `Complete` (companion test catches "every parseable summary maps to Cancelled" regression)
- [x] Headless-browser smoke confirms identical red badge on both overview and detail views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)