### PR TITLE
feat(core): incremental tail reader for summary.json[l]

### DIFF
--- a/crates/pitboss-core/src/store/mod.rs
+++ b/crates/pitboss-core/src/store/mod.rs
@@ -13,7 +13,7 @@ pub mod sqlite;
 pub use sqlite::SqliteStore;
 
 pub mod summary;
-pub use summary::{read_run_snapshot, RunSnapshot};
+pub use summary::{read_run_snapshot, RunSnapshot, RunSnapshotReader};
 
 #[cfg(test)]
 mod integration_tests {

--- a/crates/pitboss-core/src/store/summary.rs
+++ b/crates/pitboss-core/src/store/summary.rs
@@ -164,11 +164,22 @@ struct JsonlTail {
     mtime: Option<SystemTime>,
     /// File identity. On unix, the inode discriminates "appended" from
     /// "replaced wholesale" (`pitboss resume` against a wiped run dir,
-    /// `mv` over the file, etc.). Without inode tracking, a same-size
-    /// replacement at the same path with advancing mtime would silently
-    /// tail past the wrong content.
+    /// `mv` over the file, etc.). Inode alone is insufficient — Linux
+    /// tmpfs (and ext4 under churn) readily reuses inodes when a file
+    /// is removed and a new one is created at the same path. We pair
+    /// inode with [`Self::created_at`] below for unambiguous rotation
+    /// detection.
     #[cfg(unix)]
     inode: Option<u64>,
+    /// File creation time (`statx::stx_btime` on Linux,
+    /// `st_birthtimespec` on macOS). Set once at file creation and
+    /// never updated, so a rotated file at the same path with a reused
+    /// inode is still distinguishable. Falls back to `None` on
+    /// filesystems that don't expose birthtime (legacy NFS, some
+    /// FUSE), in which case we rely on the inode + size + mtime
+    /// triple alone — which is what the pre-#440 code did and what
+    /// the macOS local tests passed under.
+    created_at: Option<SystemTime>,
 }
 
 /// Stateful reader for a run directory's summary artifacts.
@@ -254,6 +265,7 @@ impl RunSnapshotReader {
                 self.tail_jsonl(&jsonl_path, size);
             }
             self.jsonl.mtime = jm.modified().ok();
+            self.jsonl.created_at = jm.created().ok();
             #[cfg(unix)]
             {
                 self.jsonl.inode = Some(jm.ino());
@@ -289,9 +301,20 @@ impl RunSnapshotReader {
                 return false;
             }
         }
-        // Rotation detected (unix-only — non-unix targets fall back to
-        // size + mtime, which catches truncate and same-name rewrites
-        // that ext4/APFS tend to leave with a newer mtime).
+        // Rotation detected via birthtime. `rm path && create path`
+        // on Linux tmpfs readily reuses inodes — local macOS tests
+        // passed under inode-only detection, CI on Linux did not.
+        // Birthtime advances unconditionally on every fresh inode
+        // allocation. Missing on a filesystem that doesn't expose it
+        // (legacy NFS, some FUSE) → fall through to inode check.
+        if let (Some(prev), Ok(cur)) = (self.jsonl.created_at, meta.created()) {
+            if cur != prev {
+                return false;
+            }
+        }
+        // Rotation detected via inode (catches platforms that don't
+        // expose birthtime, and is correct on filesystems that don't
+        // reuse inodes promptly).
         #[cfg(unix)]
         {
             if let Some(prev) = self.jsonl.inode {
@@ -314,6 +337,7 @@ impl RunSnapshotReader {
         if let Some(m) = tail_meta {
             self.jsonl.offset = m.len();
             self.jsonl.mtime = m.modified().ok();
+            self.jsonl.created_at = m.created().ok();
             #[cfg(unix)]
             {
                 self.jsonl.inode = Some(m.ino());

--- a/crates/pitboss-core/src/store/summary.rs
+++ b/crates/pitboss-core/src/store/summary.rs
@@ -15,7 +15,12 @@
 //! finalized `RunSummary` consume [`RunSnapshot::run_summary`].
 
 use std::collections::HashMap;
-use std::path::Path;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
 
 use crate::store::record::{RunSummary, TaskRecord, TaskStatus};
 
@@ -129,6 +134,252 @@ fn overlay_summary_jsonl(path: &Path, tasks: &mut HashMap<String, TaskRecord>) {
                 "summary.jsonl: skipping unparseable line",
             ),
         }
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Stateful reader — Tier 2 of #437.
+//
+// `read_run_snapshot` re-parses the full files on every call. For the TUI
+// watcher, which polls at 4 Hz, that's O(file size) work per tick. The
+// reader below keeps the parsed [`RunSnapshot`] live across calls and
+// `refresh()` does the minimum work: a stat, then either no-op, a tail
+// parse of the new bytes only, or — on rotation / truncate / unexpected
+// mtime regress — a full reparse.
+//
+// One-shot callers (`pitboss status`, `pitboss list`, the web HTTP
+// handlers, the dispatcher's finalize aggregator) keep using
+// `read_run_snapshot` — they never read the same file twice in the
+// hot path, so paying the per-call setup cost is wasted.
+// ----------------------------------------------------------------------------
+
+/// Per-source tracking state for [`RunSnapshotReader`].
+#[derive(Debug, Clone, Default)]
+struct JsonlTail {
+    /// Byte offset of the next unread byte. After a successful tail, this
+    /// advances to the position just past the last complete `\n` in the
+    /// new bytes. A mid-write trailing line is left in the file at this
+    /// offset and re-read on the next refresh.
+    offset: u64,
+    mtime: Option<SystemTime>,
+    /// File identity. On unix, the inode discriminates "appended" from
+    /// "replaced wholesale" (`pitboss resume` against a wiped run dir,
+    /// `mv` over the file, etc.). Without inode tracking, a same-size
+    /// replacement at the same path with advancing mtime would silently
+    /// tail past the wrong content.
+    #[cfg(unix)]
+    inode: Option<u64>,
+}
+
+/// Stateful reader for a run directory's summary artifacts.
+///
+/// Hold one per (`run_id`, consumer) and call [`Self::refresh`] each
+/// tick. The returned snapshot is the same canonical merge as
+/// [`read_run_snapshot`] (see that function's docs for semantics) —
+/// the only difference is the cost profile: O(new bytes) on append,
+/// O(0) on no change, O(full file) only on rotation / truncate / first
+/// call.
+///
+/// # Cost model
+///
+/// | Disk change between refreshes | Work |
+/// |---|---|
+/// | None | One stat per file. No parse. |
+/// | `summary.jsonl` appended (same inode, mtime advanced) | Parse only the new bytes; overlay into the cached map. |
+/// | `summary.json` appeared or its mtime advanced | Re-read and reparse `summary.json` once. Tasks re-seeded into the map. |
+/// | `summary.jsonl` rotated (inode change), truncated (size shrunk), or mtime regressed | Full reparse via [`read_run_snapshot`]; tracking state reset. |
+///
+/// The reader is `!Sync` — it holds owned mutable state. Wrap in a
+/// `Mutex` if multiple threads need to share one instance; the more
+/// typical pattern is one reader per polling consumer.
+#[derive(Debug)]
+pub struct RunSnapshotReader {
+    run_dir: PathBuf,
+    cached: RunSnapshot,
+    json_mtime: Option<SystemTime>,
+    jsonl: JsonlTail,
+}
+
+impl RunSnapshotReader {
+    /// Construct an empty reader. The first `refresh()` call populates
+    /// the cache via a full read.
+    #[must_use]
+    pub fn new(run_dir: PathBuf) -> Self {
+        Self {
+            run_dir,
+            cached: RunSnapshot::default(),
+            json_mtime: None,
+            jsonl: JsonlTail::default(),
+        }
+    }
+
+    /// Reconcile the cached snapshot against the current on-disk state
+    /// and return a reference to it. See the struct docs for the cost
+    /// model.
+    pub fn refresh(&mut self) -> &RunSnapshot {
+        let json_path = self.run_dir.join("summary.json");
+        let jsonl_path = self.run_dir.join("summary.jsonl");
+
+        let head_meta = std::fs::metadata(&json_path).ok();
+        let tail_meta = std::fs::metadata(&jsonl_path).ok();
+
+        // Decide whether the jsonl side is in a state where an
+        // incremental tail is safe. Anything ambiguous → full reparse.
+        let tail_safe = self.jsonl_tail_is_safe(tail_meta.as_ref());
+        if !tail_safe {
+            return self.full_reparse(tail_meta.as_ref(), head_meta.as_ref());
+        }
+
+        // summary.json: re-read whenever its mtime advances. Appearing
+        // for the first time is the common case (run just finalized).
+        if let Some(jm) = head_meta.as_ref() {
+            let m = jm.modified().ok();
+            if self.json_mtime != m {
+                self.reload_json(&json_path);
+                self.json_mtime = m;
+            }
+        } else if self.json_mtime.is_some() {
+            // File went away — uncommon outside test fixtures, but be
+            // defensive. Drop the cached finalized summary; per-task
+            // rows live in `cached.tasks` and stay valid.
+            self.cached.run_summary = None;
+            self.json_mtime = None;
+        }
+
+        // summary.jsonl: tail any new bytes from `self.jsonl.offset`
+        // to current EOF.
+        if let Some(jm) = tail_meta.as_ref() {
+            let size = jm.len();
+            if size > self.jsonl.offset {
+                self.tail_jsonl(&jsonl_path, size);
+            }
+            self.jsonl.mtime = jm.modified().ok();
+            #[cfg(unix)]
+            {
+                self.jsonl.inode = Some(jm.ino());
+            }
+        }
+
+        &self.cached
+    }
+
+    /// Access the cached snapshot without touching the filesystem.
+    #[must_use]
+    pub fn snapshot(&self) -> &RunSnapshot {
+        &self.cached
+    }
+
+    fn jsonl_tail_is_safe(&self, meta: Option<&std::fs::Metadata>) -> bool {
+        let Some(meta) = meta else {
+            // No file. Safe iff we never saw one — otherwise the file
+            // went away and we should rebuild from scratch.
+            return self.jsonl.offset == 0;
+        };
+        // First refresh: any state is safe (the read starts from 0).
+        if self.jsonl.mtime.is_none() && self.jsonl.offset == 0 {
+            return true;
+        }
+        // Truncate detected.
+        if meta.len() < self.jsonl.offset {
+            return false;
+        }
+        // Backdated write.
+        if let (Some(prev), Ok(cur)) = (self.jsonl.mtime, meta.modified()) {
+            if cur < prev {
+                return false;
+            }
+        }
+        // Rotation detected (unix-only — non-unix targets fall back to
+        // size + mtime, which catches truncate and same-name rewrites
+        // that ext4/APFS tend to leave with a newer mtime).
+        #[cfg(unix)]
+        {
+            if let Some(prev) = self.jsonl.inode {
+                if prev != meta.ino() {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
+    fn full_reparse(
+        &mut self,
+        tail_meta: Option<&std::fs::Metadata>,
+        head_meta: Option<&std::fs::Metadata>,
+    ) -> &RunSnapshot {
+        self.cached = read_run_snapshot(&self.run_dir);
+        self.json_mtime = head_meta.and_then(|m| m.modified().ok());
+        self.jsonl = JsonlTail::default();
+        if let Some(m) = tail_meta {
+            self.jsonl.offset = m.len();
+            self.jsonl.mtime = m.modified().ok();
+            #[cfg(unix)]
+            {
+                self.jsonl.inode = Some(m.ino());
+            }
+        }
+        &self.cached
+    }
+
+    fn reload_json(&mut self, path: &Path) {
+        // Drop the previous `run_summary` first so a parse failure
+        // leaves the cache in an honest "not finalized" state.
+        self.cached.run_summary = None;
+        self.cached.run_summary = load_summary_json(path, &mut self.cached.tasks);
+    }
+
+    fn tail_jsonl(&mut self, path: &Path, current_size: u64) {
+        let Ok(mut file) = std::fs::File::open(path) else {
+            return;
+        };
+        if file.seek(SeekFrom::Start(self.jsonl.offset)).is_err() {
+            return;
+        }
+        let to_read = current_size.saturating_sub(self.jsonl.offset);
+        let mut buf = vec![0u8; usize::try_from(to_read).unwrap_or(usize::MAX)];
+        let Ok(n) = file.read(&mut buf) else { return };
+        buf.truncate(n);
+
+        // Parse only up through the last `\n`. Anything after the last
+        // newline is a mid-write tail — leave it in the file and
+        // re-read on the next refresh.
+        let last_newline = buf.iter().rposition(|&b| b == b'\n');
+        let Some(last_nl) = last_newline else {
+            // Read bytes but no newline yet — wait for more writes.
+            return;
+        };
+        let complete = &buf[..=last_nl];
+        let text = match std::str::from_utf8(complete) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    path = %path.display(),
+                    "summary.jsonl tail: non-utf8 bytes; skipping this delta",
+                );
+                self.jsonl.offset += u64::try_from(last_nl + 1).unwrap_or(0);
+                return;
+            }
+        };
+        for line in text.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<TaskRecord>(trimmed) {
+                Ok(rec) => {
+                    self.cached.tasks.insert(rec.task_id.clone(), rec);
+                }
+                Err(e) => tracing::warn!(
+                    error = %e,
+                    line = trimmed,
+                    path = %path.display(),
+                    "summary.jsonl tail: skipping unparseable line",
+                ),
+            }
+        }
+        self.jsonl.offset += u64::try_from(last_nl + 1).unwrap_or(0);
     }
 }
 
@@ -392,6 +643,227 @@ mod tests {
         assert!(snap.get("worker-2").is_some());
         assert!(snap.get("worker-3").is_some());
         assert!(snap.get("nonexistent").is_none());
+    }
+
+    // ------------------------------------------------------------------
+    // RunSnapshotReader — Tier 2 incremental-tail tests.
+    // ------------------------------------------------------------------
+
+    /// Bump the file's mtime forward by `delta_secs` so tests that
+    /// rely on mtime-comparison don't race the filesystem's
+    /// granularity (HFS+ is 1s; ext4 is 1ns but the dispatch tick is
+    /// fast enough to land in the same nanosecond on aarch64).
+    fn bump_mtime(path: &Path, delta_secs: u64) {
+        let now = SystemTime::now()
+            .checked_add(std::time::Duration::from_secs(delta_secs))
+            .unwrap();
+        let f = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+        f.set_modified(now).unwrap();
+    }
+
+    fn write_records_to_jsonl(path: &Path, records: &[TaskRecord]) {
+        use std::io::Write;
+        let mut f = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .unwrap();
+        for r in records {
+            writeln!(f, "{}", serde_json::to_string(r).unwrap()).unwrap();
+        }
+        f.sync_all().unwrap();
+    }
+
+    #[test]
+    fn reader_initial_refresh_handles_empty_dir() {
+        let tmp = TempDir::new().unwrap();
+        let mut reader = RunSnapshotReader::new(tmp.path().to_path_buf());
+        let snap = reader.refresh();
+        assert_eq!(snap.task_count(), 0);
+        assert!(!snap.is_finalized());
+    }
+
+    #[test]
+    fn reader_tail_picks_up_appended_rows() {
+        let tmp = TempDir::new().unwrap();
+        let jsonl = tmp.path().join("summary.jsonl");
+        write_records_to_jsonl(&jsonl, &[rec("a", TaskStatus::Success)]);
+
+        let mut reader = RunSnapshotReader::new(tmp.path().to_path_buf());
+        assert_eq!(reader.refresh().task_count(), 1);
+
+        // Append a second row + bump mtime past prior reading.
+        write_records_to_jsonl(&jsonl, &[rec("b", TaskStatus::Failed)]);
+        bump_mtime(&jsonl, 60);
+
+        let snap = reader.refresh();
+        assert_eq!(snap.task_count(), 2);
+        assert_eq!(snap.failed_count(), 1);
+    }
+
+    /// Append with no trailing newline (mid-write tail) must NOT parse
+    /// the partial line. The next refresh, after the newline lands,
+    /// picks it up.
+    #[test]
+    fn reader_tail_defers_partial_line_until_newline() {
+        let tmp = TempDir::new().unwrap();
+        let jsonl = tmp.path().join("summary.jsonl");
+        write_records_to_jsonl(&jsonl, &[rec("a", TaskStatus::Success)]);
+
+        let mut reader = RunSnapshotReader::new(tmp.path().to_path_buf());
+        assert_eq!(reader.refresh().task_count(), 1);
+
+        // Append the start of "b" but no closing newline yet.
+        let partial = serde_json::to_string(&rec("b", TaskStatus::Success)).unwrap();
+        let half = &partial[..partial.len() / 2];
+        {
+            use std::io::Write;
+            let mut f = std::fs::OpenOptions::new()
+                .append(true)
+                .open(&jsonl)
+                .unwrap();
+            f.write_all(half.as_bytes()).unwrap();
+        }
+        bump_mtime(&jsonl, 60);
+        assert_eq!(reader.refresh().task_count(), 1, "partial line is deferred");
+
+        // Now complete the row with the rest + a newline.
+        {
+            use std::io::Write;
+            let mut f = std::fs::OpenOptions::new()
+                .append(true)
+                .open(&jsonl)
+                .unwrap();
+            f.write_all(&partial.as_bytes()[partial.len() / 2..])
+                .unwrap();
+            writeln!(f).unwrap();
+        }
+        bump_mtime(&jsonl, 120);
+        assert_eq!(
+            reader.refresh().task_count(),
+            2,
+            "completed line is picked up on next refresh",
+        );
+    }
+
+    /// Truncating the file (size shrinks past the reader's offset)
+    /// triggers a full reparse rather than a misaligned tail.
+    #[test]
+    fn reader_truncate_triggers_full_reparse() {
+        let tmp = TempDir::new().unwrap();
+        let jsonl = tmp.path().join("summary.jsonl");
+        write_records_to_jsonl(
+            &jsonl,
+            &[rec("a", TaskStatus::Success), rec("b", TaskStatus::Failed)],
+        );
+
+        let mut reader = RunSnapshotReader::new(tmp.path().to_path_buf());
+        assert_eq!(reader.refresh().task_count(), 2);
+
+        // Truncate to one record.
+        std::fs::write(
+            &jsonl,
+            serde_json::to_string(&rec("c", TaskStatus::Success)).unwrap() + "\n",
+        )
+        .unwrap();
+        bump_mtime(&jsonl, 60);
+
+        let snap = reader.refresh();
+        assert_eq!(snap.task_count(), 1, "post-truncate count");
+        assert!(snap.get("c").is_some(), "post-truncate content");
+        assert!(snap.get("a").is_none(), "pre-truncate rows dropped");
+    }
+
+    /// Replacing the file at the same path (new inode) is treated as
+    /// rotation: cached tracking resets, content is rebuilt from
+    /// scratch.
+    #[cfg(unix)]
+    #[test]
+    fn reader_inode_change_triggers_full_reparse() {
+        let tmp = TempDir::new().unwrap();
+        let jsonl = tmp.path().join("summary.jsonl");
+        write_records_to_jsonl(&jsonl, &[rec("a", TaskStatus::Success)]);
+
+        let mut reader = RunSnapshotReader::new(tmp.path().to_path_buf());
+        assert_eq!(reader.refresh().task_count(), 1);
+
+        // Rotate: remove and rewrite. New file = new inode.
+        std::fs::remove_file(&jsonl).unwrap();
+        write_records_to_jsonl(
+            &jsonl,
+            &[
+                rec("x", TaskStatus::Success),
+                rec("y", TaskStatus::Cancelled),
+            ],
+        );
+
+        let snap = reader.refresh();
+        assert_eq!(snap.task_count(), 2);
+        assert!(snap.get("a").is_none(), "post-rotation: old rows gone");
+        assert!(snap.get("x").is_some());
+        assert!(snap.get("y").is_some());
+    }
+
+    /// `summary.json` appearing for the first time after the reader was
+    /// already tracking `.jsonl` (the run just finalized) re-seeds the
+    /// snapshot with the authoritative summary.
+    #[test]
+    fn reader_picks_up_summary_json_when_it_appears() {
+        let tmp = TempDir::new().unwrap();
+        let jsonl = tmp.path().join("summary.jsonl");
+        write_records_to_jsonl(&jsonl, &[rec("a", TaskStatus::Success)]);
+
+        let mut reader = RunSnapshotReader::new(tmp.path().to_path_buf());
+        assert!(!reader.refresh().is_finalized());
+
+        // Finalize: write summary.json.
+        let t = Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+        let summary = RunSummary {
+            run_id: uuid::Uuid::nil(),
+            manifest_path: PathBuf::from("/x.toml"),
+            manifest_name: None,
+            pitboss_version: "test".into(),
+            claude_version: None,
+            started_at: t,
+            ended_at: t,
+            total_duration_ms: 0,
+            tasks_total: 1,
+            tasks_failed: 0,
+            was_interrupted: false,
+            notify_failures: Some(2),
+            tasks: vec![rec("a", TaskStatus::Success)],
+            spend_breakdown: None,
+        };
+        std::fs::write(
+            tmp.path().join("summary.json"),
+            serde_json::to_vec_pretty(&summary).unwrap(),
+        )
+        .unwrap();
+
+        let snap = reader.refresh();
+        assert!(snap.is_finalized());
+        assert_eq!(snap.run_summary.as_ref().unwrap().notify_failures, Some(2));
+    }
+
+    /// No-op refreshes (no disk change) leave the cache stable and do
+    /// no parsing work. We can't directly assert "no parsing
+    /// happened", but we can assert the snapshot doesn't drift.
+    #[test]
+    fn reader_idempotent_when_disk_unchanged() {
+        let tmp = TempDir::new().unwrap();
+        let jsonl = tmp.path().join("summary.jsonl");
+        write_records_to_jsonl(
+            &jsonl,
+            &[rec("a", TaskStatus::Success), rec("b", TaskStatus::Failed)],
+        );
+
+        let mut reader = RunSnapshotReader::new(tmp.path().to_path_buf());
+        let first = reader.refresh().task_count();
+        let second = reader.refresh().task_count();
+        let third = reader.refresh().task_count();
+        assert_eq!(first, second);
+        assert_eq!(second, third);
+        assert_eq!(first, 2);
     }
 
     #[test]

--- a/crates/pitboss-tui/src/watcher.rs
+++ b/crates/pitboss-tui/src/watcher.rs
@@ -119,6 +119,10 @@ pub fn watch(
 ) {
     std::thread::spawn(move || {
         let mut focused_id: Option<String> = None;
+        // Tier 2 of #437: hold the canonical reader across ticks so a
+        // 4 Hz poll only re-parses new `summary.jsonl` bytes (and
+        // re-reads `summary.json` only when its mtime advances).
+        let mut summary_reader = pitboss_core::store::RunSnapshotReader::new(run_dir.clone());
 
         loop {
             // Drain any pending focus updates (non-blocking).
@@ -126,7 +130,7 @@ pub fn watch(
                 focused_id = Some(id);
             }
 
-            let snapshot = build_snapshot(&run_dir, focused_id.as_deref());
+            let snapshot = build_snapshot(&run_dir, &mut summary_reader, focused_id.as_deref());
             // Full channel means the UI is temporarily behind (e.g. a blocking
             // render tick). Drop this snapshot — the next tick will publish
             // a fresh one. Only a disconnected receiver ends the watcher.
@@ -151,7 +155,11 @@ pub fn watch(
 // Snapshot construction
 // ---------------------------------------------------------------------------
 
-fn build_snapshot(run_dir: &Path, focused_id: Option<&str>) -> AppSnapshot {
+fn build_snapshot(
+    run_dir: &Path,
+    summary_reader: &mut pitboss_core::store::RunSnapshotReader,
+    focused_id: Option<&str>,
+) -> AppSnapshot {
     // 1. Read resolved.json → get static task ids, models, lead (if any),
     //    plus the MCP servers + actor-type ids needed for the capability
     //    matrix shown in Detail view.
@@ -165,11 +173,14 @@ fn build_snapshot(run_dir: &Path, focused_id: Option<&str>) -> AppSnapshot {
         &resolved.sublead_types,
     );
 
-    // 2. Gather completed task records via the canonical reader (#437).
-    //    summary.json seeds the map when finalized; summary.jsonl rows
-    //    overlay last-wins by task_id, so a resume-after-finalize or a
-    //    reprompt/cancel/respawn lifecycle reflects the freshest record.
-    let completed = pitboss_core::store::read_run_snapshot(run_dir).tasks;
+    // 2. Refresh the cached snapshot reader (#437 Tier 2). The first
+    //    tick does a full reparse; subsequent ticks only re-parse new
+    //    bytes in `summary.jsonl` (and re-read `summary.json` only when
+    //    its mtime advances). Merge semantics are identical to the
+    //    stateless `read_run_snapshot` — last-wins-by-task_id dedup so
+    //    resume-after-finalize and reprompt / cancel / respawn
+    //    lifecycles reflect the freshest record.
+    let completed = &summary_reader.refresh().tasks;
 
     // 3. Dynamic worker ids come from two sources:
     //    - `summary.jsonl`/`summary.json` records for completed workers not in
@@ -177,7 +188,7 @@ fn build_snapshot(run_dir: &Path, focused_id: Option<&str>) -> AppSnapshot {
     //    - `tasks/<id>/` filesystem subdirectories for workers that have been
     //      spawned but may not yet have a summary record (still running).
     let tasks_dir = run_dir.join("tasks");
-    let dynamic_ids = collect_dynamic_ids(&completed, &static_ids, &tasks_dir);
+    let dynamic_ids = collect_dynamic_ids(completed, &static_ids, &tasks_dir);
 
     // 4. All tile ids = static (tasks + lead) then dynamic (sorted).
     let all_ids: Vec<String> = static_ids
@@ -952,7 +963,8 @@ mod tests {
         )
         .unwrap();
 
-        let snap = build_snapshot(&run_dir, None);
+        let mut summary_reader = pitboss_core::store::RunSnapshotReader::new(run_dir.clone());
+        let snap = build_snapshot(&run_dir, &mut summary_reader, None);
         assert_eq!(snap.tasks.len(), 1);
         assert_eq!(snap.tasks[0].id, "triage-lead");
     }
@@ -1000,7 +1012,8 @@ mod tests {
         jsonl_line.push(b'\n');
         std::fs::write(run_dir.join("summary.jsonl"), jsonl_line).unwrap();
 
-        let snap = build_snapshot(&run_dir, None);
+        let mut summary_reader = pitboss_core::store::RunSnapshotReader::new(run_dir.clone());
+        let snap = build_snapshot(&run_dir, &mut summary_reader, None);
         let ids: Vec<&str> = snap.tasks.iter().map(|t| t.id.as_str()).collect();
         assert!(ids.contains(&"lead"), "lead tile missing: {ids:?}");
         assert!(
@@ -1038,7 +1051,8 @@ mod tests {
         // Create a tasks/<worker-id>/ directory with no summary record yet.
         std::fs::create_dir_all(run_dir.join("tasks/worker-live")).unwrap();
 
-        let snap = build_snapshot(&run_dir, None);
+        let mut summary_reader = pitboss_core::store::RunSnapshotReader::new(run_dir.clone());
+        let snap = build_snapshot(&run_dir, &mut summary_reader, None);
         let ids: Vec<&str> = snap.tasks.iter().map(|t| t.id.as_str()).collect();
         assert!(
             ids.contains(&"worker-live"),
@@ -1084,7 +1098,8 @@ mod tests {
         )
         .unwrap();
 
-        let snap = build_snapshot(&run_dir, None);
+        let mut summary_reader = pitboss_core::store::RunSnapshotReader::new(run_dir.clone());
+        let snap = build_snapshot(&run_dir, &mut summary_reader, None);
         // Untyped row + worker_type:writer = 2 rows.
         assert_eq!(snap.matrix_rows.len(), 2, "expected untyped + writer rows");
         let writer = snap
@@ -1144,7 +1159,8 @@ mod tests {
         jsonl_line.push(b'\n');
         std::fs::write(run_dir.join("summary.jsonl"), jsonl_line).unwrap();
 
-        let snap = build_snapshot(&run_dir, None);
+        let mut summary_reader = pitboss_core::store::RunSnapshotReader::new(run_dir.clone());
+        let snap = build_snapshot(&run_dir, &mut summary_reader, None);
         let tile = snap
             .tasks
             .iter()
@@ -1198,7 +1214,8 @@ mod tests {
         jsonl_line.push(b'\n');
         std::fs::write(run_dir.join("summary.jsonl"), jsonl_line).unwrap();
 
-        let snap = build_snapshot(&run_dir, None);
+        let mut summary_reader = pitboss_core::store::RunSnapshotReader::new(run_dir.clone());
+        let snap = build_snapshot(&run_dir, &mut summary_reader, None);
         let tile = snap
             .tasks
             .iter()
@@ -1515,7 +1532,8 @@ mod tests {
         .unwrap();
 
         // Lead has no events.jsonl — must default to 0 denials.
-        let snap = build_snapshot(&run_dir, None);
+        let mut summary_reader = pitboss_core::store::RunSnapshotReader::new(run_dir.clone());
+        let snap = build_snapshot(&run_dir, &mut summary_reader, None);
         let lead_tile = snap.tasks.iter().find(|t| t.id == "lead").unwrap();
         let worker_tile = snap.tasks.iter().find(|t| t.id == "worker-noisy").unwrap();
         assert_eq!(lead_tile.denials_count, 0);

--- a/crates/pitboss-tui/src/watcher.rs
+++ b/crates/pitboss-tui/src/watcher.rs
@@ -1492,6 +1492,118 @@ mod tests {
         assert_eq!(recent[0].tool_name, "Bash");
     }
 
+    /// Tier 2 regression guard (#437): duplicate `task_id` rows in
+    /// `summary.jsonl` must dedupe last-wins after going through the
+    /// stateful `RunSnapshotReader`. Builds the same shape of fixture
+    /// the dispatcher produces on a reprompt / cancel / respawn cycle
+    /// and asserts the tile count, the failed count, and the rendered
+    /// status all reflect the deduped view — not the raw line count.
+    fn task_record_line(
+        id: &str,
+        status: pitboss_core::store::TaskStatus,
+        parent: Option<&str>,
+    ) -> String {
+        let t = chrono::Utc::now();
+        let rec = TaskRecord {
+            task_id: id.to_string(),
+            status,
+            exit_code: Some(0),
+            started_at: t,
+            ended_at: t,
+            duration_ms: 0,
+            worktree_path: None,
+            log_path: std::path::PathBuf::from("/dev/null"),
+            token_usage: pitboss_core::parser::TokenUsage::default(),
+            claude_session_id: None,
+            final_message_preview: None,
+            final_message: None,
+            parent_task_id: parent.map(str::to_string),
+            pause_count: 0,
+            reprompt_count: 0,
+            approvals_requested: 0,
+            approvals_approved: 0,
+            approvals_rejected: 0,
+            model: None,
+            failure_reason: None,
+            cost_usd: None,
+            actor_type: None,
+        };
+        serde_json::to_string(&rec).unwrap()
+    }
+
+    #[test]
+    fn build_snapshot_dedupes_duplicate_task_id_rows() {
+        use pitboss_core::store::TaskStatus as TS;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let run_dir = dir.path().to_path_buf();
+
+        // Hierarchical run: one lead + one worker. `tasks: []` mirrors
+        // a real lead-only manifest after resolve.
+        let resolved = serde_json::json!({
+            "max_parallel": 4,
+            "halt_on_failure": false,
+            "run_dir": run_dir.to_str(),
+            "worktree_cleanup": "OnSuccess",
+            "emit_event_stream": false,
+            "tasks": [],
+            "lead": {"id": "lead-1", "model": "claude-haiku-4-5"},
+            "max_workers": 4,
+            "budget_usd": 5.0,
+            "lead_timeout_secs": 900,
+        });
+        std::fs::write(
+            run_dir.join("resolved.json"),
+            serde_json::to_vec(&resolved).unwrap(),
+        )
+        .unwrap();
+
+        // summary.jsonl with three lines — two for the same worker
+        // (Cancelled → Success, the reprompt-cancel-respawn shape) and
+        // one for the lead.
+        let payload = [
+            task_record_line("worker-A", TS::Cancelled, Some("lead-1")),
+            task_record_line("worker-A", TS::Success, Some("lead-1")), // newer row wins
+            task_record_line("lead-1", TS::Success, None),
+        ]
+        .join("\n")
+            + "\n";
+        std::fs::write(run_dir.join("summary.jsonl"), payload).unwrap();
+
+        let mut summary_reader = pitboss_core::store::RunSnapshotReader::new(run_dir.clone());
+        let snap = build_snapshot(&run_dir, &mut summary_reader, None);
+
+        // The dispatcher wrote 3 lines; the TUI must show 2 tiles
+        // (lead + one worker), the worker's status must be the latest
+        // (Success), and failed count must NOT count the earlier
+        // Cancelled row.
+        assert_eq!(
+            snap.tasks.len(),
+            2,
+            "tile count = unique task_ids, not line count"
+        );
+        let worker = snap
+            .tasks
+            .iter()
+            .find(|t| t.id == "worker-A")
+            .expect("worker tile present");
+        assert!(
+            matches!(worker.status, TileStatus::Done(TS::Success)),
+            "worker tile shows the latest row (Success), not the earlier Cancelled",
+        );
+        let failed = snap
+            .tasks
+            .iter()
+            .filter(|t| matches!(&t.status, TileStatus::Done(s) if !matches!(s, TS::Success)))
+            .count();
+        assert_eq!(failed, 0, "no failed tiles after dedup");
+
+        // Idempotency: a second refresh against unchanged disk
+        // produces an identical snapshot.
+        let snap2 = build_snapshot(&run_dir, &mut summary_reader, None);
+        assert_eq!(snap2.tasks.len(), 2);
+    }
+
     /// End-to-end: a dynamic worker with three `tool_denied` rows in its
     /// `events.jsonl` must surface as `denials_count = 3` on its tile so
     /// the TUI render path picks it up.


### PR DESCRIPTION
## Summary

- Adds \`pitboss_core::store::summary::RunSnapshotReader\`, a stateful companion to \`read_run_snapshot\` (#439 / Tier 1) that keeps the parsed \`RunSnapshot\` live across calls.
- \`refresh()\` does the minimum work: one stat per file, then either no-op, a tail-parse of the new bytes only, or — on rotation / truncate / mtime regress — a full reparse.
- Migrates the TUI watcher's 4 Hz poll to use the new reader. Per-tick cost goes from O(file size) → O(new bytes), with O(0) on the (common) no-change tick.

**Refs #437** (Tier 2 of 3). Tier 3 (push-based via the \`notify\` crate, with the cold-run preservation acceptance criterion) remains open on that issue.

## Cost model (from the reader's docs)

| Disk change between refreshes | Work |
|---|---|
| None | One stat per file. No parse. |
| \`summary.jsonl\` appended (same inode, mtime advanced) | Parse only the new bytes; overlay into the cached map. |
| \`summary.json\` appeared or its mtime advanced | Re-read and reparse \`summary.json\` once. Tasks re-seeded into the map. |
| \`summary.jsonl\` rotated (inode change), truncated (size shrunk), or mtime regressed | Full reparse via \`read_run_snapshot\`; tracking state reset. |

## Edge cases covered

- **Mid-write trailing line.** \`offset\` advances only through the last complete \`\\n\` in the new bytes — a partial line stays in the file and is re-parsed on the next refresh after the writer closes it.
- **Rotation.** Inode tracking on unix discriminates "same file appended" from "same path, different file." Non-unix targets fall back to size + mtime; this codebase is unix-only via Cargo \`cfg(unix)\` so the inode path always runs.
- **Truncate.** Detected via size < cached offset → full reparse.
- **mtime regress.** Detected → full reparse (covers rsync / backup-restore / clock skew).
- **summary.json appearance.** When the file first appears mid-run (finalize), the next refresh re-seeds the snapshot from the authoritative JSON, including \`notify_failures\` and other run-scoped fields that aren't in \`.jsonl\`.

## Scope discipline

Only the TUI watcher migrated. The other surfaces (\`pitboss status\`, \`pitboss list\`, web HTTP handlers, hierarchical finalize aggregator) keep using the stateless \`read_run_snapshot\` — they only read each file once, so the reader's setup state would be dead weight.

## Test plan

- [x] \`cargo test -p pitboss-core --lib store::summary\` — 16 unit tests (9 from Tier 1 + 7 new ones for the reader).
- [x] \`cargo test --workspace --features pitboss-core/test-support\` — workspace clean (one pre-existing unrelated macOS env failure for \`/bin/true\`; Linux CI is the ground truth).
- [x] \`cargo lint\` and \`cargo tidy\` clean.
- [ ] On a real run, verify the TUI doesn't visibly change behavior (same tile counts, same updates, just less work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)