### PR TITLE
fix(cli): exclude host user-scope claude settings inside containers

### DIFF
--- a/crates/pitboss-cli/src/dispatch/container.rs
+++ b/crates/pitboss-cli/src/dispatch/container.rs
@@ -17,6 +17,32 @@ use crate::manifest::schema::ContainerConfig;
 const DEFAULT_IMAGE: &str = "ghcr.io/sds-mode/pitboss-with-claude:latest";
 const PITBOSS_CONTAINER_USER_UID: u32 = 1000;
 
+/// Cheap runtime probe for "are we inside a Docker/Podman container?".
+/// Both runtimes write a marker file at one of these paths during
+/// container init; the absence of both is reliable for "host process".
+pub(crate) fn detect_in_container() -> bool {
+    Path::new("/run/.containerenv").exists() || Path::new("/.dockerenv").exists()
+}
+
+/// Additional CLI args to pass to every `claude … -p` spawn so the host
+/// operator's user-scope `~/.claude/settings.json` (hooks, etc.) doesn't
+/// leak into containerized runs.
+///
+/// `--setting-sources project,local` excludes the `user` scope where
+/// host hooks live, while keeping project- and local-scope settings
+/// active. OAuth/keychain credentials are not loaded via setting-sources
+/// so the bind-mounted `~/.claude/credentials.json` continues to work.
+///
+/// Returns an empty vec on the host so flat-mode `pitboss dispatch` is
+/// unchanged. (#426)
+pub(crate) fn claude_setting_sources_args(in_container: bool) -> Vec<String> {
+    if in_container {
+        vec!["--setting-sources".into(), "project,local".into()]
+    } else {
+        Vec::new()
+    }
+}
+
 /// Entry point called from `main.rs` for `pitboss container-dispatch`.
 ///
 /// Validates that the manifest has a `[container]` section, then builds and
