### PR TITLE
fix(notify): serialize env-touching tests crate-wide via serial_test (#351)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -73,7 +73,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -610,7 +610,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -658,7 +658,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1655,7 +1655,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1897,6 +1897,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2",
  "shellexpand",
  "tempfile",
@@ -2551,7 +2552,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2611,6 +2612,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2641,6 +2651,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "semver"
@@ -2735,6 +2751,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2825,7 +2867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2959,7 +3001,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3773,7 +3815,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/pitboss-cli/Cargo.toml
+++ b/crates/pitboss-cli/Cargo.toml
@@ -69,3 +69,8 @@ fake-mcp-client = { path = "../../tests-support/fake-mcp-client" }
 fake-control-client = { path = "../../tests-support/fake-control-client" }
 wiremock           = { workspace = true }
 tracing-test       = { workspace = true }
+# #351: serializes env-touching tests across the whole crate so that
+# concurrent set_var/remove_var calls don't race glibc's environ
+# reallocation against background getenv readers (tracing, reqwest,
+# locale init). All env-touching tests must carry `#[serial(env)]`.
+serial_test        = "3.4"

--- a/crates/pitboss-cli/src/control/mod.rs
+++ b/crates/pitboss-cli/src/control/mod.rs
@@ -79,15 +79,16 @@ fn sweep_stale_sockets(dir: &Path) {
 #[cfg(test)]
 mod path_tests {
     use super::*;
-    use std::sync::Mutex;
+    use serial_test::serial;
     use tempfile::TempDir;
 
-    // Serializes tests that mutate XDG_RUNTIME_DIR (env vars are process-global).
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    // #351: `#[serial(env)]` replaces the previous module-local
+    // `ENV_LOCK` so XDG_RUNTIME_DIR mutations here serialize against
+    // every other env-touching test in the crate, not just this file.
 
     #[test]
+    #[serial(env)]
     fn uses_xdg_runtime_dir_when_set() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = TempDir::new().unwrap();
         std::env::set_var("XDG_RUNTIME_DIR", dir.path());
         let run_id = Uuid::now_v7();
@@ -98,8 +99,8 @@ mod path_tests {
     }
 
     #[test]
+    #[serial(env)]
     fn falls_back_to_run_dir_when_xdg_unset() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         std::env::remove_var("XDG_RUNTIME_DIR");
         let dir = TempDir::new().unwrap();
         let run_id = Uuid::now_v7();
@@ -113,8 +114,8 @@ mod path_tests {
     /// than the TTL and non-`.control.sock` files in the same dir must
     /// be left alone.
     #[test]
+    #[serial(env)]
     fn sweep_unlinks_only_stale_control_sockets() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let xdg = TempDir::new().unwrap();
         std::env::set_var("XDG_RUNTIME_DIR", xdg.path());
 

--- a/crates/pitboss-cli/src/dispatch/resume.rs
+++ b/crates/pitboss-cli/src/dispatch/resume.rs
@@ -366,6 +366,7 @@ mod tests {
     use chrono::Utc;
     use pitboss_core::parser::TokenUsage;
     use pitboss_core::store::{RunSummary, TaskRecord, TaskStatus};
+    use serial_test::serial;
     use tempfile::TempDir;
     use uuid::Uuid;
 
@@ -1162,6 +1163,7 @@ mod tests {
     /// same as the original dispatch's router. The placeholder uses a
     /// var prefixed `PITBOSS_NOTIFY_` (only such vars are substitutable).
     #[test]
+    #[serial(env)]
     fn read_resolved_manifest_repopulates_notifications_from_snapshot() {
         let tmp = TempDir::new().unwrap();
 
@@ -1253,6 +1255,7 @@ url = "https://hooks.slack.com/services/T00/B00/${PITBOSS_NOTIFY_SLACK_TOKEN}"
     /// loudly. Silent fallback to empty notifications would re-create
     /// the silent-disable failure mode #346 is closing.
     #[test]
+    #[serial(env)]
     fn read_resolved_manifest_fails_clearly_when_env_var_missing() {
         let tmp = TempDir::new().unwrap();
 

--- a/crates/pitboss-cli/src/manifest/resolve.rs
+++ b/crates/pitboss-cli/src/manifest/resolve.rs
@@ -517,6 +517,7 @@ fn resolve_approval_rule(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     fn man(src: &str) -> Manifest {
         toml::from_str(src).unwrap()
@@ -887,6 +888,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(env)]
     fn resolves_notifications_with_env_substitution() {
         // The substitution prefix is `PITBOSS_NOTIFY_` (#156 M3) — narrower
         // than the previous `PITBOSS_` so a manifest can't sneak

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -1636,17 +1636,17 @@ impl Drop for McpServer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
+    use serial_test::serial;
     use tempfile::TempDir;
     use uuid::Uuid;
 
-    // Serializes tests that mutate XDG_RUNTIME_DIR, since env vars are
-    // process-global and cargo runs tests in parallel by default.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    // #351: `#[serial(env)]` replaces the previous module-local
+    // `ENV_LOCK` so XDG_RUNTIME_DIR mutations here serialize against
+    // every other env-touching test in the crate, not just this file.
 
     #[test]
+    #[serial(env)]
     fn socket_path_uses_xdg_runtime_dir_when_set() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = TempDir::new().unwrap();
         std::env::set_var("XDG_RUNTIME_DIR", dir.path());
         let run_id = Uuid::now_v7();
@@ -1657,8 +1657,8 @@ mod tests {
     }
 
     #[test]
+    #[serial(env)]
     fn socket_path_falls_back_to_run_dir_when_xdg_unset() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         std::env::remove_var("XDG_RUNTIME_DIR");
         let dir = TempDir::new().unwrap();
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/src/notify/config.rs
+++ b/crates/pitboss-cli/src/notify/config.rs
@@ -404,8 +404,10 @@ fn is_disallowed_ip(ip: &IpAddr) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
+    #[serial(env)]
     fn env_var_substitution_replaces_tokens() {
         std::env::set_var("PITBOSS_NOTIFY_TEST_URL", "https://example.com/hook");
         let out = substitute_env_vars("${PITBOSS_NOTIFY_TEST_URL}/sub").unwrap();
@@ -413,6 +415,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(env)]
     fn env_var_missing_fails_loud() {
         std::env::remove_var("PITBOSS_NOTIFY_TEST_MISSING_XYZ");
         let err = substitute_env_vars("${PITBOSS_NOTIFY_TEST_MISSING_XYZ}").unwrap_err();
@@ -425,6 +428,7 @@ mod tests {
     /// URL — both are runtime values pitboss itself sets, and one of them
     /// (PITBOSS_PARENT_NOTIFY_URL) is itself a sensitive operator endpoint.
     #[test]
+    #[serial(env)]
     fn env_var_pitboss_run_id_not_substitutable() {
         std::env::set_var("PITBOSS_RUN_ID", "019d0000-aaaa-bbbb-cccc-dddddddddddd");
         let err = substitute_env_vars("${PITBOSS_RUN_ID}").unwrap_err();
@@ -469,6 +473,7 @@ url = "https://example.com""#;
     }
 
     #[test]
+    #[serial(env)]
     fn env_var_without_pitboss_prefix_rejected() {
         std::env::set_var("NOTIFY_TEST_FOREIGN", "leaked");
         let err = substitute_env_vars("${NOTIFY_TEST_FOREIGN}").unwrap_err();

--- a/crates/pitboss-cli/src/notify/mod.rs
+++ b/crates/pitboss-cli/src/notify/mod.rs
@@ -423,6 +423,7 @@ fn is_fatal(err: &anyhow::Error) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn severity_ord_is_info_warning_error_critical() {
@@ -652,6 +653,7 @@ mod tests {
     /// size directly, so we verify the constructor doesn't panic for an
     /// extreme value (which a misuse of NonZeroUsize might).
     #[test]
+    #[serial(env)]
     fn router_new_honors_dedup_cache_size_env() {
         std::env::set_var(DEDUP_CACHE_SIZE_ENV, "1024");
         let _ = NotificationRouter::new(vec![]);

--- a/crates/pitboss-cli/src/notify/parent.rs
+++ b/crates/pitboss-cli/src/notify/parent.rs
@@ -137,41 +137,23 @@ pub fn build_router(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
-    /// All tests that read or write the parent-notify env vars must hold this
-    /// mutex for their duration. `cargo test` runs unit tests in parallel
-    /// within the same process, and env vars are global — without serialization
-    /// these tests trample each other (a `remove_var` in one races a
-    /// `set_var` in another). `tokio::sync::Mutex` rather than `std::sync` so
-    /// the async tests can hold the guard across `.await` points without
-    /// tripping clippy's `await_holding_lock`.
-    static ENV_GUARD: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
-    async fn alock() -> tokio::sync::MutexGuard<'static, ()> {
-        ENV_GUARD.lock().await
-    }
-
-    fn lock() -> tokio::sync::MutexGuard<'static, ()> {
-        // Sync tests block on the runtime-less mutex via try_lock loop. In
-        // practice the guard is rarely contended (these tests are fast).
-        loop {
-            match ENV_GUARD.try_lock() {
-                Ok(g) => return g,
-                Err(_) => std::thread::sleep(std::time::Duration::from_millis(10)),
-            }
-        }
-    }
+    // #351: every test in this module mutates parent-notify env vars.
+    // `#[serial(env)]` serializes against every other env-touching
+    // test in the crate, replacing the previous module-local
+    // `ENV_GUARD` (which only protected this file).
 
     #[test]
+    #[serial(env)]
     fn parent_run_id_returns_none_when_unset() {
-        let _g = lock();
         std::env::remove_var(RUN_ID_ENV);
         assert!(parent_run_id().is_none());
     }
 
     #[test]
+    #[serial(env)]
     fn parent_run_id_returns_some_when_set() {
-        let _g = lock();
         std::env::set_var(RUN_ID_ENV, "  019d0000-aaaa-bbbb-cccc-dddddddddddd  ");
         let v = parent_run_id();
         std::env::remove_var(RUN_ID_ENV);
@@ -179,8 +161,8 @@ mod tests {
     }
 
     #[test]
+    #[serial(env)]
     fn parent_run_id_returns_none_when_empty() {
-        let _g = lock();
         std::env::set_var(RUN_ID_ENV, "   ");
         let v = parent_run_id();
         std::env::remove_var(RUN_ID_ENV);
@@ -188,18 +170,18 @@ mod tests {
     }
 
     #[test]
+    #[serial(env)]
     fn build_parent_sink_returns_none_when_env_unset() {
-        let _g = lock();
         std::env::remove_var(PARENT_NOTIFY_URL_ENV);
         let http = Arc::new(reqwest::Client::new());
         assert!(build_parent_sink(&http).is_none());
     }
 
     #[test]
+    #[serial(env)]
     fn build_parent_sink_returns_none_when_env_unparseable() {
         // A typo'd scheme (`htttp://…`) used to silently construct a sink
         // that failed on first emit. Catch it at dispatch start instead.
-        let _g = lock();
         // No scheme delimiter at all → reqwest::Url::parse rejects.
         // (`htttp://…` parses fine: any token is a valid scheme.)
         std::env::set_var(PARENT_NOTIFY_URL_ENV, "definitely not a url");
@@ -213,8 +195,8 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial(env)]
     async fn parent_sink_posts_run_dispatched_to_localhost() {
-        let _g = alock().await;
         // End-to-end: env var → trusted webhook sink → POST to a local mock.
         // Verifies that the SSRF bypass actually lets a localhost target work
         // (the manifest path would refuse it at parse time).
@@ -252,8 +234,8 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial(env)]
     async fn parent_sink_bypasses_https_only_check() {
-        let _g = alock().await;
         // Manifest webhook validation rejects http:// + loopback. The env-var
         // path must accept both, since the canonical orchestrator topology is
         // `http://localhost:N` on the same host.
@@ -292,8 +274,8 @@ mod tests {
     }
 
     #[test]
+    #[serial(env)]
     fn build_router_returns_none_when_no_sources() {
-        let _g = lock();
         std::env::remove_var(PARENT_NOTIFY_URL_ENV);
         let http = Arc::new(reqwest::Client::new());
         let router = build_router(&[], &http).unwrap();
@@ -301,8 +283,8 @@ mod tests {
     }
 
     #[test]
+    #[serial(env)]
     fn build_router_includes_parent_sink_when_env_set() {
-        let _g = lock();
         std::env::set_var(PARENT_NOTIFY_URL_ENV, "http://127.0.0.1:9/x");
         let http = Arc::new(reqwest::Client::new());
         let router = build_router(&[], &http).unwrap();

--- a/crates/pitboss-cli/src/runs.rs
+++ b/crates/pitboss-cli/src/runs.rs
@@ -438,6 +438,7 @@ pub fn format_mtime(mtime: SystemTime) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::fs;
     use tempfile::TempDir;
 
@@ -682,6 +683,7 @@ mod tests {
     // ── #141: socket-path resolution doesn't double-nest the run id ─────
 
     #[test]
+    #[serial(env)]
     fn resolve_socket_path_does_not_double_nest_run_id() {
         // Simulate the no-XDG case where the fallback path matters.
         // Stash and restore the env so the test is hermetic regardless of

--- a/crates/pitboss-cli/tests/control_flows.rs
+++ b/crates/pitboss-cli/tests/control_flows.rs
@@ -18,6 +18,7 @@ use tempfile::TempDir;
 use uuid::Uuid;
 
 #[test]
+#[serial_test::serial(env)]
 fn control_socket_path_uses_xdg_or_run_dir() {
     // Ensure the helper at least produces a valid path (regression guard for
     // Phase 1 wiring).

--- a/crates/pitboss-cli/tests/e2e_sublead_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_sublead_flows.rs
@@ -761,6 +761,7 @@ async fn budget_envelope_returns_to_root_pool() {
 /// This proves the full subprocess-spawn → monitor → reconcile path that
 /// v0.6 sub-task 3 wires up.
 #[tokio::test]
+#[serial_test::serial(env)]
 async fn sublead_session_spawns_runs_and_reconciles() {
     ensure_built();
 


### PR DESCRIPTION
## Summary

- Replaces three module-local env mutexes (`ENV_GUARD` in `notify/parent.rs`, `ENV_LOCK` in `control/mod.rs` and `mcp/server.rs`) with `#[serial_test::serial(env)]`, giving every env-touching unit test in `pitboss-cli` a single serialization domain.
- Annotates every `set_var`/`remove_var` test site I could find: `notify/parent.rs` (9), `notify/config.rs` (4), `notify/mod.rs` (1), `manifest/resolve.rs` (1), `dispatch/resume.rs` (2), `control/mod.rs` (3), `mcp/server.rs` (2), `runs.rs` (1), and the two integration tests `tests/control_flows.rs` + `tests/e2e_sublead_flows.rs`.
- Adds `serial_test = "3.4"` to `pitboss-cli` dev-dependencies.

## Why

Closes the test-isolation half of #351. Per-module env mutexes meant a test holding `ENV_GUARD` in `notify::parent::tests` could still race a `set_var` from `notify::config::tests`, `manifest::resolve::tests`, or any of the `XDG_RUNTIME_DIR` tests in `control` / `mcp::server`. `serial_test`'s `serial(env)` group is process-global, so all annotated tests now run mutually exclusive, regardless of which module they live in.

## Out of scope

The underlying glibc `setenv` reallocation hazard against background `getenv` readers (`tracing`, `reqwest`, locale init) is unchanged — `#[serial(env)]` only solves test-vs-test races. A follow-up refactoring `notify/config.rs::substitute_env_vars` and `notify/mod.rs::router_new`'s cache-size parser to take their input as a parameter (Path 4 from #351) would close that, and would let those tests drop the `#[serial]` annotation. Tracked as a follow-up in #351.

## Test plan

- [x] `cargo build -p pitboss-cli --tests` clean
- [x] All env-touching tests pass: `cargo test -p pitboss-cli --features pitboss-core/test-support --lib -- notify::parent notify::config notify::tests::router_new_honors_dedup manifest::resolve::tests::resolves_notifications dispatch::resume::tests::read_resolved_manifest control::path_tests mcp::server::tests::socket_path runs::tests::resolve_socket_path` — 62 passed, 0 failed
- [x] `cargo test --workspace --features pitboss-core/test-support` — full suite green
- [x] `cargo lint` clean
- [x] `cargo tidy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)