### PR TITLE
fix(ci): build pitboss-web SPA before dist build + cargo test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,19 @@ jobs:
       - name: Cache Cargo build
         uses: Swatinem/rust-cache@v2
 
+      # Build pitboss-web SPA before cargo test so the workspace compile
+      # exercises the real rust-embed payload, not the placeholder
+      # (issue #435 regression guard).
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Build pitboss-web SPA
+        run: |
+          cd crates/pitboss-web/spa
+          npm ci
+          npm run build
+
       - name: cargo fmt --all -- --check
         run: cargo fmt --all -- --check
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,6 +157,19 @@ jobs:
       - name: Install dependencies
         run: |
           ${{ matrix.packages_install }}
+      # Build the pitboss-web SPA before `dist build` so rust-embed
+      # captures real assets into the binary instead of an empty
+      # directory (issue #435). Required for every target since
+      # cargo-dist builds the full workspace, including pitboss-web.
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Build pitboss-web SPA
+        run: |
+          cd crates/pitboss-web/spa
+          npm ci
+          npm run build
       - name: Build artifacts
         run: |
           # Actually do builds and make zips and whatnot


### PR DESCRIPTION
## Summary

- cargo-dist's \`build-local-artifacts\` job ran \`dist build\` directly, with no SPA build step beforehand → \`crates/pitboss-web/spa/build/\` was empty when \`rust-embed\` snapshotted it into the binary → every distributed \`pitboss-web\` shipped with only the placeholder HTML.
- Adds \`actions/setup-node@v4\` + \`npm ci && npm run build\` to \`release.yml/build-local-artifacts\` (primary fix) and \`ci.yml/test\` (regression guard so a future SPA-build break trips PR CI instead of slipping through to release).
- Dockerfile builds only \`pitboss-cli\` + \`pitboss-tui\`, so container CI is unaffected — no Dockerfile change needed.

Closes #435.

## Test plan

- [ ] CI \`test + lint + fmt\` job passes (proves the SPA build step works on the standard ubuntu-latest runner before cargo test).
- [ ] After merge, a release-tag push triggers \`build-local-artifacts\` across all matrix targets — verify each builds the SPA successfully on its runner (`x86_64-unknown-linux-gnu` container, `aarch64-unknown-linux-gnu` container, `aarch64-apple-darwin` on macos-14).
- [ ] After release, a fresh \`brew install SDS-Mode/pitboss/pitboss-web\` + \`pitboss-web\` serves the real SvelteKit SPA (look for \`_app/immutable/...\` chunks in the HTML, not the placeholder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)