### PR TITLE
feat(control): dispatcher-assigned seq on EventEnvelope (PR-B of #438)

### DIFF
--- a/crates/pitboss-cli/src/control/protocol.rs
+++ b/crates/pitboss-cli/src/control/protocol.rs
@@ -56,6 +56,16 @@ pub struct EventEnvelope {
     /// empty (e.g. run-level events with no actor context).
     #[serde(default, skip_serializing_if = "ActorPath::is_empty")]
     pub actor_path: ActorPath,
+    /// Dispatcher-assigned monotonic sequence number. Added in PR-B of
+    /// #438 (unified envelope API). Zero is the legacy sentinel: pre-PR-B
+    /// dispatchers don't write this field, and `#[serde(default)]`
+    /// deserializes its absence as 0. New envelopes start at 1.
+    ///
+    /// Today the counter is per-connection (resets on TUI reconnect);
+    /// when #259 adds `events.jsonl` persistence, the counter moves up
+    /// to per-run lifetime.
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub seq: u64,
     /// The actual event payload, inlined into the same JSON object.
     #[serde(flatten)]
     pub event: ControlEvent,
@@ -649,6 +659,46 @@ mod tests {
         };
         let s = serde_json::to_string(&ev).unwrap();
         assert!(!s.contains("parent_task_id"));
+    }
+
+    /// PR-B of #438: envelopes carry a `seq` field. Default (zero) is
+    /// omitted on the wire so legacy clients see byte-identical JSON.
+    #[test]
+    fn envelope_seq_omitted_when_zero() {
+        use crate::dispatch::actor::ActorPath;
+        let envelope = EventEnvelope {
+            actor_path: ActorPath::default(),
+            seq: 0,
+            event: ControlEvent::Superseded,
+        };
+        let s = serde_json::to_string(&envelope).unwrap();
+        assert!(!s.contains("\"seq\""), "default seq must be elided: {s}");
+    }
+
+    /// PR-B of #438: non-zero seq round-trips on the wire and can be
+    /// read by the consumer.
+    #[test]
+    fn envelope_seq_roundtrips_when_nonzero() {
+        use crate::dispatch::actor::ActorPath;
+        let envelope = EventEnvelope {
+            actor_path: ActorPath::default(),
+            seq: 42,
+            event: ControlEvent::Superseded,
+        };
+        let s = serde_json::to_string(&envelope).unwrap();
+        assert!(s.contains("\"seq\":42"), "seq must serialize: {s}");
+        let back: EventEnvelope = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.seq, 42);
+    }
+
+    /// PR-B back-compat: an envelope JSON written by a pre-PR-B
+    /// dispatcher (no seq field) deserializes with seq = 0.
+    #[test]
+    fn pre_pr_b_envelope_deserializes_as_seq_zero() {
+        let legacy = r#"{"event":"superseded"}"#;
+        let env: EventEnvelope = serde_json::from_str(legacy).unwrap();
+        assert_eq!(env.seq, 0);
+        assert!(matches!(env.event, ControlEvent::Superseded));
     }
 
     #[test]

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -10,6 +10,7 @@
 #![allow(dead_code)] // Some fields are set by Phase 2 tasks.
 
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -20,7 +21,8 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 
-use crate::control::protocol::{ControlEvent, ControlOp};
+use crate::control::protocol::{ControlEvent, ControlOp, EventEnvelope};
+use crate::dispatch::actor::ActorPath;
 
 /// Handle returned from `start_control_server`. Drop terminates the accept loop
 /// and removes the socket file.
