### PR TITLE
docs(readme): add pitboss-web to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ dispatcher (`pitboss`) fans out `claude` subprocesses under a concurrency
 cap, captures structured artifacts per run, and — in hierarchical mode —
 lets a **lead** dynamically spawn more workers via MCP. The TUI
 (`pitboss-tui`) gives the floor view: tile grid, live log tailing, budget +
-token counters.
+token counters. The web console (`pitboss-web`) is a single-binary axum
+server with an embedded SvelteKit SPA — manifest wizard, run dashboards,
+the post-run actor inspector, and a cross-run failures view.
 
 Language models are stochastic. A well-run pit is not. Give the house a
 clear manifest, a budget, and a prompt — the pit turns variance into
@@ -63,14 +65,16 @@ consistently usable output.
 ### Via shell installer (recommended)
 
 Pitboss releases ship through [`cargo-dist`][cargo-dist], which
-produces two `curl | sh` installers per release (one per binary):
+produces a `curl | sh` installer per binary:
 
 ```bash
 curl -LsSf https://github.com/SDS-Mode/pitboss/releases/latest/download/pitboss-cli-installer.sh | sh
 curl -LsSf https://github.com/SDS-Mode/pitboss/releases/latest/download/pitboss-tui-installer.sh | sh
+curl -LsSf https://github.com/SDS-Mode/pitboss/releases/latest/download/pitboss-web-installer.sh | sh
 
 pitboss version
 pitboss-tui --version
+pitboss-web --version
 ```
 
 Each installer detects your platform, downloads the matching `tar.xz`
@@ -83,6 +87,7 @@ Current target matrix: `x86_64-unknown-linux-gnu`,
 ```bash
 brew install SDS-Mode/pitboss/pitboss-cli
 brew install SDS-Mode/pitboss/pitboss-tui
+brew install SDS-Mode/pitboss/pitboss-web
 ```
 
 Formulae are auto-published to the [`SDS-Mode/homebrew-pitboss`][tap] tap
@@ -108,8 +113,9 @@ A variant image `ghcr.io/sds-mode/pitboss-with-claude` bundles a pinned Claude C
 
 ### Direct tarball download
 
-Prefer the tarball? Grab `pitboss-cli-<target>.tar.xz` or
-`pitboss-tui-<target>.tar.xz` from the [latest release][releases]:
+Prefer the tarball? Grab `pitboss-cli-<target>.tar.xz`,
+`pitboss-tui-<target>.tar.xz`, or `pitboss-web-<target>.tar.xz` from the
+[latest release][releases]:
 
 ```bash
 curl -L https://github.com/SDS-Mode/pitboss/releases/latest/download/pitboss-cli-x86_64-unknown-linux-gnu.tar.xz \
@@ -127,6 +133,15 @@ git clone https://github.com/SDS-Mode/pitboss.git
 cd pitboss
 cargo install --path crates/pitboss-cli
 cargo install --path crates/pitboss-tui
+cargo install --path crates/pitboss-web
+```
+
+`pitboss-web` embeds the SvelteKit SPA via `rust-embed` at build time —
+build the SPA once before installing from source:
+
+```bash
+(cd crates/pitboss-web/spa && npm install && npm run build)
+cargo install --path crates/pitboss-web
 ```
 
 ## Subcommands


### PR DESCRIPTION
## Summary

- The `pitboss-web` binary has shipped via cargo-dist since v0.13.0 — the v0.13.0 release contains `pitboss-web-<target>.tar.xz`, `pitboss-web-installer.sh`, and `pitboss-web.rb` — but the README only listed install paths for `pitboss-cli` and `pitboss-tui`.
- Add `pitboss-web` to: the upfront binaries paragraph, the shell-installer block, the Homebrew block, the direct-tarball block, and the from-source block (with a note that the embedded SPA needs `npm run build` before `cargo install`).

## Test plan

- [ ] Render the README on github.com and confirm the install blocks read cleanly.
- [ ] Spot-check that the three installer URLs and three brew formula names match the v0.13.0 release assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)