@@ -438,6 +464,23 @@ mod tests {
     use std::sync::atomic::{AtomicU32, Ordering};
 
     static TEST_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    #[test]
+    fn claude_setting_sources_args_in_container_excludes_user_scope() {
+        let argv = claude_setting_sources_args(true);
+        assert_eq!(
+            argv,
+            vec!["--setting-sources".to_string(), "project,local".to_string()],
+            "in-container claude spawn must drop user-scope settings (#426)"
+        );
+    }
+
+    #[test]
+    fn claude_setting_sources_args_on_host_is_empty() {
+        // Flat-mode `pitboss dispatch` is unchanged — the operator's
+        // host-side ~/.claude/settings.json continues to apply.
+        assert!(claude_setting_sources_args(false).is_empty());
+    }
 
     fn make_config(mounts: Vec<MountSpec>) -> ContainerConfig {
         ContainerConfig {

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -838,6 +838,11 @@ fn spawn_args(task: &ResolvedTask) -> Vec<String> {
         "--strict-mcp-config".into(),
         "--disable-slash-commands".into(),
     ];
+    // Inside containers, exclude the host operator's user-scope settings
+    // (hooks, etc.) so they don't leak in. (#426)
+    args.extend(crate::dispatch::container::claude_setting_sources_args(
+        crate::dispatch::container::detect_in_container(),
+    ));
     if !task.tools.is_empty() {
         args.push("--allowedTools".into());
         args.push(task.tools.join(","));
@@ -1018,6 +1023,11 @@ pub fn lead_spawn_args(
     // (skills, MCP servers, agents, hooks) from bleeding in.
     args.push("--strict-mcp-config".into());
     args.push("--disable-slash-commands".into());
+    // Inside containers, exclude user-scope settings (hooks, etc.) — the
+    // companion piece that actually delivers on the comment above. (#426)
+    args.extend(crate::dispatch::container::claude_setting_sources_args(
+        crate::dispatch::container::detect_in_container(),
+    ));
 
     // Build the allowed-tools set: user tools + pitboss MCP tools.
     // Path-B: per-server `[[mcp_server]].tools` allowlists filter the
@@ -1079,6 +1089,10 @@ pub fn lead_resume_spawn_args(
     // Plugin/skill isolation (see lead_spawn_args doc).
     args.push("--strict-mcp-config".into());
     args.push("--disable-slash-commands".into());
+    // Inside containers, exclude user-scope settings (hooks, etc.). (#426)
+    args.extend(crate::dispatch::container::claude_setting_sources_args(
+        crate::dispatch::container::detect_in_container(),
+    ));
     // Path-B: filter user-declared tools through per-server allowlists
     // before unioning with the pitboss MCP set. Path A: no-op. (#391/#399)
     let mut allowed: Vec<String> = crate::manifest::mcp_tools::filter_actor_tools_by_mcp_allowlists(
@@ -1151,6 +1165,10 @@ pub fn sublead_spawn_args(
     // Plugin/skill isolation (see lead_spawn_args doc).
     args.push("--strict-mcp-config".into());
     args.push("--disable-slash-commands".into());
+    // Inside containers, exclude user-scope settings (hooks, etc.). (#426)
+    args.extend(crate::dispatch::container::claude_setting_sources_args(
+        crate::dispatch::container::detect_in_container(),
+    ));
 
     // Build the allowed-tools set. Operator-supplied tools (if any) are
     // listed first; pitboss MCP tools always appended so the sub-lead can

--- a/crates/pitboss-cli/src/mcp/tools/spawn.rs
+++ b/crates/pitboss-cli/src/mcp/tools/spawn.rs
@@ -903,6 +903,10 @@ pub(super) fn worker_spawn_args(
     // Plugin/skill isolation (see runner::lead_spawn_args doc).
     args.push("--strict-mcp-config".into());
     args.push("--disable-slash-commands".into());
+    // Inside containers, exclude user-scope settings (hooks, etc.). (#426)
+    args.extend(crate::dispatch::container::claude_setting_sources_args(
+        crate::dispatch::container::detect_in_container(),
+    ));
     // Workers always get the shared-store MCP tools in their allowlist when
     // an mcp-config is supplied, alongside their user-declared tools. Without
     // this, kv_set / lease_acquire / etc. hit the permission prompt which


### PR DESCRIPTION
## Summary

- Host's `~/.claude/settings.json` is bind-mounted alongside credentials when pitboss runs claude subprocesses inside a container. Any hook the operator has configured there gets invoked inside the container, where the referenced binaries don't exist (`anipal-hook`, `bun`, etc.). Every session logs `exit_code: 127` for SessionStart hooks; SessionEnd hooks on the cancel path get promoted to `failure_reason` and produce duplicate `summary.jsonl` rows that #425 tripped on.
- Adds `detect_in_container()` and `claude_setting_sources_args()` in `crates/pitboss-cli/src/dispatch/container.rs`. The five argv-build sites that produce `claude … -p` (lead spawn, sub-lead spawn, two worker spawn paths in `runner.rs`, plus the `mcp__pitboss__spawn_worker` tool in `spawn.rs`) call the helper alongside the existing `--disable-slash-commands` push, so containerized runs emit `--setting-sources project,local`.
- Flat `pitboss dispatch` is unchanged: `detect_in_container()` returns false on the host, the helper returns an empty vec, no flag added.
- OAuth/keychain auth is unaffected — those aren't loaded via setting sources, so the bind-mounted `~/.claude/credentials.json` continues to work.

Closes #426.

## Verification on the live D&D dispatch

Before the fix (run `019e0868`):

```
$ grep -c '"hook_event":"SessionStart"' tasks/module-director/stdout.log
2
```

Two `exit_code: 127` SessionStart hook errors per session (`anipal-hook` and `bun` not found inside the container).

After the fix (run `019e090a`, started against a container baked off this branch):

```
$ grep -c '"hook_event":"SessionStart"' tasks/module-director/stdout.log
0
$ grep -c 'anipal-hook' tasks/module-director/stdout.log
0
```

Zero. No host hooks are loaded; no failures need to be classified; no duplicate `summary.jsonl` rows from cancel-path SessionEnd failures. Reprompt and cancel paths are clean now too — the trigger condition for #425 is gone.

## Test plan

- [x] `cargo test -p pitboss-cli --features pitboss-core/test-support --lib dispatch::container` — adds two unit tests on the helper:
  - `claude_setting_sources_args_in_container_excludes_user_scope` — asserts the in-container case emits `["--setting-sources", "project,local"]`
  - `claude_setting_sources_args_on_host_is_empty` — asserts host-mode is unchanged
- [x] `cargo clippy -p pitboss-cli --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] End-to-end on a containerized dispatch: built `pitboss-with-claude:v0.13.1-dev` from this branch, dispatched the live D&D manifest, confirmed the SessionStart and `anipal-hook`/`bun` log entries are gone.

## What's deliberately out of scope

- **Manifest knob** (`[run].claude_setting_sources = "..."`) for explicit per-run override. The container-default covers the common pain point and ships in one PR; the manifest field can land separately if there's demand for non-default scopes (e.g. `"project,user,local"`).
- **`--bare` mode support.** Disables keychain/OAuth, incompatible with the current bind-mounted credentials pattern. Separate issue if/when needed.
- **Pitboss-side classification fix for SessionEnd hook stderr on cancel paths.** Cancellation is operator-initiated; a hook stderr shouldn't elevate to `failure_reason`. With #426 in place the trigger doesn't fire, but the classification rule itself is still wrong — worth a separate issue.

## Related

- #425 — duplicate task_id in `summary.jsonl` crashes non-Live tabs (PR #429). This PR removes the trigger condition; #429 keeps the renderer robust against any other path that could produce duplicate rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)