### PR TITLE
fix(dispatch): close out sub-lead's own worker-row on termination

### DIFF
--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -76,6 +76,24 @@ impl SubleadOutcome {
             SubleadOutcome::ApprovalTimedOut => "approval_timed_out",
         }
     }
+
+    /// Map to the `TaskStatus` used in `TaskRecord` and the
+    /// `WorkerSnapshotEntry.state` wire string. Mirrors the on-exit
+    /// classification done by `spawn_sublead_session` so the sub-lead's
+    /// own row in its layer's workers map (set by
+    /// `reconcile_terminated_sublead`) carries the same terminal
+    /// status as the canonical record persisted to summary.jsonl.
+    pub fn to_task_status(&self) -> pitboss_core::store::TaskStatus {
+        use pitboss_core::store::TaskStatus;
+        match self {
+            SubleadOutcome::Success => TaskStatus::Success,
+            SubleadOutcome::Cancel => TaskStatus::Cancelled,
+            SubleadOutcome::Timeout => TaskStatus::TimedOut,
+            SubleadOutcome::Error(_) => TaskStatus::Failed,
+            SubleadOutcome::ApprovalRejected => TaskStatus::ApprovalRejected,
+            SubleadOutcome::ApprovalTimedOut => TaskStatus::ApprovalTimedOut,
+        }
+    }
 }
 
 /// Configuration for a sub-lead spawn, validated against root's caps.
@@ -774,14 +792,7 @@ async fn spawn_sublead_session(
         }
 
         // 8. Map to TaskStatus for the TaskRecord.
-        let status = match &sublead_outcome {
-            SubleadOutcome::Success => TaskStatus::Success,
-            SubleadOutcome::Cancel => TaskStatus::Cancelled,
-            SubleadOutcome::Timeout => TaskStatus::TimedOut,
-            SubleadOutcome::Error(_) => TaskStatus::Failed,
-            SubleadOutcome::ApprovalRejected => TaskStatus::ApprovalRejected,
-            SubleadOutcome::ApprovalTimedOut => TaskStatus::ApprovalTimedOut,
-        };
+        let status: TaskStatus = sublead_outcome.to_task_status();
 
         // 9. Build and persist a TaskRecord for the sub-lead's compound session.
         //    Uses total_token_usage across all subprocess iterations.
