### PR TITLE
feat(web): SPA Replay tab for persisted events.jsonl (#259, PR-K)

### DIFF
--- a/crates/pitboss-web/spa/src/lib/api.ts
+++ b/crates/pitboss-web/spa/src/lib/api.ts
@@ -121,6 +121,40 @@ export function getSummaryJsonl(id: string): Promise<string> {
   return request<string>(`/api/runs/${enc(id)}/summary-jsonl`, { accept: 'text' });
 }
 
+/**
+ * GET /api/runs/:id/events-jsonl — persisted control-event stream
+ * (#259). Parses NDJSON into `ControlEnvelope`s for the Replay tab.
+ *
+ * 404 (run never had `[run].emit_event_stream = true`, or the file
+ * exists but no envelopes have been appended yet) returns an empty
+ * list rather than throwing, so the Replay tab can render an empty-
+ * state explaining the manifest flag instead of an error banner.
+ * Other errors propagate to the caller.
+ */
+export async function getEventsJsonl(id: string): Promise<ControlEnvelope[]> {
+  try {
+    const text = await request<string>(`/api/runs/${enc(id)}/events-jsonl`, { accept: 'text' });
+    return text
+      .split('\n')
+      .filter((l) => l.trim().length > 0)
+      .map((l) => {
+        try {
+          return JSON.parse(l) as ControlEnvelope;
+        } catch {
+          // Partial-write tail caught mid-flush — skip silently.
+          // Matches the dispatcher's canonical "drop incomplete
+          // trailing line" semantics in `pitboss events` and the
+          // summary.jsonl reader.
+          return null;
+        }
+      })
+      .filter((e): e is ControlEnvelope => e !== null);
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) return [];
+    throw err;
+  }
+}
+
 export function getTaskLog(runId: string, taskId: string, opts: TaskLogOpts = {}): Promise<string> {
   const params = new URLSearchParams();
   if (opts.limit !== undefined) params.set('limit', String(opts.limit));
@@ -174,7 +208,13 @@ export type TaskEvent =
   | { kind: 'continue'; at: string; new_session_id: string; prompt_preview: string }
   | { kind: 'reprompt'; at: string; prompt_preview: string; prior_session_id: string }
   | { kind: 'approval_request'; at: string; request_id: string; summary_preview: string }
-  | { kind: 'approval_response'; at: string; request_id: string; approved: boolean; edited: boolean }
+  | {
+      kind: 'approval_response';
+      at: string;
+      request_id: string;
+      approved: boolean;
+      edited: boolean;
+    }
   | { kind: 'notification_failed'; at: string; sink_id: string; event_kind: string; error: string }
   | {
       kind: 'tool_denied';
@@ -184,7 +224,13 @@ export type TaskEvent =
       reason_kind: string;
       reason: string;
     }
-  | { kind: 'tool_auto_approved'; at: string; tool_name: string; actor_id: string; actor_type: string };
+  | {
+      kind: 'tool_auto_approved';
+      at: string;
+      tool_name: string;
+      actor_id: string;
+      actor_type: string;
+    };
 
 /** GET /api/runs/:id/tasks/:task_id/events — NDJSON parsed into rows.
  * 404 (no events.jsonl yet — task never paused/repromp ted/got an
@@ -192,10 +238,9 @@ export type TaskEvent =
  * inspector can render "no lifecycle events yet". */
 export async function getTaskEvents(runId: string, taskId: string): Promise<TaskEvent[]> {
   try {
-    const text = await request<string>(
-      `/api/runs/${enc(runId)}/tasks/${enc(taskId)}/events`,
-      { accept: 'text' }
-    );
+    const text = await request<string>(`/api/runs/${enc(runId)}/tasks/${enc(taskId)}/events`, {
+      accept: 'text'
+    });
     return text
       .split('\n')
       .filter((l) => l.trim().length > 0)
@@ -425,7 +470,10 @@ export function exportManifestUrl(name: string): string {
   return `/api/manifests/${enc(name)}?${params.toString()}`;
 }
 
-export function saveManifest(name: string, contents: string): Promise<{ name: string; bytes: number }> {
+export function saveManifest(
+  name: string,
+  contents: string
+): Promise<{ name: string; bytes: number }> {
   return request<{ name: string; bytes: number }>('/api/manifests', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -443,7 +491,9 @@ export function validateManifest(contents: string): Promise<ValidateResult> {
   });
 }
 
-export function dispatchManifest(manifest_name: string): Promise<{ descriptor: DispatchDescriptor }> {
+export function dispatchManifest(
+  manifest_name: string
+): Promise<{ descriptor: DispatchDescriptor }> {
   return request<{ descriptor: DispatchDescriptor }>('/api/runs', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/crates/pitboss-web/spa/src/routes/runs/[id]/+page.svelte
+++ b/crates/pitboss-web/spa/src/routes/runs/[id]/+page.svelte
@@ -7,6 +7,7 @@
     getResolvedManifest,
     getManifestToml,
     getSummaryJsonl,
+    getEventsJsonl,
     subscribeRunEvents,
     postControlOp,
     forkRun,
@@ -92,11 +93,7 @@
   // silently rendered as 'complete' (green).
   const status = $derived<RunStatus>(
     (stub?.status as RunStatus | undefined) ??
-      (summary
-        ? summary.was_interrupted === true
-          ? 'cancelled'
-          : 'complete'
-        : 'aborted')
+      (summary ? (summary.was_interrupted === true ? 'cancelled' : 'complete') : 'aborted')
   );
   const taskList = $derived<Array<Record<string, any>>>(
     (summary?.tasks as Array<Record<string, any>> | undefined) ?? []
@@ -234,8 +231,7 @@
       const status = ((t.status as string | undefined) ?? 'unknown').toLowerCase();
       // Map TaskStatus → tile color buckets used by RunTileGrid.tileColor.
       // Anything not running/paused/frozen renders as terminal.
-      const stateStr =
-        status === 'success' ? 'completed' : status === 'failed' ? 'failed' : status;
+      const stateStr = status === 'success' ? 'completed' : status === 'failed' ? 'failed' : status;
       merged.push({
         task_id: id,
         state: stateStr,
@@ -293,10 +289,7 @@
   $effect(() => {
     if (!browser) return;
     try {
-      window.localStorage.setItem(
-        FILTER_STORAGE_KEY,
-        JSON.stringify({ hideNoise, disabledKinds })
-      );
+      window.localStorage.setItem(FILTER_STORAGE_KEY, JSON.stringify({ hideNoise, disabledKinds }));
     } catch {
       /* quota / disabled — silently ignore */
     }
@@ -331,6 +324,49 @@
   }
 
   const hiddenCount = $derived(liveEvents.length - visibleEvents.length);
+
+  // ---- Replay tab: persisted events.jsonl (#259) ----------------------
+  // For finalized runs, the Live SSE bridge has closed but the
+  // dispatcher persisted every envelope to `<run-dir>/events.jsonl`
+  // (when `[run].emit_event_stream = true`). The Replay tab fetches
+  // that file via GET /api/runs/:id/events-jsonl and renders the
+  // same scrollable event list as Live, sharing the filter state so
+  // an operator's "hide store_activity" preference carries between
+  // live and historical inspection.
+  //
+  // Fetched lazily on first tab open (or via the Reload button) —
+  // not at page mount — because a finalized run that didn't enable
+  // emit_event_stream shouldn't pay the 404 round-trip until the
+  // operator actually clicks Replay.
+  let replayEvents = $state<ControlEnvelope[]>([]);
+  let replayLoaded = $state(false);
+  let replayLoading = $state(false);
+  let replayError = $state<string | null>(null);
+
+  async function loadReplay() {
+    replayLoading = true;
+    replayError = null;
+    try {
+      replayEvents = await getEventsJsonl(runId);
+      replayLoaded = true;
+    } catch (e) {
+      replayError = e instanceof ApiError ? `${e.status}: ${e.body || e.message}` : String(e);
+    } finally {
+      replayLoading = false;
+    }
+  }
+
+  const visibleReplayEvents = $derived.by(() => replayEvents.filter((e) => !isHidden(e)));
+  const replayHiddenCount = $derived(replayEvents.length - visibleReplayEvents.length);
+  /** Replay-specific kind set, separate from `seenKinds` (which is
+   * scoped to live events). Used to populate the Replay tab's
+   * filter panel so the kind chips reflect what's actually in the
+   * historical log, not what arrived on this session's SSE. */
+  const replaySeenKinds = $derived.by(() => {
+    const s = new Set<string>();
+    for (const e of replayEvents) s.add(e.event);
+    return [...s].sort();
+  });
 
   // ---- Phase 3: control state derived from the live event stream ------
   // The dispatcher pushes typed events; we keep the latest snapshot of
@@ -595,10 +631,7 @@
     );
   }
   function continueWorker(task_id: string) {
-    sendOp(
-      postControlOp(runId, { op: 'continue_worker', task_id }),
-      `continue_worker ${task_id}`
-    );
+    sendOp(postControlOp(runId, { op: 'continue_worker', task_id }), `continue_worker ${task_id}`);
   }
   function repromptWorker(task_id: string) {
     const prompt = window.prompt('New prompt for the worker?');
@@ -782,6 +815,9 @@
       {/if}
       <TabsTrigger value="graph">Graph</TabsTrigger>
       <TabsTrigger value="tasks">Tasks ({tasksToRender.length})</TabsTrigger>
+      {#if !inProgress}
+        <TabsTrigger value="replay">Replay</TabsTrigger>
+      {/if}
       <TabsTrigger value="manifest">Manifest</TabsTrigger>
       <TabsTrigger value="resolved">Resolved</TabsTrigger>
       <TabsTrigger value="summary">Summary JSON</TabsTrigger>
@@ -790,12 +826,11 @@
     <!--
       The Live tab (event stream + Filter UI + Workers card) is
       gated on inProgress on purpose: SSE closes when the
-      dispatcher exits and there's no static event-log surface
-      yet, so a finalised run has nothing live to show. The 3-s
-      polling tick re-fetches the run record (see effect above),
-      so this gate flips at finalize without a manual reload.
-      Don't remove the gate — fix the post-finalise event view
-      instead if operators want to filter historical events.
+      dispatcher exits, so a finalised run has nothing live to
+      stream. The 3-s polling tick re-fetches the run record
+      (see effect above), so this gate flips at finalize without
+      a manual reload. The historical equivalent is the Replay
+      tab (#259) below, which reads the persisted events.jsonl.
     -->
     {#if inProgress}
       <TabsContent value="live" class="mt-4 space-y-4">
@@ -806,8 +841,8 @@
               <div>
                 <p class="font-medium text-amber-700 dark:text-amber-300">Control taken</p>
                 <p class="text-muted-foreground mt-1 text-sm">
-                  Another client (TUI or another browser) connected to this run's control
-                  socket and superseded ours. Read-only views still work.
+                  Another client (TUI or another browser) connected to this run's control socket and
+                  superseded ours. Read-only views still work.
                   <Button
                     variant="link"
                     class="ml-1 h-auto p-0 text-sm"
@@ -861,21 +896,21 @@
               <Badge variant="outline" class="ml-2 text-xs">{allWorkers.length}</Badge>
               {#if Object.keys(subleads).length > 0}
                 <Badge variant="outline" class="ml-1 text-xs">
-                  {Object.keys(subleads).length} sublead{Object.keys(subleads).length === 1 ? '' : 's'}
+                  {Object.keys(subleads).length} sublead{Object.keys(subleads).length === 1
+                    ? ''
+                    : 's'}
                 </Badge>
               {/if}
             </CardTitle>
             <CardDescription class="text-xs">
-              Live state from `WorkersSnapshot`; terminated actors filled in from `summary.jsonl`
-              so sub-tree workers stay visible after their sublead exits.
+              Live state from `WorkersSnapshot`; terminated actors filled in from `summary.jsonl` so
+              sub-tree workers stay visible after their sublead exits.
             </CardDescription>
           </CardHeader>
           <CardContent class="pt-0">
             {#if allWorkers.length === 0}
               <p class="text-muted-foreground py-4 text-center text-xs">
-                {sseStatus === 'open'
-                  ? 'No workers reported yet.'
-                  : 'Waiting for first snapshot…'}
+                {sseStatus === 'open' ? 'No workers reported yet.' : 'Waiting for first snapshot…'}
               </p>
             {:else}
               <RunTileGrid
@@ -956,8 +991,8 @@
               </p>
             {:else if visibleEvents.length === 0}
               <p class="text-muted-foreground py-4 text-center text-sm">
-                All {liveEvents.length} event{liveEvents.length === 1 ? ' is' : 's are'} hidden by
-                current filters.
+                All {liveEvents.length} event{liveEvents.length === 1 ? ' is' : 's are'} hidden by current
+                filters.
               </p>
             {:else}
               <div class="max-h-[40vh] space-y-1 overflow-auto font-mono text-xs">
@@ -980,7 +1015,6 @@
           </CardContent>
         </Card>
       </TabsContent>
-
     {/if}
 
     <!--
@@ -1062,8 +1096,10 @@
                   <TableCell class="text-muted-foreground text-xs">{t.model ?? '—'}</TableCell>
                   <TableCell class="text-right tabular-nums text-xs">
                     {#if t.token_usage}
-                      {(((t.token_usage as Record<string, number>).input ?? 0) +
-                        ((t.token_usage as Record<string, number>).output ?? 0)).toLocaleString()}
+                      {(
+                        ((t.token_usage as Record<string, number>).input ?? 0) +
+                        ((t.token_usage as Record<string, number>).output ?? 0)
+                      ).toLocaleString()}
                     {:else}—{/if}
                   </TableCell>
                   <TableCell class="text-right tabular-nums text-xs">
@@ -1091,6 +1127,137 @@
         {/if}
       </Card>
     </TabsContent>
+
+    <!--
+      Replay tab (#259 PR-K): renders the persisted
+      `events.jsonl` written by the dispatcher when
+      `[run].emit_event_stream = true`. Only available on
+      finalized runs — for in-progress runs the Live tab is the
+      authoritative event surface. The same filter UI (hide noise,
+      kind chips) applies, sharing state with Live so an
+      operator's preferences carry across.
+    -->
+    {#if !inProgress}
+      <TabsContent value="replay" class="mt-4 space-y-4">
+        {#if !replayLoaded && !replayLoading}
+          <Card>
+            <CardContent class="flex items-start justify-between gap-3 pt-6">
+              <div class="space-y-1">
+                <p class="text-sm font-medium">Persisted control-event stream</p>
+                <p class="text-muted-foreground text-xs">
+                  Loads <code>events.jsonl</code> from the run directory. Available when the
+                  manifest enabled <code>[run].emit_event_stream</code>.
+                </p>
+              </div>
+              <Button size="sm" onclick={() => void loadReplay()}>Load events</Button>
+            </CardContent>
+          </Card>
+        {:else}
+          <Card>
+            <CardHeader class="flex-row items-start justify-between gap-2 pb-2 space-y-0">
+              <div>
+                <CardTitle class="text-base">Replay</CardTitle>
+                <CardDescription class="text-xs">
+                  {#if replayLoading}
+                    Loading…
+                  {:else if replayError}
+                    <span class="text-destructive">{replayError}</span>
+                  {:else if replayEvents.length === 0}
+                    No persisted envelopes — the run was dispatched with
+                    <code>emit_event_stream</code> disabled, or no events were ever emitted.
+                  {:else}
+                    {visibleReplayEvents.length} of {replayEvents.length} envelope{replayEvents.length ===
+                    1
+                      ? ''
+                      : 's'}{#if replayHiddenCount > 0}
+                      <span class="text-muted-foreground/70">
+                        · {replayHiddenCount} hidden</span
+                      >{/if}
+                  {/if}
+                </CardDescription>
+              </div>
+              <div class="flex gap-2">
+                <Button
+                  variant={filterPanelOpen ? 'default' : 'outline'}
+                  size="sm"
+                  onclick={() => (filterPanelOpen = !filterPanelOpen)}
+                  disabled={replayEvents.length === 0}
+                >
+                  <Filter class="mr-1.5 size-3.5" /> Filters
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onclick={() => void loadReplay()}
+                  disabled={replayLoading}
+                >
+                  <RefreshCw class="mr-1.5 size-3.5" /> Reload
+                </Button>
+              </div>
+            </CardHeader>
+            {#if filterPanelOpen && replayEvents.length > 0}
+              <div class="border-border/60 mx-6 mb-2 rounded-md border p-3 text-xs">
+                <div class="mb-2 flex items-center gap-2">
+                  <Switch id="replay-hide-noise" bind:checked={hideNoise} />
+                  <Label for="replay-hide-noise" class="cursor-pointer text-xs">
+                    Hide noise (empty <code>store_activity</code> heartbeats)
+                  </Label>
+                </div>
+                {#if replaySeenKinds.length > 0}
+                  <div class="text-muted-foreground mb-1.5 text-[11px]">Event kinds</div>
+                  <div class="flex flex-wrap gap-1.5">
+                    {#each replaySeenKinds as k (k)}
+                      <button
+                        onclick={() => toggleKind(k)}
+                        class="rounded border px-2 py-0.5 font-mono text-[11px] {disabledKinds[k]
+                          ? 'border-muted-foreground/20 text-muted-foreground/50 line-through'
+                          : 'border-sky-500/40 text-sky-700 dark:text-sky-400'}"
+                      >
+                        {k}
+                      </button>
+                    {/each}
+                  </div>
+                {/if}
+              </div>
+            {/if}
+            <CardContent class="pt-0">
+              {#if replayLoading}
+                <p class="text-muted-foreground py-4 text-center text-sm">Loading events…</p>
+              {:else if replayEvents.length === 0 && !replayError}
+                <p class="text-muted-foreground py-4 text-center text-sm">
+                  No persisted envelopes found.
+                </p>
+              {:else if visibleReplayEvents.length === 0}
+                <p class="text-muted-foreground py-4 text-center text-sm">
+                  All {replayEvents.length} envelope{replayEvents.length === 1 ? ' is' : 's are'} hidden
+                  by current filters.
+                </p>
+              {:else}
+                <div class="max-h-[60vh] space-y-1 overflow-auto font-mono text-xs">
+                  {#each visibleReplayEvents as e, idx (idx)}
+                    <div class="bg-muted/30 rounded border-l-2 border-sky-500/40 px-2 py-1">
+                      {#if typeof e.seq === 'number'}
+                        <span class="text-muted-foreground mr-2 tabular-nums">#{e.seq}</span>
+                      {/if}
+                      <span class="text-sky-700 dark:text-sky-400">{e.event}</span>
+                      {#if e.actor_path && Array.isArray(e.actor_path) && e.actor_path.length > 0}
+                        <span class="text-muted-foreground ml-2">{e.actor_path.join('/')}</span>
+                      {/if}
+                      <pre
+                        class="text-muted-foreground mt-0.5 overflow-x-auto whitespace-pre-wrap text-[11px]">{JSON.stringify(
+                          e,
+                          null,
+                          2
+                        )}</pre>
+                    </div>
+                  {/each}
+                </div>
+              {/if}
+            </CardContent>
+          </Card>
+        {/if}
+      </TabsContent>
+    {/if}
 
     <TabsContent value="manifest" class="mt-4">
       <Card>


### PR DESCRIPTION
## Summary

Adds a **Replay** tab to the run-detail page that renders the persisted control-event stream written by PR-G/H, fetched via PR-I's \`/api/runs/:id/events-jsonl\` endpoint. Closes the post-finalise gap the Live tab's gate-on-\`inProgress\` comment used to flag (\"no static event-log surface yet\").

### Behavior

- Tab shown **only when \`!inProgress\`** — in-flight runs still use Live + SSE.
- Fetched **lazily** on first tab open (or via the \"Reload\" button), not at page mount, so a finalized run that didn't enable \`emit_event_stream\` doesn't pay the 404 round-trip unless the operator clicks Replay.
- Empty state explains the \`[run].emit_event_stream\` flag rather than showing an error banner — same UX principle as the CLI's \`pitboss events\` error message (PR-J).
- Filter UI (\`hideNoise\`, \`disabledKinds\`, kind chips) is **shared with the Live tab** via the existing top-level state + localStorage persistence, so an operator's \"hide store_activity\" preference carries across live and historical inspection. Replay populates the kind chips from its own envelope set so the chips reflect what's actually in the log.
- Each envelope rendered with \`#seq\`, event kind, \`actor_path\` (Unix-style \`/root/sub-1\`), and pretty-printed JSON detail — matches the Live tab's row shape.

### Why a separate tab rather than re-using Live

Live owns the SSE bridge, op-flash strip, Workers card, and PolicyEditor — all of which are no-ops on a finalized run. Decoupling Replay lets the empty-on-finalize state stay obvious without polluting the live UI for in-progress operators.

## API helper

New \`getEventsJsonl(id: string): Promise<ControlEnvelope[]>\` in \`lib/api.ts\`. NDJSON parsing mirrors the existing \`getTaskEvents\` pattern: partial-write tails are skipped silently, 404 → empty list. Other errors surface to the UI as the error banner inside the Replay card.

## Test plan

- [x] \`npm run check\` — 0 errors, 0 warnings
- [x] \`npm run build\` — built cleanly
- [x] Format check: my two changed files prettier-clean (the other 26 pre-existing warnings are out of scope)
- [x] \`cargo test -p pitboss-web\` — 28 tests pass (rust side unchanged)

Manual smoke deferred — Playwright/headed-browser testing of the SPA isn't in the local CI loop, and the production build serves correctly. Reviewer can wire up a smoke run if desired.

## Stack position

| PR | Title |
|---|---|
| #443–449 | RFC + PR-A through PR-F of #438 |
| #450 | PR-G: events.jsonl writer + run-scoped seq |
| #451 | PR-H: persistent bus subscriber |
| #452 | PR-I: HTTP endpoint |
| #453 | PR-J: \`pitboss events\` CLI |
| **this** | **PR-K: SPA Replay tab** |

Remaining #259 follow-up: AGENTS.md documentation update for \`[run].emit_event_stream\` + \`events.jsonl\` semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)