### PR TITLE
feat(tui,cli): live-side cutover to unified consumer (PR-D of #438)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2130,6 +2130,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tui-textarea",
  "uuid",

--- a/crates/pitboss-cli/src/stream.rs
+++ b/crates/pitboss-cli/src/stream.rs
@@ -36,7 +36,9 @@
 //! rather than `seq` until #259 enables a unified counter.
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
+use anyhow::Result;
 use chrono::{DateTime, Utc};
 use futures_util::stream::Stream;
 use pitboss_core::store::record::TaskRecord;
@@ -44,8 +46,9 @@ use pitboss_core::stream::{
     open_run_stream, LifecycleEvent, RunStreamItem, RunStreamPayload, StreamMode,
 };
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::net::UnixStream;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Mutex};
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_stream::StreamExt;
 use uuid::Uuid;
@@ -168,21 +171,32 @@ async fn drive_socket(socket_path: PathBuf, tx: mpsc::Sender<LiveStreamItem>) {
     };
     let (r, mut w) = stream.into_split();
 
-    // Send hello.
-    let hello = ControlOp::Hello {
-        client_version: env!("CARGO_PKG_VERSION").to_string(),
-    };
-    let Ok(mut line) = serde_json::to_string(&hello) else {
-        return;
-    };
-    line.push('\n');
-    if w.write_all(line.as_bytes()).await.is_err() {
-        return;
-    }
-    if w.flush().await.is_err() {
+    if send_hello(&mut w).await.is_err() {
         return;
     }
 
+    drive_socket_reads(r, tx).await;
+}
+
+/// Write a `Hello` op to a fresh socket connection. The dispatcher's
+/// server requires this as the first message; without it the connection
+/// is dropped before any envelopes are emitted.
+async fn send_hello(w: &mut OwnedWriteHalf) -> Result<()> {
+    let hello = ControlOp::Hello {
+        client_version: env!("CARGO_PKG_VERSION").to_string(),
+    };
+    let mut line = serde_json::to_string(&hello)?;
+    line.push('\n');
+    w.write_all(line.as_bytes()).await?;
+    w.flush().await?;
+    Ok(())
+}
+
+/// Pump envelopes from a pre-opened read half into `tx` as
+/// [`LiveStreamItem::Event`] items. Used by both [`drive_socket`] (one-
+/// shot stream consumer) and [`open_run_session`] (session that exposes
+/// a writer alongside the stream).
+async fn drive_socket_reads(r: OwnedReadHalf, tx: mpsc::Sender<LiveStreamItem>) {
     let mut reader = BufReader::new(r).lines();
     while let Ok(Some(text)) = reader.next_line().await {
         let envelope: EventEnvelope = match serde_json::from_str(&text) {
@@ -209,6 +223,123 @@ async fn drive_socket(socket_path: PathBuf, tx: mpsc::Sender<LiveStreamItem>) {
             return;
         }
     }
+}
+
+// ----------------------------------------------------------------------------
+// Session API — for consumers that need to write ops in addition to read
+// envelopes. Used by the TUI cutover (PR-D of #438). The dispatcher allows
+// only one client connection per socket, so the read and write halves must
+// share one connection.
+// ----------------------------------------------------------------------------
+
+/// A run-stream session that owns one socket connection and exposes its
+/// read half as a [`Stream`] of [`LiveStreamItem`] and its write half via
+/// [`RunStreamSession::writer`]. Use [`open_run_session`] to construct.
+pub struct RunStreamSession {
+    /// The unified envelope stream. Items arrive in mode order:
+    /// `ReplayOnly` / `ReplayThenLive` drain disk first; live items
+    /// follow (or are the only output in `LiveOnly`).
+    pub stream: ReceiverStream<LiveStreamItem>,
+    /// Writer over the control socket, present iff a live socket
+    /// connection was established. Use [`RunStreamWriter::send_op`].
+    pub writer: Option<Arc<RunStreamWriter>>,
+}
+
+/// Owning handle to a control-socket writer. Cloneable via `Arc`. Drop
+/// or task abort tears down the underlying write half.
+#[derive(Debug)]
+pub struct RunStreamWriter {
+    inner: Mutex<OwnedWriteHalf>,
+}
+
+impl RunStreamWriter {
+    /// Send a single control op as one JSON line. Fails if the socket
+    /// is closed or the write errors.
+    pub async fn send_op(&self, op: &ControlOp) -> Result<()> {
+        let mut line = serde_json::to_string(op)?;
+        line.push('\n');
+        let mut guard = self.inner.lock().await;
+        guard.write_all(line.as_bytes()).await?;
+        guard.flush().await?;
+        Ok(())
+    }
+}
+
+/// Open a unified run-stream session that exposes both a read stream
+/// and (when a live socket is available) a writer.
+///
+/// Unlike [`open_live_run_stream`], this function is **async** —
+/// the socket connection happens before it returns, so callers receive
+/// the writer (or `None` for disconnected sessions) without waiting on
+/// a background task. The stream's items still flow asynchronously.
+///
+/// `socket_path = None` or a missing socket file → writer is `None`
+/// and the live arm is skipped (effectively `ReplayOnly` regardless of
+/// `mode`). This matches the existing fail-soft behavior of the
+/// TUI's `ControlClient::connect`.
+pub async fn open_run_session(
+    run_dir: PathBuf,
+    socket_path: Option<PathBuf>,
+    mode: LiveStreamMode,
+) -> RunStreamSession {
+    let (tx, rx) = mpsc::channel(64);
+
+    // Try to establish the live socket up front so the writer is
+    // available before this function returns. ReplayOnly skips this.
+    let live_state = if matches!(
+        mode,
+        LiveStreamMode::LiveOnly | LiveStreamMode::ReplayThenLive
+    ) {
+        if let Some(sock) = socket_path {
+            connect_session_socket(&sock).await
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    let writer = live_state.as_ref().map(|(_, w)| w.clone());
+
+    // Spawn the drainers in order: disk first (if applicable), then
+    // socket reads.
+    tokio::spawn(async move {
+        if matches!(
+            mode,
+            LiveStreamMode::ReplayOnly | LiveStreamMode::ReplayThenLive
+        ) {
+            let disk = open_run_stream(&run_dir, StreamMode::ReplayOnly);
+            let mut disk = std::pin::pin!(disk);
+            while let Some(item) = disk.next().await {
+                if tx.send(item.into()).await.is_err() {
+                    return;
+                }
+            }
+        }
+        if let Some((read_half, _writer)) = live_state {
+            drive_socket_reads(read_half, tx).await;
+        }
+    });
+
+    RunStreamSession {
+        stream: ReceiverStream::new(rx),
+        writer,
+    }
+}
+
+/// Try to open a control socket, send Hello, and split into read+write
+/// halves wrapped for session use. Returns `None` on connect/handshake
+/// failure (fail-soft).
+async fn connect_session_socket(
+    socket_path: &std::path::Path,
+) -> Option<(OwnedReadHalf, Arc<RunStreamWriter>)> {
+    let stream = UnixStream::connect(socket_path).await.ok()?;
+    let (read_half, mut write_half) = stream.into_split();
+    send_hello(&mut write_half).await.ok()?;
+    let writer = Arc::new(RunStreamWriter {
+        inner: Mutex::new(write_half),
+    });
+    Some((read_half, writer))
 }
 
 #[cfg(test)]

--- a/crates/pitboss-cli/tests/live_stream_flows.rs
+++ b/crates/pitboss-cli/tests/live_stream_flows.rs
@@ -6,11 +6,14 @@
 //! PR-C of #438.
 
 use futures_util::StreamExt;
+use pitboss_cli::control::protocol::{ControlEvent, ControlOp};
 use pitboss_cli::control::server::start_control_server;
 use pitboss_cli::dispatch::state::{ApprovalPolicy, DispatchState, WorkerState};
 use pitboss_cli::manifest::resolve::ResolvedManifest;
 use pitboss_cli::manifest::schema::WorktreeCleanup;
-use pitboss_cli::stream::{open_live_run_stream, LiveStreamMode, LiveStreamPayload};
+use pitboss_cli::stream::{
+    open_live_run_stream, open_run_session, LiveStreamMode, LiveStreamPayload,
+};
 use pitboss_core::parser::TokenUsage;
 use pitboss_core::process::{ProcessSpawner, TokioSpawner};
 use pitboss_core::session::CancelToken;
@@ -257,4 +260,104 @@ async fn replay_then_live_drains_disk_then_emits_socket_events() {
         saw_event,
         "live socket arm should produce at least one Event after disk drain"
     );
+}
+
+/// `open_run_session` returns a writer alongside the stream when a
+/// live socket is available. Sending an op through the writer must
+/// reach the server and produce an `OpAcked` envelope on the stream.
+#[tokio::test]
+async fn run_session_writer_send_op_round_trips_to_server() {
+    let dir = TempDir::new().unwrap();
+    let run_id = Uuid::now_v7();
+    let run_subdir = dir.path().join(run_id.to_string());
+    tokio::fs::create_dir_all(&run_subdir).await.unwrap();
+
+    let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
+    let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
+    let wt_mgr = Arc::new(WorktreeManager::new());
+    let state = Arc::new(DispatchState::new(
+        run_id,
+        manifest(dir.path().to_path_buf()),
+        store,
+        CancelToken::new(),
+        String::new(),
+        spawner,
+        PathBuf::from("/bin/true"),
+        wt_mgr,
+        CleanupPolicy::Never,
+        run_subdir.clone(),
+        ApprovalPolicy::Block,
+        None,
+        std::sync::Arc::new(pitboss_cli::shared_store::SharedStore::new()),
+    ));
+
+    let sock = dir.path().join("session.sock");
+    let _h = start_control_server(
+        sock.clone(),
+        "0.13.0".into(),
+        run_id.to_string(),
+        "flat".into(),
+        state,
+    )
+    .await
+    .unwrap();
+
+    let session = open_run_session(
+        run_subdir.clone(),
+        Some(sock.clone()),
+        LiveStreamMode::LiveOnly,
+    )
+    .await;
+    let writer = session.writer.expect("writer present when socket exists");
+    let mut stream = std::pin::pin!(session.stream);
+
+    // Drain the hello.
+    let _hello = tokio::time::timeout(Duration::from_secs(2), stream.next())
+        .await
+        .unwrap()
+        .expect("hello envelope");
+
+    // Send an op via the writer; the server replies with a
+    // `WorkersSnapshot` envelope on the read stream. (ListWorkers is
+    // the op that exercises the read-back path without requiring
+    // worker state — it returns an empty snapshot.)
+    writer
+        .send_op(&ControlOp::ListWorkers)
+        .await
+        .expect("send_op succeeds");
+
+    let mut saw_snapshot = false;
+    for _ in 0..4 {
+        let next = tokio::time::timeout(Duration::from_secs(2), stream.next()).await;
+        if let Ok(Some(item)) = next {
+            if let LiveStreamPayload::Event(env) = item.payload {
+                if matches!(env.event, ControlEvent::WorkersSnapshot { .. }) {
+                    saw_snapshot = true;
+                    break;
+                }
+            }
+        } else {
+            break;
+        }
+    }
+    assert!(
+        saw_snapshot,
+        "writer.send_op should produce a WorkersSnapshot envelope back on the stream"
+    );
+}
+
+/// When the socket doesn't exist, `open_run_session` still returns a
+/// session but the writer is `None`. The stream completes promptly
+/// (no live items, no disk items in `LiveOnly` mode).
+#[tokio::test]
+async fn run_session_writer_none_when_socket_missing() {
+    let dir = TempDir::new().unwrap();
+    let run_subdir = dir.path().join("no-run");
+    tokio::fs::create_dir_all(&run_subdir).await.unwrap();
+    let bogus = dir.path().join("nope.sock");
+
+    let session = open_run_session(run_subdir, Some(bogus), LiveStreamMode::LiveOnly).await;
+    assert!(session.writer.is_none());
+    let items: Vec<_> = session.stream.collect().await;
+    assert!(items.is_empty());
 }

--- a/crates/pitboss-tui/Cargo.toml
+++ b/crates/pitboss-tui/Cargo.toml
@@ -32,6 +32,7 @@ uuid         = { workspace = true }
 tracing      = { workspace = true }
 tui-textarea = { workspace = true }
 tokio        = { workspace = true }
+tokio-stream = { workspace = true }
 # #437 Tier 3: push-based summary.json[l] watch. inotify on Linux,
 # FSEvents on macOS, ReadDirectoryChangesW on Windows — all auto-
 # selected by `notify::recommended_watcher`.

--- a/crates/pitboss-tui/src/app.rs
+++ b/crates/pitboss-tui/src/app.rs
@@ -35,12 +35,18 @@ pub fn run(run_dir: PathBuf, run_id: String) -> anyhow::Result<()> {
 
     let mut state = AppState::new(run_dir.clone(), run_id);
 
-    // Build a tokio runtime for the ControlClient + its background reader task.
+    // Build a tokio runtime for the live-stream session + its background
+    // reader task.
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?;
+    // PR-D of #438: the inbound channel now carries `LiveStreamItem`
+    // (the unified envelope) rather than bare `ControlEvent`. Today only
+    // the `Event` payload arm is consumed; PR-E will route the disk-
+    // sourced `Task` and `Lifecycle` arms through this same channel and
+    // retire the watcher's separate snapshot path.
     let (ctrl_events_tx, ctrl_events_rx) =
-        std::sync::mpsc::channel::<pitboss_cli::control::protocol::ControlEvent>();
+        std::sync::mpsc::channel::<pitboss_cli::stream::LiveStreamItem>();
 
     // Channel for asynchronously-computed git-diff summaries (#154 M3).
     // `enter_detail_for` spawns a worker thread that shells out to `git
@@ -68,52 +74,63 @@ pub fn run(run_dir: PathBuf, run_id: String) -> anyhow::Result<()> {
     // events that would open a modal whose request_id the new
     // dispatcher cannot ack (#104, #154 L1+L3).
     let connect_control = |state: &mut AppState| -> Option<tokio::task::AbortHandle> {
-        let mut forwarder_abort: Option<tokio::task::AbortHandle> = None;
-        let client = match uuid::Uuid::parse_str(&state.run_id) {
-            Ok(uuid) => {
-                let socket_path = pitboss_cli::control::control_socket_path(uuid, &state.run_dir);
-                let (bridge_tx, mut bridge_rx) =
-                    tokio::sync::mpsc::channel::<pitboss_cli::control::protocol::ControlEvent>(64);
+        // Resolve the run's control-socket path. If the run-id isn't a
+        // UUID (e.g. fixture names in tests), or if the socket simply
+        // isn't there, we still construct a session — `open_run_session`
+        // returns a `writer: None` and an empty stream in that case,
+        // matching the pre-PR-D observe-only behavior.
+        let socket_path = uuid::Uuid::parse_str(&state.run_id)
+            .ok()
+            .map(|uuid| pitboss_cli::control::control_socket_path(uuid, &state.run_dir));
+        let run_dir = state.run_dir.clone();
+
+        // #154 M1: bound the connect by a short timeout so a slow
+        // dispatcher accept doesn't stall the 50 ms input loop for
+        // hundreds of milliseconds.
+        let session = runtime
+            .block_on(async {
+                tokio::time::timeout(
+                    std::time::Duration::from_millis(200),
+                    pitboss_cli::stream::open_run_session(
+                        run_dir,
+                        socket_path,
+                        pitboss_cli::stream::LiveStreamMode::LiveOnly,
+                    ),
+                )
+                .await
+            })
+            .ok();
+
+        let (client, forwarder_abort) = match session {
+            Some(mut session) => {
+                let client = session
+                    .writer
+                    .take()
+                    .map(|w| Arc::new(crate::control::ControlClient::new(w)));
+                // Drive the session's stream into the sync mpsc the
+                // main loop reads. The abort handle is stored so a
+                // SwitchRun can tear down the previous run's forwarder
+                // before connecting to the new one (#154 L1+L3, #104):
+                // without that, the prior session keeps pushing items
+                // onto the shared `ctrl_events_tx` and stale
+                // ApprovalRequest envelopes can open modals the new
+                // dispatcher cannot ack.
                 let forward_tx = ctrl_events_tx.clone();
                 let handle = runtime.spawn(async move {
-                    while let Some(ev) = bridge_rx.recv().await {
-                        if forward_tx.send(ev).is_err() {
+                    use tokio_stream::StreamExt;
+                    let mut stream = session.stream;
+                    while let Some(item) = stream.next().await {
+                        if forward_tx.send(item).is_err() {
                             break;
                         }
                     }
                 });
-                forwarder_abort = Some(handle.abort_handle());
-                // #154 M1: bound the connect by a short timeout so a
-                // slow dispatcher accept doesn't stall the 50ms input
-                // loop for hundreds of milliseconds. The connect path
-                // is otherwise blocking on the main UI thread because
-                // the rest of `connect_control` synchronously assigns
-                // into `state` before the next render. Worst case the
-                // client comes back as None, the operator sees the
-                // "no control" status, and a future SwitchRun/reset
-                // can rebuild it cheaply — same UX as before for that
-                // case but without the stall.
-                // `tokio::time::timeout(...)` registers with the timer
-                // driver at construction time and panics ("no reactor
-                // running") if called outside a runtime context. The
-                // argument to `block_on` is evaluated BEFORE block_on
-                // enters the runtime, so we wrap in an `async` block to
-                // ensure the timeout is constructed *inside* the runtime.
-                runtime
-                    .block_on(async {
-                        tokio::time::timeout(
-                            std::time::Duration::from_millis(200),
-                            crate::control::ControlClient::connect(socket_path, bridge_tx),
-                        )
-                        .await
-                    })
-                    .ok()
-                    .and_then(Result::ok)
-                    .map(Arc::new)
+                (client, Some(handle.abort_handle()))
             }
-            Err(_) => None,
+            None => (None, None),
         };
-        state.control_connected = client.as_ref().is_some_and(|c| c.is_connected());
+
+        state.control_connected = client.is_some();
         state.control_client = client;
         state.runtime_handle = Some(runtime.handle().clone());
         forwarder_abort
@@ -279,9 +296,15 @@ pub fn run(run_dir: PathBuf, run_id: String) -> anyhow::Result<()> {
             }
         }
 
-        // --- Drain any queued control events (non-blocking). ---
-        while let Ok(ev) = ctrl_events_rx.try_recv() {
-            apply_control_event(&mut state, ev);
+        // --- Drain any queued live-stream items (non-blocking). ---
+        // PR-D of #438: the channel carries `LiveStreamItem`. Only the
+        // `Event` payload is consumed here today; PR-E will route
+        // `Task`/`Lifecycle` payloads from the watcher through this
+        // same channel and the watcher will retire.
+        while let Ok(item) = ctrl_events_rx.try_recv() {
+            if let pitboss_cli::stream::LiveStreamPayload::Event(env) = item.payload {
+                apply_control_event(&mut state, env.event);
+            }
         }
 
         // --- Drain async git-diff results (non-blocking, #154 M3). ---

--- a/crates/pitboss-tui/src/control.rs
+++ b/crates/pitboss-tui/src/control.rs
@@ -1,104 +1,44 @@
-//! TUI-side client for the per-run control socket. Handles connect,
-//! handshake, reader task that forwards events via `mpsc::Sender`, and a
-//! `send_op` entry point for keypress handlers.
+//! TUI-side control-socket client.
+//!
+//! Wraps the writer half of a [`pitboss_cli::stream::RunStreamSession`]
+//! so keypress handlers can issue control ops while the read half feeds
+//! the unified stream consumed by the main event loop. Updated for
+//! PR-D of #438 (TUI cutover to unified consumer).
 
 #![allow(dead_code)]
 
-use std::path::PathBuf;
 use std::sync::Arc;
 
-use anyhow::{Context, Result};
-use pitboss_cli::control::protocol::{ControlEvent, ControlOp};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
-use tokio::net::UnixStream;
-use tokio::sync::{mpsc, Mutex};
+use anyhow::Result;
+use pitboss_cli::control::protocol::ControlOp;
+use pitboss_cli::stream::RunStreamWriter;
 
 #[derive(Debug)]
 pub struct ControlClient {
-    writer: Arc<Mutex<Option<OwnedWriteHalf>>>,
-    connected: Arc<std::sync::atomic::AtomicBool>,
+    writer: Arc<RunStreamWriter>,
 }
 
 impl ControlClient {
-    /// Connect to `socket`, send hello, spawn a reader task that forwards
-    /// events onto `events_tx`. Returns immediately even on connection failure
-    /// — the client enters disconnected state and `send_op` no-ops with Err.
-    pub async fn connect(socket: PathBuf, events_tx: mpsc::Sender<ControlEvent>) -> Result<Self> {
-        let connected = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let writer_holder: Arc<Mutex<Option<OwnedWriteHalf>>> = Arc::new(Mutex::new(None));
-
-        if let Ok(stream) = UnixStream::connect(&socket).await {
-            let (r, mut w) = stream.into_split();
-            let hello = ControlOp::Hello {
-                client_version: env!("CARGO_PKG_VERSION").to_string(),
-            };
-            let mut line = serde_json::to_string(&hello)?;
-            line.push('\n');
-            w.write_all(line.as_bytes()).await.context("send hello")?;
-            w.flush().await?;
-
-            *writer_holder.lock().await = Some(w);
-            connected.store(true, std::sync::atomic::Ordering::Relaxed);
-
-            let events_tx_bg = events_tx.clone();
-            let connected_bg = connected.clone();
-            tokio::spawn(read_loop(r, events_tx_bg, connected_bg));
-        }
-        // Socket doesn't exist (run already finished) or dispatcher not ready.
-        // Remain disconnected; the TUI stays observe-only.
-
-        Ok(Self {
-            writer: writer_holder,
-            connected,
-        })
+    /// Wrap a session writer. The writer is produced by
+    /// [`pitboss_cli::stream::open_run_session`] when a live socket
+    /// connection succeeds; otherwise no client is constructed and the
+    /// TUI stays observe-only.
+    #[must_use]
+    pub fn new(writer: Arc<RunStreamWriter>) -> Self {
+        Self { writer }
     }
 
+    /// PR-D: the client exists iff a writer exists, so this is always
+    /// true once constructed. Kept for back-compat with call sites
+    /// that previously distinguished connect-failed from disconnect.
+    #[must_use]
     pub fn is_connected(&self) -> bool {
-        self.connected.load(std::sync::atomic::Ordering::Relaxed)
+        true
     }
 
-    /// Send a single control op. Returns Err if disconnected or write fails.
+    /// Send a single control op as one JSON line. Returns Err if the
+    /// socket has closed or the write fails.
     pub async fn send_op(&self, op: ControlOp) -> Result<()> {
-        let mut guard = self.writer.lock().await;
-        let Some(w) = guard.as_mut() else {
-            anyhow::bail!("control client is disconnected");
-        };
-        let mut line = serde_json::to_string(&op)?;
-        line.push('\n');
-        w.write_all(line.as_bytes()).await?;
-        w.flush().await?;
-        Ok(())
-    }
-}
-
-async fn read_loop(
-    r: OwnedReadHalf,
-    events_tx: mpsc::Sender<ControlEvent>,
-    connected: Arc<std::sync::atomic::AtomicBool>,
-) {
-    let mut lines = BufReader::new(r).lines();
-    while let Ok(Some(line)) = lines.next_line().await {
-        if let Ok(ev) = serde_json::from_str::<ControlEvent>(&line) {
-            if events_tx.send(ev).await.is_err() {
-                break;
-            }
-        }
-    }
-    connected.store(false, std::sync::atomic::Ordering::Relaxed);
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use tempfile::TempDir;
-
-    #[tokio::test]
-    async fn connect_to_nonexistent_socket_returns_disconnected_client() {
-        let dir = TempDir::new().unwrap();
-        let sock = dir.path().join("missing.sock");
-        let (tx, _rx) = mpsc::channel(16);
-        let client = ControlClient::connect(sock, tx).await.unwrap();
-        assert!(!client.is_connected());
+        self.writer.send_op(&op).await
     }
 }


### PR DESCRIPTION
## Summary

Fourth PR landing the TUI cutover from [#438](https://github.com/SDS-Mode/pitboss/issues/438). Replaces the TUI's bespoke `ControlClient::connect` read loop with the unified `pitboss_cli::stream::open_run_session` from [PR-C (#446)](https://github.com/SDS-Mode/pitboss/pull/446).

> **Stacked on #446.** Base is `feat/438-pr-c-live-consumer`; rebase once the chain merges.

## Scope cut from the original PR-C plan

Original PR-C was "TUI cutover." Once the TUI internals were measured (`watcher.rs` 1879 lines, `state.rs` 2088 lines, `tui.rs` 3391 lines), splitting the cutover into adapter (PR-C) + wiring (PR-D) became the responsible call. This PR delivers the **live-side wiring**. PR-E will route disk-sourced `Task` and `Lifecycle` payloads through the same `LiveStreamItem` channel and retire the watcher's separate snapshot path.

## What's in PR-D

### pitboss-cli::stream additions

- `RunStreamSession { stream, writer }` — async-constructed session that owns one socket connection. The dispatcher allows only one client per socket, so read + write must share a connection.
- `open_run_session(run_dir, socket_path, mode)` — async constructor that connects the socket up front and returns the writer synchronously (or `None` for socket-less sessions). The pre-existing `open_live_run_stream` stays for read-only callers (future web SSE / CLI one-shots).
- `RunStreamWriter::send_op` — `Arc`-shareable for the TUI's keypress handlers.

### TUI rewiring

- `control.rs`: `ControlClient` becomes a thin write-only wrapper over `Arc<RunStreamWriter>`. `connect` is gone; `new(writer)` replaces it. `send_op` delegates to the writer.
- `app.rs`: `ctrl_events_*` channel type is now `LiveStreamItem` (was `ControlEvent`). `connect_control` calls `open_run_session(..., LiveOnly)` inside the existing block_on / 200 ms timeout pattern. A spawned forwarder drains `session.stream` into the sync mpsc the main loop reads. The drain loop pattern-matches `LiveStreamPayload::Event(env)` and feeds `env.event` to the unchanged `apply_control_event`.

### What stays untouched (PR-E target)

- `watcher.rs` (1879 lines) — disk-driven snapshot path. PR-E will route its outputs through the unified channel and retire the separate `snapshot_rx`.
- `apply_control_event` — dispatch logic for each `ControlEvent` variant. Unchanged.
- TUI rendering (`tui.rs`) — same data, same render.
- Per-task `events.jsonl` reading (denials) and log-tailing.

## Test plan

- [x] New integration test `run_session_writer_send_op_round_trips_to_server` proves the writer half works against a real control server (sends `ListWorkers`, observes `WorkersSnapshot` envelope back on the stream)
- [x] `run_session_writer_none_when_socket_missing` proves fail-soft matches pre-PR-D `ControlClient::connect` behavior
- [x] 139/139 pitboss-tui lib tests pass (no regression)
- [x] 7/7 tui_control rendering tests pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] **Reviewer: manual TUI verification needed.** I can't drive the TUI in a TTY from the agent loop. Recommended: launch a small flat-mode dispatch, run `pitboss-tui <run-id>`, confirm tile updates land, approval modals open and approve cleanly, control ops (pause/cancel/reprompt) reach the dispatcher.
- [ ] Reviewer: confirm `tokio_stream::wrappers::ReceiverStream` exposure via `RunStreamSession.stream` is acceptable as a public type (alternative: `Box<dyn Stream<Item = LiveStreamItem>>`)

## Pre-existing flake (not from this PR)

`process::tokio_impl::tests::terminate_after_exit_is_ok` fails on macOS because the test uses `/bin/true` which doesn't exist on darwin (Linux-only path). Reproduces on plain `main`. Not addressed here.

## Stacking

| PR | Base | Required for |
|---|---|---|
| #443 (RFC) | `main` | — |
| #444 (PR-A) | `main` | PR-C |
| #445 (PR-B) | `main` | PR-C |
| #446 (PR-C) | `feat/438-pr-b-seq-envelopes` | this |
| **#?? (this, PR-D)** | `feat/438-pr-c-live-consumer` | PR-E (disk-side cutover) |

When the chain merges, rebase against `main`.

## Follows

- RFC at #443
- PR-A foundation at #444
- PR-B seq plumbing at #445
- PR-C consumer adapter at #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Note:** supersedes #447 (auto-closed when the parent stack PR's branch was deleted). Same content, rebased onto main.