### PR TITLE
feat(control): persistent events.jsonl bus subscriber (#259, PR-H)

### DIFF
--- a/crates/pitboss-cli/src/control/event_log.rs
+++ b/crates/pitboss-cli/src/control/event_log.rs
@@ -16,17 +16,37 @@
 //!   `[run].emit_event_stream = true`. Absent when the flag is off
 //!   (today's back-compat default).
 //!
+//! ## How persistence runs
+//!
+//! PR-H of #259 separates the *emission* of an envelope from its
+//! *persistence*. Emitters call
+//! [`crate::dispatch::layer::LayerState::broadcast_control_event`]
+//! which publishes onto the per-run broadcast bus
+//! ([`LayerState::events_tx`]). The bus has two subscribers:
+//!
+//! 1. A persistent task spawned in
+//!    [`crate::dispatch::state::DispatchState::new`] that drains the
+//!    bus and calls [`EventLog::persist`] for every envelope. This
+//!    task is alive for the whole run, so **headless** dispatches
+//!    (no TUI, no web bridge) still produce a complete
+//!    `events.jsonl`.
+//! 2. A per-connection bridge spawned in `control/server.rs` that
+//!    forwards the bus into the connected client's outbound mpsc.
+//!
 //! ## What this does not own
 //!
 //! - The decision of which events to emit; that stays in the
 //!   dispatcher's existing emit sites.
 //! - The HTTP endpoint, SPA replay, or `pitboss events` CLI
 //!   subcommand from #259's full scope — those are follow-up PRs.
-//! - Persisting events emitted via `broadcast_control_event` when
-//!   **no** client is connected (events are dropped at the channel
-//!   today; persistence today rides on the pump path). Lifting that
-//!   guarantee is a future PR; for typical pitboss runs the TUI or
-//!   web bridge is attached and the gap is empty.
+//! - Persisting connection-scoped envelopes (Hello reply, op replies,
+//!   queued-approval drain, bridge replay, Superseded sent to a
+//!   displaced client, `StoreActivity` ticks). These bypass the bus
+//!   on purpose — they're addressed to a specific client, not to
+//!   the run — and persist via the inline helpers in
+//!   `control/server.rs` whenever they fire. `Hello` itself is
+//!   filtered at the [`EventLog::persist`] boundary because it is
+//!   pure handshake noise.
 
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -338,6 +338,50 @@ async fn serve_connection(
         let _ = enqueue_envelope(&ev_tx, &event_log, ev).await;
     }
 
+    // PR-H of #259: bus → mpsc bridge. The per-run events broadcast
+    // bus carries every `broadcast_control_event` emission. A
+    // dedicated subscriber forwards bus envelopes into THIS
+    // connection's mpsc so the existing pump (below) can stay
+    // single-source and the batched-flush optimisation is unchanged.
+    //
+    // Lag handling: a slow pump can starve the broadcast subscriber
+    // past `EVENTS_BROADCAST_CAP`. `recv()` then returns `Lagged(n)`
+    // — we log and continue. The dropped envelopes are still in
+    // `events.jsonl` (the persistence subscriber drains the bus
+    // independently), so the lag manifests as missing wire frames
+    // on this client only, not as missing audit-log rows.
+    //
+    // Bridge-only sites (direct mpsc pushes from server.rs:
+    // queued-approval drain, bridge replay, activity ticker, op
+    // replies, Hello, Superseded-to-displaced) bypass the bus on
+    // purpose — they're connection-scoped, not run-wide events.
+    let ev_tx_bus = ev_tx.clone();
+    let mut events_bus_rx = state.root.events_tx.subscribe();
+    let bus_bridge = tokio::spawn(async move {
+        loop {
+            match events_bus_rx.recv().await {
+                Ok(envelope) => {
+                    if ev_tx_bus.try_send(envelope).is_err() {
+                        // mpsc is closed or full. Closed means pump is
+                        // gone; full means pump is wedged — neither
+                        // recoverable from here. Persistence is
+                        // unaffected; the bus's other subscriber
+                        // (event_log writer in DispatchState::new) is
+                        // independent.
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    tracing::warn!(
+                        lagged = n,
+                        "control bus → mpsc bridge lagged; \
+                         some envelopes dropped from this client's wire stream",
+                    );
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    });
+
     // Concurrent outbound pump: forward events from the mpsc to the socket.
     //
     // Batched-flush optimisation (#152 L5): the hello handshake bursts
@@ -472,6 +516,7 @@ async fn serve_connection(
     }
     pump.abort();
     activity_pump.abort();
+    bus_bridge.abort();
 }
 
 /// Best-effort SIGCONT helper: if `task_id` is currently `Frozen`,

--- a/crates/pitboss-cli/src/dispatch/failure_detection.rs
+++ b/crates/pitboss-cli/src/dispatch/failure_detection.rs
@@ -403,13 +403,12 @@ mod tests {
             Arc::new(SharedStore::new()),
             None,
         );
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<EventEnvelope>(
-            crate::dispatch::layer::CONTROL_EVENT_QUEUE_CAP,
-        );
-        *layer.control_writer.lock().await = Some(crate::dispatch::layer::ControlWriterSlot {
-            id: uuid::Uuid::now_v7(),
-            sender: tx,
-        });
+        // PR-H of #259: `broadcast_control_event` publishes on the
+        // per-run broadcast bus rather than directly into the
+        // `control_writer` mpsc. Subscribe to the bus to observe the
+        // envelope from this test fixture (no `DispatchState` /
+        // server / pump runs here).
+        let mut rx = layer.events_tx.subscribe();
 
         broadcast_worker_failed(
             &layer,

--- a/crates/pitboss-cli/src/dispatch/layer.rs
+++ b/crates/pitboss-cli/src/dispatch/layer.rs
@@ -38,6 +38,16 @@ type RepromptHook = Arc<dyn Fn(String) + Send + Sync + 'static>;
 /// re-syncs via the Hello snapshot.
 pub const CONTROL_EVENT_QUEUE_CAP: usize = 512;
 
+/// Capacity of the per-run event broadcast bus (PR-H of #259).
+///
+/// Sized 2× `CONTROL_EVENT_QUEUE_CAP` so the headless persistence
+/// subscriber has enough slack to absorb a burst even while one
+/// connected pump is briefly stalled on socket I/O. Lag past this
+/// bound surfaces as `broadcast::error::RecvError::Lagged(n)` on the
+/// affected subscriber and is logged but not fatal — the run's
+/// canonical state still lands in `summary.jsonl`.
+pub const EVENTS_BROADCAST_CAP: usize = 1024;
+
 /// One installed outbound control-event sender.
 ///
 /// `id` is a UUID minted when the connection is accepted. The disconnect
@@ -145,10 +155,31 @@ pub struct LayerState {
     /// Per-run event-stream log (#259, co-spec'd with #438). Cloned
     /// from `DispatchState.event_log` at LayerState construction so
     /// the per-layer `broadcast_control_event` can assign the
-    /// run-scoped seq + persist envelopes without going through the
-    /// pump (which only runs when a client is connected). Shared
-    /// across the root layer and every sub-tree layer.
+    /// run-scoped seq without going through the pump (which only runs
+    /// when a client is connected). Shared across the root layer and
+    /// every sub-tree layer.
     pub event_log: Arc<crate::control::event_log::EventLog>,
+    /// Per-run event broadcast bus (#259 PR-H). Every envelope
+    /// produced by [`Self::broadcast_control_event`] (and direct
+    /// emitters in `control::server` / `mcp::approval`) is sent here
+    /// **regardless of whether a client is connected**. Subscribers:
+    ///
+    /// 1. A persistent task spawned in `DispatchState::new` that
+    ///    drains the broadcast and persists each envelope to
+    ///    `events.jsonl` — this is what makes headless dispatches
+    ///    produce a complete log.
+    /// 2. Per-connection pump tasks in `control::server` that forward
+    ///    to the connected socket.
+    ///
+    /// 1024 capacity covers multi-second bursts (sub-lead spawn fan-
+    /// out, approvals) without unbounded memory. A lagged subscriber
+    /// sees `broadcast::error::RecvError::Lagged(n)` and logs a warn;
+    /// the headless persistence task is unlikely to lag because
+    /// `event_log.persist` is a small append.
+    ///
+    /// Shared by clone across the root layer and every sub-tree
+    /// layer so the entire run funnels into a single bus.
+    pub events_tx: broadcast::Sender<crate::control::protocol::EventEnvelope>,
     /// Per-task event counters.
     pub worker_counters: RwLock<HashMap<String, WorkerCounters>>,
     /// v0.4.1: notification router.
@@ -242,6 +273,11 @@ impl LayerState {
             false,
         ));
         let (done_tx, _) = broadcast::channel(64);
+        // PR-H of #259: each `LayerState::new` mints its own broadcast
+        // bus by default. Prod callers (`DispatchState::new`, sub-lead
+        // spawn) override via [`Self::with_events_tx`] to share the
+        // root layer's bus so the entire run funnels into one stream.
+        let (events_tx, _) = broadcast::channel(EVENTS_BROADCAST_CAP);
         Self {
             run_id,
             manifest,
@@ -269,6 +305,7 @@ impl LayerState {
             approval_policy,
             control_writer: Mutex::new(None),
             event_log,
+            events_tx,
             worker_counters: RwLock::new(HashMap::new()),
             notification_router,
             shared_store,
@@ -291,6 +328,21 @@ impl LayerState {
     #[must_use]
     pub fn with_event_log(mut self, event_log: Arc<crate::control::event_log::EventLog>) -> Self {
         self.event_log = event_log;
+        self
+    }
+
+    /// Builder: install the run-scoped event broadcast bus on this
+    /// freshly-constructed layer. PR-H of #259 — sub-leads call this
+    /// with the root layer's `events_tx` so the whole run funnels
+    /// into one bus, which the headless persistence subscriber
+    /// drains. Test callers that don't care about the broadcast can
+    /// omit and inherit the per-layer default.
+    #[must_use]
+    pub fn with_events_tx(
+        mut self,
+        events_tx: broadcast::Sender<crate::control::protocol::EventEnvelope>,
+    ) -> Self {
+        self.events_tx = events_tx;
         self
     }
 
@@ -400,39 +452,36 @@ impl LayerState {
         }
     }
 
-    /// Broadcast a control-plane event. PR-G of #259: this call assigns
-    /// the run-scoped seq from [`Self::event_log`], persists the
-    /// envelope to `events.jsonl` (no-op when `emit_event_stream` is
-    /// off), and — if a TUI/web bridge is connected — forwards the
-    /// envelope to the pump for wire emission.
+    /// Broadcast a control-plane event. PR-H of #259: this call
+    /// assigns the run-scoped seq from [`Self::event_log`] and
+    /// publishes the envelope onto [`Self::events_tx`]. Subscribers
+    /// fan out from there:
     ///
-    /// Persistence happens **regardless of whether a client is
-    /// connected**: headless dispatches still produce a complete
-    /// `events.jsonl` for post-run replay. The caller's `envelope.seq`
-    /// is overwritten; the caller is expected to construct envelopes
-    /// with `seq: 0` placeholders (pre-PR-G call sites still compile
-    /// unchanged).
+    /// - The persistent task spawned in `DispatchState::new` reads
+    ///   off the bus and appends to `events.jsonl` (gated by
+    ///   `emit_event_stream`). This is what makes headless
+    ///   dispatches produce a complete log.
+    /// - The connected control-socket pump (if any) reads off the
+    ///   bus and writes to the connected client.
     ///
-    /// `try_send` drops the wire emission on a full queue (slow /
-    /// frozen TUI) rather than blocking the dispatcher — the archived
-    /// row is unaffected.
+    /// The caller's `envelope.seq` is overwritten; call sites pass
+    /// `seq: 0` placeholders.
+    ///
+    /// `events_tx.send` returns `Err` only when there are zero
+    /// subscribers — possible only during the narrow window before
+    /// the persistence subscriber has been spawned (in tests that
+    /// build a bare `LayerState` without a `DispatchState`). The
+    /// error is logged and swallowed; the envelope is dropped.
     pub async fn broadcast_control_event(
         &self,
         mut envelope: crate::control::protocol::EventEnvelope,
     ) {
         envelope.seq = self.event_log.next_seq();
-        self.event_log.persist(&envelope).await;
-
-        if let Some(w) = self.control_writer.lock().await.as_ref() {
-            if let Err(e) = w.sender.try_send(envelope) {
-                tracing::debug!(
-                    "control_writer try_send dropped envelope: {}",
-                    match &e {
-                        tokio::sync::mpsc::error::TrySendError::Full(_) => "queue full",
-                        tokio::sync::mpsc::error::TrySendError::Closed(_) => "receiver dropped",
-                    },
-                );
-            }
+        if let Err(e) = self.events_tx.send(envelope) {
+            tracing::debug!(
+                "events_tx send dropped envelope: {} (no active subscribers)",
+                e,
+            );
         }
     }
 

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -463,6 +463,12 @@ impl DispatchState {
             &run_subdir,
             manifest.emit_event_stream,
         ));
+        // PR-H of #259: run-scoped event broadcast bus. Subscribers
+        // are spawned below (persistence) and inside `serve_connection`
+        // (per-connection pump). Sub-leads inherit this same Sender via
+        // `with_events_tx` so the whole run funnels into one bus.
+        let (events_tx, _) =
+            tokio::sync::broadcast::channel(crate::dispatch::layer::EVENTS_BROADCAST_CAP);
         let root = Arc::new(
             LayerState::new(
                 run_id,
@@ -480,8 +486,40 @@ impl DispatchState {
                 shared_store,
                 None,
             )
-            .with_event_log(event_log.clone()),
+            .with_event_log(event_log.clone())
+            .with_events_tx(events_tx.clone()),
         );
+
+        // PR-H: persistent events.jsonl subscriber. Drains the bus
+        // and persists every envelope, regardless of whether a TUI /
+        // web bridge is connected. This is what makes headless
+        // dispatches produce a complete log: the bus is alive for
+        // the lifetime of the run, the subscriber is spawned before
+        // any emission can happen, and `event_log.persist` no-ops
+        // gracefully when `emit_event_stream = false`.
+        //
+        // The task exits when all `events_tx` clones (root + every
+        // sub-tree layer) drop, which happens after `DispatchState`
+        // is dropped at run finalization.
+        {
+            let mut rx = events_tx.subscribe();
+            let log = event_log.clone();
+            tokio::spawn(async move {
+                loop {
+                    match rx.recv().await {
+                        Ok(envelope) => log.persist(&envelope).await,
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                            tracing::warn!(
+                                lagged = n,
+                                "events.jsonl persistence subscriber lagged; \
+                                 some envelopes will be missing from the log",
+                            );
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                    }
+                }
+            });
+        }
         Self {
             root,
             subleads: RwLock::new(HashMap::new()),

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -374,7 +374,8 @@ pub async fn spawn_sublead(
                 sub_store,
                 reserved_amount,
             )
-            .with_event_log(state.event_log.clone()),
+            .with_event_log(state.event_log.clone())
+            .with_events_tx(state.root.events_tx.clone()),
         );
 
         // 8. Register sub-tree LayerState on root DispatchState. Inserts into

--- a/crates/pitboss-cli/src/mcp/approval.rs
+++ b/crates/pitboss-cli/src/mcp/approval.rs
@@ -325,6 +325,27 @@ impl ApprovalBridge {
             // drain when a TUI connects (see control/server.rs). AutoApprove
             // / AutoReject already short-circuited above, so this branch is
             // reachable only under `block`.
+            //
+            // PR-H of #259: persist an `ApprovalRequest` envelope here so
+            // **headless** approval flows (no TUI ever attaches, decision
+            // resolves via TTL fallback or a later `respond_approval` op)
+            // still leave an audit trail in `events.jsonl`. The seq is
+            // canonical — the run-scoped counter — and matches the wire
+            // seq the queue drain (`control/server.rs`) will emit if a
+            // client connects later. `event_log.persist` no-ops when
+            // `emit_event_stream = false`.
+            let queue_envelope = crate::control::protocol::EventEnvelope {
+                actor_path: crate::dispatch::actor::ActorPath::default(),
+                seq: self.state.root.event_log.next_seq(),
+                event: crate::control::protocol::ControlEvent::ApprovalRequest {
+                    request_id: request_id.clone(),
+                    task_id: task_id.clone(),
+                    summary: summary.clone(),
+                    plan: plan.clone().map(approval_plan_to_wire),
+                    kind,
+                },
+            };
+            self.state.root.event_log.persist(&queue_envelope).await;
             self.state
                 .root
                 .approval_queue

--- a/crates/pitboss-cli/tests/control_flows.rs
+++ b/crates/pitboss-cli/tests/control_flows.rs
@@ -573,6 +573,129 @@ async fn emit_event_stream_off_does_not_create_events_jsonl() {
     );
 }
 
+/// PR-H of #259: headless dispatches (no control server, no client)
+/// must still produce `events.jsonl` when `emit_event_stream = true`.
+/// Persistence rides on a bus subscriber spawned in
+/// `DispatchState::new` rather than on the per-connection pump path.
+/// Without this, a hierarchical run with no operator attached would
+/// silently lose its sub-lead lifecycle, worker-failure, and
+/// approval-queue audit trail.
+#[tokio::test]
+async fn headless_broadcast_persists_events_jsonl_without_client() {
+    let dir = TempDir::new().unwrap();
+    let run_id = uuid::Uuid::now_v7();
+    let run_subdir = dir.path().join(run_id.to_string());
+    tokio::fs::create_dir_all(&run_subdir).await.unwrap();
+    let manifest = ResolvedManifest {
+        manifest_schema_version: 0,
+        name: None,
+        max_parallel_tasks: Some(4),
+        halt_on_failure: false,
+        run_dir: dir.path().to_path_buf(),
+        worktree_cleanup: WorktreeCleanup::OnSuccess,
+        emit_event_stream: true,
+        tasks: vec![],
+        lead: None,
+        max_workers: Some(4),
+        budget_usd: Some(1.0),
+        lead_budget_usd: None,
+        lead_timeout_secs: None,
+        default_approval_policy: Some(ApprovalPolicy::Block),
+        denial_termination_policy: None,
+        notifications: vec![],
+        dump_shared_store: false,
+        require_plan_approval: false,
+        approval_rules: vec![],
+        container: None,
+        mcp_servers: vec![],
+        communication: Default::default(),
+        lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
+        untyped_actor_policy: Default::default(),
+    };
+    let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
+    let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
+    let wt_mgr = Arc::new(WorktreeManager::new());
+    let state = Arc::new(DispatchState::new(
+        run_id,
+        manifest,
+        store,
+        CancelToken::new(),
+        "lead".into(),
+        spawner,
+        PathBuf::from("/bin/true"),
+        wt_mgr,
+        CleanupPolicy::Never,
+        run_subdir.clone(),
+        ApprovalPolicy::Block,
+        None,
+        std::sync::Arc::new(pitboss_cli::shared_store::SharedStore::new()),
+    ));
+
+    // No control server. No client. Fire two broadcast events
+    // directly on the root layer — the only path that exercises the
+    // dispatcher-internal bus.
+    state
+        .root
+        .broadcast_control_event(pitboss_cli::control::protocol::EventEnvelope {
+            actor_path: pitboss_cli::dispatch::actor::ActorPath::default(),
+            seq: 0,
+            event: ControlEvent::WorkerFailed {
+                task_id: "w-1".into(),
+                parent_task_id: None,
+                reason: pitboss_core::store::FailureReason::Unknown {
+                    message: "test failure".into(),
+                },
+            },
+        })
+        .await;
+    state
+        .root
+        .broadcast_control_event(pitboss_cli::control::protocol::EventEnvelope {
+            actor_path: pitboss_cli::dispatch::actor::ActorPath::default(),
+            seq: 0,
+            event: ControlEvent::SubleadSpawned {
+                sublead_id: "sub-1".into(),
+                budget_usd: Some(0.5),
+                lead_budget_usd: Some(0.1),
+                max_workers: Some(2),
+                read_down: false,
+            },
+        })
+        .await;
+
+    // Wait for the persistence subscriber task to drain the bus and
+    // flush both envelopes. 200 ms is conservative — broadcast send
+    // is in-process and `event_log.persist` is one append per row.
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    let events_path = run_subdir.join("events.jsonl");
+    let contents = tokio::fs::read_to_string(&events_path)
+        .await
+        .expect("events.jsonl must be created by the headless bus subscriber");
+    let lines: Vec<&str> = contents.lines().collect();
+    assert_eq!(
+        lines.len(),
+        2,
+        "expected two persisted envelopes, got: {contents}",
+    );
+    assert!(
+        lines[0].contains("\"worker_failed\""),
+        "first envelope payload: {}",
+        lines[0],
+    );
+    assert!(
+        lines[1].contains("\"sublead_spawned\""),
+        "second envelope payload: {}",
+        lines[1],
+    );
+    // Seqs come from the run-scoped EventLog and start at 1.
+    assert!(lines[0].contains("\"seq\":1"), "first seq: {}", lines[0]);
+    assert!(lines[1].contains("\"seq\":2"), "second seq: {}", lines[1]);
+}
+
 #[tokio::test]
 async fn block_policy_queue_drains_on_tui_connect() {
     use std::time::Duration;


### PR DESCRIPTION
## Summary

Closes the headless-persistence gap PR-G ([#450](https://github.com/SDS-Mode/pitboss/pull/450)) left open. PR-G persisted via `broadcast_control_event` directly, but that call path was the only one — any event that needed to flow through `serve_connection`'s per-connection pump still required a connected TUI / web bridge for persistence. A pure-flat-mode dispatch with no failures, no sub-leads, and no client could legitimately produce an empty / missing `events.jsonl`; more importantly, queued `ApprovalRequest`s that arrived before any client connected were never persisted.

PR-H separates *emission* from *persistence*:

- New `events_tx: broadcast::Sender<EventEnvelope>` on `LayerState`. Shared across the root layer and every sub-tree via the new `with_events_tx` builder, so the entire run funnels into one bus (capacity `EVENTS_BROADCAST_CAP = 1024`).
- `DispatchState::new` spawns a **persistent subscriber task** that drains the bus and writes every envelope through `EventLog::persist`. Alive for the full run, regardless of operator presence — this is the dispatcher-internal listener referenced in PR-G's known-gap note.
- `broadcast_control_event` now publishes on the bus instead of calling `event_log.persist` + `try_send` to the writer mpsc directly. Sub-lead lifecycle (`SubleadSpawned` / `SubleadTerminated`) and worker-failure (`WorkerFailed`) emissions automatically participate.
- Each `serve_connection` spawns a **bus → mpsc bridge** task that forwards bus envelopes into the connected client's outbound mpsc. The existing batched-flush pump is unchanged. `broadcast::error::RecvError::Lagged(n)` is logged; persistence is independent of the bridge, so a slow client can only lose wire frames, never audit-log rows.
- `mcp/approval.rs` writer-absent path persists the `ApprovalRequest` envelope at queue-push time so a headless approval (resolved via TTL fallback or a deferred `respond_approval`) leaves an audit trail. Seq is canonical — assigned from the run-scoped `EventLog`.

The `broadcast_worker_failed_delivers_event` unit test now subscribes to `layer.events_tx` instead of installing a `control_writer` mpsc.

## What stays connection-scoped

`Hello`, `OpAcked`/`OpFailed`/`OpUnknown`, queued-approval drain, bridge replay, `StoreActivity` ticks, and `Superseded` sent to a displaced client all bypass the bus on purpose — they're addressed to a specific client, not the run. They persist via the inline `wrap_with_seq` + `event_log.persist` helpers, as in PR-G. Documented in the `event_log.rs` module doc.

## Test plan

- [x] `cargo test --workspace --features pitboss-core/test-support` — 187/188 pitboss-cli pass (one pre-existing macOS-only flake: `terminate_after_exit_is_ok` fails because `/bin/true` doesn't exist on this Darwin install; passes on CI). All 14 `control_flows` tests pass including the new `headless_broadcast_persists_events_jsonl_without_client`.
- [x] `cargo lint` clean
- [x] `cargo tidy` clean

## Stack position

Sits on top of PR-G (#450) in the #259 sequence. Once both land, the writer side of #259 is fully closed for both attached and headless dispatches; remaining #259 follow-ups (HTTP endpoint, SPA replay, `pitboss events` CLI subcommand, AGENTS.md doc) stay tracked on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)