### PR TITLE
feat(tui): notify-driven watcher with periodic safety net

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,6 +455,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,7 +477,7 @@ checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags 2.11.1",
  "crossterm_winapi",
- "mio",
+ "mio 1.2.0",
  "parking_lot",
  "rustix 0.38.44",
  "signal-hook",
@@ -480,7 +495,7 @@ dependencies = [
  "crossterm_winapi",
  "derive_more",
  "document-features",
- "mio",
+ "mio 1.2.0",
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook",
@@ -786,6 +801,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,6 +853,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1357,6 +1391,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1436,6 +1490,26 @@ dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "285efcf12ef41bec907b3000d5ffaeb54191d4d9d83c0d6157e6cbc2db255e64"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
 ]
 
 [[package]]
@@ -1657,6 +1731,18 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
@@ -1700,6 +1786,25 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2013,6 +2118,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "crossterm 0.29.0",
+ "notify",
  "pitboss-cli",
  "pitboss-core",
  "ratatui 0.30.0",
@@ -2893,7 +2999,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio",
+ "mio 1.2.0",
  "signal-hook",
 ]
 
@@ -3235,7 +3341,7 @@ checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.2.0",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -3992,6 +4098,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4024,6 +4139,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4070,6 +4200,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4082,6 +4218,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4091,6 +4233,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4118,6 +4266,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4127,6 +4281,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4142,6 +4302,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4151,6 +4317,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/pitboss-tui/Cargo.toml
+++ b/crates/pitboss-tui/Cargo.toml
@@ -32,6 +32,10 @@ uuid         = { workspace = true }
 tracing      = { workspace = true }
 tui-textarea = { workspace = true }
 tokio        = { workspace = true }
+# #437 Tier 3: push-based summary.json[l] watch. inotify on Linux,
+# FSEvents on macOS, ReadDirectoryChangesW on Windows — all auto-
+# selected by `notify::recommended_watcher`.
+notify       = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/pitboss-tui/src/watcher.rs
+++ b/crates/pitboss-tui/src/watcher.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::time::Duration;
 
+use notify::Watcher;
 use pitboss_core::parser::{parse_line_all, Event};
 use pitboss_core::store::{TaskRecord, TaskStatus};
 use serde::Deserialize;
