### PR TITLE
feat(web): rework Graph tab into post-run actor inspector (#260)

### DIFF
--- a/crates/pitboss-web/spa/package-lock.json
+++ b/crates/pitboss-web/spa/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",
         "@xyflow/svelte": "^1.5.2",
-        "bits-ui": "^2.0.0-next.1",
         "clsx": "^2.1.1",
         "echarts": "^5.5.1",
         "lucide-svelte": "^0.460.0",
@@ -20,12 +19,15 @@
         "tw-animate-css": "^1.0.0"
       },
       "devDependencies": {
+        "@internationalized/date": "^3.12.1",
+        "@lucide/svelte": "^1.14.0",
         "@sveltejs/adapter-static": "^3.0.6",
         "@sveltejs/kit": "^2.8.0",
         "@sveltejs/vite-plugin-svelte": "^4.0.0",
         "@tailwindcss/vite": "^4.0.0",
         "@types/node": "^22.9.0",
         "autoprefixer": "^10.4.20",
+        "bits-ui": "^2.18.1",
         "prettier": "^3.3.3",
         "prettier-plugin-svelte": "^3.2.7",
         "svelte": "^5.1.16",
@@ -446,6 +448,7 @@
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
       "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/utils": "^0.2.11"
@@ -455,6 +458,7 @@
       "version": "1.7.6",
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
       "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
@@ -465,12 +469,14 @@
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@internationalized/date": {
       "version": "3.12.1",
       "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.1.tgz",
       "integrity": "sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -522,11 +528,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lucide/svelte": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@lucide/svelte/-/svelte-1.14.0.tgz",
+      "integrity": "sha512-MVuP5VRCBQa2OaIpaRbuEV4k5OV2dy9MyxA6Tf4Sz/IN0v3zzUU72ObHc9r2Zn/wSMXDg6lLrHrczqI7w7gCzQ==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "svelte": "^5"
+      }
+    },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.29",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -883,7 +899,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@svelte-put/shortcut": {
@@ -918,7 +934,7 @@
       "version": "2.58.0",
       "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.58.0.tgz",
       "integrity": "sha512-kT9GCN8yJTkCK1W+Gi/bvGooWAM7y7WXP+yd+rf6QOIjyoK1ERPrMwSufXJUNu2pMWIqruhFvmz+LbOqsEmKmA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -961,7 +977,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-4.0.4.tgz",
       "integrity": "sha512-0ba1RQ/PHen5FGpdSrW7Y3fAMQjrXantECALeOiOdBdzR5+5vPP6HVZRLmZaQL+W8m++o+haIAKq5qT+MiZ7VA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -984,7 +1000,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-3.0.1.tgz",
       "integrity": "sha512-2CKypmj1sM4GE7HjllT7UKmo4Q6L5xFRd7VMGEWhYnZ+wc6AUVU01IBd7yUi6WnFndEwWoMNOd6e8UjoN0nbvQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.7"
@@ -1002,6 +1018,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
       "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -1283,7 +1300,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-color": {
@@ -1470,9 +1487,10 @@
       }
     },
     "node_modules/bits-ui": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/bits-ui/-/bits-ui-2.18.0.tgz",
