### PR TITLE
feat(core): canonical summary.json[l] reader for TUI/web/CLI

### DIFF
--- a/crates/pitboss-cli/src/diff.rs
+++ b/crates/pitboss-cli/src/diff.rs
@@ -1,7 +1,6 @@
 //! `pitboss diff <run-a> <run-b>` — compare two prior runs side-by-side.
 
 use std::collections::HashMap;
-use std::io::BufRead;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -42,43 +41,22 @@ pub fn resolve_run_under(base: &Path, id_or_prefix: &str) -> Result<PathBuf> {
 /// `summary.jsonl` and constructing a partial `RunSummary` with
 /// `was_interrupted = true`.
 pub fn load_summary(run_dir: &Path) -> Result<RunSummary> {
-    // Prefer the finalized summary.json.
-    let json_path = run_dir.join("summary.json");
-    if json_path.exists() {
-        let bytes =
-            std::fs::read(&json_path).with_context(|| format!("read {}", json_path.display()))?;
-        return serde_json::from_slice(&bytes)
-            .with_context(|| format!("parse {}", json_path.display()));
+    // Canonical reader (#437): if `summary.json` parsed cleanly, return
+    // it directly. Otherwise reconstruct from the deduped task map +
+    // `meta.json`.
+    let snap = pitboss_core::store::read_run_snapshot(run_dir);
+    if let Some(summary) = snap.run_summary {
+        return Ok(summary);
     }
 
-    // Fall back to summary.jsonl (in-progress or interrupted run).
     let jsonl_path = run_dir.join("summary.jsonl");
-    let f = std::fs::File::open(&jsonl_path)
-        .with_context(|| format!("open {}", jsonl_path.display()))?;
-
-    let mut tasks = Vec::new();
-    for line in std::io::BufReader::new(f)
-        .lines()
-        .map_while(std::io::Result::ok)
-    {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        match serde_json::from_str::<pitboss_core::store::TaskRecord>(trimmed) {
-            Ok(rec) => tasks.push(rec),
-            Err(e) => {
-                // Warn rather than silently skip — corrupt/truncated lines
-                // cause silent undercounting of tasks_total, tasks_failed,
-                // token sums, and cost (#107). In-progress runs can have a
-                // genuinely partial trailing line (mid-write truncation), but
-                // that is indistinguishable here from format skew or disk
-                // corruption, so we always surface it.
-                tracing::warn!(error = %e, line = trimmed, "summary.jsonl: skipping unparseable line — diff output may be incomplete");
-            }
-        }
+    if !jsonl_path.exists() {
+        anyhow::bail!(
+            "no summary found in {}: neither summary.json nor summary.jsonl present",
+            run_dir.display()
+        );
     }
-
+    let tasks: Vec<pitboss_core::store::TaskRecord> = snap.tasks.into_values().collect();
     let tasks_failed = tasks
         .iter()
         .filter(|t| !matches!(t.status, pitboss_core::store::TaskStatus::Success))
@@ -92,7 +70,7 @@ pub fn load_summary(run_dir: &Path) -> Result<RunSummary> {
         .with_context(|| format!("parse {}", meta_path.display()))?;
 
     let started = meta.started_at;
-    let ended = tasks.last().map_or(started, |t| t.ended_at);
+    let ended = tasks.iter().map(|t| t.ended_at).max().unwrap_or(started);
 
     // Best-effort: pull manifest_name from resolved.json if present so partial
     // (in-progress) runs synthesized from summary.jsonl still surface the run

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -32,41 +32,27 @@ use crate::mcp::{socket_path_for_run, McpServer};
 /// in-progress reads, or future format skew). Returns an io error if
 /// the file is missing — finalize callers always have the file because
 /// the lead's record was appended a few hundred lines above.
-async fn read_summary_jsonl_records(
-    path: &std::path::Path,
+/// Read summary.jsonl for finalize aggregation, returning the deduplicated
+/// records and their id set. Thin wrapper around the canonical
+/// [`pitboss_core::store::read_run_snapshot`] (#437) that adds the
+/// finalize-specific contract: the file MUST exist (the lead's own
+/// record was appended a few hundred lines above the call site).
+fn read_summary_jsonl_records(
+    run_dir: &std::path::Path,
 ) -> Result<(
     Vec<pitboss_core::store::TaskRecord>,
     std::collections::HashSet<String>,
 )> {
-    let bytes = tokio::fs::read(path).await.with_context(|| {
-        format!(
-            "read summary.jsonl for finalize aggregation: {}",
+    let path = run_dir.join("summary.jsonl");
+    if !path.exists() {
+        anyhow::bail!(
+            "read summary.jsonl for finalize aggregation: {} not found",
             path.display()
-        )
-    })?;
-    let text = std::str::from_utf8(&bytes)
-        .map_err(|e| anyhow::anyhow!("summary.jsonl is not utf-8: {e}"))?;
-    let mut records: Vec<pitboss_core::store::TaskRecord> = Vec::new();
-    let mut ids: std::collections::HashSet<String> = std::collections::HashSet::new();
-    for line in text.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        match serde_json::from_str::<pitboss_core::store::TaskRecord>(trimmed) {
-            Ok(rec) => {
-                ids.insert(rec.task_id.clone());
-                records.push(rec);
-            }
-            Err(e) => {
-                tracing::warn!(
-                    error = %e,
-                    line = trimmed,
-                    "summary.jsonl: skipping unparseable line in finalize aggregation"
-                );
-            }
-        }
+        );
     }
+    let snap = pitboss_core::store::read_run_snapshot(run_dir);
+    let ids: std::collections::HashSet<String> = snap.tasks.keys().cloned().collect();
+    let records: Vec<pitboss_core::store::TaskRecord> = snap.tasks.into_values().collect();
     Ok((records, ids))
 }
 
@@ -638,8 +624,7 @@ pub async fn run_hierarchical(
     // workers live in their sub-lead's `LayerState`, not root, so a
     // 5-actor smoke run produced `tasks_total: 1` in the operational
     // console. Reading the JSONL captures every layer for free.
-    let (mut all_records, mut existing_ids) =
-        read_summary_jsonl_records(&run_subdir.join("summary.jsonl")).await?;
+    let (mut all_records, mut existing_ids) = read_summary_jsonl_records(&run_subdir)?;
 
     // Synthesise Cancelled `TaskRecord`s for every still-in-flight worker
     // across **every layer** (root + each sub-tree). A worker that
@@ -1414,8 +1399,8 @@ mod summary_jsonl_aggregation_tests {
 
     /// #221 regression: a hierarchical run's `summary.jsonl` carries the
     /// lead, every sub-lead, and every Done worker (root or sub-tree)
-    /// across all layers. `read_summary_jsonl_records` must aggregate
-    /// every parseable line in append order so the finalize phase can
+    /// across all layers. The wrapper around the canonical reader (#437)
+    /// must aggregate every parseable line so the finalize phase can
     /// build a `summary.json` with the full hierarchy.
     #[tokio::test]
     async fn read_summary_jsonl_aggregates_lead_subleads_and_workers() {
@@ -1436,7 +1421,7 @@ mod summary_jsonl_aggregation_tests {
             .collect();
         tokio::fs::write(&path, payload).await.unwrap();
 
-        let (records, ids) = read_summary_jsonl_records(&path).await.unwrap();
+        let (records, ids) = read_summary_jsonl_records(dir.path()).unwrap();
         assert_eq!(records.len(), 5, "all 5 actors present");
         assert_eq!(ids.len(), 5);
         for actor in [
@@ -1448,37 +1433,35 @@ mod summary_jsonl_aggregation_tests {
         ] {
             assert!(ids.contains(actor), "missing actor {actor}");
         }
-        // First-seen order is preserved (matters when callers want a
-        // chronological / append-order rendering).
-        assert_eq!(records[0].task_id, "worker-1");
-        assert_eq!(records[4].task_id, "smoke-lead");
     }
 
-    /// Unparseable lines (mid-write truncation, future format skew)
-    /// are skipped; the surrounding records still land.
+    /// #437: reprompt / cancel / respawn lifecycles append multiple
+    /// rows for one `task_id`. The finalize aggregator now dedupes
+    /// last-wins so the resulting `summary.json` doesn't over-count
+    /// tasks_total or tasks_failed.
     #[tokio::test]
-    async fn read_summary_jsonl_skips_unparseable_lines() {
+    async fn read_summary_jsonl_dedupes_duplicate_task_ids() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("summary.jsonl");
-        let mut payload = String::new();
-        payload.push_str(&format!(
-            "{}\n",
-            serde_json::to_string(&rec("a", None, TaskStatus::Success)).unwrap()
-        ));
-        payload.push_str("{\"task_id\":\"truncated\",\"sta\n"); // mid-write
-        payload.push('\n'); // empty line
-        payload.push_str("not even json\n");
-        payload.push_str(&format!(
-            "{}\n",
-            serde_json::to_string(&rec("b", None, TaskStatus::Failed)).unwrap()
-        ));
+        let lines = [
+            rec("worker-1", None, TaskStatus::Cancelled),
+            rec("worker-1", None, TaskStatus::Success), // newer row wins
+            rec("worker-2", None, TaskStatus::Failed),
+        ];
+        let payload: String = lines
+            .iter()
+            .map(|r| format!("{}\n", serde_json::to_string(r).unwrap()))
+            .collect();
         tokio::fs::write(&path, payload).await.unwrap();
 
-        let (records, ids) = read_summary_jsonl_records(&path).await.unwrap();
-        assert_eq!(records.len(), 2, "two valid records survive");
-        assert_eq!(records[0].task_id, "a");
-        assert_eq!(records[1].task_id, "b");
+        let (records, ids) = read_summary_jsonl_records(dir.path()).unwrap();
+        assert_eq!(records.len(), 2, "dedupe by task_id");
         assert_eq!(ids.len(), 2);
+        let worker_1 = records
+            .iter()
+            .find(|r| r.task_id == "worker-1")
+            .expect("worker-1 present");
+        assert!(matches!(worker_1.status, TaskStatus::Success));
     }
 
     /// Empty file (race: read before any record was appended) returns
@@ -1488,7 +1471,7 @@ mod summary_jsonl_aggregation_tests {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("summary.jsonl");
         tokio::fs::write(&path, "").await.unwrap();
-        let (records, ids) = read_summary_jsonl_records(&path).await.unwrap();
+        let (records, ids) = read_summary_jsonl_records(dir.path()).unwrap();
         assert!(records.is_empty());
         assert!(ids.is_empty());
     }
@@ -1499,10 +1482,9 @@ mod summary_jsonl_aggregation_tests {
     #[tokio::test]
     async fn read_summary_jsonl_missing_file_errors() {
         let dir = TempDir::new().unwrap();
-        let path = dir.path().join("nope.jsonl");
-        let err = read_summary_jsonl_records(&path).await.unwrap_err();
+        let err = read_summary_jsonl_records(dir.path()).unwrap_err();
         assert!(
-            err.to_string().contains("read summary.jsonl"),
+            err.to_string().contains("not found"),
             "context attached: {err}"
         );
     }

--- a/crates/pitboss-cli/src/runs.rs
+++ b/crates/pitboss-cli/src/runs.rs
@@ -40,7 +40,6 @@
 //! ECONNREFUSED almost instantly) and uses the `summary.jsonl` mtime as
 //! a recency floor.
 
-use std::io::BufRead;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
@@ -276,7 +275,11 @@ pub fn collect_run_entry(run_dir: &Path, run_id: String, mtime: SystemTime) -> R
     };
 
     let jsonl = run_dir.join("summary.jsonl");
-    let (settled_total, failed) = count_jsonl_tasks(&jsonl);
+    // Canonical reader (#437): dedupe by task_id so reprompt /
+    // cancel / respawn lifecycles don't over-count the list view.
+    let snap = pitboss_core::store::read_run_snapshot(run_dir);
+    let settled_total = snap.task_count();
+    let failed = snap.failed_count();
     let spawned_count = count_tasks_subdirs(run_dir);
     let total = settled_total.max(spawned_count);
 
@@ -400,29 +403,6 @@ fn jsonl_recent(jsonl: &Path) -> bool {
         .unwrap_or(true)
 }
 
-/// Count total and failed task records from a `summary.jsonl` file.
-pub fn count_jsonl_tasks(path: &Path) -> (usize, usize) {
-    let Ok(file) = std::fs::File::open(path) else {
-        return (0, 0);
-    };
-    let reader = std::io::BufReader::new(file);
-    let mut total = 0;
-    let mut failed = 0;
-    for line in reader.lines().map_while(Result::ok) {
-        let trimmed = line.trim().to_string();
-        if trimmed.is_empty() {
-            continue;
-        }
-        total += 1;
-        if let Ok(r) = serde_json::from_str::<pitboss_core::store::TaskRecord>(&trimmed) {
-            if !matches!(r.status, pitboss_core::store::TaskStatus::Success) {
-                failed += 1;
-            }
-        }
-    }
-    (total, failed)
-}
-
 /// Format a [`SystemTime`] as `"YYYY-MM-DD HH:MM:SS UTC"`.
 pub fn format_mtime(mtime: SystemTime) -> String {
     use std::time::UNIX_EPOCH;
@@ -446,6 +426,40 @@ mod tests {
         let d = base.join(name);
         fs::create_dir_all(&d).unwrap();
         d
+    }
+
+    /// Minimal valid `TaskRecord` serialized to one JSON line — used
+    /// by the stale-classification fixtures below. After #437 the
+    /// canonical reader only counts records that round-trip through
+    /// `TaskRecord` deserialization, so fixtures must produce real
+    /// records, not the malformed JSON the line-counter accepted.
+    fn task_line(task_id: &str, status: pitboss_core::store::TaskStatus) -> String {
+        let t = chrono::Utc::now();
+        let rec = pitboss_core::store::TaskRecord {
+            task_id: task_id.into(),
+            status,
+            exit_code: Some(0),
+            started_at: t,
+            ended_at: t,
+            duration_ms: 0,
+            worktree_path: None,
+            log_path: PathBuf::from("/dev/null"),
+            token_usage: pitboss_core::parser::TokenUsage::default(),
+            claude_session_id: None,
+            final_message_preview: None,
+            final_message: None,
+            parent_task_id: None,
+            pause_count: 0,
+            reprompt_count: 0,
+            approvals_requested: 0,
+            approvals_approved: 0,
+            approvals_rejected: 0,
+            model: None,
+            failure_reason: None,
+            cost_usd: None,
+            actor_type: None,
+        };
+        serde_json::to_string(&rec).unwrap()
     }
 
     #[test]
@@ -503,13 +517,6 @@ mod tests {
     }
 
     #[test]
-    fn count_jsonl_tasks_missing_file_returns_zero() {
-        let tmp = TempDir::new().unwrap();
-        let (total, failed) = count_jsonl_tasks(&tmp.path().join("nonexistent.jsonl"));
-        assert_eq!((total, failed), (0, 0));
-    }
-
-    #[test]
     fn format_mtime_epoch() {
         let s = format_mtime(SystemTime::UNIX_EPOCH);
         assert!(s.starts_with("1970-01-01"));
@@ -558,15 +565,12 @@ mod tests {
     fn collect_run_entry_with_old_jsonl_no_socket_is_stale() {
         let tmp = TempDir::new().unwrap();
         let run_dir = make_run_dir(tmp.path(), "run-stale");
-        // Write a summary.jsonl with one row, then back-date its mtime
-        // past the staleness threshold. No control socket exists.
+        // Write a summary.jsonl with one valid TaskRecord row, then
+        // back-date its mtime past the staleness threshold. No control
+        // socket exists.
         let jsonl = run_dir.join("summary.jsonl");
-        fs::write(
-            &jsonl,
-            br#"{"task_id":"t","status":"failure","error":"x","cost_usd":0,"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}
-"#,
-        )
-        .unwrap();
+        let line = task_line("t", pitboss_core::store::TaskStatus::Failed);
+        fs::write(&jsonl, format!("{line}\n")).unwrap();
         // Back-date mtime past the staleness threshold.
         let five_h_ago =
             SystemTime::now() - Duration::from_secs(STALENESS_THRESHOLD.as_secs() + 3600);

--- a/crates/pitboss-cli/src/status.rs
+++ b/crates/pitboss-cli/src/status.rs
@@ -6,7 +6,7 @@
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 use pitboss_core::store::TaskStatus;
 
 /// Entry point for the `status` subcommand.
@@ -14,7 +14,6 @@ pub fn run(run_id_prefix: &str, json: bool, run_dir_override: Option<PathBuf>) -
     let base = run_dir_override.unwrap_or_else(default_runs_dir);
     let run_dir = resolve_run_dir(&base, run_id_prefix)?;
 
-    // Prefer summary.json (finalized run) over summary.jsonl (in-flight).
     let summary_json = run_dir.join("summary.json");
     let summary_jsonl = run_dir.join("summary.jsonl");
 
@@ -25,40 +24,16 @@ pub fn run(run_id_prefix: &str, json: bool, run_dir_override: Option<PathBuf>) -
         );
     }
 
-    // `notify_failures` only exists on a finalized `summary.json`; the
-    // in-flight `summary.jsonl` is per-task records and never carries
-    // run-scoped fields. Operators reading status during a live run see
-    // no notify count — that's correct (the count is only authoritative
-    // at finalize), and the journaled `notifications.jsonl` is still
-    // available for live debugging.
-    let (records, notify_failures) = if summary_json.exists() {
-        let bytes = std::fs::read(&summary_json)
-            .with_context(|| format!("read {}", summary_json.display()))?;
-        let summary: serde_json::Value = serde_json::from_slice(&bytes)?;
-        let notify_failures = summary
-            .get("notify_failures")
-            .and_then(|v| v.as_u64())
-            .map(|n| u32::try_from(n).unwrap_or(u32::MAX));
-        let recs = summary
-            .get("tasks")
-            .and_then(|t| t.as_array())
-            .cloned()
-            .unwrap_or_default()
-            .into_iter()
-            .map(serde_json::from_value::<pitboss_core::store::TaskRecord>)
-            .collect::<Result<Vec<_>, _>>()?;
-        (recs, notify_failures)
-    } else {
-        let content = std::fs::read_to_string(&summary_jsonl)
-            .with_context(|| format!("read {}", summary_jsonl.display()))?;
-        let recs = content
-            .lines()
-            .filter(|l| !l.trim().is_empty())
-            .map(serde_json::from_str::<pitboss_core::store::TaskRecord>)
-            .collect::<Result<Vec<_>, _>>()
-            .with_context(|| format!("parse {}", summary_jsonl.display()))?;
-        (recs, None)
-    };
+    // Canonical reader (#437): summary.json seeds, summary.jsonl
+    // overlays last-wins by task_id. `notify_failures` is only present
+    // on a finalized `summary.json`; in-flight runs report None — that's
+    // correct (the count is only authoritative at finalize), and the
+    // journaled `notifications.jsonl` is still available for live
+    // debugging. Reprompt / cancel / respawn lifecycles no longer
+    // over-count tasks_total (#437).
+    let snap = pitboss_core::store::read_run_snapshot(&run_dir);
+    let notify_failures = snap.run_summary.as_ref().and_then(|s| s.notify_failures);
+    let records: Vec<pitboss_core::store::TaskRecord> = snap.tasks.into_values().collect();
 
     if json {
         let out = serde_json::to_string_pretty(&records)?;

--- a/crates/pitboss-core/src/store/mod.rs
+++ b/crates/pitboss-core/src/store/mod.rs
@@ -12,6 +12,9 @@ pub use json_file::JsonFileStore;
 pub mod sqlite;
 pub use sqlite::SqliteStore;
 
+pub mod summary;
+pub use summary::{read_run_snapshot, RunSnapshot};
+
 #[cfg(test)]
 mod integration_tests {
     use super::*;

--- a/crates/pitboss-core/src/store/summary.rs
+++ b/crates/pitboss-core/src/store/summary.rs
@@ -1,0 +1,409 @@
+//! Canonical reader for a run directory's summary artifacts.
+//!
+//! Before this module existed, every reader surface — the TUI watcher,
+//! the TUI launcher, `pitboss status`, `pitboss diff`, `pitboss list`,
+//! the dispatcher's hierarchical finalize aggregator, the pitboss-web
+//! `/api/runs/:id/tasks/:task_id` handler, and the insights aggregator
+//! — implemented its own `summary.json` / `summary.jsonl` parser. Three
+//! different merge strategies coexisted; only one of them deduplicated
+//! by `task_id`. The SPA-side fix in #429 covered the JS reader; this
+//! module unifies the Rust readers behind one shape so the same class
+//! of bug cannot recur. See #437 for the empirical drift catalogue.
+//!
+//! [`read_run_snapshot`] is the entry point. Surfaces that need a
+//! per-task view consume [`RunSnapshot::tasks`]; those that need the
+//! finalized `RunSummary` consume [`RunSnapshot::run_summary`].
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::store::record::{RunSummary, TaskRecord, TaskStatus};
+
+/// Merged, deduplicated view of a run's task state.
+///
+/// Built by [`read_run_snapshot`] from a run directory's
+/// `summary.json` (finalized, optional) and `summary.jsonl`
+/// (append-only, always present once `init_run` ran). Merge rules:
+///
+/// 1. `summary.json`, when present and parseable, seeds [`Self::tasks`]
+///    from its `tasks` array.
+/// 2. `summary.jsonl` rows are overlaid with **last-wins by `task_id`**.
+///    Reprompt / cancel / respawn lifecycles append multiple rows for
+///    one `task_id`; the freshest row is canonical. This is the same
+///    semantic the `SvelteKit` SPA adopted in #429.
+/// 3. Truncated trailing lines and malformed JSON are dropped with a
+///    `tracing::warn`. The read never errors on parse failure.
+/// 4. Missing files are treated as empty inputs. A brand-new run dir
+///    (after `init_run` but before any worker has finished) yields a
+///    default-constructed snapshot.
+#[derive(Debug, Clone, Default)]
+pub struct RunSnapshot {
+    /// The finalized `summary.json` payload when present; `None` for
+    /// in-progress, aborted, or interrupted runs.
+    pub run_summary: Option<RunSummary>,
+    /// All task records, keyed by `task_id`, after merge + dedup.
+    pub tasks: HashMap<String, TaskRecord>,
+}
+
+impl RunSnapshot {
+    /// Whether `summary.json` was found and parsed cleanly.
+    #[must_use]
+    pub fn is_finalized(&self) -> bool {
+        self.run_summary.is_some()
+    }
+
+    /// Total deduplicated task count.
+    #[must_use]
+    pub fn task_count(&self) -> usize {
+        self.tasks.len()
+    }
+
+    /// Count of tasks not in [`TaskStatus::Success`].
+    #[must_use]
+    pub fn failed_count(&self) -> usize {
+        self.tasks
+            .values()
+            .filter(|t| !matches!(t.status, TaskStatus::Success))
+            .count()
+    }
+
+    /// Look up a single record by `task_id`.
+    #[must_use]
+    pub fn get(&self, task_id: &str) -> Option<&TaskRecord> {
+        self.tasks.get(task_id)
+    }
+}
+
+/// Read the canonical run snapshot from a run directory.
+///
+/// All surfaces (TUI, web, CLI) should call this rather than rolling
+/// their own parser. Synchronous: async callers can wrap in
+/// `tokio::task::spawn_blocking` when the run dir lives on a slow
+/// filesystem; for typical `~/.local/share/pitboss/runs/<run-id>/`
+/// volumes the files are small enough that direct calls from axum
+/// handlers are acceptable.
+#[must_use]
+pub fn read_run_snapshot(run_dir: &Path) -> RunSnapshot {
+    let mut tasks = HashMap::new();
+    let run_summary = load_summary_json(&run_dir.join("summary.json"), &mut tasks);
+    overlay_summary_jsonl(&run_dir.join("summary.jsonl"), &mut tasks);
+    RunSnapshot { run_summary, tasks }
+}
+
+fn load_summary_json(path: &Path, tasks: &mut HashMap<String, TaskRecord>) -> Option<RunSummary> {
+    let bytes = std::fs::read(path).ok()?;
+    let summary: RunSummary = match serde_json::from_slice(&bytes) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                path = %path.display(),
+                "summary.json: failed to parse; falling back to summary.jsonl only",
+            );
+            return None;
+        }
+    };
+    for rec in &summary.tasks {
+        tasks.insert(rec.task_id.clone(), rec.clone());
+    }
+    Some(summary)
+}
+
+fn overlay_summary_jsonl(path: &Path, tasks: &mut HashMap<String, TaskRecord>) {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return;
+    };
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<TaskRecord>(trimmed) {
+            Ok(rec) => {
+                tasks.insert(rec.task_id.clone(), rec);
+            }
+            Err(e) => tracing::warn!(
+                error = %e,
+                line = trimmed,
+                path = %path.display(),
+                "summary.jsonl: skipping unparseable line",
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::TokenUsage;
+    use chrono::{TimeZone, Utc};
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn rec(task_id: &str, status: TaskStatus) -> TaskRecord {
+        let t = Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+        TaskRecord {
+            task_id: task_id.into(),
+            status,
+            exit_code: Some(0),
+            started_at: t,
+            ended_at: t,
+            duration_ms: 0,
+            worktree_path: None,
+            log_path: PathBuf::from("/dev/null"),
+            token_usage: TokenUsage::default(),
+            claude_session_id: None,
+            final_message_preview: None,
+            final_message: None,
+            parent_task_id: None,
+            pause_count: 0,
+            reprompt_count: 0,
+            approvals_requested: 0,
+            approvals_approved: 0,
+            approvals_rejected: 0,
+            model: None,
+            failure_reason: None,
+            cost_usd: None,
+            actor_type: None,
+        }
+    }
+
+    fn write_jsonl(path: &Path, records: &[TaskRecord]) {
+        let lines: Vec<String> = records
+            .iter()
+            .map(|r| serde_json::to_string(r).unwrap())
+            .collect();
+        std::fs::write(path, lines.join("\n") + "\n").unwrap();
+    }
+
+    #[test]
+    fn empty_dir_yields_default_snapshot() {
+        let tmp = TempDir::new().unwrap();
+        let snap = read_run_snapshot(tmp.path());
+        assert!(!snap.is_finalized());
+        assert_eq!(snap.task_count(), 0);
+        assert_eq!(snap.failed_count(), 0);
+    }
+
+    #[test]
+    fn jsonl_only_in_progress_run() {
+        let tmp = TempDir::new().unwrap();
+        write_jsonl(
+            &tmp.path().join("summary.jsonl"),
+            &[rec("a", TaskStatus::Success), rec("b", TaskStatus::Failed)],
+        );
+        let snap = read_run_snapshot(tmp.path());
+        assert!(!snap.is_finalized());
+        assert_eq!(snap.task_count(), 2);
+        assert_eq!(snap.failed_count(), 1);
+        assert!(snap.get("a").is_some());
+    }
+
+    /// The motivating bug from #437: reprompt / cancel / respawn writes
+    /// multiple `.jsonl` rows for one `task_id`. Last wins. Task counts
+    /// must reflect the unique actor set, not the line count.
+    #[test]
+    fn jsonl_duplicate_task_id_last_wins() {
+        let tmp = TempDir::new().unwrap();
+        write_jsonl(
+            &tmp.path().join("summary.jsonl"),
+            &[
+                rec("worker-1", TaskStatus::Cancelled),
+                rec("worker-1", TaskStatus::Success), // newer row wins
+                rec("worker-2", TaskStatus::Failed),
+            ],
+        );
+        let snap = read_run_snapshot(tmp.path());
+        assert_eq!(snap.task_count(), 2, "dedupe by task_id");
+        assert_eq!(snap.failed_count(), 1, "only worker-2 stays Failed");
+        assert!(matches!(
+            snap.get("worker-1").unwrap().status,
+            TaskStatus::Success
+        ));
+    }
+
+    #[test]
+    fn malformed_lines_are_skipped() {
+        let tmp = TempDir::new().unwrap();
+        let mut bytes = serde_json::to_string(&rec("a", TaskStatus::Success)).unwrap();
+        bytes.push('\n');
+        bytes.push_str("{not valid json}\n");
+        bytes.push('\n'); // blank line
+        bytes.push_str(&serde_json::to_string(&rec("b", TaskStatus::Failed)).unwrap());
+        bytes.push('\n');
+        std::fs::write(tmp.path().join("summary.jsonl"), bytes).unwrap();
+        let snap = read_run_snapshot(tmp.path());
+        assert_eq!(snap.task_count(), 2);
+    }
+
+    /// In-progress run that crashed mid-write of the last record. The
+    /// canonical reader must drop the truncated tail without failing.
+    #[test]
+    fn truncated_trailing_line_is_dropped() {
+        let tmp = TempDir::new().unwrap();
+        let good = serde_json::to_string(&rec("a", TaskStatus::Success)).unwrap();
+        let truncated = "{\"task_id\":\"b\",\"status\":\"Suc"; // mid-write
+        let bytes = format!("{good}\n{truncated}");
+        std::fs::write(tmp.path().join("summary.jsonl"), bytes).unwrap();
+        let snap = read_run_snapshot(tmp.path());
+        assert_eq!(snap.task_count(), 1);
+        assert!(snap.get("a").is_some());
+    }
+
+    #[test]
+    fn finalized_summary_json_seeds_snapshot() {
+        let tmp = TempDir::new().unwrap();
+        let t = Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+        let summary = RunSummary {
+            run_id: uuid::Uuid::nil(),
+            manifest_path: PathBuf::from("/x.toml"),
+            manifest_name: None,
+            pitboss_version: "test".into(),
+            claude_version: None,
+            started_at: t,
+            ended_at: t,
+            total_duration_ms: 0,
+            tasks_total: 2,
+            tasks_failed: 1,
+            was_interrupted: false,
+            notify_failures: None,
+            tasks: vec![rec("a", TaskStatus::Success), rec("b", TaskStatus::Failed)],
+            spend_breakdown: None,
+        };
+        std::fs::write(
+            tmp.path().join("summary.json"),
+            serde_json::to_vec_pretty(&summary).unwrap(),
+        )
+        .unwrap();
+
+        let snap = read_run_snapshot(tmp.path());
+        assert!(snap.is_finalized());
+        assert_eq!(snap.task_count(), 2);
+        assert_eq!(snap.failed_count(), 1);
+        assert_eq!(snap.run_summary.unwrap().tasks_total, 2);
+    }
+
+    /// The interesting merge case: `summary.json` is older than the
+    /// most recent `summary.jsonl` row (e.g. resume after finalize).
+    /// The newer `.jsonl` row wins.
+    #[test]
+    fn jsonl_overlays_summary_json() {
+        let tmp = TempDir::new().unwrap();
+        let t = Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+        let snapshot_json = RunSummary {
+            run_id: uuid::Uuid::nil(),
+            manifest_path: PathBuf::from("/x.toml"),
+            manifest_name: None,
+            pitboss_version: "test".into(),
+            claude_version: None,
+            started_at: t,
+            ended_at: t,
+            total_duration_ms: 0,
+            tasks_total: 1,
+            tasks_failed: 1,
+            was_interrupted: false,
+            notify_failures: None,
+            tasks: vec![rec("a", TaskStatus::Failed)],
+            spend_breakdown: None,
+        };
+        std::fs::write(
+            tmp.path().join("summary.json"),
+            serde_json::to_vec(&snapshot_json).unwrap(),
+        )
+        .unwrap();
+        write_jsonl(
+            &tmp.path().join("summary.jsonl"),
+            &[rec("a", TaskStatus::Success)],
+        );
+        let snap = read_run_snapshot(tmp.path());
+        assert_eq!(snap.task_count(), 1);
+        assert!(
+            matches!(snap.get("a").unwrap().status, TaskStatus::Success),
+            ".jsonl overlays .json for the same task_id",
+        );
+    }
+
+    /// Cross-surface parity contract (#437 acceptance criterion). Every
+    /// consumer of the canonical reader derives its counts and lookups
+    /// from the same `RunSnapshot`, so the same fixture must produce
+    /// identical numbers regardless of which surface is asking.
+    ///
+    /// Surfaces and the shape they consume:
+    ///
+    /// - TUI watcher / TUI launcher: `snapshot.tasks` (`HashMap` iterated
+    ///   for tile rendering).
+    /// - `pitboss status`: `snapshot.tasks.into_values().collect::<Vec>()`
+    ///   + `snapshot.run_summary.notify_failures`.
+    /// - `pitboss list` / Stale-state classifier: `snapshot.task_count()`
+    ///   + `snapshot.failed_count()` — the latent over-count bug #429
+    ///     missed on the SPA side.
+    /// - `pitboss diff`: `snapshot.run_summary` when present, else
+    ///   `snapshot.tasks.into_values().collect()` for reconstruction.
+    /// - Dispatcher finalize aggregation: `snapshot.tasks.keys()` for the
+    ///   "is this actor already settled?" filter + the records for the
+    ///   `summary.json` write.
+    /// - `pitboss-web` `task_detail`: `snapshot.tasks.get(task_id)`.
+    /// - `pitboss-web` insights aggregator: `snapshot.run_summary`.
+    ///
+    /// If this test breaks, a consumer has either drifted away from the
+    /// canonical reader or the canonical reader's merge semantics have
+    /// changed without a coordinated audit of the consumers.
+    #[test]
+    fn cross_surface_parity_on_duplicate_task_ids() {
+        let tmp = TempDir::new().unwrap();
+        write_jsonl(
+            &tmp.path().join("summary.jsonl"),
+            &[
+                // worker-1 cycled through cancel + respawn before
+                // landing Success — the reprompt/cancel/respawn lifecycle
+                // that motivated #429.
+                rec("worker-1", TaskStatus::Cancelled),
+                rec("worker-1", TaskStatus::Success),
+                rec("worker-2", TaskStatus::Failed),
+                rec("worker-3", TaskStatus::Success),
+            ],
+        );
+        let snap = read_run_snapshot(tmp.path());
+
+        // ---- TUI surface (HashMap iteration for tile rendering) ----
+        assert_eq!(snap.tasks.len(), 3, "TUI tile count");
+
+        // ---- pitboss status / diff / hierarchical (Vec<TaskRecord>) ----
+        let vec: Vec<&TaskRecord> = snap.tasks.values().collect();
+        assert_eq!(vec.len(), 3, "status/diff/hierarchical tasks_total");
+        assert_eq!(
+            vec.iter()
+                .filter(|t| !matches!(t.status, TaskStatus::Success))
+                .count(),
+            1,
+            "tasks_failed = worker-2 only",
+        );
+
+        // ---- pitboss list / Stale classifier (helper methods) ----
+        assert_eq!(snap.task_count(), 3, "list view tasks_total");
+        assert_eq!(snap.failed_count(), 1, "list view tasks_failed");
+
+        // ---- pitboss-web task_detail (get by id) ----
+        let w1 = snap.get("worker-1").expect("worker-1 present");
+        assert!(
+            matches!(w1.status, TaskStatus::Success),
+            "task_detail returns the freshest row, not the Cancelled one",
+        );
+        assert!(snap.get("worker-2").is_some());
+        assert!(snap.get("worker-3").is_some());
+        assert!(snap.get("nonexistent").is_none());
+    }
+
+    #[test]
+    fn corrupt_summary_json_falls_back_to_jsonl() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("summary.json"), "{not json").unwrap();
+        write_jsonl(
+            &tmp.path().join("summary.jsonl"),
+            &[rec("a", TaskStatus::Success)],
+        );
+        let snap = read_run_snapshot(tmp.path());
+        assert!(!snap.is_finalized(), "broken .json doesn't mark finalized");
+        assert_eq!(snap.task_count(), 1);
+    }
+}

--- a/crates/pitboss-tui/src/main.rs
+++ b/crates/pitboss-tui/src/main.rs
@@ -226,10 +226,9 @@ fn cmd_screenshot(run: Option<&str>, cols: u16, rows: u16) -> Result<()> {
 /// Same shape as `watcher::build_snapshot` but synchronous and self-contained.
 #[allow(clippy::too_many_lines)] // mirror of watcher::build_snapshot; two fns share the schema
 fn build_one_shot_snapshot(run_dir: &std::path::Path) -> state::AppSnapshot {
-    use pitboss_core::store::{TaskRecord, TaskStatus};
+    use pitboss_core::store::TaskStatus;
     use pitboss_tui::state::{AppSnapshot, TileState, TileStatus};
     use serde::Deserialize;
-    use std::io::BufRead;
 
     #[derive(Deserialize)]
     struct ResTask {
@@ -254,26 +253,12 @@ fn build_one_shot_snapshot(run_dir: &std::path::Path) -> state::AppSnapshot {
         .collect();
     let task_ids: Vec<String> = resolved_tasks.into_iter().map(|t| t.id).collect();
 
-    let mut completed: std::collections::HashMap<String, TaskRecord> =
-        std::collections::HashMap::new();
-    // Prefer summary.json (finalized) over summary.jsonl (which is cleared on
-    // finalize in some code paths). Fall back to jsonl when the run is in-progress.
-    if let Ok(bytes) = std::fs::read(run_dir.join("summary.json")) {
-        if let Ok(sum) = serde_json::from_slice::<pitboss_core::store::RunSummary>(&bytes) {
-            for rec in sum.tasks {
-                completed.insert(rec.task_id.clone(), rec);
-            }
-        }
-    }
-    if completed.is_empty() {
-        if let Ok(f) = std::fs::File::open(run_dir.join("summary.jsonl")) {
-            for line in std::io::BufReader::new(f).lines().map_while(Result::ok) {
-                if let Ok(rec) = serde_json::from_str::<TaskRecord>(line.trim()) {
-                    completed.insert(rec.task_id.clone(), rec);
-                }
-            }
-        }
-    }
+    // Merged + deduped snapshot via the canonical reader (#437). Replaces
+    // the previous "summary.json OR fall back to summary.jsonl" branch —
+    // the canonical reader now overlays jsonl on top of json with
+    // last-wins by task_id, so resume-after-finalize and reprompt /
+    // cancel / respawn lifecycles all render the freshest record.
+    let completed = pitboss_core::store::read_run_snapshot(run_dir).tasks;
 
     let tasks_dir = run_dir.join("tasks");
     let mut tiles: Vec<TileState> = Vec::new();

--- a/crates/pitboss-tui/src/watcher.rs
+++ b/crates/pitboss-tui/src/watcher.rs
@@ -165,16 +165,11 @@ fn build_snapshot(run_dir: &Path, focused_id: Option<&str>) -> AppSnapshot {
         &resolved.sublead_types,
     );
 
-    // 2. Gather completed task records. Prefer summary.json (written on clean
-    //    finalize) since summary.jsonl may be empty or truncated after
-    //    finalization. Merge the jsonl records on top so in-progress runs
-    //    still show completed tiles live.
-    let mut completed: std::collections::HashMap<String, TaskRecord> =
-        read_summary_json(&run_dir.join("summary.json"));
-    let jsonl = read_summary_jsonl(&run_dir.join("summary.jsonl"));
-    for (k, v) in jsonl {
-        completed.entry(k).or_insert(v);
-    }
+    // 2. Gather completed task records via the canonical reader (#437).
+    //    summary.json seeds the map when finalized; summary.jsonl rows
+    //    overlay last-wins by task_id, so a resume-after-finalize or a
+    //    reprompt/cancel/respawn lifecycle reflects the freshest record.
+    let completed = pitboss_core::store::read_run_snapshot(run_dir).tasks;
 
     // 3. Dynamic worker ids come from two sources:
     //    - `summary.jsonl`/`summary.json` records for completed workers not in
@@ -636,39 +631,6 @@ fn scan_live_stats(path: &Path) -> (Option<String>, pitboss_core::parser::TokenU
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-fn read_summary_jsonl(path: &Path) -> std::collections::HashMap<String, TaskRecord> {
-    let mut map = std::collections::HashMap::new();
-    let Ok(file) = std::fs::File::open(path) else {
-        return map;
-    };
-    let reader = BufReader::new(file);
-    for line in reader.lines().map_while(Result::ok) {
-        let line = line.trim().to_string();
-        if line.is_empty() {
-            continue;
-        }
-        if let Ok(rec) = serde_json::from_str::<TaskRecord>(&line) {
-            map.insert(rec.task_id.clone(), rec);
-        }
-    }
-    map
-}
-
-/// Reads the finalized summary.json (present only on clean exit) and returns
-/// a map of task records. Empty map if the file is missing or unreadable.
-fn read_summary_json(path: &Path) -> std::collections::HashMap<String, TaskRecord> {
-    let mut map = std::collections::HashMap::new();
-    let Ok(bytes) = std::fs::read(path) else {
-        return map;
-    };
-    if let Ok(summary) = serde_json::from_slice::<pitboss_core::store::RunSummary>(&bytes) {
-        for rec in summary.tasks {
-            map.insert(rec.task_id.clone(), rec);
-        }
-    }
-    map
-}
 
 /// Returns `Some(seconds_since_last_modification)` if the file exists,
 /// or `None` if it does not exist or metadata cannot be read.

--- a/crates/pitboss-web/src/api/runs.rs
+++ b/crates/pitboss-web/src/api/runs.rs
@@ -124,12 +124,13 @@ pub struct LogQuery {
 }
 
 /// `GET /api/runs/:run_id/tasks/:task_id` — single `TaskRecord` for one
-/// actor (lead, sub-lead, or worker). Reads `summary.jsonl` line by line
-/// and returns the first record whose `task_id` matches. `summary.jsonl`
-/// is the source of truth — it captures every actor across every layer
-/// (root + sub-leads + workers), unlike `summary.json` which is written
-/// once at finalize and aggregates only what the dispatcher had visible
-/// at that moment (#221).
+/// actor (lead, sub-lead, or worker). Uses the canonical reader (#437)
+/// so the returned record reflects last-wins dedup across the merged
+/// `summary.json` + `summary.jsonl` view — a reprompt / cancel /
+/// respawn lifecycle no longer leaks an earlier `Cancelled` row when
+/// the actor eventually succeeded. `summary.jsonl` remains the source
+/// of truth for in-progress runs and for cross-layer actors that
+/// `summary.json` may miss until finalize (#221).
 ///
 /// 404 when the run dir exists but no record carries the given task_id.
 pub async fn task_detail(
@@ -137,38 +138,25 @@ pub async fn task_detail(
     AxPath((run_id, task_id)): AxPath<(String, String)>,
 ) -> ApiResult<Response> {
     let run_dir = run_dir(state.runs_dir(), &run_id)?;
-    // task_id is rendered into a JSON string match below, not into a
-    // path, so the path-segment sanitizer doesn't apply here. We still
-    // bound the length to keep the substring scan cheap.
     if task_id.is_empty() || task_id.len() > 256 {
         return Err(ApiError::BadRequest("invalid task_id length".into()));
     }
-    let path = run_dir.join("summary.jsonl");
-    let bytes = match tokio::fs::read(&path).await {
-        Ok(b) => b,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Err(ApiError::NotFound),
-        Err(e) => return Err(e.into()),
-    };
-    // Lossy decode: a partial-write tail (the dispatcher appends as
-    // each actor finishes) shouldn't 500 the request — better to skip
-    // a malformed line than to fail a perfectly-readable lookup.
-    let text = String::from_utf8_lossy(&bytes);
-    let needle = format!("\"task_id\":\"{task_id}\"");
-    for line in text.lines() {
-        if !line.contains(&needle) {
-            continue;
-        }
-        // Substring match isn't authoritative (the task_id could appear
-        // inside another field — a parent_task_id reference, the log
-        // path, etc.). Confirm with a real parse.
-        let Ok(rec) = serde_json::from_str::<pitboss_core::store::TaskRecord>(line) else {
-            continue;
-        };
-        if rec.task_id == task_id {
-            return Ok(Json(rec).into_response());
-        }
+    // 404 the request before snapshotting if neither summary file
+    // exists — covers the "run id directory present but never wrote
+    // summary.jsonl" race window.
+    let jsonl = run_dir.join("summary.jsonl");
+    let summary_json = run_dir.join("summary.json");
+    if !jsonl.exists() && !summary_json.exists() {
+        return Err(ApiError::NotFound);
     }
-    Err(ApiError::NotFound)
+    let snap =
+        tokio::task::spawn_blocking(move || pitboss_core::store::read_run_snapshot(&run_dir))
+            .await
+            .map_err(|e| std::io::Error::other(format!("snapshot read task panicked: {e}")))?;
+    match snap.tasks.get(&task_id).cloned() {
+        Some(rec) => Ok(Json(rec).into_response()),
+        None => Err(ApiError::NotFound),
+    }
 }
 
 /// `GET /api/runs/:id/tasks/:task_id/log` — task `stdout.log`.

--- a/crates/pitboss-web/src/insights/aggregator.rs
+++ b/crates/pitboss-web/src/insights/aggregator.rs
@@ -8,7 +8,7 @@
 use std::path::{Path, PathBuf};
 
 use pitboss_cli::runs::{collect_run_entries, RunStatus};
-use pitboss_core::store::{FailureReason, RunSummary, TaskStatus};
+use pitboss_core::store::{FailureReason, TaskStatus};
 use serde::Deserialize;
 
 use super::digest::{RunDigest, TaskFailureDigest};
@@ -46,11 +46,12 @@ impl AggregateSet {
         let mut failures = Vec::new();
 
         for entry in entries {
-            let summary_path = entry.run_dir.join("summary.json");
-            let summary = match std::fs::read(&summary_path) {
-                Ok(bytes) => serde_json::from_slice::<RunSummary>(&bytes).ok(),
-                Err(_) => None,
-            };
+            // Canonical reader (#437): single point of summary.json
+            // parse-error logging. The aggregator still keys off the
+            // finalized snapshot — in-progress runs (run_summary =
+            // None) contribute only their resolved.json / meta.json
+            // breadcrumbs below.
+            let summary = pitboss_core::store::read_run_snapshot(&entry.run_dir).run_summary;
 
             // For in-progress / aborted runs without a summary.json,
             // attempt to read the (newer) name field from resolved.json.


### PR DESCRIPTION
## Summary

- Adds \`pitboss_core::store::summary::{RunSnapshot, read_run_snapshot}\` as the single canonical reader for a run's \`summary.json\` + \`summary.jsonl\` artifacts, with documented merge semantics: \`.json\` seeds, \`.jsonl\` overlays **last-wins by \`task_id\`**, truncated / malformed lines drop with \`tracing::warn\`, missing files yield default.
- Migrates all 10 reader sites in pitboss-tui, pitboss-cli, and pitboss-web to the canonical reader. Net -122 lines.
- Fixes a **latent CLI over-count bug** that was the parallel of #429 (SPA-side dedup) — \`pitboss status\` / \`pitboss diff\` / \`pitboss list\` previously over-counted \`tasks_total\` and \`tasks_failed\` for any run with a reprompt / cancel / respawn lifecycle.
- Adds a cross-surface parity test that documents the contract every consumer relies on (\`pitboss_core::store::summary::tests::cross_surface_parity_on_duplicate_task_ids\`).

Closes #437.

## Background

Before this PR there were three different merge strategies for the same on-disk schema, scattered across:

| Surface | Site | Pre-PR semantics |
|---|---|---|
| TUI watcher | \`watcher.rs:640\` | HashMap last-wins; \`.json\` overlaid by \`.jsonl\` |
| TUI launcher | \`main.rs:257\` | HashMap last-wins; **exclusive** \`.json\` OR \`.jsonl\` |
| CLI hierarchical | \`dispatch/hierarchical.rs:35\` | \`Vec<TaskRecord>\` with **no dedup** |
| CLI status | \`status.rs:34\` | \`Vec\`, **no dedup**, prefers \`.json\` |
| CLI diff | \`diff.rs:44\` | \`Vec\`, **no dedup** |
| CLI list / Stale | \`runs.rs:404\` | line count, **no dedup** |
| Web task_detail | \`api/runs.rs:135\` | substring scan + **first match** |
| Web insights | \`insights/aggregator.rs:43\` | \`.json\` only, no dedup needed |

The 6-month drift incident from \`run_meta.outcome\` (SPA #169 → #409) and the latent CLI bug above are direct consequences of "three readers, one schema." The new module enforces the contract structurally — a future \`TaskRecord\` field add can no longer fall through to one consumer that forgot to update.

## What was deliberately *not* done in this PR

- **Tier 2** (incremental tail / mtime + byte-offset caching) and **Tier 3** (push via the \`notify\` crate, preserving cold-run rendering via initial-snapshot + delta) are tracked separately under the same umbrella (#437).
- **Tier 4** lives in #438 (unified envelope API for live socket fan-out + historical file replay).
- \`JsonFileStore::load_run\` and \`SqliteStore::load_run\` still have their own dedup-free reconstructions, but they're only exercised by tests in production. Worth a follow-up sweep but not in scope here.

## Test plan

- [x] \`cargo test -p pitboss-core --lib store::summary\` — 9 unit tests including the parity contract.
- [x] \`cargo test --workspace --features pitboss-core/test-support\` — 1500+ tests pass. One unrelated env-only failure (\`process::tokio_impl::tests::terminate_after_exit_is_ok\` — \`BinaryNotFound { path: "/bin/true" }\`) that's a macOS sandbox quirk; Linux CI unaffected.
- [x] \`cargo lint\` clean.
- [x] \`cargo tidy\` clean.
- [ ] Verify on a real run with a reprompt-cancel-respawn lifecycle that \`pitboss status\` / \`pitboss list\` no longer over-count vs \`pitboss-web\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)