@@ -117,38 +118,155 @@ pub fn watch(
     snapshot_tx: mpsc::SyncSender<AppSnapshot>,
     focus_rx: mpsc::Receiver<String>,
 ) {
+    std::thread::spawn(move || run_watch_loop(run_dir, snapshot_tx, focus_rx));
+}
+
+/// What woke the watcher thread on a given loop iteration. Each variant
+/// fans into the same `wake_rx` channel; the main loop reacts to it and
+/// rebuilds the snapshot.
+enum Wake {
+    /// Operator changed the focused tile via the UI thread.
+    Focus(String),
+    /// A filesystem event from `notify` landed somewhere under
+    /// `run_dir`. Most of these are `summary.jsonl` appends, but any
+    /// non-rescan event just triggers a snapshot rebuild.
+    FsEvent,
+    /// `Event::need_rescan()` flag: kernel notification buffer
+    /// overran, so `notify`'s view of what changed is incomplete.
+    /// We respond by dropping the [`RunSnapshotReader`]'s cached
+    /// tracking state — the next [`RunSnapshotReader::refresh`] will
+    /// do a full reparse rather than trust its byte-offset.
+    Rescan,
+    /// Periodic safety-net timer fired. Covers two failure modes:
+    /// (1) `notify` silently dropped an event we'd otherwise miss
+    /// (rare on local filesystems, more common on NFS); (2) `notify`
+    /// failed to register at all and we're in poll-only fallback
+    /// mode. With Tier 2's stateful reader, a periodic tick costs one
+    /// stat per file when nothing changed.
+    Periodic,
+}
+
+// The arguments are consumed by the thread when this function returns;
+// clippy's `needless_pass_by_value` doesn't see the implicit drop.
+#[allow(clippy::needless_pass_by_value)]
+fn run_watch_loop(
+    run_dir: PathBuf,
+    snapshot_tx: mpsc::SyncSender<AppSnapshot>,
+    focus_rx: mpsc::Receiver<String>,
+) {
+    let mut focused_id: Option<String> = None;
+    // Tier 2 of #437: hold the canonical reader across ticks so we
+    // only re-parse new `summary.jsonl` bytes (and re-read
+    // `summary.json` only when its mtime advances).
+    let mut summary_reader = pitboss_core::store::RunSnapshotReader::new(run_dir.clone());
+
+    // Push the initial snapshot before `notify` subscribes (#437
+    // Tier 3 acceptance: historical / finalized runs must render
+    // entirely from the initial snapshot even when no FS events ever
+    // fire). The full-reparse cost here is unavoidable on first
+    // open — subsequent ticks ride the reader's incremental path.
+    let snapshot = build_snapshot(&run_dir, &mut summary_reader, focused_id.as_deref());
+    if matches!(
+        snapshot_tx.try_send(snapshot),
+        Err(mpsc::TrySendError::Disconnected(_))
+    ) {
+        return;
+    }
+
+    let (wake_tx, wake_rx) = mpsc::channel::<Wake>();
+
+    // Bridge: pump focus updates from the caller's channel into the
+    // unified wake channel. Owns its own thread so the public watch()
+    // API stays unchanged.
+    let wake_for_focus = wake_tx.clone();
     std::thread::spawn(move || {
-        let mut focused_id: Option<String> = None;
-        // Tier 2 of #437: hold the canonical reader across ticks so a
-        // 4 Hz poll only re-parses new `summary.jsonl` bytes (and
-        // re-reads `summary.json` only when its mtime advances).
-        let mut summary_reader = pitboss_core::store::RunSnapshotReader::new(run_dir.clone());
-
-        loop {
-            // Drain any pending focus updates (non-blocking).
-            while let Ok(id) = focus_rx.try_recv() {
-                focused_id = Some(id);
-            }
-
-            let snapshot = build_snapshot(&run_dir, &mut summary_reader, focused_id.as_deref());
-            // Full channel means the UI is temporarily behind (e.g. a blocking
-            // render tick). Drop this snapshot — the next tick will publish
-            // a fresh one. Only a disconnected receiver ends the watcher.
-            match snapshot_tx.try_send(snapshot) {
-                Ok(()) | Err(mpsc::TrySendError::Full(_)) => {}
-                Err(mpsc::TrySendError::Disconnected(_)) => break,
-            }
-
-            // Wait up to POLL_INTERVAL_MS for the next tick, OR wake early
-            // when the user changes focus so the new tile's log tails
-            // without an up-to-half-second delay.
-            match focus_rx.recv_timeout(Duration::from_millis(POLL_INTERVAL_MS)) {
-                Ok(id) => focused_id = Some(id),
-                Err(mpsc::RecvTimeoutError::Timeout) => {}
-                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        while let Ok(id) = focus_rx.recv() {
+            if wake_for_focus.send(Wake::Focus(id)).is_err() {
+                break;
             }
         }
     });
+
+    // Try to register a recursive `notify` watcher on the run dir.
+    // On success, future loop ticks are driven by FS events plus a
+    // slow safety-net timer. On failure (out-of-watches, NFS without
+    // inotify, etc.), fall back to today's poll cadence so the TUI
+    // still updates — the cost profile is now O(0) per tick with
+    // Tier 2's reader, so the fallback isn't expensive either.
+    let wake_for_fs = wake_tx.clone();
+    let watcher_result: notify::Result<notify::RecommendedWatcher> =
+        notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+            if let Ok(event) = res {
+                let wake = if event.need_rescan() {
+                    Wake::Rescan
+                } else {
+                    Wake::FsEvent
+                };
+                let _ = wake_for_fs.send(wake);
+            }
+        });
+    let (notify_active, _watcher_guard) = match watcher_result {
+        Ok(mut w) => match w.watch(&run_dir, notify::RecursiveMode::Recursive) {
+            Ok(()) => (true, Some(w)),
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    path = %run_dir.display(),
+                    "notify::watch failed; using poll-only fallback for the summary surface",
+                );
+                (false, None)
+            }
+        },
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "notify::recommended_watcher init failed; using poll-only fallback",
+            );
+            (false, None)
+        }
+    };
+
+    // Spawn the safety-net timer. When notify is alive, ticks every
+    // 5s catch any missed events on flakey backends. When notify is
+    // dead, ticks every POLL_INTERVAL_MS (matches the pre-#440
+    // cadence so the operator perceives no change in update speed).
+    let wake_for_timer = wake_tx.clone();
+    let tick_interval = if notify_active {
+        Duration::from_secs(5)
+    } else {
+        Duration::from_millis(POLL_INTERVAL_MS)
+    };
+    std::thread::spawn(move || loop {
+        std::thread::sleep(tick_interval);
+        if wake_for_timer.send(Wake::Periodic).is_err() {
+            break;
+        }
+    });
+
+    // Drop our own copy of wake_tx so wake_rx can observe a
+    // disconnect once every helper thread also drops its sender.
+    drop(wake_tx);
+
+    while let Ok(wake) = wake_rx.recv() {
+        match wake {
+            Wake::Focus(id) => focused_id = Some(id),
+            Wake::Rescan => {
+                // Drop the reader's cached byte-offset tracking so
+                // the next refresh does a full reparse from disk.
+                summary_reader = pitboss_core::store::RunSnapshotReader::new(run_dir.clone());
+            }
+            Wake::FsEvent | Wake::Periodic => {}
+        }
+
+        let snapshot = build_snapshot(&run_dir, &mut summary_reader, focused_id.as_deref());
+        match snapshot_tx.try_send(snapshot) {
+            Ok(()) | Err(mpsc::TrySendError::Full(_)) => {}
+            Err(mpsc::TrySendError::Disconnected(_)) => break,
+        }
+    }
+    // _watcher_guard drops here, releasing the inotify/FSEvents
+    // registration. Helper threads observe wake_rx as disconnected
+    // and exit on their next send.
 }
 
 // ---------------------------------------------------------------------------
