### PR TITLE
fix(ci): pr-gate stops requiring test job on docs-only PRs

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -89,7 +89,13 @@ jobs:
             //               category fired (e.g. "code" or "book")
             // Adding a required check: append a row here. Removing: delete.
             const required = [
-              { name: 'test + lint + fmt',               always: true },
+              // 'test + lint + fmt' lives in ci.yml which has its own
+              // paths-ignore for CHANGELOG.md / README.md. Hardcoding it as
+              // `always: true` here meant docs-only PRs would wait 25 min
+              // for a check that never runs, then fail. Treat it as code-
+              // gated so the gate's path filter and the CI workflow's path
+              // filter agree.
+              { name: 'test + lint + fmt',               requires: 'code' },
               { name: 'plan',                            always: true },
               { name: 'Build runtime (linux-amd64)',     requires: 'code' },
               { name: 'Build runtime (linux-arm64)',     requires: 'code' },


### PR DESCRIPTION
## Summary

- \`ci.yml\` has \`paths-ignore: ['CHANGELOG.md', 'README.md']\` so the \`test + lint + fmt\` job never runs on docs-only PRs.
- \`pr-gate.yml\` hardcoded that check as \`always: true\`, so the gate waited the full 25-minute budget for a check that would never run and then failed. Every docs-only PR was getting blocked until admin override.
- Treat \`test + lint + fmt\` as \`requires: 'code'\` so the gate's path filter and the CI workflow's path filter agree. Code PRs still gate on it; docs PRs no longer hang.

Discovered while waiting for #423 (README pitboss-web install) to land — same fix unblocks every future docs-only PR.

## Test plan

- [ ] This PR itself touches \`.github/workflows/pr-gate.yml\` (not in \`paths-ignore\`), so the test job WILL run and the gate WILL wait for it. Green gate proves code-path behavior is unchanged.
- [ ] After merge, rerun pr-gate on #423; it should pass without waiting on the never-running test job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)