-      "integrity": "sha512-GLOBZRVy3hxNHIQ2MpD/+5aK9KcBFZRhUJtZ1UDABXdlVR4K6zFpgt4T+Rwuhf2sQzlc6yK1q/DprHPjwT4Pjw==",
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/bits-ui/-/bits-ui-2.18.1.tgz",
+      "integrity": "sha512-KkemzKFH4T3gt3H+P86JcnAWExjByv/6vlwjm/BoCwTPHu03yiCdxbghdJLvFReQTe0acCAiRcKfmixxD6XvlA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/core": "^1.7.1",
@@ -1578,7 +1596,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -1694,7 +1712,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1712,7 +1730,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1722,6 +1740,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -1784,7 +1803,7 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
       "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -1910,6 +1929,7 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-reference": {
@@ -1935,7 +1955,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
       "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2221,6 +2241,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "lz-string": "bin/bin.js"
@@ -2258,7 +2279,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
       "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2268,14 +2289,14 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2301,14 +2322,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/postcss": {
       "version": "8.5.12",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
       "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2387,7 +2408,7 @@
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
       "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -2432,6 +2453,7 @@
       "version": "0.35.1",
       "resolved": "https://registry.npmjs.org/runed/-/runed-0.35.1.tgz",
       "integrity": "sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q==",
+      "dev": true,
       "funding": [
         "https://github.com/sponsors/huntabyte",
         "https://github.com/sponsors/tglide"
@@ -2469,14 +2491,14 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
       "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sirv": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
       "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@polka/url": "^1.0.0-next.24",
@@ -2491,7 +2513,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -2501,6 +2523,7 @@
       "version": "1.0.14",
       "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
       "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inline-style-parser": "0.2.7"
@@ -2562,6 +2585,7 @@
       "version": "0.10.6",
       "resolved": "https://registry.npmjs.org/svelte-toolbelt/-/svelte-toolbelt-0.10.6.tgz",
       "integrity": "sha512-YWuX+RE+CnWYx09yseAe4ZVMM7e7GRFZM6OYWpBKOb++s+SQ8RBIMMe+Bs/CznBMc0QPLjr+vDBxTAkozXsFXQ==",
+      "dev": true,
       "funding": [
         "https://github.com/sponsors/huntabyte"
       ],
@@ -2582,6 +2606,7 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
       "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tailwind-merge": {
@@ -2645,7 +2670,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
       "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2655,6 +2680,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tw-animate-css": {
@@ -2723,7 +2749,7 @@
       "version": "5.4.21",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2784,7 +2810,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
       "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "workspaces": [
         "tests/deps/*",

--- a/crates/pitboss-web/spa/package.json
+++ b/crates/pitboss-web/spa/package.json
@@ -13,12 +13,15 @@
     "format:check": "prettier --check ."
   },
   "devDependencies": {
+    "@internationalized/date": "^3.12.1",
+    "@lucide/svelte": "^1.14.0",
     "@sveltejs/adapter-static": "^3.0.6",
     "@sveltejs/kit": "^2.8.0",
     "@sveltejs/vite-plugin-svelte": "^4.0.0",
     "@tailwindcss/vite": "^4.0.0",
     "@types/node": "^22.9.0",
     "autoprefixer": "^10.4.20",
+    "bits-ui": "^2.18.1",
     "prettier": "^3.3.3",
     "prettier-plugin-svelte": "^3.2.7",
     "svelte": "^5.1.16",
@@ -31,7 +34,6 @@
   "dependencies": {
     "@dagrejs/dagre": "^3.0.0",
     "@xyflow/svelte": "^1.5.2",
-    "bits-ui": "^2.0.0-next.1",
     "clsx": "^2.1.1",
     "echarts": "^5.5.1",
     "lucide-svelte": "^0.460.0",

--- a/crates/pitboss-web/spa/src/lib/api.ts
+++ b/crates/pitboss-web/spa/src/lib/api.ts
@@ -160,6 +160,57 @@ export interface TaskRecord {
   approvals_rejected: number;
   model: string | null;
   failure_reason: unknown | null;
+  /** Dispatcher-stamped USD cost (#258); falls back to client-side
+   * `prices.ts` table when null on older runs. */
+  cost_usd?: number | null;
+  /** Resolved profile id (`worker_type` / `sublead_type`); v0.12+. */
+  actor_type?: string | null;
+}
+
+/** NDJSON event row from `tasks/<task_id>/events.jsonl`. The kind tag is
+ * snake-case to match `pitboss-cli/src/dispatch/events.rs::TaskEvent`. */
+export type TaskEvent =
+  | { kind: 'pause'; at: string; reason?: string }
+  | { kind: 'continue'; at: string; new_session_id: string; prompt_preview: string }
+  | { kind: 'reprompt'; at: string; prompt_preview: string; prior_session_id: string }
+  | { kind: 'approval_request'; at: string; request_id: string; summary_preview: string }
+  | { kind: 'approval_response'; at: string; request_id: string; approved: boolean; edited: boolean }
+  | { kind: 'notification_failed'; at: string; sink_id: string; event_kind: string; error: string }
+  | {
+      kind: 'tool_denied';
+      at: string;
+      tool_name: string;
+      actor_id: string;
+      reason_kind: string;
+      reason: string;
+    }
+  | { kind: 'tool_auto_approved'; at: string; tool_name: string; actor_id: string; actor_type: string };
+
+/** GET /api/runs/:id/tasks/:task_id/events — NDJSON parsed into rows.
+ * 404 (no events.jsonl yet — task never paused/repromp ted/got an
+ * approval, etc.) returns an empty list rather than throwing so the
+ * inspector can render "no lifecycle events yet". */
+export async function getTaskEvents(runId: string, taskId: string): Promise<TaskEvent[]> {
+  try {
+    const text = await request<string>(
+      `/api/runs/${enc(runId)}/tasks/${enc(taskId)}/events`,
+      { accept: 'text' }
+    );
+    return text
+      .split('\n')
+      .filter((l) => l.trim().length > 0)
+      .map((l) => {
+        try {
+          return JSON.parse(l) as TaskEvent;
+        } catch {
+          return null;
+        }
+      })
+      .filter((e): e is TaskEvent => e !== null);
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) return [];
+    throw err;
+  }
 }
 
 export function getTaskDetail(runId: string, taskId: string): Promise<TaskRecord> {

--- a/crates/pitboss-web/spa/src/lib/components/run-graph-inspector.svelte
+++ b/crates/pitboss-web/spa/src/lib/components/run-graph-inspector.svelte
@@ -1,0 +1,383 @@
+<script lang="ts">
+  import {
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetHeader,
+    SheetTitle
+  } from '$lib/components/ui/sheet';
+  import { Badge } from '$lib/components/ui/badge';
+  import { Button } from '$lib/components/ui/button';
+  import { Separator } from '$lib/components/ui/separator';
+  import {
+    getTaskEvents,
+    type ActorActivity,
+    type FailureReason,
+    type SubleadInfo,
+    type TaskEvent,
+    type TaskRecord,
+    type WorkerEntry
+  } from '$lib/api';
+  import { costUsd, fmtCost } from '$lib/prices';
+  import { ExternalLink, ArrowLeftRight, AlertTriangle } from 'lucide-svelte';
+
+  let {
+    runId,
+    open = $bindable(false),
+    selectedTaskId,
+    task,
+    worker,
+    failure,
+    sublead,
+    activity,
+    allTasks,
+    onJumpTo
+  }: {
+    runId: string;
+    open?: boolean;
+    selectedTaskId: string | null;
+    /** Matching TaskRecord from `summary.jsonl` (post-finalize) or
+     *  `summary.json` (post-finalize). Undefined when the actor only
+     *  exists in live SSE state. */
+    task: TaskRecord | undefined;
+    /** Live `WorkersSnapshot` row if the actor is still active. */
+    worker: WorkerEntry | undefined;
+    failure: FailureReason | undefined;
+    sublead: SubleadInfo | undefined;
+    activity: ActorActivity | undefined;
+    /** Full task list — used to compute parent/children for the
+     *  hierarchy section. Same source the graph already consumes. */
+    allTasks: TaskRecord[];
+    /** Click-jump on parent / child rows to swap the selection. */
+    onJumpTo: (taskId: string) => void;
+  } = $props();
+
+  // Lazy-fetch lifecycle events when the inspector opens for a new id.
+  // The fetch is bounded to the currently-selected task; if the user
+  // switches selection mid-fetch, the previous request's result is
+  // dropped via the `lastFetchedFor` token check.
+  let events = $state<TaskEvent[]>([]);
+  let eventsLoading = $state(false);
+  let eventsError = $state<string | null>(null);
+  let lastFetchedFor = $state<string | null>(null);
+
+  $effect(() => {
+    const id = selectedTaskId;
+    if (!open || !id) {
+      events = [];
+      eventsError = null;
+      lastFetchedFor = null;
+      return;
+    }
+    if (id === lastFetchedFor) return;
+    lastFetchedFor = id;
+    eventsLoading = true;
+    eventsError = null;
+    getTaskEvents(runId, id)
+      .then((rows) => {
+        // Drop the result if the selection has moved on.
+        if (lastFetchedFor !== id) return;
+        events = rows;
+      })
+      .catch((err) => {
+        if (lastFetchedFor !== id) return;
+        eventsError = err instanceof Error ? err.message : String(err);
+      })
+      .finally(() => {
+        if (lastFetchedFor === id) eventsLoading = false;
+      });
+  });
+
+  const status = $derived(task?.status ?? worker?.state ?? 'unknown');
+  const startedIso = $derived(task?.started_at ?? worker?.started_at);
+  const endedIso = $derived(task?.ended_at);
+  const duration = $derived(task?.duration_ms);
+
+  const parentId = $derived(task?.parent_task_id ?? worker?.parent_task_id ?? null);
+  const childrenIds = $derived(
+    allTasks
+      .filter((t) => t.parent_task_id === selectedTaskId)
+      .map((t) => t.task_id)
+  );
+
+  const totalTokens = $derived(
+    (task?.token_usage?.input ?? 0) +
+      (task?.token_usage?.output ?? 0) +
+      (task?.token_usage?.cache_read ?? 0) +
+      (task?.token_usage?.cache_creation ?? 0)
+  );
+
+  const cost = $derived(
+    typeof task?.cost_usd === 'number' ? task.cost_usd : costUsd(task?.model, task?.token_usage)
+  );
+
+  const failureKind = $derived.by(() => {
+    const r = (task?.failure_reason ?? failure) as { kind?: string } | null | undefined;
+    return r && typeof r === 'object' ? (r.kind ?? null) : null;
+  });
+  const failureMessage = $derived.by(() => {
+    const r = (task?.failure_reason ?? failure) as { message?: string } | null | undefined;
+    return r && typeof r === 'object' ? (r.message ?? null) : null;
+  });
+
+  function fmtDuration(ms?: number): string {
+    if (typeof ms !== 'number' || !Number.isFinite(ms) || ms < 0) return '—';
+    const s = Math.floor(ms / 1000);
+    if (s < 60) return `${s}s`;
+    if (s < 3600) return `${Math.floor(s / 60)}m ${s % 60}s`;
+    return `${Math.floor(s / 3600)}h ${Math.floor((s % 3600) / 60)}m`;
+  }
+
+  function fmtTime(iso?: string | null): string {
+    if (!iso) return '—';
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return iso;
+    return d.toLocaleString();
+  }
+
+  function statusBadgeVariant(s: string): 'destructive' | 'secondary' | 'outline' {
+    const lc = s.toLowerCase();
+    if (lc === 'failed' || lc === 'aborted' || lc === 'cancelled') return 'destructive';
+    if (lc === 'success' || lc === 'completed') return 'secondary';
+    return 'outline';
+  }
+
+  function eventLabel(e: TaskEvent): string {
+    switch (e.kind) {
+      case 'pause':
+        return 'paused' + (e.reason ? ` (${e.reason})` : '');
+      case 'continue':
+        return `continued → ${e.new_session_id}`;
+      case 'reprompt':
+        return 'reprompted';
+      case 'approval_request':
+        return `approval requested (${e.request_id.slice(0, 8)}…)`;
+      case 'approval_response':
+        return `approval ${e.approved ? 'granted' : 'denied'}${e.edited ? ' (edited)' : ''}`;
+      case 'notification_failed':
+        return `notify_failed: ${e.sink_id}`;
+      case 'tool_denied':
+        return `denied: ${e.tool_name} (${e.reason_kind})`;
+      case 'tool_auto_approved':
+        return `auto-approved: ${e.tool_name}`;
+    }
+  }
+</script>
+
+<Sheet
+  bind:open
+  onOpenChange={(o: boolean) => {
+    // Bubble close-via-overlay/ESC up to the parent so it can clear
+    // `selectedTaskId`. Without this, hitting ESC closes the sheet but
+    // the graph keeps highlighting the node.
+    if (!o && selectedTaskId !== null) onJumpTo('');
+  }}
+>
+  <SheetContent class="w-full overflow-y-auto sm:max-w-md">
+    {#if !selectedTaskId}
+      <SheetHeader>
+        <SheetTitle>No selection</SheetTitle>
+      </SheetHeader>
+    {:else}
+      <SheetHeader class="space-y-1">
+        <SheetTitle class="flex items-center gap-2">
+          <code class="text-base font-mono">{selectedTaskId}</code>
+          <Badge variant={statusBadgeVariant(status)} class="text-[10px]">
+            {status}
+          </Badge>
+          {#if sublead}
+            <Badge variant="outline" class="text-[10px]">sublead</Badge>
+          {/if}
+        </SheetTitle>
+        <SheetDescription class="text-xs">
+          {task?.model ?? worker?.session_id ?? 'unknown model'}
+          {#if task?.actor_type}
+            · profile <code class="font-mono">{task.actor_type}</code>
+          {/if}
+        </SheetDescription>
+      </SheetHeader>
+
+      <div class="space-y-4 px-4 pb-6">
+        <!-- Timing -->
+        <section class="space-y-1 text-xs">
+          <h3 class="text-muted-foreground text-[11px] font-medium uppercase tracking-wide">Timing</h3>
+          <dl class="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1">
+            <dt class="text-muted-foreground">Started</dt>
+            <dd class="font-mono">{fmtTime(startedIso)}</dd>
+            <dt class="text-muted-foreground">Ended</dt>
+            <dd class="font-mono">{endedIso ? fmtTime(endedIso) : '—'}</dd>
+            <dt class="text-muted-foreground">Duration</dt>
+            <dd class="font-mono">{fmtDuration(duration)}</dd>
+            {#if task?.exit_code !== undefined && task.exit_code !== null}
+              <dt class="text-muted-foreground">Exit code</dt>
+              <dd class="font-mono">{task.exit_code}</dd>
+            {/if}
+          </dl>
+        </section>
+
+        <Separator />
+
+        <!-- Tokens / cost -->
+        <section class="space-y-1 text-xs">
+          <h3 class="text-muted-foreground text-[11px] font-medium uppercase tracking-wide">Tokens &amp; cost</h3>
+          {#if totalTokens === 0 && cost === null}
+            <p class="text-muted-foreground italic">No usage data yet.</p>
+          {:else}
+            <dl class="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 tabular-nums">
+              <dt class="text-muted-foreground">Input</dt>
+              <dd class="font-mono">{(task?.token_usage?.input ?? 0).toLocaleString()}</dd>
+              <dt class="text-muted-foreground">Output</dt>
+              <dd class="font-mono">{(task?.token_usage?.output ?? 0).toLocaleString()}</dd>
+              <dt class="text-muted-foreground">Cache read</dt>
+              <dd class="font-mono">{(task?.token_usage?.cache_read ?? 0).toLocaleString()}</dd>
+              <dt class="text-muted-foreground">Cache create</dt>
+              <dd class="font-mono">{(task?.token_usage?.cache_creation ?? 0).toLocaleString()}</dd>
+              <dt class="text-muted-foreground">Cost</dt>
+              <dd class="font-mono">{fmtCost(cost)}</dd>
+            </dl>
+          {/if}
+        </section>
+
+        <Separator />
+
+        <!-- Counters -->
+        <section class="space-y-1 text-xs">
+          <h3 class="text-muted-foreground text-[11px] font-medium uppercase tracking-wide">Counters</h3>
+          <dl class="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 tabular-nums">
+            <dt class="text-muted-foreground">Pauses</dt>
+            <dd class="font-mono">{task?.pause_count ?? 0}</dd>
+            <dt class="text-muted-foreground">Reprompts</dt>
+            <dd class="font-mono">{task?.reprompt_count ?? 0}</dd>
+            <dt class="text-muted-foreground">Approvals (req / ok / denied)</dt>
+            <dd class="font-mono">
+              {task?.approvals_requested ?? 0} / {task?.approvals_approved ?? 0} / {task?.approvals_rejected ?? 0}
+            </dd>
+            {#if activity}
+              <dt class="text-muted-foreground">Store ops (kv / lease / msg / art)</dt>
+              <dd class="font-mono">
+                {activity.kv_ops} / {activity.lease_ops} / {activity.message_ops ?? 0} / {activity.artifact_ops ?? 0}
+              </dd>
+            {/if}
+          </dl>
+        </section>
+
+        <!-- Failure detail -->
+        {#if failureKind}
+          <Separator />
+          <section class="space-y-1 text-xs">
+            <h3 class="text-destructive flex items-center gap-1 text-[11px] font-medium uppercase tracking-wide">
+              <AlertTriangle class="size-3" /> Failure
+            </h3>
+            <dl class="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1">
+              <dt class="text-muted-foreground">Kind</dt>
+              <dd class="font-mono">{failureKind}</dd>
+              {#if failureMessage}
+                <dt class="text-muted-foreground">Message</dt>
+                <dd class="font-mono break-words">{failureMessage}</dd>
+              {/if}
+            </dl>
+          </section>
+        {/if}
+
+        <Separator />
+
+        <!-- Hierarchy -->
+        <section class="space-y-1 text-xs">
+          <h3 class="text-muted-foreground text-[11px] font-medium uppercase tracking-wide">Hierarchy</h3>
+          <div class="flex flex-col gap-1.5">
+            <div class="flex items-center gap-2">
+              <span class="text-muted-foreground w-12">Parent</span>
+              {#if parentId}
+                <Button
+                  variant="link"
+                  size="sm"
+                  class="h-auto p-0 font-mono"
+                  onclick={() => onJumpTo(parentId)}
+                >
+                  <ArrowLeftRight class="mr-1 size-3" />
+                  {parentId}
+                </Button>
+              {:else}
+                <span class="text-muted-foreground italic">root</span>
+              {/if}
+            </div>
+            <div class="flex items-start gap-2">
+              <span class="text-muted-foreground w-12 pt-0.5">Children</span>
+              {#if childrenIds.length === 0}
+                <span class="text-muted-foreground italic">none</span>
+              {:else}
+                <div class="flex flex-wrap gap-1">
+                  {#each childrenIds as id (id)}
+                    <Button
+                      variant="link"
+                      size="sm"
+                      class="h-auto p-0 font-mono"
+                      onclick={() => onJumpTo(id)}
+                    >
+                      {id}
+                    </Button>
+                  {/each}
+                </div>
+              {/if}
+            </div>
+          </div>
+        </section>
+
+        <!-- Final message -->
+        {#if task?.final_message ?? task?.final_message_preview}
+          <Separator />
+          <section class="space-y-1 text-xs">
+            <h3 class="text-muted-foreground text-[11px] font-medium uppercase tracking-wide">Final message</h3>
+            <pre class="bg-muted/30 max-h-48 overflow-auto whitespace-pre-wrap rounded p-2 font-mono text-[11px]">{task.final_message ?? task.final_message_preview}</pre>
+          </section>
+        {/if}
+
+        <!-- Lifecycle events -->
+        <Separator />
+        <section class="space-y-1 text-xs">
+          <h3 class="text-muted-foreground text-[11px] font-medium uppercase tracking-wide">Lifecycle events</h3>
+          {#if eventsLoading}
+            <p class="text-muted-foreground italic">Loading…</p>
+          {:else if eventsError}
+            <p class="text-destructive">Failed to load events: {eventsError}</p>
+          {:else if events.length === 0}
+            <p class="text-muted-foreground italic">No lifecycle events recorded.</p>
+          {:else}
+            <ul class="space-y-1">
+              {#each events as e, i (i)}
+                <li class="flex items-start gap-2 text-[11px]">
+                  <span class="text-muted-foreground/80 w-32 shrink-0 font-mono">
+                    {fmtTime(e.at)}
+                  </span>
+                  <span class="font-mono">{eventLabel(e)}</span>
+                </li>
+              {/each}
+            </ul>
+          {/if}
+        </section>
+
+        <!-- Open log -->
+        <Separator />
+        <section class="space-y-1 text-xs">
+          <Button
+            variant="outline"
+            size="sm"
+            class="w-full"
+            onclick={() => {
+              // Lean on the existing static log endpoint. Opens in a new
+              // tab so the inspector stays open for cross-referencing.
+              window.open(
+                `/api/runs/${encodeURIComponent(runId)}/tasks/${encodeURIComponent(selectedTaskId!)}/log`,
+                '_blank',
+                'noopener'
+              );
+            }}
+          >
+            <ExternalLink class="mr-1.5 size-3.5" />
+            Open stdout.log
+          </Button>
+        </section>
+      </div>
+    {/if}
+  </SheetContent>
+</Sheet>

--- a/crates/pitboss-web/spa/src/lib/components/run-graph-node.svelte
+++ b/crates/pitboss-web/spa/src/lib/components/run-graph-node.svelte
@@ -1,8 +1,15 @@
 <script lang="ts">
   import { Handle, Position, type Node, type NodeProps } from '@xyflow/svelte';
-  import type { WorkerEntry, ActorActivity, FailureReason, SubleadInfo } from '$lib/api';
+  import type {
+    WorkerEntry,
+    ActorActivity,
+    FailureReason,
+    SubleadInfo,
+    TaskRecord
+  } from '$lib/api';
   import { Badge } from '$lib/components/ui/badge';
   import { Layers, AlertTriangle } from 'lucide-svelte';
+  import { costUsd, fmtCost } from '$lib/prices';
 
   // SvelteFlow passes the node `data` payload via standard NodeProps.
   // We attach our own typed payload to avoid `any` everywhere.
@@ -11,6 +18,11 @@
     activity?: ActorActivity;
     failure?: FailureReason;
     sublead?: SubleadInfo;
+    /** Full per-task record from `summary.jsonl` (or `summary.json`).
+     * Undefined for live-only actors that haven't written a record yet. */
+    task?: TaskRecord;
+    /** True when this node matches the inspector's current selection. */
+    selected?: boolean;
     [k: string]: unknown;
   };
 
@@ -37,21 +49,102 @@
         return 'border-border bg-background';
     }
   }
+
+  function fmtDuration(ms: number | undefined): string {
+    if (typeof ms !== 'number' || !Number.isFinite(ms) || ms < 0) return '—';
+    const s = Math.floor(ms / 1000);
+    if (s < 60) return `${s}s`;
+    if (s < 3600) return `${Math.floor(s / 60)}m ${s % 60}s`;
+    return `${Math.floor(s / 3600)}h ${Math.floor((s % 3600) / 60)}m`;
+  }
+
+  function fmtTokens(n: number | undefined): string {
+    if (typeof n !== 'number' || !Number.isFinite(n)) return '0';
+    if (n < 1000) return String(n);
+    if (n < 1_000_000) return `${(n / 1000).toFixed(1)}k`;
+    return `${(n / 1_000_000).toFixed(2)}m`;
+  }
+
+  function fmtRel(iso: string): string {
+    const t = Date.parse(iso);
+    if (!Number.isFinite(t)) return '';
+    const ago = Math.max(0, Math.floor((Date.now() - t) / 1000));
+    if (ago < 60) return `${ago}s ago`;
+    if (ago < 3600) return `${Math.floor(ago / 60)}m ago`;
+    return `${Math.floor(ago / 3600)}h ago`;
+  }
+
+  /**
+   * Failure-reason chip text. `failure_reason` from TaskRecord is the
+   * post-run authoritative source; the live `failure` map (SSE) wins
+   * during an active run. Renders the variant tag plus a short
+   * substring for tagged-with-message variants.
+   */
+  function failureChip(
+    reason: unknown
+  ): { label: string; detail?: string } | null {
+    if (!reason || typeof reason !== 'object') return null;
+    const r = reason as { kind?: string; message?: string };
+    if (!r.kind) return null;
+    return { label: r.kind, detail: r.message };
+  }
+
+  // The node's headline counters. Pull from TaskRecord if present, else
+  // zero. (Live-only entries don't have these — they're accumulated by
+  // the dispatcher and only flushed at task finalize.)
+  const counters = $derived({
+    pause: d.task?.pause_count ?? 0,
+    reprompt: d.task?.reprompt_count ?? 0,
+    aprq: d.task?.approvals_requested ?? 0,
+    aprn: d.task?.approvals_rejected ?? 0
+  });
+
+  // Cost: prefer the dispatcher-stamped value (#258); fall back to the
+  // SPA's per-1M-token table when older binaries leave it null.
+  const cost = $derived(
+    typeof d.task?.cost_usd === 'number'
+      ? d.task.cost_usd
+      : costUsd(d.task?.model, d.task?.token_usage)
+  );
+
+  const failureInfo = $derived(failureChip(d.task?.failure_reason ?? d.failure));
+
+  const totalTokens = $derived(
+    (d.task?.token_usage?.input ?? 0) +
+      (d.task?.token_usage?.output ?? 0) +
+      (d.task?.token_usage?.cache_read ?? 0)
+  );
+
+  const startedIso = $derived(d.task?.started_at ?? d.worker.started_at);
+  const isTerminal = $derived(
+    d.task?.status &&
+      d.task.status !== 'Running' &&
+      d.task.status !== 'Paused' &&
+      d.task.status !== 'Frozen'
+  );
 </script>
 
 <div
-  class="bg-background w-44 rounded-md border-2 px-3 py-2 shadow-sm {tileColor(
+  class="bg-background w-52 rounded-md border-2 px-3 py-2 shadow-sm transition-shadow {tileColor(
     d.worker.state,
-    !!d.failure
-  )}"
+    !!d.failure || !!failureInfo
+  )} {d.selected
+    ? 'ring-2 ring-sky-500/70 ring-offset-1 ring-offset-background'
+    : ''}"
 >
   <Handle type="target" position={Position.Top} class="!bg-muted-foreground/40" />
+
+  <!-- Row 1: id + role + sublead glyph -->
   <div class="flex items-center justify-between gap-1">
-    <code class="truncate text-[10px] font-medium">{d.worker.task_id}</code>
+    <code class="truncate text-[10px] font-medium" title={d.worker.task_id}>
+      {d.worker.task_id}
+    </code>
     {#if d.sublead}
       <Layers class="text-muted-foreground size-3 shrink-0" />
     {/if}
   </div>
+
+  <!-- Row 2: status badge + failure indicator -->
   <div class="mt-0.5 flex items-center gap-1">
     <Badge
       variant={d.worker.state === 'failed' ? 'destructive' : 'outline'}
@@ -59,17 +152,69 @@
     >
       {d.worker.state}
     </Badge>
-    {#if d.failure}
-      <AlertTriangle class="text-destructive size-3" />
+    {#if failureInfo}
+      <AlertTriangle class="text-destructive size-3 shrink-0" />
     {/if}
   </div>
+
+  <!-- Row 3: timing -->
+  <div class="text-muted-foreground mt-1 flex items-center justify-between gap-1 text-[9px] tabular-nums">
+    {#if isTerminal && d.task?.duration_ms !== undefined}
+      <span title={`Started ${startedIso ?? ''}`}>ran {fmtDuration(d.task.duration_ms)}</span>
+    {:else if startedIso}
+      <span title={`Started ${startedIso}`}>started {fmtRel(startedIso)}</span>
+    {:else}
+      <span>—</span>
+    {/if}
+    {#if d.task?.model}
+      <span class="truncate" title={d.task.model}>
+        {d.task.model.replace(/^claude-/, '')}
+      </span>
+    {/if}
+  </div>
+
+  <!-- Row 4: tokens + cost -->
+  {#if totalTokens > 0 || cost !== null}
+    <div class="text-muted-foreground mt-0.5 flex items-center justify-between gap-1 text-[9px] tabular-nums">
+      <span title={`in ${d.task?.token_usage?.input ?? 0} / out ${d.task?.token_usage?.output ?? 0} / cr ${d.task?.token_usage?.cache_read ?? 0}`}>
+        {fmtTokens(totalTokens)} tok
+      </span>
+      <span class="font-medium">{fmtCost(cost)}</span>
+    </div>
+  {/if}
+
+  <!-- Row 5: counters (only when non-zero, to keep tile dense for typical runs) -->
+  {#if counters.pause + counters.reprompt + counters.aprq + counters.aprn > 0}
+    <div class="text-muted-foreground mt-0.5 flex flex-wrap gap-x-1.5 text-[9px] tabular-nums">
+      {#if counters.pause > 0}<span>p:{counters.pause}</span>{/if}
+      {#if counters.reprompt > 0}<span>rp:{counters.reprompt}</span>{/if}
+      {#if counters.aprq > 0}<span title="approvals requested">aq:{counters.aprq}</span>{/if}
+      {#if counters.aprn > 0}<span title="approvals rejected" class="text-destructive">an:{counters.aprn}</span>{/if}
+    </div>
+  {/if}
+
+  <!-- Row 6: live store activity (SSE-only; absent post-run) -->
   {#if d.activity}
     {@const msgOps = d.activity.message_ops ?? 0}
     {@const artOps = d.activity.artifact_ops ?? 0}
-    <div class="text-muted-foreground mt-1 text-[9px] tabular-nums">
+    <div class="text-muted-foreground/80 mt-0.5 text-[9px] tabular-nums">
       kv:{d.activity.kv_ops} lease:{d.activity.lease_ops}
       {#if msgOps > 0 || artOps > 0}msg:{msgOps} art:{artOps}{/if}
     </div>
   {/if}
+
+  <!-- Row 7: failure-reason chip -->
+  {#if failureInfo}
+    <div
+      class="bg-destructive/10 text-destructive mt-1 rounded border border-destructive/30 px-1.5 py-0.5 text-[9px]"
+      title={failureInfo.detail ?? ''}
+    >
+      <span class="font-medium">{failureInfo.label}</span>
+      {#if failureInfo.detail}
+        <span class="text-destructive/80 ml-1 truncate">{failureInfo.detail}</span>
+      {/if}
+    </div>
+  {/if}
+
   <Handle type="source" position={Position.Bottom} class="!bg-muted-foreground/40" />
 </div>

--- a/crates/pitboss-web/spa/src/lib/components/run-graph.svelte
+++ b/crates/pitboss-web/spa/src/lib/components/run-graph.svelte
@@ -3,35 +3,58 @@
   import dagre from '@dagrejs/dagre';
   import '@xyflow/svelte/dist/style.css';
   import RunGraphNode from './run-graph-node.svelte';
-  import type { WorkerEntry, ActorActivity, FailureReason, SubleadInfo } from '$lib/api';
+  import type {
+    WorkerEntry,
+    ActorActivity,
+    FailureReason,
+    SubleadInfo,
+    TaskRecord
+  } from '$lib/api';
 
   let {
     workers,
     storeActivity,
     failures,
-    subleads
+    subleads,
+    tasks,
+    selectedTaskId,
+    onSelect
   }: {
     workers: WorkerEntry[];
     storeActivity: Record<string, ActorActivity>;
     failures: Record<string, FailureReason>;
     subleads: Record<string, SubleadInfo>;
+    /** Per-task records from `summary.jsonl` / `summary.json`. Looked up
+     *  by `task_id` to densify each tile (timestamps, tokens, cost,
+     *  counters, failure reason) and to power the inspector. */
+    tasks: TaskRecord[];
+    /** Currently-inspected task_id. The matching node renders with a
+     *  ring; the inspector panel reads from this same value. Bindable so
+     *  ESC / overlay click in the inspector clears the selection too. */
+    selectedTaskId?: string | null;
+    /** Fires on node click. Parent updates `selectedTaskId` to open the
+     *  inspector. Toggling on the same node clears the selection. */
+    onSelect?: (taskId: string | null) => void;
   } = $props();
 
-  const NODE_WIDTH = 180;
-  const NODE_HEIGHT = 90;
+  const NODE_WIDTH = 208; // matches w-52 in run-graph-node.svelte
+  const NODE_HEIGHT = 130; // grew from 90 to fit the new dense rows
 
   /** Build {nodes, edges} for the current snapshot, then run dagre for layout. */
   function layout(
     workers: WorkerEntry[],
     storeActivity: Record<string, ActorActivity>,
     failures: Record<string, FailureReason>,
-    subleads: Record<string, SubleadInfo>
+    subleads: Record<string, SubleadInfo>,
+    tasks: TaskRecord[],
+    selectedTaskId: string | null | undefined
   ): { nodes: Node[]; edges: Edge[] } {
     const g = new dagre.graphlib.Graph();
     g.setGraph({ rankdir: 'TB', nodesep: 32, ranksep: 64 });
     g.setDefaultEdgeLabel(() => ({}));
 
     const knownIds = new Set(workers.map((w) => w.task_id));
+    const taskById = new Map(tasks.map((t) => [t.task_id, t]));
 
     for (const w of workers) {
       g.setNode(w.task_id, { width: NODE_WIDTH, height: NODE_HEIGHT });
@@ -56,7 +79,9 @@
           worker: w,
           activity: storeActivity[w.task_id],
           failure: failures[w.task_id],
-          sublead: subleads[w.task_id]
+          sublead: subleads[w.task_id],
+          task: taskById.get(w.task_id),
+          selected: selectedTaskId === w.task_id
         }
       };
     });
@@ -79,7 +104,9 @@
   // Recompute on every prop change. SvelteFlow's `nodes` / `edges` props
   // expect $state stores under the hood; reassigning derived arrays
   // re-renders cleanly because the component does shallow identity diff.
-  let layoutResult = $derived(layout(workers, storeActivity, failures, subleads));
+  let layoutResult = $derived(
+    layout(workers, storeActivity, failures, subleads, tasks, selectedTaskId)
+  );
   let nodes = $state<Node[]>([]);
   let edges = $state<Edge[]>([]);
   $effect(() => {
@@ -88,12 +115,20 @@
   });
 
   const nodeTypes = { runNode: RunGraphNode };
+
+  // SvelteFlow's nodeclick handler. Clicking the already-selected node
+  // clears the selection (matches the issue's "click again to dismiss"
+  // muscle memory).
+  function handleNodeClick({ node }: { node: Node }): void {
+    if (!onSelect) return;
+    onSelect(selectedTaskId === node.id ? null : node.id);
+  }
 </script>
 
 <div class="bg-muted/20 dark:bg-muted/5 h-[60vh] w-full rounded-md border">
   {#if workers.length === 0}
     <div class="text-muted-foreground flex h-full items-center justify-center text-xs">
-      No workers reported yet.
+      No actors recorded for this run yet.
     </div>
   {:else}
     <SvelteFlow
@@ -103,6 +138,7 @@
       fitView
       nodesDraggable={false}
       nodesConnectable={false}
+      onnodeclick={handleNodeClick}
       proOptions={{ hideAttribution: true }}
     >
       <Background />

--- a/crates/pitboss-web/spa/src/lib/components/ui/sheet/index.ts
+++ b/crates/pitboss-web/spa/src/lib/components/ui/sheet/index.ts
@@ -1,0 +1,34 @@
+import Root from "./sheet.svelte";
+import Portal from "./sheet-portal.svelte";
+import Trigger from "./sheet-trigger.svelte";
+import Close from "./sheet-close.svelte";
+import Overlay from "./sheet-overlay.svelte";
+import Content from "./sheet-content.svelte";
+import Header from "./sheet-header.svelte";
+import Footer from "./sheet-footer.svelte";
+import Title from "./sheet-title.svelte";
+import Description from "./sheet-description.svelte";
+
+export {
+	Root,
+	Close,
+	Trigger,
+	Portal,
+	Overlay,
+	Content,
+	Header,
+	Footer,
+	Title,
+	Description,
+	//
+	Root as Sheet,
+	Close as SheetClose,
+	Trigger as SheetTrigger,
+	Portal as SheetPortal,
+	Overlay as SheetOverlay,
+	Content as SheetContent,
+	Header as SheetHeader,
+	Footer as SheetFooter,
+	Title as SheetTitle,
+	Description as SheetDescription,
+};

--- a/crates/pitboss-web/spa/src/lib/components/ui/sheet/sheet-close.svelte
+++ b/crates/pitboss-web/spa/src/lib/components/ui/sheet/sheet-close.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from "bits-ui";
+
+	let { ref = $bindable(null), ...restProps }: SheetPrimitive.CloseProps = $props();
+</script>
+
+<SheetPrimitive.Close bind:ref data-slot="sheet-close" {...restProps} />

--- a/crates/pitboss-web/spa/src/lib/components/ui/sheet/sheet-content.svelte
+++ b/crates/pitboss-web/spa/src/lib/components/ui/sheet/sheet-content.svelte
@@ -1,0 +1,55 @@
+<script lang="ts" module>
+	export type Side = "top" | "right" | "bottom" | "left";
+</script>
+
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from "bits-ui";
+	import type { Snippet } from "svelte";
+	import SheetPortal from "./sheet-portal.svelte";
+	import SheetOverlay from "./sheet-overlay.svelte";
+	import { Button } from "$lib/components/ui/button/index.js";
+	import XIcon from '@lucide/svelte/icons/x';
+	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+	import type { ComponentProps } from "svelte";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		side = "right",
+		showCloseButton = true,
+		portalProps,
+		children,
+		...restProps
+	}: WithoutChildrenOrChild<SheetPrimitive.ContentProps> & {
+		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof SheetPortal>>;
+		side?: Side;
+		showCloseButton?: boolean;
+		children: Snippet;
+	} = $props();
+</script>
+
+<SheetPortal {...portalProps}>
+	<SheetOverlay />
+	<SheetPrimitive.Content
+		bind:ref
+		data-slot="sheet-content"
+		data-side={side}
+		class={cn(
+			"bg-popover text-popover-foreground fixed z-50 flex flex-col gap-4 bg-clip-padding text-sm shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-[side=bottom]:data-open:slide-in-from-bottom-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:animate-out data-closed:fade-out-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=right]:data-closed:slide-out-to-right-10 data-[side=top]:data-closed:slide-out-to-top-10",
+			className
+		)}
+		{...restProps}
+	>
+		{@render children?.()}
+		{#if showCloseButton}
+			<SheetPrimitive.Close data-slot="sheet-close">
+				{#snippet child({ props })}
+					<Button variant="ghost" class="absolute top-3 right-3" size="icon" {...props}>
+						<XIcon  />
+						<span class="sr-only">Close</span>
+					</Button>
+				{/snippet}
+			</SheetPrimitive.Close>
+		{/if}
+	</SheetPrimitive.Content>
+</SheetPortal>

--- a/crates/pitboss-web/spa/src/lib/components/ui/sheet/sheet-description.svelte
+++ b/crates/pitboss-web/spa/src/lib/components/ui/sheet/sheet-description.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: SheetPrimitive.DescriptionProps = $props();
+</script>
+
+<SheetPrimitive.Description
+	bind:ref
+	data-slot="sheet-description"
+	class={cn("text-muted-foreground text-sm", className)}
+	{...restProps}
+/>

--- a/crates/pitboss-web/spa/src/lib/components/ui/sheet/sheet-footer.svelte
+++ b/crates/pitboss-web/spa/src/lib/components/ui/sheet/sheet-footer.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="sheet-footer"
+	class={cn("gap-2 p-4 mt-auto flex flex-col", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/crates/pitboss-web/spa/src/lib/components/ui/sheet/sheet-header.svelte
+++ b/crates/pitboss-web/spa/src/lib/components/ui/sheet/sheet-header.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="sheet-header"
+	class={cn("gap-0.5 p-4 flex flex-col", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/crates/pitboss-web/spa/src/lib/components/ui/sheet/sheet-overlay.svelte
+++ b/crates/pitboss-web/spa/src/lib/components/ui/sheet/sheet-overlay.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: SheetPrimitive.OverlayProps = $props();
+</script>
+
+<SheetPrimitive.Overlay
+	bind:ref
+	data-slot="sheet-overlay"
+	class={cn("bg-black/10 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-50", className)}
+	{...restProps}
+/>

--- a/crates/pitboss-web/spa/src/lib/components/ui/sheet/sheet-portal.svelte
+++ b/crates/pitboss-web/spa/src/lib/components/ui/sheet/sheet-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from "bits-ui";
+
+	let { ...restProps }: SheetPrimitive.PortalProps = $props();
+</script>
+
+<SheetPrimitive.Portal {...restProps} />

--- a/crates/pitboss-web/spa/src/lib/components/ui/sheet/sheet-title.svelte
+++ b/crates/pitboss-web/spa/src/lib/components/ui/sheet/sheet-title.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: SheetPrimitive.TitleProps = $props();
+</script>
+
+<SheetPrimitive.Title
+	bind:ref
+	data-slot="sheet-title"
+	class={cn("text-foreground text-base font-medium", className)}
+	{...restProps}
+/>

--- a/crates/pitboss-web/spa/src/lib/components/ui/sheet/sheet-trigger.svelte
+++ b/crates/pitboss-web/spa/src/lib/components/ui/sheet/sheet-trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from "bits-ui";
+
+	let { ref = $bindable(null), ...restProps }: SheetPrimitive.TriggerProps = $props();
+</script>
+
+<SheetPrimitive.Trigger bind:ref data-slot="sheet-trigger" {...restProps} />

--- a/crates/pitboss-web/spa/src/lib/components/ui/sheet/sheet.svelte
+++ b/crates/pitboss-web/spa/src/lib/components/ui/sheet/sheet.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from "bits-ui";
+
+	let { open = $bindable(false), ...restProps }: SheetPrimitive.RootProps = $props();
+</script>
+
+<SheetPrimitive.Root bind:open {...restProps} />

--- a/crates/pitboss-web/spa/src/lib/utils.ts
+++ b/crates/pitboss-web/spa/src/lib/utils.ts
@@ -5,6 +5,16 @@ export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs));
 }
 
+/** Mirror the upstream shadcn-svelte type helpers so newer-style
+ *  components installed via the CLI compile against this older base. */
+export type WithElementRef<T, U extends HTMLElement = HTMLElement> = T & {
+  ref?: U | null;
+};
+
+export type WithoutChild<T> = T extends { child?: unknown } ? Omit<T, 'child'> : T;
+export type WithoutChildren<T> = T extends { children?: unknown } ? Omit<T, 'children'> : T;
+export type WithoutChildrenOrChild<T> = WithoutChild<WithoutChildren<T>>;
+
 export function formatUnixSeconds(unix: number, locale = navigator.language): string {
   if (!unix || Number.isNaN(unix)) return '—';
   const d = new Date(unix * 1000);

--- a/crates/pitboss-web/spa/src/routes/runs/[id]/+page.svelte
+++ b/crates/pitboss-web/spa/src/routes/runs/[id]/+page.svelte
@@ -26,6 +26,8 @@
   import PolicyEditor from '$lib/components/policy-editor.svelte';
   import RunTileGrid from '$lib/components/run-tile-grid.svelte';
   import RunGraph from '$lib/components/run-graph.svelte';
+  import RunGraphInspector from '$lib/components/run-graph-inspector.svelte';
+  import type { TaskRecord } from '$lib/api';
   import {
     Card,
     CardContent,
@@ -334,6 +336,19 @@
   // Banner shown when ANOTHER client takes over our slot (we get
   // `Superseded` from the dispatcher right before the socket closes).
   let superseded = $state(false);
+
+  // #260: graph node inspector — selected actor id (null = closed).
+  // Bound through to `RunGraph` (drives the ring on the matching node)
+  // and `RunGraphInspector` (drives the side panel).
+  let selectedTaskId = $state<string | null>(null);
+  const selectedTask = $derived(
+    selectedTaskId
+      ? (tasksToRender.find((t) => t.task_id === selectedTaskId) as TaskRecord | undefined)
+      : undefined
+  );
+  const selectedWorker = $derived(
+    selectedTaskId ? allWorkers.find((w) => w.task_id === selectedTaskId) : undefined
+  );
   let opFeedback = $state<{ kind: 'ok' | 'err'; text: string } | null>(null);
   let opFeedbackTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -749,8 +764,8 @@
             aria-hidden="true"
           ></span>
         </TabsTrigger>
-        <TabsTrigger value="graph">Graph</TabsTrigger>
       {/if}
+      <TabsTrigger value="graph">Graph</TabsTrigger>
       <TabsTrigger value="tasks">Tasks ({tasksToRender.length})</TabsTrigger>
       <TabsTrigger value="manifest">Manifest</TabsTrigger>
       <TabsTrigger value="resolved">Resolved</TabsTrigger>
@@ -951,21 +966,42 @@
         </Card>
       </TabsContent>
 
-      <TabsContent value="graph" class="mt-4">
-        <Card>
-          <CardHeader class="pb-3">
-            <CardTitle class="text-base">Run hierarchy</CardTitle>
-            <CardDescription class="text-xs">
-              Live graph laid out via Dagre. Animated edges trace `running` workers; sublead
-              nodes are marked with a layers icon.
-            </CardDescription>
-          </CardHeader>
-          <CardContent class="pt-0">
-            <RunGraph workers={allWorkers} {storeActivity} {failures} {subleads} />
-          </CardContent>
-        </Card>
-      </TabsContent>
     {/if}
+
+    <!--
+      Graph tab is intentionally OUTSIDE the inProgress gate (#260):
+      the actor topology + per-actor inspector should remain useful for
+      post-mortems on finalized runs, not just live ones. Live overlays
+      (animated edges, store-activity counters) gracefully degrade to
+      empty maps when SSE is dormant; per-actor TaskRecord data comes
+      from `summary.jsonl` which is live-appended and survives finalize.
+    -->
+    <TabsContent value="graph" class="mt-4">
+      <Card>
+        <CardHeader class="pb-3">
+          <CardTitle class="text-base">Run hierarchy</CardTitle>
+          <CardDescription class="text-xs">
+            Actor tree laid out via Dagre. Click a node to open the inspector.
+            {#if inProgress}
+              Animated edges trace `running` workers; sublead nodes carry the layers icon.
+            {:else}
+              Showing every actor recorded for this run, including cancelled / failed states.
+            {/if}
+          </CardDescription>
+        </CardHeader>
+        <CardContent class="pt-0">
+          <RunGraph
+            workers={allWorkers}
+            {storeActivity}
+            {failures}
+            {subleads}
+            tasks={tasksToRender as TaskRecord[]}
+            {selectedTaskId}
+            onSelect={(id) => (selectedTaskId = id)}
+          />
+        </CardContent>
+      </Card>
+    </TabsContent>
 
     <TabsContent value="tasks" class="mt-4">
       <Card>
@@ -1088,4 +1124,20 @@
   </Tabs>
 
   <ApprovalModal {runId} bind:request={activeApproval} />
+
+  <!-- Graph node inspector (#260). Bound to `selectedTaskId`; opens
+       whenever the user clicks a graph node. Lazy-fetches the per-actor
+       events.jsonl on first open. -->
+  <RunGraphInspector
+    {runId}
+    open={selectedTaskId !== null}
+    {selectedTaskId}
+    task={selectedTask}
+    worker={selectedWorker}
+    failure={selectedTaskId ? failures[selectedTaskId] : undefined}
+    sublead={selectedTaskId ? subleads[selectedTaskId] : undefined}
+    activity={selectedTaskId ? storeActivity[selectedTaskId] : undefined}
+    allTasks={tasksToRender as TaskRecord[]}
+    onJumpTo={(id) => (selectedTaskId = id === '' ? null : id)}
+  />
 {/if}

--- a/crates/pitboss-web/src/api/mod.rs
+++ b/crates/pitboss-web/src/api/mod.rs
@@ -27,6 +27,10 @@ pub fn router(state: AppState) -> Router {
         .route("/runs/{run_id}/summary-jsonl", get(runs::summary_jsonl))
         .route("/runs/{run_id}/tasks/{task_id}", get(runs::task_detail))
         .route("/runs/{run_id}/tasks/{task_id}/log", get(runs::task_log))
+        .route(
+            "/runs/{run_id}/tasks/{task_id}/events",
+            get(runs::task_events),
+        )
         .route("/runs/{run_id}/events", get(events::events))
         .route("/runs/{run_id}/control", post(control::send))
         .route("/runs/{run_id}/fork", post(manifests::fork_run))

--- a/crates/pitboss-web/src/api/runs.rs
+++ b/crates/pitboss-web/src/api/runs.rs
@@ -226,6 +226,32 @@ pub async fn task_log(
         .expect("log response"))
 }
 
+/// `GET /api/runs/:run_id/tasks/:task_id/events` — per-actor `events.jsonl`
+/// (pause / continue / reprompt / approval / tool-denied audit trail
+/// written by `pitboss-cli/src/dispatch/events.rs::append_event`). Streamed
+/// verbatim as NDJSON; the SPA's run-graph inspector parses lines as
+/// `TaskEvent` for the lifecycle list (#260).
+///
+/// 404 when the task dir exists but has never had an event appended (the
+/// dispatcher only creates the file on first append).
+pub async fn task_events(
+    State(state): State<AppState>,
+    AxPath((run_id, task_id)): AxPath<(String, String)>,
+) -> ApiResult<Response> {
+    let run_dir = run_dir(state.runs_dir(), &run_id)?;
+    let task_seg = sanitize_id(&task_id)?;
+    let path = run_dir.join("tasks").join(task_seg).join("events.jsonl");
+    match tokio::fs::read(&path).await {
+        Ok(bytes) => Ok(Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, "application/x-ndjson")
+            .body(Body::from(bytes))
+            .expect("ndjson response")),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(ApiError::NotFound),
+        Err(e) => Err(e.into()),
+    }
+}
+
 // ---- helpers -------------------------------------------------------------
 
 fn json_response(bytes: Vec<u8>) -> Response {
@@ -597,6 +623,94 @@ mod tests {
         )
         .await;
         assert!(matches!(resp, Err(ApiError::NotFound)));
+    }
+
+    // ── #260: task_events endpoint ─────────────────────────────────────────
+
+    /// Build a run dir with a synthetic `tasks/<task_id>/events.jsonl`
+    /// containing the given raw lines. The file is written verbatim so the
+    /// test can pin the exact byte stream the endpoint should echo back.
+    fn build_run_with_task_events(
+        run_id: &str,
+        task_id: &str,
+        lines: &[&str],
+    ) -> (TempDir, AppState) {
+        let tmp = TempDir::new().unwrap();
+        let runs_dir = tmp.path().to_path_buf();
+        let task_dir = runs_dir.join(run_id).join("tasks").join(task_id);
+        std::fs::create_dir_all(&task_dir).unwrap();
+        let mut content = String::new();
+        for l in lines {
+            content.push_str(l);
+            content.push('\n');
+        }
+        std::fs::write(task_dir.join("events.jsonl"), content).unwrap();
+        let manifests_dir = tmp.path().join("manifests");
+        std::fs::create_dir_all(&manifests_dir).unwrap();
+        let state = AppState::new(runs_dir, manifests_dir, None);
+        (tmp, state)
+    }
+
+    #[tokio::test]
+    async fn task_events_returns_ndjson_for_existing_file() {
+        let run_id = "01950000-0000-7000-8000-000000000020";
+        let lines = [
+            r#"{"kind":"pause","at":"2026-05-01T00:00:00Z"}"#,
+            r#"{"kind":"continue","at":"2026-05-01T00:00:05Z","new_session_id":"sess-2","prompt_preview":"continue"}"#,
+            r#"{"kind":"tool_denied","at":"2026-05-01T00:00:10Z","tool_name":"Bash","actor_id":"worker-A","reason_kind":"denied_by_profile","reason":"Bash not in profile allowlist"}"#,
+        ];
+        let (_tmp, state) = build_run_with_task_events(run_id, "worker-A", &lines);
+
+        let resp = task_events(
+            State(state),
+            AxPath((run_id.to_string(), "worker-A".to_string())),
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/x-ndjson"
+        );
+        let body = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+        let text = std::str::from_utf8(&body).unwrap();
+        let got: Vec<&str> = text.lines().collect();
+        assert_eq!(got, lines, "endpoint must echo events.jsonl verbatim");
+    }
+
+    /// A task that never had an event appended has no `events.jsonl` file
+    /// (the writer in `dispatch/events.rs::append_event` creates it lazily).
+    /// 404 — the inspector will treat that as "no lifecycle events".
+    #[tokio::test]
+    async fn task_events_returns_404_when_events_jsonl_missing() {
+        let run_id = "01950000-0000-7000-8000-000000000021";
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join(run_id).join("tasks").join("worker-A")).unwrap();
+        let manifests_dir = tmp.path().join("manifests");
+        std::fs::create_dir_all(&manifests_dir).unwrap();
+        let state = AppState::new(tmp.path().to_path_buf(), manifests_dir, None);
+
+        let resp = task_events(
+            State(state),
+            AxPath((run_id.to_string(), "worker-A".to_string())),
+        )
+        .await;
+        assert!(matches!(resp, Err(ApiError::NotFound)));
+    }
+
+    /// A task_id with a path separator must be rejected before the read.
+    /// Same sanitizer the `task_log` endpoint uses (`sanitize_id`).
+    #[tokio::test]
+    async fn task_events_rejects_traversal_in_task_id() {
+        let run_id = "01950000-0000-7000-8000-000000000022";
+        let (_tmp, state) = build_run_with_task_events(run_id, "worker-A", &[]);
+
+        let resp = task_events(
+            State(state),
+            AxPath((run_id.to_string(), "../../etc/passwd".to_string())),
+        )
+        .await;
+        assert!(matches!(resp, Err(ApiError::BadRequest(_))));
     }
 
     /// Malformed JSON lines (e.g., a partial-write tail caught mid-flush)


### PR DESCRIPTION
Closes the core #260 asks: drilldown + post-run persistence + per-node data density. Theming pass / edge tooltips / sticky legend / compact toggle remain open as separate follow-ups.

## Summary

- **Persist beyond the run.** The `{#if inProgress}` gate around the Graph tab is gone; it now reads from `tasksToRender` (live JSONL union) so every actor — including cancelled / failed — stays visible after the dispatcher exits.
- **Per-node data density.** Each tile carries timestamps, token totals, cost, counters, and a failure-reason chip. Layout grew 180×90 → 208×130; existing state-keyed color scheme preserved.
- **Click-to-inspect side panel.** New `run-graph-inspector.svelte` docks via shadcn-svelte Sheet. Shows the full `TaskRecord`, hierarchy with click-jump on parent/child, final message preview, and a lifecycle event list lazy-fetched from a new `GET /api/runs/:id/tasks/:task_id/events` endpoint that streams the per-actor `events.jsonl` (already persisted; never exposed before).

## Architectural notes

- Data path now mirrors how the Tasks tab works post-run: graph component reads from the existing `summary.jsonl` endpoint via the already-derived `tasksToRender`. Live overlays (`storeActivity`, animated edges) gracefully degrade to empty maps when SSE is dormant.
- Inspector is self-contained — no shared primitive with #250's Gantt yet. Designed so it *can* be lifted into a shared `actor-inspector.svelte` if/when #250 lands.
- Adds `WithElementRef` / `WithoutChildrenOrChild` to `$lib/utils` so newer-style shadcn-svelte components installed via the CLI compile against this base.

## Out of scope (filed as follow-ups under #260)

- Theming pass for SVG edge colors (#260 section A).
- Edge tooltips with spawn timestamps + outcome encoding (#260 section D).
- Sticky-on-scroll legend, compact toggle for 50+ actor runs (#260 section E).

## Test plan

- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm run build` — green
- [x] `cargo test --workspace --features pitboss-core/test-support` — full suite green; 3 new tests cover the events endpoint (200/404/path-traversal)
- [x] `cargo lint` clean
- [x] `cargo tidy` clean
- [ ] Manual: open `/runs/<finalized-id>`, confirm Graph tab visible, click any node, side panel opens with full TaskRecord + lifecycle events
- [ ] Manual: live run continuity — start a hierarchical run, confirm graph populates live, let it finish, confirm graph stays visible and the previously-running actor's panel now shows full ended_at + cost

🤖 Generated with [Claude Code](https://claude.com/claude-code)