### PR TITLE
fix(tui): wrap connect timeout in async block (panic on launch)

### DIFF
--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -93,11 +93,20 @@ pub fn run(run_dir: PathBuf, run_id: String) -> anyhow::Result<()> {
                 // "no control" status, and a future SwitchRun/reset
                 // can rebuild it cheaply — same UX as before for that
                 // case but without the stall.
+                // `tokio::time::timeout(...)` registers with the timer
+                // driver at construction time and panics ("no reactor
+                // running") if called outside a runtime context. The
+                // argument to `block_on` is evaluated BEFORE block_on
+                // enters the runtime, so we wrap in an `async` block to
+                // ensure the timeout is constructed *inside* the runtime.
                 runtime
-                    .block_on(tokio::time::timeout(
-                        std::time::Duration::from_millis(200),
-                        crate::control::ControlClient::connect(socket_path, bridge_tx),
-                    ))
+                    .block_on(async {
+                        tokio::time::timeout(
+                            std::time::Duration::from_millis(200),
+                            crate::control::ControlClient::connect(socket_path, bridge_tx),
+                        )
+                        .await
+                    })
                     .ok()
                     .and_then(Result::ok)
                     .map(Arc::new)


### PR DESCRIPTION
## Summary

- `tokio::time::timeout(...)` constructed outside a runtime context panics with *"no reactor running"* — its argument was being evaluated before `block_on` entered the runtime, so every `pitboss-tui` launch crashed on the connect-control path. v0.13.0 ships unusable.
- Wraps the timeout in an `async { … .await }` so it's constructed inside the runtime. Adds a comment at the call site explaining the gotcha.
- Regression introduced in `93b6391` (#154 connect-timeout audit). Existing tests didn't cover the connect path; `screenshot` and `list` skip it.

Closes #427.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p pitboss-tui --all-targets --all-features -- -D warnings` clean
- [x] `cargo install --path crates/pitboss-tui --force`, verified `pitboss-tui` launches against an active run with no panic and connects to the control socket
- [ ] Reviewer: confirm on macOS — the panic is OS-agnostic but worth a sanity check
- [ ] Follow-up (separate PR): extract `connect_control` into a free function so it can be exercised by an integration test that owns a real `Runtime` + temp socket. Out of scope here — keeps this fix mergeable for a v0.13.1 patch release.

## Severity

Critical — `pitboss-tui` is unusable for any user on v0.13.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)