### PR TITLE
fix(web): dedupe summary.jsonl rows by task_id (run-view tabs crash)

### DIFF
--- a/crates/pitboss-web/spa/src/routes/runs/[id]/+page.svelte
+++ b/crates/pitboss-web/spa/src/routes/runs/[id]/+page.svelte
@@ -164,19 +164,34 @@
 
   // Parsed JSONL of in-progress task records — lets the Tasks tab show
   // partial state while the run hasn't finalized.
+  //
+  // Dedupe by task_id, keeping the LAST entry per id. summary.jsonl is
+  // append-only and certain failure recovery paths (reprompt → cancel →
+  // respawn, hook-failure-on-cancel) can produce multiple rows for the
+  // same task_id. Keyed `{#each}` blocks downstream require unique keys,
+  // so collapse here at the parse boundary. (#425)
   const liveTasks = $derived<Array<Record<string, any>>>(
     summaryJsonl
-      ? summaryJsonl
-          .split('\n')
-          .filter((l) => l.trim().length > 0)
-          .map((l) => {
-            try {
-              return JSON.parse(l) as Record<string, any>;
-            } catch {
-              return {};
-            }
-          })
-          .filter((o) => Object.keys(o).length > 0)
+      ? Array.from(
+          summaryJsonl
+            .split('\n')
+            .filter((l) => l.trim().length > 0)
+            .map((l) => {
+              try {
+                return JSON.parse(l) as Record<string, any>;
+              } catch {
+                return {};
+              }
+            })
+            .filter((o) => Object.keys(o).length > 0)
+            .reduce((m: Map<string | symbol, Record<string, any>>, o) => {
+              // Records without a task_id keep their own slot via Symbol()
+              // so we don't collapse unrelated parse-error rows together.
+              const key = (o.task_id as string | undefined) ?? Symbol();
+              return m.set(key, o);
+            }, new Map())
+            .values()
+        )
       : []
   );
 
@@ -1023,7 +1038,7 @@
               </TableRow>
             </TableHeader>
             <TableBody>
-              {#each tasksToRender as t (t.task_id ?? Math.random())}
+              {#each tasksToRender as t, idx ((t.task_id ?? '') + '#' + idx)}
                 <TableRow>
                   <TableCell>
                     <code class="text-xs">{t.task_id ?? '—'}</code>


### PR DESCRIPTION
## Summary

- `summary.jsonl` is append-only; recovery paths (reprompt → cancel → respawn, hook-failure-on-cancel) can produce multiple rows per `task_id`. Svelte 5's keyed `{#each}` threw `each_key_duplicate` on Tasks-tab mount, jamming every non-Live tab on the run-detail view.
- Dedupes `liveTasks` at the parse boundary on `task_id`, keeping the latest row per id. `summary.jsonl` is canonical-by-most-recent so the latest entry reflects current state.
- Belt-and-suspenders: change the Tasks-tab `{#each}` key to `(t.task_id ?? '') + '#' + idx` so the renderer survives even if a future change re-introduces duplicate rows.

Closes #425.

## Repro that surfaced this

Live D&D dispatch run `019e0868-0c21-7552-9a46-30a159b800b0`. Operator reprompted a worker; cancel-path SessionEnd hook (host-scope `~/.claude/settings.json` referencing a binary that doesn't exist in the container — see #426) failed and pitboss promoted the hook stderr to `failure_reason`, producing a `Cancelled` row + a `Failed` row for the same `task_id`. Result: Live tab worked; Tasks/Graph/Manifest/Resolved/Summary tabs all blank.

After the fix: the same run renders all tabs correctly with the duplicate row collapsed to its latest entry. Verified locally against the running run before patch (broken) and after rebuild (working).

## Test plan

- [x] Hand-validate against the live D&D run with two `summary.jsonl` rows for `worker-019e0875-…`: all tabs now render after rebuild + restart of pitboss-web.
- [ ] Reviewer: an integration test that crafts a `summary.jsonl` fixture with a duplicate `task_id`, opens the run page, and asserts each non-Live tab body mounts without throwing. The current SPA test surface in `crates/pitboss-web/spa/` is thin — adding a Playwright/Vitest harness for this is bigger than this PR; calling it out as a gap rather than blocking on it.
- [ ] Reviewer: confirm `tasksToRender.length` displayed in the Tasks-tab heading still matches the unique-task count (it does — `tasksToRender = taskList.length > 0 ? taskList : liveTasks` and `liveTasks` is now deduped at source).

## Related

- #426 — host user-scope hooks leaking into containers. Fixing #426 removes the trigger condition that produces duplicate rows; this PR makes the renderer robust to any other path that might produce them.
- #427 — pitboss-tui reactor panic (PR #428). Independent regression in v0.13.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)