@@ -1650,5 +1768,112 @@ mod tests {
         let worker_tile = snap.tasks.iter().find(|t| t.id == "worker-noisy").unwrap();
         assert_eq!(lead_tile.denials_count, 0);
         assert_eq!(worker_tile.denials_count, 2);
+    }
+
+    // ------------------------------------------------------------------
+    // Tier 3 integration tests — exercise the full `watch()` thread,
+    // not just `build_snapshot`. These prove notify subscription is
+    // wired up and that the initial snapshot fires before any FS event.
+    // ------------------------------------------------------------------
+
+    fn minimal_hierarchical_run(run_dir: &std::path::Path) {
+        let resolved = serde_json::json!({
+            "max_parallel": 4,
+            "halt_on_failure": false,
+            "run_dir": run_dir.to_str(),
+            "worktree_cleanup": "OnSuccess",
+            "emit_event_stream": false,
+            "tasks": [],
+            "lead": {"id": "lead-1", "model": "claude-haiku-4-5"},
+            "max_workers": 4,
+            "budget_usd": 5.0,
+            "lead_timeout_secs": 900,
+        });
+        std::fs::write(
+            run_dir.join("resolved.json"),
+            serde_json::to_vec(&resolved).unwrap(),
+        )
+        .unwrap();
+        // Empty summary.jsonl so the canonical reader doesn't NotFound.
+        std::fs::write(run_dir.join("summary.jsonl"), b"").unwrap();
+    }
+
+    /// Acceptance criterion from #437 Tier 3: the watcher MUST push an
+    /// initial snapshot before subscribing to FS events, so historical
+    /// or finalized runs (which never fire FS events) still render.
+    #[test]
+    fn watch_emits_initial_snapshot_before_any_event() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let run_dir = dir.path().to_path_buf();
+        minimal_hierarchical_run(&run_dir);
+
+        let (snap_tx, snap_rx) = std::sync::mpsc::sync_channel(1);
+        let (_focus_tx, focus_rx) = std::sync::mpsc::channel();
+        super::watch(run_dir, snap_tx, focus_rx);
+
+        // The initial snapshot lands quickly — no FS event needed.
+        let snap = snap_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("initial snapshot delivered without an FS event");
+        assert!(
+            snap.tasks.iter().any(|t| t.id == "lead-1"),
+            "initial snapshot includes the resolved.json lead",
+        );
+    }
+
+    /// An append to `summary.jsonl` after the initial snapshot must
+    /// produce a new snapshot reflecting the new row. The path can be
+    /// notify-driven (typical) or periodic-timer-driven (fallback) —
+    /// either way the consumer observes the update.
+    #[test]
+    fn watch_pushes_snapshot_after_summary_jsonl_append() {
+        use pitboss_core::store::TaskStatus as TS;
+        let dir = tempfile::TempDir::new().unwrap();
+        let run_dir = dir.path().to_path_buf();
+        minimal_hierarchical_run(&run_dir);
+
+        let (snap_tx, snap_rx) = std::sync::mpsc::sync_channel(4);
+        let (_focus_tx, focus_rx) = std::sync::mpsc::channel();
+        super::watch(run_dir.clone(), snap_tx, focus_rx);
+
+        // Drain the initial snapshot.
+        let _initial = snap_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("initial snapshot");
+
+        // Append a worker row. The watcher's snapshot for the next
+        // tick must include a tile for worker-A.
+        let line = task_record_line("worker-A", TS::Success, Some("lead-1"));
+        {
+            use std::io::Write;
+            let mut f = std::fs::OpenOptions::new()
+                .append(true)
+                .open(run_dir.join("summary.jsonl"))
+                .unwrap();
+            writeln!(f, "{line}").unwrap();
+            f.sync_all().unwrap();
+        }
+
+        // Wait up to 6s for a snapshot reflecting the append. That
+        // budget covers FSEvents latency on macOS (~10–100ms),
+        // inotify latency on Linux (~ms), and the 5s safety-net
+        // periodic on platforms where notify silently dropped the
+        // event.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(6);
+        loop {
+            let remaining = deadline
+                .saturating_duration_since(std::time::Instant::now())
+                .max(std::time::Duration::from_millis(100));
+            let snap = snap_rx
+                .recv_timeout(remaining)
+                .expect("snapshot delivered before deadline");
+            if snap.tasks.iter().any(|t| t.id == "worker-A") {
+                return;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "no snapshot ever included worker-A within deadline",
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Replaces the TUI watcher's 4 Hz \`recv_timeout(250ms)\` poll with a unified wake channel fed by \`notify::recommended_watcher\` (inotify / FSEvents / RDC), a periodic safety-net timer, and the existing focus channel.
- Pushes the **initial snapshot before** \`notify\` subscribes — historical and finalized runs (which never fire FS events) render entirely from that initial read, preserving the cold-run viewing experience.
- Honors \`Event::need_rescan()\` by resetting the \`RunSnapshotReader\` so a kernel-buffer-overrun triggers a full reparse rather than a silent miss.
- If \`notify\` fails to register, drops to a 250 ms periodic-timer fallback — matching the pre-Tier-3 cadence so the operator sees no UX regression.

**Closes #437** (this is Tier 3 / final tier of the three-tier consolidation; Tier 1 in #439, Tier 2 in #440).

## Acceptance criteria from #437

- [x] **Subscribes after the initial snapshot.** \`watch_emits_initial_snapshot_before_any_event\` proves this empirically.
- [x] **Falls back to today's poll if \`notify\` fails.** Safety-net timer drops from 5 s → 250 ms when notify init or watch registration errors.
- [x] **Historical / finalized runs render entirely from the initial snapshot.** Same test as above; the snapshot lands within 2 s with no FS event needed.
- [x] **Honors \`Event::need_rescan()\`.** The Rescan branch recreates the \`RunSnapshotReader\` so the next refresh does a full reparse.
- [x] **Tier 3 changes only the trigger.** \`build_snapshot\` is unchanged — \`stdout.log\` tail, \`events.jsonl\` denial scan, and \`resolved.json\` keep their existing in-loop refresh, each can be migrated independently if it pays off.

## Wake channel shape

\`\`\`
enum Wake {
    Focus(String),    // UI thread — operator changed focused tile
    FsEvent,          // notify — file modified somewhere under run_dir
    Rescan,           // notify — need_rescan(): full reparse next refresh
    Periodic,         // safety-net timer (5s when notify is alive, 250ms when not)
}
\`\`\`

Three helper threads feed the wake channel (focus adapter, notify callback, timer). Main loop \`recv()\`s and rebuilds the snapshot, dropping any backed-up snapshots via \`try_send\` exactly as before.

## Test plan

- [x] \`cargo test -p pitboss-tui --lib\` — 140 tests pass (138 prior + 2 new integration tests for \`watch()\`).
- [x] \`cargo test --workspace --features pitboss-core/test-support\` — workspace clean except the pre-existing unrelated macOS \`/bin/true\` env failure.
- [x] \`cargo lint\` and \`cargo tidy\` clean.
- [ ] Sanity-check on a real run: open the TUI on an in-progress dispatch and confirm tile updates land without obvious latency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)