### PR TITLE
feat(web): Pretty/Raw toggle for stream-json task logs (#260)

### DIFF
--- a/crates/pitboss-web/spa/src/lib/components/log-pretty.svelte
+++ b/crates/pitboss-web/spa/src/lib/components/log-pretty.svelte
@@ -1,0 +1,179 @@
+<script lang="ts">
+  import { parseStreamJson, toolInputPreview, type StreamJsonRow } from '$lib/stream-json';
+  import { Brain, MessageSquare, Wrench, ArrowLeft, AlertTriangle, Cog, Hash } from 'lucide-svelte';
+
+  let {
+    text,
+    hideHooks = true,
+    hideThinking = false,
+    class: className = ''
+  }: {
+    /** Raw NDJSON blob from `tasks/<task_id>/stdout.log`. */
+    text: string;
+    /** Suppress `system/hook_*` rows by default — they're scaffold noise
+     *  for routine log review. Operators can flip the toggle in the
+     *  caller. */
+    hideHooks?: boolean;
+    /** Suppress `assistant.thinking` rows. They're verbose, and post-run
+     *  audits often only want the actions + outputs. */
+    hideThinking?: boolean;
+    class?: string;
+  } = $props();
+
+  const rows = $derived(parseStreamJson(text));
+  const visible = $derived(
+    rows.filter((r) => {
+      if (hideHooks && r.kind === 'hook') return false;
+      if (hideThinking && r.kind === 'thinking') return false;
+      return true;
+    })
+  );
+
+  function truncate(s: string, n = 240): string {
+    if (s.length <= n) return s;
+    return s.slice(0, n - 1) + '…';
+  }
+
+  /** Stable key: index + kind + a tiny content-derived fingerprint so
+   *  re-renders with the same row don't cascade DOM thrash. */
+  function rowKey(r: StreamJsonRow, i: number): string {
+    if (r.kind === 'tool_use') return `${i}-tu-${r.tool_use_id}`;
+    if (r.kind === 'tool_result') return `${i}-tr-${r.tool_use_id}`;
+    return `${i}-${r.kind}`;
+  }
+</script>
+
+<div class={`space-y-1 font-mono text-[11px] leading-relaxed ${className}`}>
+  {#if visible.length === 0}
+    <p class="text-muted-foreground italic">No parseable rows.</p>
+  {:else}
+    {#each visible as r, i (rowKey(r, i))}
+      {#if r.kind === 'init'}
+        <div class="flex items-start gap-2">
+          <Cog class="text-muted-foreground mt-0.5 size-3 shrink-0" />
+          <div class="text-muted-foreground">
+            <span class="font-semibold uppercase tracking-wide">init</span>
+            {#if r.model}
+              · <span class="text-foreground">{r.model}</span>
+            {/if}
+            {#if r.tool_count !== undefined}
+              · {r.tool_count} tools
+            {/if}
+            {#if r.cwd}
+              · cwd <code>{r.cwd}</code>
+            {/if}
+            {#if r.session_id}
+              · sess <code>{r.session_id.slice(0, 8)}…</code>
+            {/if}
+          </div>
+        </div>
+      {:else if r.kind === 'hook'}
+        <div class="flex items-start gap-2">
+          <Hash class="text-muted-foreground/60 mt-0.5 size-3 shrink-0" />
+          <div class="text-muted-foreground/80">
+            <span class="uppercase tracking-wide">hook {r.phase}</span>
+            {#if r.name}
+              · {r.name}
+            {/if}
+            {#if r.outcome}
+              · {r.outcome}
+            {/if}
+            {#if r.exit_code !== undefined}
+              · exit {r.exit_code}
+            {/if}
+          </div>
+        </div>
+      {:else if r.kind === 'system'}
+        <div class="flex items-start gap-2">
+          <Cog class="text-muted-foreground mt-0.5 size-3 shrink-0" />
+          <div class="text-muted-foreground">
+            <span class="uppercase tracking-wide">system</span> · {r.subtype}
+          </div>
+        </div>
+      {:else if r.kind === 'thinking'}
+        <div class="flex items-start gap-2">
+          <Brain class="mt-0.5 size-3 shrink-0 text-purple-500/80" />
+          <div class="text-muted-foreground/90 italic whitespace-pre-wrap">
+            {truncate(r.text, 600)}
+          </div>
+        </div>
+      {:else if r.kind === 'assistant_text'}
+        <div class="flex items-start gap-2">
+          <MessageSquare class="mt-0.5 size-3 shrink-0 text-sky-500/80" />
+          <div class="whitespace-pre-wrap">{r.text}</div>
+        </div>
+      {:else if r.kind === 'tool_use'}
+        <div class="flex items-start gap-2">
+          <Wrench class="mt-0.5 size-3 shrink-0 text-amber-500/80" />
+          <div class="min-w-0 flex-1">
+            <span class="font-semibold text-amber-700 dark:text-amber-400">
+              → {r.tool_name}
+            </span>
+            {#if toolInputPreview(r.input)}
+              <span class="text-foreground/90 ml-1">{toolInputPreview(r.input)}</span>
+            {/if}
+          </div>
+        </div>
+      {:else if r.kind === 'tool_result'}
+        <div class="flex items-start gap-2">
+          <ArrowLeft
+            class="mt-0.5 size-3 shrink-0 {r.is_error
+              ? 'text-destructive'
+              : 'text-emerald-500/80'}"
+          />
+          <div class="min-w-0 flex-1">
+            <span
+              class="font-semibold {r.is_error
+                ? 'text-destructive'
+                : 'text-emerald-700 dark:text-emerald-400'}"
+            >
+              ← {r.is_error ? 'error' : 'result'}
+            </span>
+            {#if r.content}
+              <span class="text-muted-foreground ml-1 whitespace-pre-wrap">
+                {truncate(r.content, 400)}
+              </span>
+            {/if}
+          </div>
+        </div>
+      {:else if r.kind === 'user_message'}
+        <div class="flex items-start gap-2">
+          <MessageSquare class="text-muted-foreground mt-0.5 size-3 shrink-0" />
+          <div class="text-muted-foreground italic whitespace-pre-wrap">
+            {truncate(r.text, 400)}
+          </div>
+        </div>
+      {:else if r.kind === 'result'}
+        <div class="flex items-start gap-2">
+          {#if r.is_error}
+            <AlertTriangle class="text-destructive mt-0.5 size-3 shrink-0" />
+            <div class="text-destructive font-semibold">
+              [done · error{r.subtype ? ` · ${r.subtype}` : ''}]
+              {#if r.text}<span class="font-normal ml-1">{truncate(r.text, 240)}</span>{/if}
+            </div>
+          {:else}
+            <Cog class="text-emerald-500 mt-0.5 size-3 shrink-0" />
+            <div class="font-semibold text-emerald-700 dark:text-emerald-400">
+              [done · success]
+              {#if r.text}<span class="text-foreground font-normal ml-1">{truncate(r.text, 240)}</span>{/if}
+            </div>
+          {/if}
+        </div>
+      {:else if r.kind === 'rate_limit'}
+        <div class="flex items-start gap-2">
+          <AlertTriangle class="text-amber-500 mt-0.5 size-3 shrink-0" />
+          <div class="text-amber-700 dark:text-amber-400">
+            rate-limited · {r.status}{r.resets_at ? ` · resets at ${r.resets_at}` : ''}
+          </div>
+        </div>
+      {:else}
+        <div class="flex items-start gap-2">
+          <Hash class="text-muted-foreground/60 mt-0.5 size-3 shrink-0" />
+          <div class="text-muted-foreground/80">
+            unknown: <code class="text-[10px]">{truncate(JSON.stringify(r.raw), 200)}</code>
+          </div>
+        </div>
+      {/if}
+    {/each}
+  {/if}
+</div>

--- a/crates/pitboss-web/spa/src/lib/components/run-graph-inspector.svelte
+++ b/crates/pitboss-web/spa/src/lib/components/run-graph-inspector.svelte
@@ -21,6 +21,7 @@
     type WorkerEntry
   } from '$lib/api';
   import { costUsd, fmtCost } from '$lib/prices';
+  import LogPretty from '$lib/components/log-pretty.svelte';
   import { ExternalLink, ArrowLeftRight, AlertTriangle, Pause, Play } from 'lucide-svelte';
 
   let {
@@ -108,8 +109,17 @@
    *  switches to a different actor. Useful for inspecting a stable
    *  window without the view jumping on every poll. */
   let tailPaused = $state(false);
-  /** Pre element bound for auto-scroll-to-bottom on content change. */
-  let logPaneEl = $state<HTMLPreElement | null>(null);
+  /** Scroll container bound for auto-scroll-to-bottom on content change.
+   *  Wraps either the raw `<pre>` or the `LogPretty` component so the
+   *  scroll logic is identical across modes. */
+  let logPaneEl = $state<HTMLDivElement | null>(null);
+  /** Renderer mode. Pretty parses each NDJSON line via stream-json.ts
+   *  and renders kind-styled rows; Raw just dumps the bytes. */
+  let logFormat = $state<'pretty' | 'raw'>('pretty');
+  /** Hide hook noise + thinking blocks in pretty mode. Off by default
+   *  (hide hooks; show thinking). */
+  let hideHooks = $state(true);
+  let hideThinking = $state(false);
   /** Whether the most recent scroll position is at the bottom. If the
    *  user scrolled up to read history, polling continues but the view
    *  stays put. */
@@ -483,6 +493,32 @@
               </span>
             </h3>
             <div class="flex items-center gap-1">
+              <!-- Pretty / Raw toggle (#260 follow-up). Default Pretty:
+                   the raw stream-json is dense and noisy for log
+                   review; the pretty renderer parses each line and
+                   collapses tool_use / tool_result / assistant text /
+                   thinking into one styled row each. Raw stays a click
+                   away for debugging the wire format. -->
+              <div class="bg-muted/30 mr-1 inline-flex items-center rounded text-[10px]">
+                <button
+                  class="px-1.5 py-0.5 rounded {logFormat === 'pretty'
+                    ? 'bg-background border border-border shadow-sm font-medium'
+                    : 'text-muted-foreground hover:text-foreground'}"
+                  onclick={() => (logFormat = 'pretty')}
+                  title="Human-readable rows (parsed stream-json)"
+                >
+                  Pretty
+                </button>
+                <button
+                  class="px-1.5 py-0.5 rounded {logFormat === 'raw'
+                    ? 'bg-background border border-border shadow-sm font-medium'
+                    : 'text-muted-foreground hover:text-foreground'}"
+                  onclick={() => (logFormat = 'raw')}
+                  title="Raw NDJSON as written by the claude subprocess"
+                >
+                  Raw
+                </button>
+              </div>
               {#if inProgress && (worker || task?.status === 'Running' || task?.status === 'Paused' || task?.status === 'Frozen')}
                 <Button
                   variant="ghost"
@@ -518,6 +554,18 @@
               </Button>
             </div>
           </div>
+          {#if logFormat === 'pretty'}
+            <div class="text-muted-foreground flex items-center gap-3 text-[10px]">
+              <label class="inline-flex cursor-pointer items-center gap-1">
+                <input type="checkbox" class="size-3" bind:checked={hideHooks} />
+                hide hooks
+              </label>
+              <label class="inline-flex cursor-pointer items-center gap-1">
+                <input type="checkbox" class="size-3" bind:checked={hideThinking} />
+                hide thinking
+              </label>
+            </div>
+          {/if}
           {#if logError}
             <p class="text-destructive text-[11px]">{logError}</p>
           {:else if logLoading && logText.length === 0}
@@ -527,10 +575,18 @@
               {isLogTailing ? 'Waiting for first output…' : 'Log is empty.'}
             </p>
           {:else}
-            <pre
+            <div
               bind:this={logPaneEl}
               onscroll={onLogScroll}
-              class="bg-muted/40 max-h-72 overflow-auto rounded p-2 font-mono text-[10px] leading-relaxed whitespace-pre-wrap">{logText}</pre>
+              class="bg-muted/40 max-h-72 overflow-auto rounded p-2"
+            >
+              {#if logFormat === 'pretty'}
+                <LogPretty text={logText} {hideHooks} {hideThinking} />
+              {:else}
+                <pre
+                  class="font-mono text-[10px] leading-relaxed whitespace-pre-wrap m-0">{logText}</pre>
+              {/if}
+            </div>
             {#if !stickToBottom}
               <button
                 class="text-sky-700 dark:text-sky-400 mt-1 text-[10px] underline hover:no-underline"

--- a/crates/pitboss-web/spa/src/lib/stream-json.ts
+++ b/crates/pitboss-web/spa/src/lib/stream-json.ts
@@ -1,0 +1,254 @@
+// Parser for the `claude --output-format stream-json` line dialect that
+// pitboss captures verbatim into `tasks/<task_id>/stdout.log`. Mirrors
+// the variants in `pitboss_core::parser::Event` (events.rs) but with
+// the extra detail the SPA needs for human display: tool_use input,
+// tool_result content, the thinking-vs-text split inside an assistant
+// message.
+//
+// Unknown shapes fall through to `kind: 'unknown'` rather than throw —
+// claude's wire format evolves and one new field shouldn't blank an
+// operator's whole log view.
+
+/** One parsed line from `stdout.log`. Discriminated by `kind`. */
+export type StreamJsonRow =
+  /** `type:"system", subtype:"init"` — once per session start. */
+  | {
+      kind: 'init';
+      cwd?: string;
+      model?: string;
+      session_id?: string;
+      tool_count?: number;
+      claude_code_version?: string;
+    }
+  /** `type:"system", subtype:"hook_started"|"hook_response"` — Claude's
+   *  pre/post hook scaffold. Verbose; usually noise for log review. */
+  | {
+      kind: 'hook';
+      phase: 'started' | 'response';
+      name?: string;
+      event?: string;
+      outcome?: string;
+      exit_code?: number;
+    }
+  /** Other system events (rate-limit notices, end-of-turn etc.). */
+  | { kind: 'system'; subtype: string; raw: unknown }
+  /** assistant.content[i].type === 'thinking' */
+  | { kind: 'thinking'; text: string }
+  /** assistant.content[i].type === 'text' */
+  | { kind: 'assistant_text'; text: string }
+  /** assistant.content[i].type === 'tool_use' */
+  | { kind: 'tool_use'; tool_name: string; tool_use_id: string; input: unknown }
+  /** user.content[i].type === 'tool_result' (carries previous tool's output) */
+  | { kind: 'tool_result'; tool_use_id: string; content: string; is_error: boolean }
+  /** Free-form user message (rare in pitboss runs but possible during reprompt). */
+  | { kind: 'user_message'; text: string }
+  /** Final-turn `type:"result"` row. */
+  | {
+      kind: 'result';
+      subtype?: string;
+      session_id?: string;
+      text?: string;
+      is_error: boolean;
+    }
+  /** First-class rate-limit row (Claude Code emits these inline). */
+  | { kind: 'rate_limit'; status: string; resets_at?: number }
+  /** Anything else. The `raw` payload is JSON-stringified for the toggle. */
+  | { kind: 'unknown'; raw: unknown };
+
+/** Parse one stream-json line. Returns `null` for empty / blank lines or
+ *  bytes that don't parse as JSON at all (partial-write tail, etc.) so
+ *  the caller can `filter(Boolean)` them out. */
+export function parseStreamJsonLine(line: string): StreamJsonRow | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  let obj: unknown;
+  try {
+    obj = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  if (!obj || typeof obj !== 'object') return null;
+  const o = obj as Record<string, unknown>;
+  const type = typeof o.type === 'string' ? o.type : '';
+
+  if (type === 'system') return parseSystem(o);
+  if (type === 'assistant') return parseAssistant(o);
+  if (type === 'user') return parseUser(o);
+  if (type === 'result') return parseResult(o);
+  if (type === 'rate_limit') return parseRateLimit(o);
+
+  return { kind: 'unknown', raw: obj };
+}
+
+/** Parse all lines in a NDJSON blob. Skips unparseable / blank lines. */
+export function parseStreamJson(blob: string): StreamJsonRow[] {
+  const rows: StreamJsonRow[] = [];
+  for (const line of blob.split('\n')) {
+    const row = parseStreamJsonLine(line);
+    if (row) rows.push(row);
+  }
+  return rows;
+}
+
+// ---- internals ----------------------------------------------------------
+
+function parseSystem(o: Record<string, unknown>): StreamJsonRow {
+  const subtype = typeof o.subtype === 'string' ? o.subtype : '';
+  if (subtype === 'init') {
+    const tools = Array.isArray(o.tools) ? o.tools : null;
+    return {
+      kind: 'init',
+      cwd: strField(o, 'cwd'),
+      model: strField(o, 'model'),
+      session_id: strField(o, 'session_id'),
+      tool_count: tools ? tools.length : undefined,
+      claude_code_version: strField(o, 'claude_code_version')
+    };
+  }
+  if (subtype === 'hook_started' || subtype === 'hook_response') {
+    return {
+      kind: 'hook',
+      phase: subtype === 'hook_started' ? 'started' : 'response',
+      name: strField(o, 'hook_name'),
+      event: strField(o, 'hook_event'),
+      outcome: strField(o, 'outcome'),
+      exit_code: numField(o, 'exit_code')
+    };
+  }
+  return { kind: 'system', subtype: subtype || '(unknown)', raw: o };
+}
+
+function parseAssistant(o: Record<string, unknown>): StreamJsonRow {
+  const message = (o.message as Record<string, unknown> | undefined) ?? null;
+  if (!message) return { kind: 'unknown', raw: o };
+  const content = Array.isArray(message.content) ? message.content : [];
+  // Each line emits one block at a time in claude's stream-json mode, so
+  // `content` typically has length 1. We render the first non-empty
+  // block we recognise; multi-block lines fall back to assistant_text.
+  for (const block of content) {
+    if (!block || typeof block !== 'object') continue;
+    const b = block as Record<string, unknown>;
+    const t = typeof b.type === 'string' ? b.type : '';
+    if (t === 'thinking') {
+      const text = strField(b, 'thinking') ?? '';
+      if (text) return { kind: 'thinking', text };
+    } else if (t === 'text') {
+      const text = strField(b, 'text') ?? '';
+      if (text) return { kind: 'assistant_text', text };
+    } else if (t === 'tool_use') {
+      return {
+        kind: 'tool_use',
+        tool_name: strField(b, 'name') ?? '?',
+        tool_use_id: strField(b, 'id') ?? '',
+        input: b.input ?? null
+      };
+    }
+  }
+  return { kind: 'unknown', raw: o };
+}
+
+function parseUser(o: Record<string, unknown>): StreamJsonRow {
+  const message = (o.message as Record<string, unknown> | undefined) ?? null;
+  if (!message) return { kind: 'unknown', raw: o };
+  const content = message.content;
+  if (typeof content === 'string') {
+    return { kind: 'user_message', text: content };
+  }
+  if (Array.isArray(content)) {
+    for (const block of content) {
+      if (!block || typeof block !== 'object') continue;
+      const b = block as Record<string, unknown>;
+      const t = typeof b.type === 'string' ? b.type : '';
+      if (t === 'tool_result') {
+        return {
+          kind: 'tool_result',
+          tool_use_id: strField(b, 'tool_use_id') ?? '',
+          content: extractToolResultText(b.content),
+          is_error: b.is_error === true
+        };
+      }
+      if (t === 'text') {
+        const text = strField(b, 'text') ?? '';
+        if (text) return { kind: 'user_message', text };
+      }
+    }
+  }
+  return { kind: 'unknown', raw: o };
+}
+
+function parseResult(o: Record<string, unknown>): StreamJsonRow {
+  return {
+    kind: 'result',
+    subtype: strField(o, 'subtype'),
+    session_id: strField(o, 'session_id'),
+    text: strField(o, 'result') ?? strField(o, 'text'),
+    is_error: o.is_error === true || strField(o, 'subtype') === 'error_during_execution'
+  };
+}
+
+function parseRateLimit(o: Record<string, unknown>): StreamJsonRow {
+  return {
+    kind: 'rate_limit',
+    status: strField(o, 'status') ?? 'rate_limited',
+    resets_at: numField(o, 'resets_at')
+  };
+}
+
+/** Tool-result content is sometimes a string, sometimes an array of
+ *  `{type: 'text', text: '...'}` blocks. Flatten to a single string. */
+function extractToolResultText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    const parts: string[] = [];
+    for (const block of content) {
+      if (typeof block === 'string') {
+        parts.push(block);
+      } else if (block && typeof block === 'object') {
+        const b = block as Record<string, unknown>;
+        const text = strField(b, 'text');
+        if (text) parts.push(text);
+      }
+    }
+    return parts.join('\n');
+  }
+  return '';
+}
+
+function strField(o: Record<string, unknown>, key: string): string | undefined {
+  const v = o[key];
+  return typeof v === 'string' ? v : undefined;
+}
+
+function numField(o: Record<string, unknown>, key: string): number | undefined {
+  const v = o[key];
+  return typeof v === 'number' ? v : undefined;
+}
+
+/** Compact one-line preview of a tool_use input object. Truncates to
+ *  `maxLen` chars; uses `command` / `file_path` / `pattern` when present
+ *  (Bash / Read / Grep) so the row reads naturally. */
+export function toolInputPreview(input: unknown, maxLen = 120): string {
+  if (!input || typeof input !== 'object') return '';
+  const o = input as Record<string, unknown>;
+  // Common fields used by built-in claude tools.
+  const ranked = ['command', 'file_path', 'pattern', 'path', 'url', 'query', 'prompt'];
+  for (const key of ranked) {
+    const v = o[key];
+    if (typeof v === 'string' && v.length > 0) {
+      return truncate(v, maxLen);
+    }
+  }
+  // Fallback: first string field, in declaration order.
+  for (const key of Object.keys(o)) {
+    const v = o[key];
+    if (typeof v === 'string' && v.length > 0) {
+      return truncate(`${key}=${v}`, maxLen);
+    }
+  }
+  return truncate(JSON.stringify(o), maxLen);
+}
+
+function truncate(s: string, maxLen: number): string {
+  const collapsed = s.replace(/\s+/g, ' ').trim();
+  return collapsed.length > maxLen ? collapsed.slice(0, maxLen - 1) + '…' : collapsed;
+}

--- a/crates/pitboss-web/spa/src/routes/runs/[id]/tasks/[task_id]/+page.svelte
+++ b/crates/pitboss-web/spa/src/routes/runs/[id]/tasks/[task_id]/+page.svelte
@@ -5,6 +5,7 @@
   import { Button } from '$lib/components/ui/button';
   import { Badge } from '$lib/components/ui/badge';
   import { ArrowLeft, ChevronRight, RefreshCw, AlertTriangle, Download } from 'lucide-svelte';
+  import LogPretty from '$lib/components/log-pretty.svelte';
 
   const runId = $derived(page.params.id ?? '');
   const taskId = $derived(page.params.task_id ?? '');
@@ -14,6 +15,12 @@
   let loading = $state(false);
   let tail = $state(true);
   let detail = $state<TaskRecord | null>(null);
+  // #260 follow-up: render mode for the log body. Pretty parses each
+  // stream-json line into a styled row; Raw keeps the original
+  // dispatch-side bytes for wire-format debugging.
+  let logFormat = $state<'pretty' | 'raw'>('pretty');
+  let hideHooks = $state(true);
+  let hideThinking = $state(false);
   const limit = 256 * 1024; // 256 KiB
 
   async function load() {
@@ -88,6 +95,26 @@
     </p>
   </div>
   <div class="flex items-center gap-2">
+    <div class="bg-muted/30 inline-flex items-center rounded text-xs">
+      <button
+        class="px-2 py-1 rounded {logFormat === 'pretty'
+          ? 'bg-background border border-border shadow-sm font-medium'
+          : 'text-muted-foreground hover:text-foreground'}"
+        onclick={() => (logFormat = 'pretty')}
+        title="Human-readable rows"
+      >
+        Pretty
+      </button>
+      <button
+        class="px-2 py-1 rounded {logFormat === 'raw'
+          ? 'bg-background border border-border shadow-sm font-medium'
+          : 'text-muted-foreground hover:text-foreground'}"
+        onclick={() => (logFormat = 'raw')}
+        title="Raw NDJSON"
+      >
+        Raw
+      </button>
+    </div>
     <Badge
       variant={tail ? 'default' : 'outline'}
       class="cursor-pointer"
@@ -189,6 +216,20 @@
         <p class="text-muted-foreground py-6 text-center text-sm">Loading log…</p>
       {:else if log.length === 0}
         <p class="text-muted-foreground py-6 text-center text-sm">Log is empty.</p>
+      {:else if logFormat === 'pretty'}
+        <div class="text-muted-foreground mb-2 flex items-center gap-3 text-xs">
+          <label class="inline-flex cursor-pointer items-center gap-1">
+            <input type="checkbox" class="size-3.5" bind:checked={hideHooks} />
+            hide hooks
+          </label>
+          <label class="inline-flex cursor-pointer items-center gap-1">
+            <input type="checkbox" class="size-3.5" bind:checked={hideThinking} />
+            hide thinking
+          </label>
+        </div>
+        <div class="bg-muted/40 max-h-[75vh] overflow-auto rounded-md p-4">
+          <LogPretty text={log} {hideHooks} {hideThinking} />
+        </div>
       {:else}
         <pre
           class="bg-muted/40 max-h-[75vh] overflow-auto rounded-md p-4 text-xs leading-relaxed font-mono"><code


### PR DESCRIPTION
Stacks on **#420** — that PR adds the inline log pane this one densifies.
If #420 merges first, this PR rebases cleanly to main; otherwise it'll
look like a single ~530-line diff at review time.

## Summary

Both task-log surfaces (graph inspector inline pane, standalone task page) get a **Pretty / Raw** toggle. Pretty is default. Raw is the existing dump.

Pretty parses each NDJSON line via a new `$lib/stream-json.ts` (mirrors `pitboss_core::parser::Event` with extra detail for display) and renders kind-styled rows:

| Kind | Render |
|---|---|
| `init` | model · tool count · cwd · session id |
| `hook started/response` | muted; suppressed by default via "hide hooks" |
| `thinking` | italic, purple icon, truncated; "hide thinking" toggle |
| `assistant_text` | plain prose, sky icon |
| `tool_use` | `→ Bash: ls -la` (canonical-field preview: command / file_path / pattern / path / url / query / prompt) |
| `tool_result` | `← result: ...` or red `← error: ...` truncated |
| `result` | `[done · success]` / `[done · error]` |
| `rate_limit` | first-class amber row |
| unknown | JSON snippet fallback so wire-format additions don't blank the view |

## Why no backend change

The renderer is a pure transform of the bytes the existing `/log` endpoint already returns. Pushing parse+format to the server would couple every wire-format tweak to a dispatcher rebuild; client-side keeps it loose.

## Test plan

- [x] `npm run check` clean
- [x] `npm run build` clean
- [x] `cargo lint` clean, `cargo tidy` clean
- [ ] Manual: pretty mode renders the smoke-run log readably; raw mode still shows the original NDJSON; toggling between them preserves scroll position; "hide hooks" / "hide thinking" toggles work.
- [ ] Manual: standalone task page (`/runs/<id>/tasks/<task_id>`) renders both modes the same way the inspector does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)