@@ -142,6 +144,11 @@ async fn serve_connection(
     let (read_half, write_half) = stream.into_split();
     let writer = Arc::new(Mutex::new(write_half));
     let mut reader = BufReader::new(read_half).lines();
+    // Per-connection monotonic seq counter for the `EventEnvelope.seq`
+    // field (PR-B of #438). Starts at 0; `fetch_add(1) + 1` makes the
+    // first emitted envelope's seq = 1. Reset on reconnect — #259's
+    // `events.jsonl` persistence will lift this to per-run lifetime.
+    let seq = Arc::new(AtomicU64::new(0));
 
     // Hello handshake.
     let first = match reader.next_line().await {
@@ -153,6 +160,7 @@ async fn serve_connection(
         Ok(other) => {
             let _ = send_event(
                 &writer,
+                &seq,
                 &ControlEvent::OpFailed {
                     op: format!("{other:?}"),
                     task_id: None,
@@ -165,6 +173,7 @@ async fn serve_connection(
         Err(e) => {
             let _ = send_event(
                 &writer,
+                &seq,
                 &ControlEvent::OpFailed {
                     op: "hello".into(),
                     task_id: None,
@@ -198,6 +207,7 @@ async fn serve_connection(
     // Send server hello.
     let _ = send_event(
         &writer,
+        &seq,
         &ControlEvent::Hello {
             server_version,
             run_id,
@@ -332,6 +342,7 @@ async fn serve_connection(
     // Falls back to the old per-message behaviour when no further
     // events are queued — latency is unchanged for sparse traffic.
     let writer_for_pump = writer.clone();
+    let seq_for_pump = seq.clone();
     let pump = tokio::spawn(async move {
         while let Some(ev) = ev_rx.recv().await {
             let mut batch: Vec<ControlEvent> = vec![ev];
@@ -341,7 +352,10 @@ async fn serve_connection(
             while let Ok(next) = ev_rx.try_recv() {
                 batch.push(next);
             }
-            if send_events_batch(&writer_for_pump, &batch).await.is_err() {
+            if send_events_batch(&writer_for_pump, &seq_for_pump, &batch)
+                .await
+                .is_err()
+            {
                 break;
             }
         }
@@ -423,7 +437,7 @@ async fn serve_connection(
                 error: format!("parse error: {e}"),
             },
         };
-        if send_event(&writer, &reply).await.is_err() {
+        if send_event(&writer, &seq, &reply).await.is_err() {
             break;
         }
     }
@@ -591,11 +605,27 @@ async fn find_worker_layer(
 /// slower feels laggy. Constant so tests can match expected payloads.
 const STORE_ACTIVITY_INTERVAL_MS: u64 = 1000;
 
+/// Wrap a `ControlEvent` in an `EventEnvelope` with the next monotonic
+/// seq. PR-B of #438: every wire event now carries a `seq` field so
+/// consumers can implement transport-switching (disk-replay → live)
+/// without gap or duplicate. `actor_path` is left empty here — the
+/// server-side emit path is run-scoped, not actor-scoped; sub-actor
+/// paths get populated in a later PR if/when needed.
+fn wrap_with_seq(seq: &AtomicU64, ev: &ControlEvent) -> EventEnvelope {
+    EventEnvelope {
+        actor_path: ActorPath::default(),
+        seq: seq.fetch_add(1, Ordering::Relaxed) + 1,
+        event: ev.clone(),
+    }
+}
+
 async fn send_event(
     writer: &Arc<Mutex<tokio::net::unix::OwnedWriteHalf>>,
+    seq: &AtomicU64,
     ev: &ControlEvent,
 ) -> Result<()> {
-    let mut line = serde_json::to_string(ev)?;
+    let envelope = wrap_with_seq(seq, ev);
+    let mut line = serde_json::to_string(&envelope)?;
     line.push('\n');
     let mut guard = writer.lock().await;
     guard.write_all(line.as_bytes()).await?;
@@ -610,6 +640,7 @@ async fn send_event(
 /// pump only; ad-hoc senders still use `send_event`. (#152 L5)
 async fn send_events_batch(
     writer: &Arc<Mutex<tokio::net::unix::OwnedWriteHalf>>,
+    seq: &AtomicU64,
     batch: &[ControlEvent],
 ) -> Result<()> {
     if batch.is_empty() {
@@ -618,7 +649,8 @@ async fn send_events_batch(
     // Serialize first so the lock window is just the syscalls.
     let mut payload = Vec::with_capacity(batch.len() * 256 /* heuristic per-event size */);
     for ev in batch {
-        let line = serde_json::to_string(ev)?;
+        let envelope = wrap_with_seq(seq, ev);
+        let line = serde_json::to_string(&envelope)?;
         payload.extend_from_slice(line.as_bytes());
         payload.push(b'\n');
     }

--- a/crates/pitboss-cli/src/dispatch/failure_detection.rs
+++ b/crates/pitboss-cli/src/dispatch/failure_detection.rs
@@ -183,6 +183,12 @@ pub async fn broadcast_worker_failed(
 ) {
     let envelope = EventEnvelope {
         actor_path: ActorPath::new(actor_path_segments.iter().copied()),
+        // Seq is reassigned by the server's pump (see `send_events_batch`
+        // in `control/server.rs`); the value here is a placeholder. The
+        // `broadcast_control_event` path discards the envelope wrapper
+        // and only forwards `envelope.event`, so this never reaches the
+        // wire.
+        seq: 0,
         event: ControlEvent::WorkerFailed {
             task_id,
             parent_task_id,

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -411,6 +411,9 @@ pub async fn spawn_sublead(
             };
             let ev = EventEnvelope {
                 actor_path: ActorPath::new(["root", sublead_id.as_str()]),
+                // Seq is reassigned by the server's pump; see comment in
+                // `failure_detection::broadcast_worker_failed`.
+                seq: 0,
                 event: ControlEvent::SubleadSpawned {
                     sublead_id: sublead_id.clone(),
                     budget_usd: budget_usd_val,
@@ -1112,6 +1115,9 @@ pub async fn reconcile_terminated_sublead(
     {
         let ev = EventEnvelope {
             actor_path: ActorPath::new(["root", sublead_id]),
+            // Seq is reassigned by the server's pump; see comment in
+            // `failure_detection::broadcast_worker_failed`.
+            seq: 0,
             event: ControlEvent::SubleadTerminated {
                 sublead_id: sublead_id.to_string(),
                 spent_usd: actual_spend,

--- a/crates/pitboss-cli/tests/control_flows.rs
+++ b/crates/pitboss-cli/tests/control_flows.rs
@@ -139,6 +139,7 @@ async fn control_event_carries_actor_path() {
     // Build an envelope wrapping an existing event with a deep actor path.
     let envelope = EventEnvelope {
         actor_path: ActorPath::new(["root", "S1", "W3"]),
+        seq: 0,
         event: ControlEvent::Superseded,
     };
 
@@ -230,6 +231,7 @@ async fn event_envelope_empty_actor_path_omitted_on_wire() {
     // actor_path key (backward-compat: v0.5 clients parse unmodified events).
     let envelope = EventEnvelope {
         actor_path: ActorPath::default(),
+        seq: 0,
         event: ControlEvent::Superseded,
     };
     let s = serde_json::to_string(&envelope).unwrap();
@@ -242,6 +244,141 @@ async fn event_envelope_empty_actor_path_omitted_on_wire() {
     let back: EventEnvelope = serde_json::from_str(&s).unwrap();
     assert!(back.actor_path.is_empty());
     assert!(matches!(back.event, ControlEvent::Superseded));
+}
+
+/// PR-B of #438: the live control wire now carries a `seq` field on
+/// every envelope. The dispatcher's server emits monotonic per-connection
+/// seqs starting at 1. This is the foundation for the transport-switching
+/// algorithm spec'd in book/src/architecture/unified-envelope-api.md —
+/// PR-C consumes it.
+#[tokio::test]
+async fn server_emits_monotonic_seqs_on_wire() {
+    let dir = TempDir::new().unwrap();
+    let run_id = uuid::Uuid::now_v7();
+    let run_subdir = dir.path().join(run_id.to_string());
+    tokio::fs::create_dir_all(&run_subdir).await.unwrap();
+    let manifest = ResolvedManifest {
+        manifest_schema_version: 0,
+        name: None,
+        max_parallel_tasks: Some(4),
+        halt_on_failure: false,
+        run_dir: dir.path().to_path_buf(),
+        worktree_cleanup: WorktreeCleanup::OnSuccess,
+        emit_event_stream: false,
+        tasks: vec![],
+        lead: None,
+        max_workers: Some(4),
+        budget_usd: Some(1.0),
+        lead_budget_usd: None,
+        lead_timeout_secs: None,
+        default_approval_policy: Some(ApprovalPolicy::Block),
+        denial_termination_policy: None,
+        notifications: vec![],
+        dump_shared_store: false,
+        require_plan_approval: false,
+        approval_rules: vec![],
+        container: None,
+        mcp_servers: vec![],
+        communication: Default::default(),
+        lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
+        untyped_actor_policy: Default::default(),
+    };
+    let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
+    let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
+    let wt_mgr = Arc::new(WorktreeManager::new());
+    let state = Arc::new(DispatchState::new(
+        run_id,
+        manifest,
+        store,
+        CancelToken::new(),
+        String::new(),
+        spawner,
+        PathBuf::from("/bin/true"),
+        wt_mgr,
+        CleanupPolicy::Never,
+        run_subdir.clone(),
+        ApprovalPolicy::Block,
+        None,
+        std::sync::Arc::new(pitboss_cli::shared_store::SharedStore::new()),
+    ));
+    state.root.workers.write().await.insert(
+        "w-seq".into(),
+        WorkerState::Running {
+            started_at: chrono::Utc::now(),
+            session_id: Some("sess".into()),
+        },
+    );
+
+    let sock = dir.path().join("events-seq.sock");
+    let _h = start_control_server(
+        sock.clone(),
+        "0.4.0".into(),
+        run_id.to_string(),
+        "flat".into(),
+        state,
+    )
+    .await
+    .unwrap();
+
+    // Connect raw so we can inspect the hello envelope's seq directly,
+    // bypassing FakeControlClient::connect which consumes the hello.
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    let stream = tokio::net::UnixStream::connect(&sock).await.unwrap();
+    let (r, mut w) = stream.into_split();
+    let mut reader = BufReader::new(r).lines();
+    let client_hello = serde_json::to_string(&ControlOp::Hello {
+        client_version: "0.4.0".into(),
+    })
+    .unwrap()
+        + "\n";
+    w.write_all(client_hello.as_bytes()).await.unwrap();
+    w.flush().await.unwrap();
+
+    let hello_line = reader.next_line().await.unwrap().expect("hello");
+    let hello_env: pitboss_cli::control::protocol::EventEnvelope =
+        serde_json::from_str(&hello_line).unwrap();
+    assert_eq!(hello_env.seq, 1, "first envelope is seq=1");
+    assert!(matches!(hello_env.event, ControlEvent::Hello { .. }));
+
+    // Send two ops back-to-back; their OpAcked / OpFailed replies must
+    // carry monotonically increasing seqs.
+    let list_op = serde_json::to_string(&ControlOp::ListWorkers).unwrap() + "\n";
+    w.write_all(list_op.as_bytes()).await.unwrap();
+    let cancel_op = serde_json::to_string(&ControlOp::CancelWorker {
+        task_id: "w-seq".into(),
+    })
+    .unwrap()
+        + "\n";
+    w.write_all(cancel_op.as_bytes()).await.unwrap();
+    w.flush().await.unwrap();
+
+    // Collect three envelopes (workers snapshot, two op replies). The
+    // exact order isn't pinned — the activity ticker may also fire — so
+    // assert monotonicity rather than specific values.
+    let mut seqs = Vec::new();
+    for _ in 0..3 {
+        let line = tokio::time::timeout(std::time::Duration::from_secs(2), reader.next_line())
+            .await
+            .unwrap()
+            .unwrap()
+            .expect("envelope");
+        let env: pitboss_cli::control::protocol::EventEnvelope =
+            serde_json::from_str(&line).unwrap();
+        seqs.push(env.seq);
+    }
+    for window in seqs.windows(2) {
+        assert!(
+            window[1] > window[0],
+            "seqs must be strictly monotonic: saw {window:?} in {seqs:?}",
+        );
+    }
+    assert!(
+        *seqs.first().unwrap() >= 2,
+        "post-hello seqs must be >= 2: {seqs:?}",
+    );
 }
 
 #[tokio::test]

--- a/crates/pitboss-web/src/control_bridge.rs
+++ b/crates/pitboss-web/src/control_bridge.rs
@@ -209,6 +209,9 @@ async fn reader_loop(
                         // empty-actor-path envelope for uniformity.
                         Ok(ev) => EventEnvelope {
                             actor_path: Default::default(),
+                            // Bare ControlEvent had no seq; treat as
+                            // legacy (seq = 0) per PR-B of #438.
+                            seq: 0,
                             event: ev,
                         },
                         Err(e) => {

--- a/tests-support/fake-control-client/src/lib.rs
+++ b/tests-support/fake-control-client/src/lib.rs
@@ -12,7 +12,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::net::UnixStream;
 
-use pitboss_cli::control::protocol::{ControlEvent, ControlOp};
+use pitboss_cli::control::protocol::{ControlEvent, ControlOp, EventEnvelope};
 
 pub struct FakeControlClient {
     writer: OwnedWriteHalf,
@@ -66,6 +66,26 @@ impl FakeControlClient {
     pub async fn recv_timeout(&mut self, d: Duration) -> Result<Option<ControlEvent>> {
         match tokio::time::timeout(d, self.recv()).await {
             Ok(ev) => Ok(Some(ev?)),
+            Err(_) => Ok(None),
+        }
+    }
+
+    /// Read one full envelope (with `actor_path` and `seq` fields). Use
+    /// when a test needs to inspect the envelope wrapper; otherwise
+    /// `recv` is the lighter-weight path that only decodes the inner
+    /// `ControlEvent`. PR-B of #438.
+    pub async fn recv_envelope(&mut self) -> Result<EventEnvelope> {
+        let mut line = String::new();
+        let n = self.reader.read_line(&mut line).await?;
+        if n == 0 {
+            anyhow::bail!("control socket EOF");
+        }
+        Ok(serde_json::from_str(line.trim_end_matches('\n'))?)
+    }
+
+    pub async fn recv_envelope_timeout(&mut self, d: Duration) -> Result<Option<EventEnvelope>> {
+        match tokio::time::timeout(d, self.recv_envelope()).await {
+            Ok(env) => Ok(Some(env?)),
             Err(_) => Ok(None),
         }
     }


### PR DESCRIPTION
## Summary

Second of three PRs landing the TUI slice of [#438](https://github.com/SDS-Mode/pitboss/issues/438). Adds the dispatcher-side `seq` plumbing on top of [PR-A (#444)](https://github.com/SDS-Mode/pitboss/pull/444)'s consumer foundation.

Every wire envelope now carries a monotonic per-connection `seq: u64`. Legacy wire shape stays byte-identical via `skip_serializing_if = is_zero_u64` on the field; pre-PR-B JSON deserializes as `seq = 0` via `#[serde(default)]`.

## Scope cut

The original plan for PR-B included the `Subscribe { since_seq }` op. **That's deferred** — there's no in-memory broadcast buffer in the dispatcher itself (the 256-event buffer lives in `pitboss-web`'s `control_bridge.rs`), so the server can't do meaningful fast-forward without either a new buffer or an on-disk events log to read back. The natural place for that work is alongside [#259](https://github.com/SDS-Mode/pitboss/issues/259) (`events.jsonl` persistence). PR-B is scoped to the writer-side counter plus the wire field; the consumer-side `ReplayThenLive` in PR-C uses what's here (replay disk to EOF, then start a fresh socket subscription with `seq` gap detection).

## What's in PR-B

- `crates/pitboss-cli/src/control/protocol.rs`: `seq: u64` field added to `EventEnvelope` with `#[serde(default, skip_serializing_if = "is_zero_u64")]`.
- `crates/pitboss-cli/src/control/server.rs`: per-connection `Arc<AtomicU64>` seq counter; `send_event` / `send_events_batch` wrap each `ControlEvent` into an `EventEnvelope` with the next seq before serializing.
- Three direct `EventEnvelope { ... }` constructions in `dispatch/failure_detection.rs` and `dispatch/sublead.rs` get `seq: 0` placeholders — their path through `broadcast_control_event` discards the wrapper and the pump reassigns the seq.
- `crates/pitboss-web/src/control_bridge.rs`: the bare-event fallback path gets `seq: 0` for the synthesized envelope.
- `tests-support/fake-control-client`: new `recv_envelope` / `recv_envelope_timeout` methods that decode the full envelope (existing `recv` still decodes just `ControlEvent` for back-compat).

## Tests

- Unit (`crates/pitboss-cli/src/control/protocol.rs`):
  - `envelope_seq_omitted_when_zero` — wire stays byte-identical for legacy
  - `envelope_seq_roundtrips_when_nonzero` — non-zero seq survives serde
  - `pre_pr_b_envelope_deserializes_as_seq_zero` — legacy JSON parses
- Integration (`crates/pitboss-cli/tests/control_flows.rs`):
  - `server_emits_monotonic_seqs_on_wire` — connects raw, asserts hello has seq=1, sends two ops, asserts subsequent envelope seqs strictly increase

All green locally. The pre-existing `e2e_lead_request_approval_round_trip` flake under parallel execution is unchanged (passes solo).

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test -p pitboss-cli --test control_flows` 11/11 pass
- [x] `cargo test -p pitboss-cli --lib envelope_seq` 2/2 pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] Reviewer: confirm the per-connection counter (resets on reconnect) is acceptable until #259 lifts it to per-run

## Stacking

This PR is **independent** of PR-A at the source level (PR-A touches `pitboss-core::stream`, PR-B touches `pitboss-cli::control`). Either can merge first.

## Follows

- RFC at #443
- PR-A foundation at #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)