### PR TITLE
feat(cli): pitboss validate --container skips host-side dir checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,6 +257,8 @@ read_down = false
 
 The `[container]` section enables `pitboss container-dispatch`, which assembles and execs a Docker/Podman run command from the manifest. Task and lead `directory` fields are interpreted as container-side paths when `[container]` is present.
 
+To pre-flight a container-mode manifest without dispatching, use `pitboss validate --container <manifest>` (#255). The flag skips the host-side directory-existence check that would otherwise fail on the in-container mount paths. Without `--container`, validate emits a hint pointing at the flag rather than failing silently.
+
 | Key | Type | Default | Notes |
 |---|---|---|---|
 | `image` | string | `ghcr.io/sds-mode/pitboss-with-claude:latest` | Container image to run. |

--- a/crates/pitboss-cli/src/cli.rs
+++ b/crates/pitboss-cli/src/cli.rs
@@ -50,6 +50,15 @@ pub enum Command {
         /// injection so the report cannot drift from live behavior.
         #[arg(long)]
         capability_matrix: bool,
+        /// Skip the host-side directory-existence check on
+        /// `[lead].directory` and `[[task]].directory`. Pass this when
+        /// validating a container-mode manifest (`[container]` set):
+        /// those fields are interpreted as container-side paths that
+        /// don't exist on the host and would otherwise fail
+        /// `validate`. Routes through the same `validate_skip_dir_check`
+        /// path that `pitboss container-dispatch` uses internally. (#255)
+        #[arg(long, alias = "skip-dir-check")]
+        container: bool,
     },
     /// Execute a manifest.
     Dispatch {

--- a/crates/pitboss-cli/src/main.rs
+++ b/crates/pitboss-cli/src/main.rs
@@ -24,8 +24,9 @@ fn main() -> Result<()> {
         Command::Validate {
             manifest,
             capability_matrix,
+            container,
         } => {
-            std::process::exit(run_validate(&manifest, capability_matrix));
+            std::process::exit(run_validate(&manifest, capability_matrix, container));
         }
         Command::Dispatch {
             manifest,
@@ -343,15 +344,53 @@ fn init_tracing(verbose: u8, quiet: bool) {
 ///     overlapped with the OS-level "binary not found" exit code and made
 ///     it impossible to distinguish a missing `pitboss` binary from a bad
 ///     manifest. (#157)
-fn run_validate(manifest: &std::path::Path, capability_matrix: bool) -> i32 {
+fn run_validate(manifest: &std::path::Path, capability_matrix: bool, container: bool) -> i32 {
     let env_mp = parse_env_max_parallel();
-    let r = match manifest::load_manifest(manifest, env_mp) {
+    let load_result = if container {
+        manifest::load_manifest_skip_dir_check(manifest, env_mp)
+    } else {
+        manifest::load_manifest(manifest, env_mp)
+    };
+    let r = match load_result {
         Ok(r) => r,
         Err(e) => {
-            eprintln!("validation failed: {e:#}");
+            // #255: when validate fails on the host-side directory check
+            // and the manifest declares a `[container]` block, point the
+            // operator at `--container`. Without the hint, a typical
+            // failure is `validation failed: lead directory does not
+            // exist: /workspace` against a perfectly valid
+            // container-mode manifest, with no surface for fixing it.
+            //
+            // Cheap text scan over the manifest source rather than a
+            // re-parse: if parsing failed at TOML level the user has a
+            // bigger problem than the dir check. Re-parsing the
+            // already-rejected file would also risk diverging error
+            // messages.
+            let err_msg = format!("{e:#}");
+            let manifest_text = std::fs::read_to_string(manifest).unwrap_or_default();
+            let hint = if !container
+                && manifest_text.contains("[container]")
+                && err_msg.contains("directory does not exist")
+            {
+                "\n  hint: pass `--container` to validate container-mode manifests \
+                 (the [lead]/[[task]].directory fields are interpreted as \
+                 container-side paths that don't exist on the host)"
+            } else {
+                ""
+            };
+            eprintln!("validation failed: {err_msg}{hint}");
             return 2;
         }
     };
+    // Advisory when --container is set on a manifest that has no
+    // `[container]` block — the flag had no effect and the operator
+    // probably typoed something. Don't fail; the manifest IS valid.
+    if container && r.container.is_none() {
+        eprintln!(
+            "note: manifest has no [container] block — `--container` had no effect \
+             (the dir-existence check would have passed anyway)"
+        );
+    }
     if let Some(lead) = &r.lead {
         println!(
             "OK (hierarchical) — lead='{}', max_workers={}, budget=${:.2}",

--- a/crates/pitboss-cli/tests/validate_flows.rs
+++ b/crates/pitboss-cli/tests/validate_flows.rs
@@ -1,0 +1,215 @@
+//! `pitboss validate --container` (#255) — integration tests for the
+//! flag that lets operators pre-flight a container-mode manifest
+//! without the host-side directory check failing on the in-container
+//! mount paths.
+
+mod support;
+
+use std::process::Command;
+use support::*;
+use tempfile::TempDir;
+
+fn ensure_built() {
+    let status = Command::new(env!("CARGO"))
+        .args(["build", "-p", "pitboss-cli"])
+        .status()
+        .unwrap();
+    assert!(status.success(), "build failed");
+}
+
+/// `--container` against a container-mode manifest whose `[lead].directory`
+/// points at an in-container path that doesn't exist on the host.
+/// Without the flag this fails (which is what the issue reproed); with
+/// the flag it succeeds because the dir-existence check is skipped.
+#[test]
+fn validate_with_container_flag_skips_host_dir_check() {
+    ensure_built();
+    let dir = TempDir::new().unwrap();
+    let manifest_path = dir.path().join("container.toml");
+    std::fs::write(
+        &manifest_path,
+        r#"
+[run]
+name = "container-fixture"
+
+[container]
+image = "ghcr.io/example/img:latest"
+
+[lead]
+id = "lead"
+directory = "/workspace"   # container-side path; doesn't exist on host
+prompt = "p"
+model = "claude-haiku-4-5"
+use_worktree = false
+max_workers = 1
+budget_usd = 0.50
+lead_timeout_secs = 60
+"#,
+    )
+    .unwrap();
+
+    let out = Command::new(pitboss_binary())
+        .arg("validate")
+        .arg("--container")
+        .arg(&manifest_path)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "validate --container should succeed; stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        stdout.contains("OK (hierarchical)"),
+        "expected hierarchical OK line; got stdout={stdout}"
+    );
+}
+
+/// Without `--container`, the same manifest must STILL fail (existing
+/// behavior preserved) AND the error must point at the new flag so the
+/// operator knows the right escape hatch. The hint is the user-visible
+/// half of #255 — without it, operators reach for `container-dispatch
+/// --dry-run` (which works but is not what they typed first).
+#[test]
+fn validate_without_flag_on_container_manifest_emits_hint() {
+    ensure_built();
+    let dir = TempDir::new().unwrap();
+    let manifest_path = dir.path().join("container.toml");
+    std::fs::write(
+        &manifest_path,
+        r#"
+[run]
+name = "container-fixture"
+
+[container]
+image = "ghcr.io/example/img:latest"
+
+[lead]
+id = "lead"
+directory = "/workspace"
+prompt = "p"
+model = "claude-haiku-4-5"
+use_worktree = false
+max_workers = 1
+budget_usd = 0.50
+lead_timeout_secs = 60
+"#,
+    )
+    .unwrap();
+
+    let out = Command::new(pitboss_binary())
+        .arg("validate")
+        .arg(&manifest_path)
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "should still fail without --container"
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "validation failure exit code is 2 (#157) so CI can hard-gate"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("directory does not exist"),
+        "underlying error must still surface; got stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("--container"),
+        "stderr must point operator at --container; got: {stderr}"
+    );
+}
+
+/// `--container` on a manifest that has NO `[container]` block: the
+/// manifest is otherwise valid, validate succeeds, and we emit a
+/// stderr advisory so the operator notices the typoed/redundant flag.
+/// Pin both the success exit code AND the advisory text so a future
+/// refactor that drops the advisory gets caught.
+#[test]
+fn validate_with_container_flag_on_non_container_manifest_emits_advisory() {
+    ensure_built();
+    let dir = TempDir::new().unwrap();
+    init_git_repo(dir.path());
+    let manifest_path = dir.path().join("flat.toml");
+    std::fs::write(
+        &manifest_path,
+        format!(
+            r#"
+[run]
+max_parallel_tasks = 1
+
+[defaults]
+use_worktree = false
+
+[[task]]
+id = "t1"
+directory = "{}"
+prompt = "p"
+"#,
+            dir.path().display()
+        ),
+    )
+    .unwrap();
+
+    let out = Command::new(pitboss_binary())
+        .arg("validate")
+        .arg("--container")
+        .arg(&manifest_path)
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("manifest has no [container] block"),
+        "expected no-container advisory on stderr; got: {stderr}"
+    );
+}
+
+/// `--skip-dir-check` is registered as an alias of `--container` so
+/// operators who type the more literal name (matching the internal
+/// `validate_skip_dir_check` helper) get the same behavior. Pin the
+/// alias so a future clap rewrite that drops it gets caught.
+#[test]
+fn skip_dir_check_alias_resolves_to_container_flag() {
+    ensure_built();
+    let dir = TempDir::new().unwrap();
+    let manifest_path = dir.path().join("container.toml");
+    std::fs::write(
+        &manifest_path,
+        r#"
+[run]
+name = "container-fixture"
+
+[container]
+image = "ghcr.io/example/img:latest"
+
+[lead]
+id = "lead"
+directory = "/workspace"
+prompt = "p"
+model = "claude-haiku-4-5"
+use_worktree = false
+max_workers = 1
+budget_usd = 0.50
+lead_timeout_secs = 60
+"#,
+    )
+    .unwrap();
+
+    let out = Command::new(pitboss_binary())
+        .arg("validate")
+        .arg("--skip-dir-check")
+        .arg(&manifest_path)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "--skip-dir-check should resolve to --container behavior; \
+         stdout={stdout} stderr={stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #255.

Operators pre-flighting a container-mode manifest hit:

```
$ pitboss validate pitboss-warmup.toml
validation failed: lead directory does not exist: /workspace
```

`/workspace` is the in-container mount target. `[lead].directory` and `[[task]].directory` fields are interpreted as **container-side** paths when `[container]` is present (per AGENTS.md), but `validate` was running the host-side existence check unconditionally. The internal `validate_skip_dir_check` helper already handles this for `pitboss container-dispatch`'s dry-run path — this PR just exposes it as a CLI flag.

### Three behaviors pinned

1. **`pitboss validate --container <manifest>`** routes through `load_manifest_skip_dir_check`. Container-mode manifests with in-container `directory` paths now pre-flight cleanly.
2. **Without `--container`**, the existing failure stays put — but the error gains a hint pointing at the flag when the manifest declares `[container]`:

   ```
   validation failed: lead directory does not exist: /workspace
     hint: pass `--container` to validate container-mode manifests
     (the [lead]/[[task]].directory fields are interpreted as
      container-side paths that don't exist on the host)
   ```

   Catches the typed-the-wrong-thing-first case rather than leaving operators to discover `container-dispatch --dry-run`.
3. **`--container` set on a manifest without `[container]`** succeeds (the manifest IS valid) and emits a stderr advisory so the operator notices the typoed/redundant flag:

   ```
   note: manifest has no [container] block — `--container` had no effect
   ```

`--skip-dir-check` is registered as an alias to match the internal `validate_skip_dir_check` helper name; both flags resolve to the same code path.

AGENTS.md `[container]` section gains a one-line pointer.

## Test plan

- [x] `cargo lint` clean
- [x] `cargo tidy` clean
- [x] `cargo test --workspace --features pitboss-core/test-support` — all green
- [x] New `tests/validate_flows.rs` integration test file (4 tests, all passing) pinning each of the three behaviors plus the `--skip-dir-check` alias

🤖 Generated with [Claude Code](https://claude.com/claude-code)