@@ -945,6 +956,85 @@ pub async fn reconcile_terminated_sublead(
     let actual_spend = *sub_layer.spent_usd.lock().await;
     let original_reservation_usd = sub_layer.original_reservation_usd.unwrap_or(0.0);
     let unspent = (original_reservation_usd - actual_spend).max(0.0);
+
+    // Close out the sub-lead's own row in its layer's workers map. The
+    // kill+resume loop wrote a `WorkerState::Running` entry for the
+    // sub-lead at every iteration, but no terminal write ever landed —
+    // so `WorkersSnapshot` consumers (pitboss-web, TUI Live tab) saw
+    // the sub-lead as `running` for the rest of the run even after the
+    // claude subprocess had exited and a TaskRecord had been appended
+    // to summary.jsonl. The synthesized record below carries only the
+    // fields `collect_layer_workers` actually reads off
+    // `WorkerState::Done` (status, started_at, claude_session_id) plus
+    // the cosmetic ones touched by aggregation; the canonical record
+    // with full token_usage / log_path / final_message lives on disk.
+    // See #431 for the original report. Idempotent: if the row is
+    // already `Done` (a future direct caller landed it before us) we
+    // leave it alone rather than clobbering richer data.
+    {
+        use crate::dispatch::state::WorkerState;
+        let mut workers = sub_layer.workers.write().await;
+        let already_done = matches!(workers.get(sublead_id), Some(WorkerState::Done(_)));
+        if !already_done {
+            let (started_at, claude_session_id) = match workers.get(sublead_id) {
+                Some(WorkerState::Running {
+                    started_at,
+                    session_id,
+                }) => (*started_at, session_id.clone()),
+                Some(WorkerState::Paused {
+                    paused_at,
+                    session_id,
+                    ..
+                }) => (*paused_at, Some(session_id.clone())),
+                Some(WorkerState::Frozen {
+                    started_at,
+                    session_id,
+                    ..
+                }) => (*started_at, Some(session_id.clone())),
+                _ => (chrono::Utc::now(), None),
+            };
+            let ended_at = chrono::Utc::now();
+            let actor_type = state
+                .sublead_actor_types
+                .read()
+                .await
+                .get(sublead_id)
+                .cloned();
+            let synthetic = pitboss_core::store::TaskRecord {
+                task_id: sublead_id.to_string(),
+                status: outcome.to_task_status(),
+                exit_code: None,
+                started_at,
+                ended_at,
+                duration_ms: (ended_at - started_at).num_milliseconds().max(0),
+                worktree_path: None,
+                log_path: sub_layer
+                    .run_subdir
+                    .join("tasks")
+                    .join(sublead_id)
+                    .join("stdout.log"),
+                token_usage: pitboss_core::parser::TokenUsage::default(),
+                claude_session_id,
+                final_message_preview: None,
+                final_message: None,
+                parent_task_id: Some(state.root.lead_id.clone()),
+                pause_count: 0,
+                reprompt_count: 0,
+                approvals_requested: 0,
+                approvals_approved: 0,
+                approvals_rejected: 0,
+                model: None,
+                failure_reason: None,
+                cost_usd: if actual_spend > 0.0 {
+                    Some(actual_spend)
+                } else {
+                    None
+                },
+                actor_type,
+            };
+            workers.insert(sublead_id.to_string(), WorkerState::Done(synthetic));
+        }
+    }
 
     // Release the original reservation in full
     {

--- a/crates/pitboss-cli/tests/sublead_flows.rs
+++ b/crates/pitboss-cli/tests/sublead_flows.rs
@@ -1960,3 +1960,248 @@ async fn v0_5_single_shot_root_lead_unchanged_when_no_reprompts() {
         .await;
     // If we reached here without panicking, the no-channel path is safe.
 }
+
+/// #431 regression: after `reconcile_terminated_sublead` runs, the
+/// sub-lead's own row in its layer's `workers` map must transition to
+/// `WorkerState::Done(_)` with a `TaskStatus` matching the outcome.
+///
+/// Pre-fix the row stayed `Running` forever — the kill+resume loop's
+/// per-iteration `Running` write was never cleared at termination, so
+/// `collect_layer_workers` (and therefore pitboss-web's Live/Graph
+/// tabs) showed the sub-lead as active for the rest of the run even
+/// though its claude subprocess had exited and its `TaskRecord` was on
+/// disk.
+#[tokio::test]
+async fn reconcile_terminated_sublead_marks_self_row_done() {
+    use pitboss_cli::dispatch::state::WorkerState;
+    use pitboss_cli::dispatch::sublead::{reconcile_terminated_sublead, SubleadOutcome};
+    use pitboss_core::store::TaskStatus;
+
+    let (_dir, state) = mk_state_with_subleads();
+
+    // Build a sub-layer directly (bypassing spawn_sublead's spawn-side
+    // effects which we don't need) and put it on `state.subleads` so
+    // `reconcile_terminated_sublead` finds it via the live map.
+    let sub_id = "sublead-431".to_string();
+    let sub_manifest = ResolvedManifest {
+        manifest_schema_version: 0,
+        name: None,
+        max_parallel_tasks: Some(4),
+        halt_on_failure: false,
+        run_dir: state.root.manifest.run_dir.clone(),
+        worktree_cleanup: WorktreeCleanup::Never,
+        emit_event_stream: false,
+        tasks: vec![],
+        lead: None,
+        max_workers: Some(2),
+        budget_usd: Some(2.0),
+        lead_timeout_secs: Some(1800),
+        default_approval_policy: None,
+        denial_termination_policy: None,
+        notifications: vec![],
+        dump_shared_store: false,
+        require_plan_approval: false,
+        approval_rules: vec![],
+        container: None,
+        mcp_servers: vec![],
+        communication: Default::default(),
+        lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
+        untyped_actor_policy: Default::default(),
+    };
+    let sub_layer = Arc::new(pitboss_cli::dispatch::layer::LayerState::new(
+        state.root.run_id,
+        sub_manifest,
+        state.root.store.clone(),
+        CancelToken::new(),
+        sub_id.clone(),
+        state.root.spawner.clone(),
+        PathBuf::from("/bin/true"),
+        state.root.wt_mgr.clone(),
+        CleanupPolicy::Never,
+        state.root.run_subdir.clone(),
+        ApprovalPolicy::Block,
+        None,
+        Arc::new(pitboss_cli::shared_store::SharedStore::new()),
+        Some(2.0),
+    ));
+
+    // Mirror what `run_kill_resume_loop` writes for the sub-lead's own
+    // row — this is the state the bug observed (Running with a
+    // session_id, never cleared).
+    let started = chrono::Utc::now();
+    sub_layer.workers.write().await.insert(
+        sub_id.clone(),
+        WorkerState::Running {
+            started_at: started,
+            session_id: Some("sub-sess-431".into()),
+        },
+    );
+    state
+        .subleads
+        .write()
+        .await
+        .insert(sub_id.clone(), sub_layer.clone());
+
+    // Reconcile — the fix should rewrite the sub-lead's row to
+    // `WorkerState::Done(rec)` with the outcome's TaskStatus.
+    reconcile_terminated_sublead(&state, &sub_id, SubleadOutcome::Success)
+        .await
+        .expect("reconcile should succeed");
+
+    // The layer is now in `terminated_sublead_layers`. Walk it the way
+    // `collect_layer_workers` does and assert the sub-lead's own row
+    // landed in a terminal state.
+    let term = state.terminated_sublead_layers.read().await;
+    let layer = term
+        .iter()
+        .find(|l| l.lead_id == sub_id)
+        .expect("layer must be in terminated_sublead_layers after reconcile");
+    let workers = layer.workers.read().await;
+    let row = workers
+        .get(&sub_id)
+        .expect("sublead's own row must still be present after reconcile");
+    match row {
+        WorkerState::Done(rec) => {
+            assert_eq!(rec.task_id, sub_id);
+            assert!(
+                matches!(rec.status, TaskStatus::Success),
+                "expected Success, got {:?}",
+                rec.status
+            );
+            assert_eq!(rec.started_at, started, "started_at must carry over");
+            assert_eq!(
+                rec.claude_session_id.as_deref(),
+                Some("sub-sess-431"),
+                "claude_session_id must carry over from the prior Running row"
+            );
+        }
+        other => panic!("expected WorkerState::Done, got {other:?}"),
+    }
+}
+
+/// `reconcile_terminated_sublead` must map every `SubleadOutcome` to
+/// the corresponding terminal `TaskStatus` on the workers-map row. Pin
+/// the full mapping so a future refactor of `to_task_status` can't
+/// drift the `Running`-forever bug back in for any single variant.
+#[tokio::test]
+async fn reconcile_terminated_sublead_outcome_to_status_mapping() {
+    use pitboss_cli::dispatch::state::WorkerState;
+    use pitboss_cli::dispatch::sublead::{reconcile_terminated_sublead, SubleadOutcome};
+    use pitboss_core::store::TaskStatus;
+
+    fn build_sub_layer(
+        state: &Arc<DispatchState>,
+        id: &str,
+    ) -> Arc<pitboss_cli::dispatch::layer::LayerState> {
+        let sub_manifest = ResolvedManifest {
+            manifest_schema_version: 0,
+            name: None,
+            max_parallel_tasks: Some(4),
+            halt_on_failure: false,
+            run_dir: state.root.manifest.run_dir.clone(),
+            worktree_cleanup: WorktreeCleanup::Never,
+            emit_event_stream: false,
+            tasks: vec![],
+            lead: None,
+            max_workers: Some(1),
+            budget_usd: Some(1.0),
+            lead_timeout_secs: Some(60),
+            default_approval_policy: None,
+            denial_termination_policy: None,
+            notifications: vec![],
+            dump_shared_store: false,
+            require_plan_approval: false,
+            approval_rules: vec![],
+            container: None,
+            mcp_servers: vec![],
+            communication: Default::default(),
+            lifecycle: None,
+            worker_types: vec![],
+            sublead_types: vec![],
+            require_actor_type: false,
+            untyped_actor_policy: Default::default(),
+        };
+        Arc::new(pitboss_cli::dispatch::layer::LayerState::new(
+            state.root.run_id,
+            sub_manifest,
+            state.root.store.clone(),
+            CancelToken::new(),
+            id.into(),
+            state.root.spawner.clone(),
+            PathBuf::from("/bin/true"),
+            state.root.wt_mgr.clone(),
+            CleanupPolicy::Never,
+            state.root.run_subdir.clone(),
+            ApprovalPolicy::Block,
+            None,
+            Arc::new(pitboss_cli::shared_store::SharedStore::new()),
+            Some(1.0),
+        ))
+    }
+
+    let cases: Vec<(&str, SubleadOutcome, TaskStatus)> = vec![
+        (
+            "sublead-cancel",
+            SubleadOutcome::Cancel,
+            TaskStatus::Cancelled,
+        ),
+        (
+            "sublead-timeout",
+            SubleadOutcome::Timeout,
+            TaskStatus::TimedOut,
+        ),
+        (
+            "sublead-error",
+            SubleadOutcome::Error("boom".into()),
+            TaskStatus::Failed,
+        ),
+        (
+            "sublead-rejected",
+            SubleadOutcome::ApprovalRejected,
+            TaskStatus::ApprovalRejected,
+        ),
+        (
+            "sublead-tto",
+            SubleadOutcome::ApprovalTimedOut,
+            TaskStatus::ApprovalTimedOut,
+        ),
+    ];
+
+    for (id, outcome, expected) in cases {
+        let (_dir, state) = mk_state_with_subleads();
+        let sub_layer = build_sub_layer(&state, id);
+        sub_layer.workers.write().await.insert(
+            id.into(),
+            WorkerState::Running {
+                started_at: chrono::Utc::now(),
+                session_id: None,
+            },
+        );
+        state
+            .subleads
+            .write()
+            .await
+            .insert(id.into(), sub_layer.clone());
+
+        reconcile_terminated_sublead(&state, id, outcome.clone())
+            .await
+            .expect("reconcile should succeed");
+
+        let term = state.terminated_sublead_layers.read().await;
+        let layer = term.iter().find(|l| l.lead_id == id).unwrap();
+        let workers = layer.workers.read().await;
+        let row = workers.get(id).expect("row present");
+        match row {
+            WorkerState::Done(rec) => assert_eq!(
+                std::mem::discriminant(&rec.status),
+                std::mem::discriminant(&expected),
+                "outcome {outcome:?} should map to status {expected:?}, got {:?}",
+                rec.status
+            ),
+            other => panic!("expected Done for outcome {outcome:?}, got {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Sub-lead's own row in its layer's `workers` HashMap was never updated to `WorkerState::Done` after termination. The kill+resume loop wrote `Running` per iteration; nothing landed at exit.
- `collect_layer_workers` walks `terminated_sublead_layers` verbatim, so pitboss-web's Live/Graph tabs and the TUI showed every terminated sub-lead as `running` for the rest of the run — disk state was correct (`TaskRecord` in `summary.jsonl`, `pitboss status` reported Success), only the in-memory snapshot lied.
- Fix synthesizes a terminal `WorkerState::Done(TaskRecord)` inside `reconcile_terminated_sublead`, carrying the outcome's `TaskStatus` plus the `started_at` / `claude_session_id` lifted from the prior `Running` row. Canonical record with full `token_usage` / `log_path` / `final_message` still lives on disk; the synthesized one only needs to satisfy what `collect_layer_workers` actually reads (`status`, `started_at`, `session_id`) plus the cosmetic fields aggregation touches.
- Idempotent: a row that's already `Done` is left alone (defensive against future direct callers landing a richer record first).
- Pulled the `SubleadOutcome → TaskStatus` mapping into a shared `to_task_status()` so the spawn-side classifier and the new reconcile-side synth can't drift.

Closes #431.

## Test plan

- [x] `cargo test -p pitboss-cli --features pitboss-core/test-support --test sublead_flows reconcile_terminated_sublead` — two new tests pass (`reconcile_terminated_sublead_marks_self_row_done`, `reconcile_terminated_sublead_outcome_to_status_mapping` — pins all six `SubleadOutcome` variants → `TaskStatus`).
- [x] `cargo test --workspace --features pitboss-core/test-support` — no regressions.
- [x] `cargo lint` — clean.
- [x] `cargo tidy` — clean.
- [ ] Live: dispatch a depth-2 manifest, watch a sub-lead terminate while the lead is still working, confirm pitboss-web's Live tab flips the sub-lead tile to `done_success` within one snapshot interval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)