### PR TITLE
refactor(tui): rewire watcher onto tail_run_stream (PR-F of #438)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,21 +455,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,7 +462,7 @@ checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags 2.11.1",
  "crossterm_winapi",
- "mio 1.2.0",
+ "mio",
  "parking_lot",
  "rustix 0.38.44",
  "signal-hook",
@@ -495,7 +480,7 @@ dependencies = [
  "crossterm_winapi",
  "derive_more",
  "document-features",
- "mio 1.2.0",
+ "mio",
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook",
@@ -801,16 +786,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "filetime"
-version = "0.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
-dependencies = [
- "cfg-if",
- "libc",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,15 +828,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fsevent-sys"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -1391,26 +1357,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inotify"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
-dependencies = [
- "bitflags 1.3.2",
- "inotify-sys",
- "libc",
-]
-
-[[package]]
-name = "inotify-sys"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "instability"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1490,26 +1436,6 @@ dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "kqueue"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
-dependencies = [
- "kqueue-sys",
- "libc",
-]
-
-[[package]]
-name = "kqueue-sys"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "285efcf12ef41bec907b3000d5ffaeb54191d4d9d83c0d6157e6cbc2db255e64"
-dependencies = [
- "bitflags 2.11.1",
- "libc",
 ]
 
 [[package]]
@@ -1731,18 +1657,6 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
@@ -1786,25 +1700,6 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "notify"
-version = "6.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
-dependencies = [
- "bitflags 2.11.1",
- "crossbeam-channel",
- "filetime",
- "fsevent-sys",
- "inotify",
- "kqueue",
- "libc",
- "log",
- "mio 0.8.11",
- "walkdir",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2122,7 +2017,6 @@ dependencies = [
  "clap",
  "clap_complete",
  "crossterm 0.29.0",
- "notify",
  "pitboss-cli",
  "pitboss-core",
  "ratatui 0.30.0",
@@ -3004,7 +2898,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio 1.2.0",
+ "mio",
  "signal-hook",
 ]
 
@@ -3346,7 +3240,7 @@ checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.2.0",
+ "mio",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -4103,15 +3997,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4144,21 +4029,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4205,12 +4075,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4223,12 +4087,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4238,12 +4096,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4271,12 +4123,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4286,12 +4132,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4307,12 +4147,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4322,12 +4156,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/pitboss-tui/Cargo.toml
+++ b/crates/pitboss-tui/Cargo.toml
@@ -33,10 +33,8 @@ tracing      = { workspace = true }
 tui-textarea = { workspace = true }
 tokio        = { workspace = true }
 tokio-stream = { workspace = true }
-# #437 Tier 3: push-based summary.json[l] watch. inotify on Linux,
-# FSEvents on macOS, ReadDirectoryChangesW on Windows — all auto-
-# selected by `notify::recommended_watcher`.
-notify       = { workspace = true }
+# (#438 PR-F) `notify` left this crate's dep graph when watcher.rs moved
+# onto `pitboss_core::stream::tail_run_stream` for disk-tail.
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/pitboss-tui/src/watcher.rs
+++ b/crates/pitboss-tui/src/watcher.rs
@@ -1,15 +1,18 @@
-//! Background watcher thread — polls the run directory every 500ms and
-//! emits `AppSnapshot` updates via an mpsc channel.
+//! Background watcher thread — consumes `pitboss_core::stream::tail_run_stream`
+//! and emits `AppSnapshot` updates via an mpsc channel. Per-task
+//! auxiliary disk reads (focus-pane log tail, `events.jsonl` denials)
+//! stay here.
 
+use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
-use std::time::Duration;
 
-use notify::Watcher;
 use pitboss_core::parser::{parse_line_all, Event};
 use pitboss_core::store::{TaskRecord, TaskStatus};
+use pitboss_core::stream::{tail_run_stream, LifecycleEvent, RunStreamPayload};
 use serde::Deserialize;
+use tokio_stream::StreamExt;
 
 use crate::state::{AppSnapshot, DenialRow, TileState, TileStatus};
 
@@ -19,7 +22,6 @@ use crate::state::{AppSnapshot, DenialRow, TileState, TileStatus};
 /// for post-mortem inspection. (#405)
 const RECENT_DENIALS_CAP: usize = 5;
 
-const POLL_INTERVAL_MS: u64 = 250;
 /// Number of parsed focus-pane lines to keep. Deep scroll-back on long
 /// runs is worth a few extra megabytes of in-memory state per focus
 /// change (each line is ~1 KB on average).
@@ -121,31 +123,6 @@ pub fn watch(
     std::thread::spawn(move || run_watch_loop(run_dir, snapshot_tx, focus_rx));
 }
 
-/// What woke the watcher thread on a given loop iteration. Each variant
-/// fans into the same `wake_rx` channel; the main loop reacts to it and
-/// rebuilds the snapshot.
-enum Wake {
-    /// Operator changed the focused tile via the UI thread.
-    Focus(String),
-    /// A filesystem event from `notify` landed somewhere under
-    /// `run_dir`. Most of these are `summary.jsonl` appends, but any
-    /// non-rescan event just triggers a snapshot rebuild.
-    FsEvent,
-    /// `Event::need_rescan()` flag: kernel notification buffer
-    /// overran, so `notify`'s view of what changed is incomplete.
-    /// We respond by dropping the [`RunSnapshotReader`]'s cached
-    /// tracking state — the next [`RunSnapshotReader::refresh`] will
-    /// do a full reparse rather than trust its byte-offset.
-    Rescan,
-    /// Periodic safety-net timer fired. Covers two failure modes:
-    /// (1) `notify` silently dropped an event we'd otherwise miss
-    /// (rare on local filesystems, more common on NFS); (2) `notify`
-    /// failed to register at all and we're in poll-only fallback
-    /// mode. With Tier 2's stateful reader, a periodic tick costs one
-    /// stat per file when nothing changed.
-    Periodic,
-}
-
 // The arguments are consumed by the thread when this function returns;
 // clippy's `needless_pass_by_value` doesn't see the implicit drop.
 #[allow(clippy::needless_pass_by_value)]
@@ -154,119 +131,116 @@ fn run_watch_loop(
     snapshot_tx: mpsc::SyncSender<AppSnapshot>,
     focus_rx: mpsc::Receiver<String>,
 ) {
+    // PR-F of #438: the watcher consumes from
+    // `pitboss_core::stream::tail_run_stream` instead of running its
+    // own `notify` watcher + `RunSnapshotReader` directly. The stream
+    // owns the canonical disk-tail engine; this thread maintains a
+    // local `tasks_map` accumulated from `Task` items and rebuilds
+    // `AppSnapshot` on each delta.
+    //
+    // The watcher thread is sync (held that way so callers don't have
+    // to live in a tokio context), so we spin a current-thread runtime
+    // here to drive the async stream.
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => {
+            tracing::error!(error = %e, "watcher: failed to build tokio runtime");
+            return;
+        }
+    };
+
+    runtime.block_on(run_watch_loop_async(run_dir, snapshot_tx, focus_rx));
+}
+
+async fn run_watch_loop_async(
+    run_dir: PathBuf,
+    snapshot_tx: mpsc::SyncSender<AppSnapshot>,
+    focus_rx: mpsc::Receiver<String>,
+) {
+    let mut tasks_map: HashMap<String, TaskRecord> = HashMap::new();
     let mut focused_id: Option<String> = None;
-    // Tier 2 of #437: hold the canonical reader across ticks so we
-    // only re-parse new `summary.jsonl` bytes (and re-read
-    // `summary.json` only when its mtime advances).
-    let mut summary_reader = pitboss_core::store::RunSnapshotReader::new(run_dir.clone());
 
-    // Push the initial snapshot before `notify` subscribes (#437
-    // Tier 3 acceptance: historical / finalized runs must render
-    // entirely from the initial snapshot even when no FS events ever
-    // fire). The full-reparse cost here is unavoidable on first
-    // open — subsequent ticks ride the reader's incremental path.
-    let snapshot = build_snapshot(&run_dir, &mut summary_reader, focused_id.as_deref());
-    if matches!(
-        snapshot_tx.try_send(snapshot),
-        Err(mpsc::TrySendError::Disconnected(_))
-    ) {
-        return;
-    }
-
-    let (wake_tx, wake_rx) = mpsc::channel::<Wake>();
-
-    // Bridge: pump focus updates from the caller's channel into the
-    // unified wake channel. Owns its own thread so the public watch()
-    // API stays unchanged.
-    let wake_for_focus = wake_tx.clone();
+    // Bridge: pump focus updates from the caller's sync mpsc into a
+    // tokio channel so they participate in the `select!` below.
+    let (focus_async_tx, mut focus_async_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
     std::thread::spawn(move || {
         while let Ok(id) = focus_rx.recv() {
-            if wake_for_focus.send(Wake::Focus(id)).is_err() {
+            if focus_async_tx.send(id).is_err() {
                 break;
             }
         }
     });
 
-    // Try to register a recursive `notify` watcher on the run dir.
-    // On success, future loop ticks are driven by FS events plus a
-    // slow safety-net timer. On failure (out-of-watches, NFS without
-    // inotify, etc.), fall back to today's poll cadence so the TUI
-    // still updates — the cost profile is now O(0) per tick with
-    // Tier 2's reader, so the fallback isn't expensive either.
-    let wake_for_fs = wake_tx.clone();
-    let watcher_result: notify::Result<notify::RecommendedWatcher> =
-        notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
-            if let Ok(event) = res {
-                let wake = if event.need_rescan() {
-                    Wake::Rescan
-                } else {
-                    Wake::FsEvent
-                };
-                let _ = wake_for_fs.send(wake);
-            }
-        });
-    let (notify_active, _watcher_guard) = match watcher_result {
-        Ok(mut w) => match w.watch(&run_dir, notify::RecursiveMode::Recursive) {
-            Ok(()) => (true, Some(w)),
-            Err(e) => {
-                tracing::warn!(
-                    error = %e,
-                    path = %run_dir.display(),
-                    "notify::watch failed; using poll-only fallback for the summary surface",
-                );
-                (false, None)
-            }
-        },
-        Err(e) => {
-            tracing::warn!(
-                error = %e,
-                "notify::recommended_watcher init failed; using poll-only fallback",
-            );
-            (false, None)
-        }
-    };
+    // Emit the initial snapshot before any stream items arrive. #437
+    // Tier 3 acceptance criterion: historical / finalized runs must
+    // render entirely from the initial snapshot even when no events
+    // ever fire. The map is empty at first; `tail_run_stream`'s initial
+    // replay fills it on the first poll within 250 ms.
+    let initial = build_snapshot(&run_dir, &tasks_map, focused_id.as_deref());
+    if matches!(
+        snapshot_tx.try_send(initial),
+        Err(mpsc::TrySendError::Disconnected(_))
+    ) {
+        return;
+    }
 
-    // Spawn the safety-net timer. When notify is alive, ticks every
-    // 5s catch any missed events on flakey backends. When notify is
-    // dead, ticks every POLL_INTERVAL_MS (matches the pre-#440
-    // cadence so the operator perceives no change in update speed).
-    let wake_for_timer = wake_tx.clone();
-    let tick_interval = if notify_active {
-        Duration::from_secs(5)
-    } else {
-        Duration::from_millis(POLL_INTERVAL_MS)
-    };
-    std::thread::spawn(move || loop {
-        std::thread::sleep(tick_interval);
-        if wake_for_timer.send(Wake::Periodic).is_err() {
-            break;
-        }
-    });
+    let mut stream_alive = true;
+    let stream = tail_run_stream(run_dir.clone());
+    let mut stream = std::pin::pin!(stream);
 
-    // Drop our own copy of wake_tx so wake_rx can observe a
-    // disconnect once every helper thread also drops its sender.
-    drop(wake_tx);
-
-    while let Ok(wake) = wake_rx.recv() {
-        match wake {
-            Wake::Focus(id) => focused_id = Some(id),
-            Wake::Rescan => {
-                // Drop the reader's cached byte-offset tracking so
-                // the next refresh does a full reparse from disk.
-                summary_reader = pitboss_core::store::RunSnapshotReader::new(run_dir.clone());
+    loop {
+        let mut rebuild = false;
+        tokio::select! {
+            item = stream.next(), if stream_alive => {
+                match item {
+                    Some(item) => match item.payload {
+                        RunStreamPayload::Task(t) => {
+                            tasks_map.insert(t.task_id.clone(), *t);
+                            rebuild = true;
+                        }
+                        RunStreamPayload::Lifecycle(LifecycleEvent::Finalized { summary }) => {
+                            for t in &summary.tasks {
+                                tasks_map.insert(t.task_id.clone(), t.clone());
+                            }
+                            rebuild = true;
+                            stream_alive = false;
+                        }
+                        RunStreamPayload::Lifecycle(LifecycleEvent::Started { .. }) => {}
+                    },
+                    None => {
+                        // Stream ended without a Finalized lifecycle —
+                        // rare (would require the underlying drive_tail
+                        // task to exit unexpectedly). Treat as
+                        // finalize: keep responding to focus changes.
+                        stream_alive = false;
+                    }
+                }
             }
-            Wake::FsEvent | Wake::Periodic => {}
+            id = focus_async_rx.recv() => {
+                match id {
+                    Some(id) => {
+                        focused_id = Some(id);
+                        rebuild = true;
+                    }
+                    None => {
+                        // Focus side disconnected — the TUI shut down.
+                        return;
+                    }
+                }
+            }
         }
 
-        let snapshot = build_snapshot(&run_dir, &mut summary_reader, focused_id.as_deref());
-        match snapshot_tx.try_send(snapshot) {
-            Ok(()) | Err(mpsc::TrySendError::Full(_)) => {}
-            Err(mpsc::TrySendError::Disconnected(_)) => break,
+        if rebuild {
+            let snap = build_snapshot(&run_dir, &tasks_map, focused_id.as_deref());
+            match snapshot_tx.try_send(snap) {
+                Ok(()) | Err(mpsc::TrySendError::Full(_)) => {}
+                Err(mpsc::TrySendError::Disconnected(_)) => return,
+            }
         }
     }
-    // _watcher_guard drops here, releasing the inotify/FSEvents
-    // registration. Helper threads observe wake_rx as disconnected
-    // and exit on their next send.
 }
 
 // ---------------------------------------------------------------------------
@@ -275,7 +249,7 @@ fn run_watch_loop(
 
 fn build_snapshot(
     run_dir: &Path,
-    summary_reader: &mut pitboss_core::store::RunSnapshotReader,
+    completed: &std::collections::HashMap<String, TaskRecord>,
     focused_id: Option<&str>,
 ) -> AppSnapshot {
     // 1. Read resolved.json → get static task ids, models, lead (if any),
@@ -291,14 +265,13 @@ fn build_snapshot(
         &resolved.sublead_types,
     );
 
-    // 2. Refresh the cached snapshot reader (#437 Tier 2). The first
-    //    tick does a full reparse; subsequent ticks only re-parse new
-    //    bytes in `summary.jsonl` (and re-read `summary.json` only when
-    //    its mtime advances). Merge semantics are identical to the
-    //    stateless `read_run_snapshot` — last-wins-by-task_id dedup so
-    //    resume-after-finalize and reprompt / cancel / respawn
-    //    lifecycles reflect the freshest record.
-    let completed = &summary_reader.refresh().tasks;
+    // 2. PR-F of #438: `completed` is now passed in by the caller —
+    //    it's accumulated from `pitboss_core::stream::tail_run_stream`
+    //    items (Task + Lifecycle::Finalized.summary.tasks). The
+    //    canonical `RunSnapshotReader` that used to live here moved
+    //    into `tail_run_stream`'s engine. Merge semantics are
+    //    unchanged: last-wins-by-task_id (stream emits the freshest
+    //    row when a `task_id` reappears with a newer `ended_at`).
 
     // 3. Dynamic worker ids come from two sources:
     //    - `summary.jsonl`/`summary.json` records for completed workers not in
@@ -1081,8 +1054,8 @@ mod tests {
         )
         .unwrap();
 
-        let mut summary_reader = pitboss_core::store::RunSnapshotReader::new(run_dir.clone());
-        let snap = build_snapshot(&run_dir, &mut summary_reader, None);
+        let snap_source = pitboss_core::store::read_run_snapshot(&run_dir);
+        let snap = build_snapshot(&run_dir, &snap_source.tasks, None);
         assert_eq!(snap.tasks.len(), 1);
         assert_eq!(snap.tasks[0].id, "triage-lead");
     }
@@ -1130,8 +1103,8 @@ mod tests {
         jsonl_line.push(b'\n');
         std::fs::write(run_dir.join("summary.jsonl"), jsonl_line).unwrap();
 
-        let mut summary_reader = pitboss_core::store::RunSnapshotReader::new(run_dir.clone());
-        let snap = build_snapshot(&run_dir, &mut summary_reader, None);
+        let snap_source = pitboss_core::store::read_run_snapshot(&run_dir);
+        let snap = build_snapshot(&run_dir, &snap_source.tasks, None);
         let ids: Vec<&str> = snap.tasks.iter().map(|t| t.id.as_str()).collect();
         assert!(ids.contains(&"lead"), "lead tile missing: {ids:?}");
         assert!(
@@ -1169,8 +1142,8 @@ mod tests {
         // Create a tasks/<worker-id>/ directory with no summary record yet.
         std::fs::create_dir_all(run_dir.join("tasks/worker-live")).unwrap();
 
-        let mut summary_reader = pitboss_core::store::RunSnapshotReader::new(run_dir.clone());
-        let snap = build_snapshot(&run_dir, &mut summary_reader, None);
+        let snap_source = pitboss_core::store::read_run_snapshot(&run_dir);
+        let snap = build_snapshot(&run_dir, &snap_source.tasks, None);
         let ids: Vec<&str> = snap.tasks.iter().map(|t| t.id.as_str()).collect();
         assert!(
             ids.contains(&"worker-live"),
@@ -1216,8 +1189,8 @@ mod tests {
         )
         .unwrap();
 
-        let mut summary_reader = pitboss_core::store::RunSnapshotReader::new(run_dir.clone());
-        let snap = build_snapshot(&run_dir, &mut summary_reader, None);
+        let snap_source = pitboss_core::store::read_run_snapshot(&run_dir);
+        let snap = build_snapshot(&run_dir, &snap_source.tasks, None);
         // Untyped row + worker_type:writer = 2 rows.
         assert_eq!(snap.matrix_rows.len(), 2, "expected untyped + writer rows");
         let writer = snap
@@ -1277,8 +1250,8 @@ mod tests {
         jsonl_line.push(b'\n');
         std::fs::write(run_dir.join("summary.jsonl"), jsonl_line).unwrap();
 
-        let mut summary_reader = pitboss_core::store::RunSnapshotReader::new(run_dir.clone());
-        let snap = build_snapshot(&run_dir, &mut summary_reader, None);
+        let snap_source = pitboss_core::store::read_run_snapshot(&run_dir);
+        let snap = build_snapshot(&run_dir, &snap_source.tasks, None);
         let tile = snap
             .tasks
             .iter()
@@ -1332,8 +1305,8 @@ mod tests {
         jsonl_line.push(b'\n');
         std::fs::write(run_dir.join("summary.jsonl"), jsonl_line).unwrap();
 
-        let mut summary_reader = pitboss_core::store::RunSnapshotReader::new(run_dir.clone());
-        let snap = build_snapshot(&run_dir, &mut summary_reader, None);
+        let snap_source = pitboss_core::store::read_run_snapshot(&run_dir);
+        let snap = build_snapshot(&run_dir, &snap_source.tasks, None);
         let tile = snap
             .tasks
             .iter()
@@ -1688,8 +1661,8 @@ mod tests {
             + "\n";
         std::fs::write(run_dir.join("summary.jsonl"), payload).unwrap();
 
-        let mut summary_reader = pitboss_core::store::RunSnapshotReader::new(run_dir.clone());
-        let snap = build_snapshot(&run_dir, &mut summary_reader, None);
+        let snap_source = pitboss_core::store::read_run_snapshot(&run_dir);
+        let snap = build_snapshot(&run_dir, &snap_source.tasks, None);
 
         // The dispatcher wrote 3 lines; the TUI must show 2 tiles
         // (lead + one worker), the worker's status must be the latest
@@ -1718,7 +1691,7 @@ mod tests {
 
         // Idempotency: a second refresh against unchanged disk
         // produces an identical snapshot.
-        let snap2 = build_snapshot(&run_dir, &mut summary_reader, None);
+        let snap2 = build_snapshot(&run_dir, &snap_source.tasks, None);
         assert_eq!(snap2.tasks.len(), 2);
     }
 
@@ -1762,8 +1735,8 @@ mod tests {
         .unwrap();
 
         // Lead has no events.jsonl — must default to 0 denials.
-        let mut summary_reader = pitboss_core::store::RunSnapshotReader::new(run_dir.clone());
-        let snap = build_snapshot(&run_dir, &mut summary_reader, None);
+        let snap_source = pitboss_core::store::read_run_snapshot(&run_dir);
+        let snap = build_snapshot(&run_dir, &snap_source.tasks, None);
         let lead_tile = snap.tasks.iter().find(|t| t.id == "lead").unwrap();
         let worker_tile = snap.tasks.iter().find(|t| t.id == "worker-noisy").unwrap();
         assert_eq!(lead_tile.denials_count, 0);


### PR DESCRIPTION
## Summary

Completes the disk-side TUI cutover for [#438](https://github.com/SDS-Mode/pitboss/issues/438). The watcher no longer runs its own `notify`+`RunSnapshotReader`; it subscribes to [`pitboss_core::stream::tail_run_stream`](https://github.com/SDS-Mode/pitboss/pull/448) (from [PR-E (#448)](https://github.com/SDS-Mode/pitboss/pull/448)) and accumulates a `HashMap<task_id, TaskRecord>` from `Task` items. `build_snapshot` now accepts the accumulated map directly.

> **Stacked on #448.** Base is `feat/438-pr-e-disk-cutover`; rebase once the chain merges to main.

**Net diff: -201 lines.** `notify` drops out of `pitboss-tui`'s deps.

## What's gone

- The `Wake { Focus, FsEvent, Rescan, Periodic }` enum and helper threads driving it
- `notify::recommended_watcher` + the safety-net periodic timer (notify-driven fast-path can be re-added inside `tail_run_stream`'s engine in a follow-up; today it's plain 250 ms polling)
- The local `RunSnapshotReader` instance (moved into `tail_run_stream` in PR-E)
- The `notify` crate dependency on `pitboss-tui`

## What stays

- `build_snapshot`'s shape (caller-passes-tasks-map instead of caller-passes-reader)
- Per-task auxiliary disk reads (`tasks/<id>/events.jsonl` denials, focus log tailing) — out of scope for the stream API; these stay in `watcher.rs`
- The `pub fn watch(run_dir, snapshot_tx, focus_rx)` public signature — `app.rs` doesn't change
- All 139 watcher-related lib tests (mechanically rewritten to call `read_run_snapshot` instead of `RunSnapshotReader::new`)

## Implementation note

The watcher remains a sync `std::thread::spawn` so `app.rs` doesn't have to live in a tokio context. The thread builds its own current-thread tokio runtime to drive the async stream. The focus channel is bridged from sync `mpsc::Receiver<String>` to a tokio unbounded channel via a tiny sync helper thread so it can participate in `tokio::select!` alongside the stream.

When the stream emits `Lifecycle::Finalized` (run finalized), the stream arm of the `select!` becomes inert (gated by `stream_alive`); the watcher continues to respond to focus changes, matching the prior behavior for cold runs.

## Test plan

- [x] `cargo test -p pitboss-tui --lib` — 139/139 pass
- [x] `watch_emits_initial_snapshot_before_any_event` — initial snapshot lands without any events
- [x] `watch_pushes_snapshot_after_summary_jsonl_append` — exercises the new tail-driven append path end-to-end on a temp run dir
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Manual: `pitboss-tui screenshot --run <id>` renders cleanly against a finished hierarchical run
- [ ] Reviewer: TUI in TTY against a live run — should behave identically to pre-PR-F (no more notify-driven fast updates; 250 ms poll cadence matches the prior notify-dead fallback)
- [ ] Reviewer: confirm the loss of notify-driven sub-second update latency is acceptable as a tradeoff for the consolidation, or flag for a notify fast-path follow-up

## Stacking

| PR | Base | State |
|---|---|---|
| #443 (RFC) | `main` | draft |
| #444 (PR-A foundation) | `main` | draft |
| #445 (PR-B seq) | `main` | draft |
| #446 (PR-C consumer) | `feat/438-pr-b-seq-envelopes` | draft |
| #447 (PR-D live-side cutover) | `feat/438-pr-c-live-consumer` | draft |
| #448 (PR-E tail_run_stream) | `feat/438-pr-d-tui-cutover` | draft |
| **#?? (this, PR-F)** | `feat/438-pr-e-disk-cutover` | draft |

PR-F closes the loop on #438: every consumer the issue named (TUI live + historical) now flows through one consolidated channel. Web SSE and CLI one-shot migrations are out of scope for this stack and tracked as future work.

## Follows

- RFC at #443
- PR-A foundation at #444
- PR-B seq plumbing at #445
- PR-C consumer adapter at #446
- PR-D live-side TUI cutover at #447
- PR-E continuous disk-tail at #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Note:** supersedes #449 (auto-closed when the parent stack PR's branch was deleted). Same content, rebased onto main.