### PR TITLE
feat(control): events.jsonl writer + run-scoped seq counter (#259)

### DIFF
--- a/crates/pitboss-cli/src/control/event_log.rs
+++ b/crates/pitboss-cli/src/control/event_log.rs
@@ -1,0 +1,256 @@
+//! Per-run event-stream persistence + seq counter.
+//!
+//! Implements the writer side of [#259](https://github.com/SDS-Mode/pitboss/issues/259),
+//! co-spec'd with [#438](https://github.com/SDS-Mode/pitboss/issues/438)'s
+//! unified envelope API (RFC at `book/src/architecture/unified-envelope-api.md`).
+//!
+//! ## What this owns
+//!
+//! - A **run-scoped** monotonic seq counter. PR-B of #438 ran a
+//!   per-connection counter in [`crate::control::server`] as a stopgap;
+//!   this module promotes it to per-run lifetime so seqs persisted in
+//!   `events.jsonl` match seqs on the live wire and survive TUI
+//!   reconnects.
+//! - An append-only `<run-dir>/events.jsonl` file, lazily created on
+//!   the first non-`Hello` envelope written when
+//!   `[run].emit_event_stream = true`. Absent when the flag is off
+//!   (today's back-compat default).
+//!
+//! ## What this does not own
+//!
+//! - The decision of which events to emit; that stays in the
+//!   dispatcher's existing emit sites.
+//! - The HTTP endpoint, SPA replay, or `pitboss events` CLI
+//!   subcommand from #259's full scope — those are follow-up PRs.
+//! - Persisting events emitted via `broadcast_control_event` when
+//!   **no** client is connected (events are dropped at the channel
+//!   today; persistence today rides on the pump path). Lifting that
+//!   guarantee is a future PR; for typical pitboss runs the TUI or
+//!   web bridge is attached and the gap is empty.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use tokio::fs::{File, OpenOptions};
+use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex;
+
+use crate::control::protocol::{ControlEvent, EventEnvelope};
+
+/// Run-scoped event-stream log. Cheap to clone via `Arc`.
+#[derive(Debug)]
+pub struct EventLog {
+    /// Monotonic seq, fetched + incremented atomically. Starts at 0;
+    /// the first emitted envelope's seq is 1 (post-increment).
+    seq: AtomicU64,
+    /// Where `events.jsonl` would live. Constructed unconditionally so
+    /// tests can introspect; the file at this path is only created
+    /// when `enabled` is true and a non-`Hello` envelope is persisted.
+    path: PathBuf,
+    /// `[run].emit_event_stream` from the resolved manifest. When
+    /// false, [`Self::persist`] is a no-op and the file is never
+    /// created.
+    enabled: bool,
+    /// Lazily-opened file handle. `None` until the first
+    /// non-`Hello` envelope arrives with `enabled = true`. Held
+    /// behind a [`Mutex`] so concurrent writers serialize their
+    /// `write_all` calls — `O_APPEND` makes the underlying syscall
+    /// atomic for small payloads on POSIX, but per-line buffering
+    /// needs the mutex to keep lines whole.
+    file: Mutex<Option<File>>,
+}
+
+impl EventLog {
+    /// Build a new log rooted at `<run_dir>/events.jsonl`. `enabled`
+    /// is the resolved `[run].emit_event_stream` flag.
+    #[must_use]
+    pub fn new(run_dir: &Path, enabled: bool) -> Self {
+        Self {
+            seq: AtomicU64::new(0),
+            path: run_dir.join("events.jsonl"),
+            enabled,
+            file: Mutex::new(None),
+        }
+    }
+
+    /// Returns the next seq to assign to an outgoing envelope.
+    /// Monotonic per [`EventLog`] instance (i.e. per run); seq=1 is
+    /// the first envelope. Reserved sentinel `seq=0` means
+    /// "legacy / unknown" — pre-#438 wire format.
+    pub fn next_seq(&self) -> u64 {
+        self.seq.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
+    /// Whether persistence is on. Wire emitters use this to short-
+    /// circuit the envelope clone they'd otherwise pass to [`Self::persist`].
+    #[must_use]
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Path the log will be (or already is) appended to. Useful for
+    /// the `pitboss events` CLI and tests.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Append one envelope to `events.jsonl`. No-op when persistence
+    /// is disabled or the envelope is a `Hello` handshake (no
+    /// archival value per #259's spec).
+    ///
+    /// Errors writing are logged but not returned to the caller —
+    /// persistence is best-effort, matching the existing
+    /// "control socket is best-effort" semantics for the live
+    /// broadcast path. Callers proceed regardless.
+    pub async fn persist(&self, envelope: &EventEnvelope) {
+        if !self.enabled {
+            return;
+        }
+        if matches!(envelope.event, ControlEvent::Hello { .. }) {
+            return;
+        }
+
+        let mut guard = self.file.lock().await;
+        if guard.is_none() {
+            *guard = match Self::open_for_append(&self.path).await {
+                Ok(f) => Some(f),
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        path = %self.path.display(),
+                        "events.jsonl: failed to open; persistence disabled for this run",
+                    );
+                    return;
+                }
+            };
+        }
+
+        let Some(file) = guard.as_mut() else { return };
+        let line = match serde_json::to_string(envelope) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(error = %e, "events.jsonl: failed to serialize envelope");
+                return;
+            }
+        };
+        if let Err(e) = file.write_all(line.as_bytes()).await {
+            tracing::warn!(error = %e, "events.jsonl: write_all failed");
+            return;
+        }
+        if let Err(e) = file.write_all(b"\n").await {
+            tracing::warn!(error = %e, "events.jsonl: trailing newline write failed");
+            return;
+        }
+        if let Err(e) = file.flush().await {
+            tracing::warn!(error = %e, "events.jsonl: flush failed");
+        }
+    }
+
+    async fn open_for_append(path: &Path) -> std::io::Result<File> {
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::control::protocol::{ControlEvent, EventEnvelope};
+    use crate::dispatch::actor::ActorPath;
+    use tempfile::TempDir;
+
+    fn env(seq: u64, event: ControlEvent) -> EventEnvelope {
+        EventEnvelope {
+            actor_path: ActorPath::default(),
+            seq,
+            event,
+        }
+    }
+
+    #[test]
+    fn seq_is_monotonic_starting_at_one() {
+        let tmp = TempDir::new().unwrap();
+        let log = EventLog::new(tmp.path(), true);
+        assert_eq!(log.next_seq(), 1);
+        assert_eq!(log.next_seq(), 2);
+        assert_eq!(log.next_seq(), 3);
+    }
+
+    #[tokio::test]
+    async fn persist_writes_one_line_per_envelope() {
+        let tmp = TempDir::new().unwrap();
+        let log = EventLog::new(tmp.path(), true);
+        log.persist(&env(1, ControlEvent::Superseded)).await;
+        log.persist(&env(2, ControlEvent::OpUnknown { op: "x".into() }))
+            .await;
+
+        let contents = tokio::fs::read_to_string(log.path()).await.unwrap();
+        let lines: Vec<&str> = contents.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("\"event\":\"superseded\""));
+        assert!(lines[0].contains("\"seq\":1"));
+        assert!(lines[1].contains("\"op_unknown\""));
+        assert!(lines[1].contains("\"seq\":2"));
+    }
+
+    #[tokio::test]
+    async fn persist_skips_hello_envelopes() {
+        let tmp = TempDir::new().unwrap();
+        let log = EventLog::new(tmp.path(), true);
+        log.persist(&env(
+            1,
+            ControlEvent::Hello {
+                server_version: "0.13.0".into(),
+                run_id: "r".into(),
+                run_kind: "flat".into(),
+                workers: vec![],
+                policy_rules: vec![],
+            },
+        ))
+        .await;
+        log.persist(&env(2, ControlEvent::Superseded)).await;
+
+        let contents = tokio::fs::read_to_string(log.path()).await.unwrap();
+        let lines: Vec<&str> = contents.lines().collect();
+        assert_eq!(lines.len(), 1, "Hello must not be archived");
+        assert!(lines[0].contains("\"event\":\"superseded\""));
+    }
+
+    #[tokio::test]
+    async fn persist_noops_when_disabled() {
+        let tmp = TempDir::new().unwrap();
+        let log = EventLog::new(tmp.path(), false);
+        log.persist(&env(1, ControlEvent::Superseded)).await;
+        assert!(
+            !log.path().exists(),
+            "file must not be created when emit_event_stream is off",
+        );
+    }
+
+    /// Pre-existing `events.jsonl` (resume scenario) must be appended
+    /// to, not truncated.
+    #[tokio::test]
+    async fn persist_appends_to_existing_file() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("events.jsonl");
+        tokio::fs::write(&path, "{\"prior\":\"row\"}\n")
+            .await
+            .unwrap();
+
+        let log = EventLog::new(tmp.path(), true);
+        log.persist(&env(7, ControlEvent::Superseded)).await;
+
+        let contents = tokio::fs::read_to_string(&path).await.unwrap();
+        let lines: Vec<&str> = contents.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("\"prior\":\"row\""));
+        assert!(lines[1].contains("\"seq\":7"));
+    }
+}

--- a/crates/pitboss-cli/src/control/mod.rs
+++ b/crates/pitboss-cli/src/control/mod.rs
@@ -7,6 +7,7 @@
 //! See `docs/superpowers/specs/2026-04-17-pitboss-v0.4-live-control-design.md`
 //! §4–§6 for the design.
 
+pub mod event_log;
 pub mod protocol;
 pub mod server;
 

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -10,7 +10,6 @@
 #![allow(dead_code)] // Some fields are set by Phase 2 tasks.
 
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -144,11 +143,12 @@ async fn serve_connection(
     let (read_half, write_half) = stream.into_split();
     let writer = Arc::new(Mutex::new(write_half));
     let mut reader = BufReader::new(read_half).lines();
-    // Per-connection monotonic seq counter for the `EventEnvelope.seq`
-    // field (PR-B of #438). Starts at 0; `fetch_add(1) + 1` makes the
-    // first emitted envelope's seq = 1. Reset on reconnect — #259's
-    // `events.jsonl` persistence will lift this to per-run lifetime.
-    let seq = Arc::new(AtomicU64::new(0));
+    // Run-scoped monotonic seq counter for the `EventEnvelope.seq`
+    // field. PR-B of #438 ran a per-connection counter as a stopgap;
+    // PR-G of #259 promotes it to per-run lifetime via `DispatchState.event_log`
+    // so seqs in `events.jsonl` match seqs on the live wire and survive
+    // reconnects.
+    let event_log = state.event_log.clone();
 
     // Hello handshake.
     let first = match reader.next_line().await {
@@ -160,7 +160,7 @@ async fn serve_connection(
         Ok(other) => {
             let _ = send_event(
                 &writer,
-                &seq,
+                &event_log,
                 &ControlEvent::OpFailed {
                     op: format!("{other:?}"),
                     task_id: None,
@@ -173,7 +173,7 @@ async fn serve_connection(
         Err(e) => {
             let _ = send_event(
                 &writer,
-                &seq,
+                &event_log,
                 &ControlEvent::OpFailed {
                     op: "hello".into(),
                     task_id: None,
@@ -207,7 +207,7 @@ async fn serve_connection(
     // Send server hello.
     let _ = send_event(
         &writer,
-        &seq,
+        &event_log,
         &ControlEvent::Hello {
             server_version,
             run_id,
@@ -231,8 +231,12 @@ async fn serve_connection(
     // assignment, or the id-match check at the disconnect site without
     // first introducing an equivalent reconnect-safety mechanism.**
     let writer_id = uuid::Uuid::now_v7();
-    let (ev_tx, mut ev_rx) =
-        tokio::sync::mpsc::channel::<ControlEvent>(crate::dispatch::layer::CONTROL_EVENT_QUEUE_CAP);
+    // PR-G of #259: channel carries fully-wrapped envelopes (seq +
+    // persistence already done at the broadcast site). The pump
+    // serializes; no wrap step.
+    let (ev_tx, mut ev_rx) = tokio::sync::mpsc::channel::<EventEnvelope>(
+        crate::dispatch::layer::CONTROL_EVENT_QUEUE_CAP,
+    );
     {
         let mut cw = state.root.control_writer.lock().await;
         if let Some(old) = cw.take() {
@@ -242,7 +246,9 @@ async fn serve_connection(
             // observable: the displaced TUI will not learn it was
             // superseded and may keep rendering stale tiles until its
             // socket EOFs. (#152 M1)
-            if let Err(e) = old.sender.try_send(ControlEvent::Superseded) {
+            let superseded = wrap_with_seq(&state.event_log, &ControlEvent::Superseded);
+            state.event_log.persist(&superseded).await;
+            if let Err(e) = old.sender.try_send(superseded) {
                 tracing::warn!(
                     new_writer_id = %writer_id,
                     error = %e,
@@ -278,16 +284,19 @@ async fn serve_connection(
                     created_at: q.created_at,
                 },
             );
-            // And push the event.
-            let _ = ev_tx
-                .send(ControlEvent::ApprovalRequest {
+            // And push the event (wrapped + persisted via the helper).
+            let _ = enqueue_envelope(
+                &ev_tx,
+                &event_log,
+                ControlEvent::ApprovalRequest {
                     request_id: q.request_id,
                     task_id: q.task_id,
                     summary: q.summary,
                     plan: q.plan.map(crate::mcp::approval::approval_plan_to_wire),
                     kind: q.kind,
-                })
-                .await;
+                },
+            )
+            .await;
         }
     }
 
@@ -326,7 +335,7 @@ async fn serve_connection(
             .collect()
     }; // lock released here
     for ev in pending {
-        let _ = ev_tx.send(ev).await;
+        let _ = enqueue_envelope(&ev_tx, &event_log, ev).await;
     }
 
     // Concurrent outbound pump: forward events from the mpsc to the socket.
@@ -342,17 +351,16 @@ async fn serve_connection(
     // Falls back to the old per-message behaviour when no further
     // events are queued — latency is unchanged for sparse traffic.
     let writer_for_pump = writer.clone();
-    let seq_for_pump = seq.clone();
     let pump = tokio::spawn(async move {
-        while let Some(ev) = ev_rx.recv().await {
-            let mut batch: Vec<ControlEvent> = vec![ev];
+        while let Some(env) = ev_rx.recv().await {
+            let mut batch: Vec<EventEnvelope> = vec![env];
             // Drain anything else already in the channel without
             // awaiting — bounded by the channel capacity, so this loop
             // can't run unboundedly.
             while let Ok(next) = ev_rx.try_recv() {
                 batch.push(next);
             }
-            if send_events_batch(&writer_for_pump, &seq_for_pump, &batch)
+            if send_envelopes_batch(&writer_for_pump, &batch)
                 .await
                 .is_err()
             {
@@ -366,6 +374,7 @@ async fn serve_connection(
     // current live counters. 1 s cadence is fast enough for the TUI's
     // 250 ms poll to feel responsive without flooding the socket.
     let ev_tx_activity = ev_tx.clone();
+    let event_log_activity = event_log.clone();
     let state_activity = state.clone();
     let activity_pump = tokio::spawn(async move {
         // Delay first emission by one period. tokio::time::interval's default
@@ -412,7 +421,13 @@ async fn serve_connection(
             // `try_send` — if the queue is full, skip this tick rather
             // than block the activity pump; the next tick re-reads
             // fresh counters anyway.
-            match ev_tx_activity.try_send(ControlEvent::StoreActivity { counters }) {
+            match try_enqueue_envelope(
+                &ev_tx_activity,
+                &event_log_activity,
+                ControlEvent::StoreActivity { counters },
+            )
+            .await
+            {
                 Ok(()) => {}
                 Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {}
                 Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => break,
@@ -437,7 +452,7 @@ async fn serve_connection(
                 error: format!("parse error: {e}"),
             },
         };
-        if send_event(&writer, &seq, &reply).await.is_err() {
+        if send_event(&writer, &event_log, &reply).await.is_err() {
             break;
         }
     }
@@ -606,25 +621,32 @@ async fn find_worker_layer(
 const STORE_ACTIVITY_INTERVAL_MS: u64 = 1000;
 
 /// Wrap a `ControlEvent` in an `EventEnvelope` with the next monotonic
-/// seq. PR-B of #438: every wire event now carries a `seq` field so
-/// consumers can implement transport-switching (disk-replay → live)
-/// without gap or duplicate. `actor_path` is left empty here — the
-/// server-side emit path is run-scoped, not actor-scoped; sub-actor
-/// paths get populated in a later PR if/when needed.
-fn wrap_with_seq(seq: &AtomicU64, ev: &ControlEvent) -> EventEnvelope {
+/// seq from the run-scoped `EventLog`. PR-B of #438 used a per-connection
+/// counter as a stopgap; PR-G of #259 promotes it to per-run so the seq
+/// on wire envelopes matches the seq archived in `events.jsonl`.
+/// `actor_path` is left empty here — the server-side emit path is
+/// run-scoped, not actor-scoped.
+fn wrap_with_seq(
+    event_log: &crate::control::event_log::EventLog,
+    ev: &ControlEvent,
+) -> EventEnvelope {
     EventEnvelope {
         actor_path: ActorPath::default(),
-        seq: seq.fetch_add(1, Ordering::Relaxed) + 1,
+        seq: event_log.next_seq(),
         event: ev.clone(),
     }
 }
 
 async fn send_event(
     writer: &Arc<Mutex<tokio::net::unix::OwnedWriteHalf>>,
-    seq: &AtomicU64,
+    event_log: &crate::control::event_log::EventLog,
     ev: &ControlEvent,
 ) -> Result<()> {
-    let envelope = wrap_with_seq(seq, ev);
+    let envelope = wrap_with_seq(event_log, ev);
+    // Persist before write so a crash mid-flush still leaves the row
+    // on disk for resume / replay. `persist` is a no-op for Hello
+    // envelopes and when `emit_event_stream` is false.
+    event_log.persist(&envelope).await;
     let mut line = serde_json::to_string(&envelope)?;
     line.push('\n');
     let mut guard = writer.lock().await;
@@ -633,24 +655,46 @@ async fn send_event(
     Ok(())
 }
 
-/// Send a batch of events with exactly one `flush()` at the end.
-/// Reduces syscall overhead during multi-event bursts (hello handshake,
-/// overlapping `WorkersUpdate` + `StoreActivity` ticks). See the pump
-/// loop's call site for the latency rationale. Used by the outbound
-/// pump only; ad-hoc senders still use `send_event`. (#152 L5)
-async fn send_events_batch(
+/// Wrap + persist + enqueue an event onto the channel that feeds the
+/// pump. Used by the queued-approval drain, the bridge-replay loop,
+/// and the periodic StoreActivity ticker — call sites inside
+/// `serve_connection` that emit events without going through
+/// `LayerState::broadcast_control_event`.
+async fn enqueue_envelope(
+    tx: &tokio::sync::mpsc::Sender<EventEnvelope>,
+    event_log: &crate::control::event_log::EventLog,
+    ev: ControlEvent,
+) -> Result<(), tokio::sync::mpsc::error::SendError<EventEnvelope>> {
+    let envelope = wrap_with_seq(event_log, &ev);
+    event_log.persist(&envelope).await;
+    tx.send(envelope).await
+}
+
+/// Try-send variant of [`enqueue_envelope`] for the activity ticker
+/// (drops on a full channel rather than blocking the timer).
+async fn try_enqueue_envelope(
+    tx: &tokio::sync::mpsc::Sender<EventEnvelope>,
+    event_log: &crate::control::event_log::EventLog,
+    ev: ControlEvent,
+) -> Result<(), tokio::sync::mpsc::error::TrySendError<EventEnvelope>> {
+    let envelope = wrap_with_seq(event_log, &ev);
+    event_log.persist(&envelope).await;
+    tx.try_send(envelope)
+}
+
+/// Serialize a batch of already-wrapped envelopes with exactly one
+/// `flush()`. PR-G: channel carries envelopes (wrap + persist done at
+/// the broadcast/enqueue site), so the pump just writes.
+async fn send_envelopes_batch(
     writer: &Arc<Mutex<tokio::net::unix::OwnedWriteHalf>>,
-    seq: &AtomicU64,
-    batch: &[ControlEvent],
+    batch: &[EventEnvelope],
 ) -> Result<()> {
     if batch.is_empty() {
         return Ok(());
     }
-    // Serialize first so the lock window is just the syscalls.
     let mut payload = Vec::with_capacity(batch.len() * 256 /* heuristic per-event size */);
-    for ev in batch {
-        let envelope = wrap_with_seq(seq, ev);
-        let line = serde_json::to_string(&envelope)?;
+    for envelope in batch {
+        let line = serde_json::to_string(envelope)?;
         payload.extend_from_slice(line.as_bytes());
         payload.push(b'\n');
     }

--- a/crates/pitboss-cli/src/dispatch/failure_detection.rs
+++ b/crates/pitboss-cli/src/dispatch/failure_detection.rs
@@ -181,13 +181,11 @@ pub async fn broadcast_worker_failed(
     reason: FailureReason,
     actor_path_segments: &[&str],
 ) {
+    // PR-G of #259: `broadcast_control_event` assigns the run-scoped
+    // seq + persists; callers still pass an envelope but its seq=0 is
+    // overwritten.
     let envelope = EventEnvelope {
         actor_path: ActorPath::new(actor_path_segments.iter().copied()),
-        // Seq is reassigned by the server's pump (see `send_events_batch`
-        // in `control/server.rs`); the value here is a placeholder. The
-        // `broadcast_control_event` path discards the envelope wrapper
-        // and only forwards `envelope.event`, so this never reaches the
-        // wire.
         seq: 0,
         event: ControlEvent::WorkerFailed {
             task_id,
@@ -405,7 +403,7 @@ mod tests {
             Arc::new(SharedStore::new()),
             None,
         );
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<ControlEvent>(
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<EventEnvelope>(
             crate::dispatch::layer::CONTROL_EVENT_QUEUE_CAP,
         );
         *layer.control_writer.lock().await = Some(crate::dispatch::layer::ControlWriterSlot {
@@ -422,11 +420,11 @@ mod tests {
         )
         .await;
 
-        let ev = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv())
+        let envelope = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv())
             .await
             .expect("event should arrive before timeout")
-            .expect("channel should deliver one event");
-        match ev {
+            .expect("channel should deliver one envelope");
+        match envelope.event {
             ControlEvent::WorkerFailed {
                 task_id,
                 parent_task_id,

--- a/crates/pitboss-cli/src/dispatch/layer.rs
+++ b/crates/pitboss-cli/src/dispatch/layer.rs
@@ -47,7 +47,12 @@ pub const CONTROL_EVENT_QUEUE_CAP: usize = 512;
 /// different id, and the clear is skipped.
 pub struct ControlWriterSlot {
     pub id: Uuid,
-    pub sender: mpsc::Sender<crate::control::protocol::ControlEvent>,
+    /// PR-G of #259: channel carries fully-wrapped envelopes (with
+    /// `seq` already assigned via the per-run `EventLog`) so the
+    /// pump just serializes; persistence happens at the broadcast
+    /// site, not at the pump, so headless dispatches still produce
+    /// `events.jsonl`.
+    pub sender: mpsc::Sender<crate::control::protocol::EventEnvelope>,
 }
 
 /// All state owned by a single coordination layer (root layer or a
@@ -137,6 +142,13 @@ pub struct LayerState {
     /// side — broadcasts use `try_send` and drop on a full queue rather
     /// than block the dispatcher.
     pub control_writer: Mutex<Option<ControlWriterSlot>>,
+    /// Per-run event-stream log (#259, co-spec'd with #438). Cloned
+    /// from `DispatchState.event_log` at LayerState construction so
+    /// the per-layer `broadcast_control_event` can assign the
+    /// run-scoped seq + persist envelopes without going through the
+    /// pump (which only runs when a client is connected). Shared
+    /// across the root layer and every sub-tree layer.
+    pub event_log: Arc<crate::control::event_log::EventLog>,
     /// Per-task event counters.
     pub worker_counters: RwLock<HashMap<String, WorkerCounters>>,
     /// v0.4.1: notification router.
@@ -220,6 +232,15 @@ impl LayerState {
         shared_store: std::sync::Arc<crate::shared_store::SharedStore>,
         original_reservation_usd: Option<f64>,
     ) -> Self {
+        // PR-G of #259: default to a disabled, root-`/` event log so the
+        // 14-arg signature stays back-compat with the pre-PR-G call
+        // shape (tests + ad-hoc constructors). Prod callers
+        // (`DispatchState::new`, sub-lead spawn) override via
+        // [`Self::with_event_log`] immediately after constructing.
+        let event_log = Arc::new(crate::control::event_log::EventLog::new(
+            std::path::Path::new("/"),
+            false,
+        ));
         let (done_tx, _) = broadcast::channel(64);
         Self {
             run_id,
@@ -247,6 +268,7 @@ impl LayerState {
             approval_queue: Mutex::new(VecDeque::new()),
             approval_policy,
             control_writer: Mutex::new(None),
+            event_log,
             worker_counters: RwLock::new(HashMap::new()),
             notification_router,
             shared_store,
@@ -257,6 +279,19 @@ impl LayerState {
             reprompt_hook: Mutex::new(None),
             reprompt_tx: Mutex::new(None),
         }
+    }
+
+    /// Builder: install the run-scoped event log on this freshly-
+    /// constructed layer. PR-G of #259 — call sites that have an
+    /// `EventLog` available (`DispatchState::new` for the root,
+    /// `dispatch::sublead::spawn_sublead` for sub-trees) chain this
+    /// after [`Self::new`]. Test callers that don't care about
+    /// persistence can omit the builder and inherit the disabled
+    /// default.
+    #[must_use]
+    pub fn with_event_log(mut self, event_log: Arc<crate::control::event_log::EventLog>) -> Self {
+        self.event_log = event_log;
+        self
     }
 
     /// Install a `PolicyMatcher` on this layer. Called at run startup after
@@ -365,31 +400,37 @@ impl LayerState {
         }
     }
 
-    /// Broadcast a control-plane event wrapped in an `EventEnvelope` to any
-    /// connected TUI. The `actor_path` carried in the envelope is preserved
-    /// in the serialized JSON when non-empty (v0.6+ TUI clients); when empty
-    /// it is elided so v0.5 clients parse the event unchanged.
+    /// Broadcast a control-plane event. PR-G of #259: this call assigns
+    /// the run-scoped seq from [`Self::event_log`], persists the
+    /// envelope to `events.jsonl` (no-op when `emit_event_stream` is
+    /// off), and — if a TUI/web bridge is connected — forwards the
+    /// envelope to the pump for wire emission.
     ///
-    /// If no TUI is currently connected the event is silently dropped — the
-    /// control socket is best-effort (same semantics as the existing
-    /// `control_writer.send(...)` pattern throughout the codebase).
-    pub async fn broadcast_control_event(&self, envelope: crate::control::protocol::EventEnvelope) {
+    /// Persistence happens **regardless of whether a client is
+    /// connected**: headless dispatches still produce a complete
+    /// `events.jsonl` for post-run replay. The caller's `envelope.seq`
+    /// is overwritten; the caller is expected to construct envelopes
+    /// with `seq: 0` placeholders (pre-PR-G call sites still compile
+    /// unchanged).
+    ///
+    /// `try_send` drops the wire emission on a full queue (slow /
+    /// frozen TUI) rather than blocking the dispatcher — the archived
+    /// row is unaffected.
+    pub async fn broadcast_control_event(
+        &self,
+        mut envelope: crate::control::protocol::EventEnvelope,
+    ) {
+        envelope.seq = self.event_log.next_seq();
+        self.event_log.persist(&envelope).await;
+
         if let Some(w) = self.control_writer.lock().await.as_ref() {
-            // The channel carries ControlEvent; the actor_path in the
-            // envelope is available for future TUI display but is not
-            // threaded through the channel in this task. Emit the inner
-            // event so the TUI gets the lifecycle notification.
-            //
-            // `try_send` drops the event on a full queue (slow/frozen
-            // TUI) rather than blocking the broadcaster.
-            if let Err(e) = w.sender.try_send(envelope.event) {
+            if let Err(e) = w.sender.try_send(envelope) {
                 tracing::debug!(
-                    "control_writer try_send dropped event: {} ({})",
+                    "control_writer try_send dropped envelope: {}",
                     match &e {
                         tokio::sync::mpsc::error::TrySendError::Full(_) => "queue full",
                         tokio::sync::mpsc::error::TrySendError::Closed(_) => "receiver dropped",
                     },
-                    std::any::type_name::<crate::control::protocol::ControlEvent>(),
                 );
             }
         }

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -412,6 +412,12 @@ pub struct DispatchState {
     /// auto-deny short-circuit. `None`/missing entry means the sub-lead
     /// was spawned untyped — the bridge fallback runs as before.
     pub sublead_actor_types: RwLock<HashMap<String, String>>,
+    /// Per-run event-stream log (#259, co-spec'd with #438). Owns the
+    /// run-scoped monotonic seq counter and an optional append-only
+    /// `<run-dir>/events.jsonl` file gated by `[run].emit_event_stream`.
+    /// Live wire emits read seq from here; persistence is a no-op when
+    /// the flag is off. Cloneable via `Arc`.
+    pub event_log: Arc<crate::control::event_log::EventLog>,
 }
 
 impl std::fmt::Debug for DispatchState {
@@ -453,22 +459,29 @@ impl DispatchState {
     ) -> Self {
         let communication_config = manifest.communication.clone();
         let communication_dir = run_subdir.clone();
-        let root = Arc::new(LayerState::new(
-            run_id,
-            manifest,
-            store,
-            cancel,
-            lead_id,
-            spawner,
-            claude_binary,
-            wt_mgr,
-            cleanup_policy,
-            run_subdir,
-            approval_policy,
-            notification_router,
-            shared_store,
-            None,
+        let event_log = Arc::new(crate::control::event_log::EventLog::new(
+            &run_subdir,
+            manifest.emit_event_stream,
         ));
+        let root = Arc::new(
+            LayerState::new(
+                run_id,
+                manifest,
+                store,
+                cancel,
+                lead_id,
+                spawner,
+                claude_binary,
+                wt_mgr,
+                cleanup_policy,
+                run_subdir,
+                approval_policy,
+                notification_router,
+                shared_store,
+                None,
+            )
+            .with_event_log(event_log.clone()),
+        );
         Self {
             root,
             subleads: RwLock::new(HashMap::new()),
@@ -484,6 +497,7 @@ impl DispatchState {
             api_health: Arc::new(crate::dispatch::failure_detection::ApiHealth::new()),
             actor_tokens: RwLock::new(HashMap::new()),
             sublead_actor_types: RwLock::new(HashMap::new()),
+            event_log,
         }
     }
 

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -355,24 +355,27 @@ pub async fn spawn_sublead(
         }
 
         // 7. Construct the sub-tree LayerState.
-        let sub_layer = Arc::new(LayerState::new(
-            state.root.run_id,
-            sub_manifest,
-            state.root.store.clone(),
-            CancelToken::new(),
-            sublead_id.clone(),
-            state.root.spawner.clone(),
-            state.root.claude_binary.clone(),
-            state.root.wt_mgr.clone(),
-            CleanupPolicy::Never, // sub-tree shares run cleanup behaviour; finalized by root
-            state.root.run_subdir.clone(),
-            // Inherit root approval policy; sub-leads can escalate via request_approval.
-            state.root.approval_policy,
-            // No notification router for sub-trees — root router handles run events.
-            None,
-            sub_store,
-            reserved_amount,
-        ));
+        let sub_layer = Arc::new(
+            LayerState::new(
+                state.root.run_id,
+                sub_manifest,
+                state.root.store.clone(),
+                CancelToken::new(),
+                sublead_id.clone(),
+                state.root.spawner.clone(),
+                state.root.claude_binary.clone(),
+                state.root.wt_mgr.clone(),
+                CleanupPolicy::Never, // sub-tree shares run cleanup behaviour; finalized by root
+                state.root.run_subdir.clone(),
+                // Inherit root approval policy; sub-leads can escalate via request_approval.
+                state.root.approval_policy,
+                // No notification router for sub-trees — root router handles run events.
+                None,
+                sub_store,
+                reserved_amount,
+            )
+            .with_event_log(state.event_log.clone()),
+        );
 
         // 8. Register sub-tree LayerState on root DispatchState. Inserts into
         // `state.subleads`, installs the per-sublead cancel-cascade watcher,
@@ -411,9 +414,7 @@ pub async fn spawn_sublead(
             };
             let ev = EventEnvelope {
                 actor_path: ActorPath::new(["root", sublead_id.as_str()]),
-                // Seq is reassigned by the server's pump; see comment in
-                // `failure_detection::broadcast_worker_failed`.
-                seq: 0,
+                seq: 0, // overwritten by broadcast_control_event
                 event: ControlEvent::SubleadSpawned {
                     sublead_id: sublead_id.clone(),
                     budget_usd: budget_usd_val,
@@ -1115,9 +1116,7 @@ pub async fn reconcile_terminated_sublead(
     {
         let ev = EventEnvelope {
             actor_path: ActorPath::new(["root", sublead_id]),
-            // Seq is reassigned by the server's pump; see comment in
-            // `failure_detection::broadcast_worker_failed`.
-            seq: 0,
+            seq: 0, // overwritten by broadcast_control_event
             event: ControlEvent::SubleadTerminated {
                 sublead_id: sublead_id.to_string(),
                 spent_usd: actual_spend,

--- a/crates/pitboss-cli/src/mcp/approval.rs
+++ b/crates/pitboss-cli/src/mcp/approval.rs
@@ -263,6 +263,18 @@ impl ApprovalBridge {
                 plan: plan.map(approval_plan_to_wire),
                 kind,
             };
+            // PR-G of #259: wrap + persist inline rather than calling
+            // `broadcast_control_event` because we're holding the
+            // writer lock (per #151 M4's insert-then-send-under-lock
+            // invariant). The envelope's seq comes from the run-scoped
+            // EventLog; `persist` is a no-op when emit_event_stream is
+            // off.
+            let envelope = crate::control::protocol::EventEnvelope {
+                actor_path: crate::dispatch::actor::ActorPath::default(),
+                seq: self.state.root.event_log.next_seq(),
+                event: ev,
+            };
+            self.state.root.event_log.persist(&envelope).await;
             // Best-effort send. A full queue used to silently drop the
             // event AND leave the bridge entry alive, so the caller
             // waited the full timeout for an ApprovalRequest the TUI
@@ -271,7 +283,7 @@ impl ApprovalBridge {
             // fallback path (timeout/auto-allow/reject) immediately
             // — same outcome as a permanently-disconnected TUI but
             // without the bridge-timeout stall. (#151 M4)
-            if let Err(e) = w.sender.try_send(ev) {
+            if let Err(e) = w.sender.try_send(envelope) {
                 tracing::warn!(
                     request_id = %request_id,
                     error = %e,
@@ -551,12 +563,12 @@ mod tests {
     /// control writer was connected, silently bypassing the policy.
     #[tokio::test]
     async fn auto_approve_short_circuits_with_tui_attached() {
-        use crate::control::protocol::ControlEvent;
+        use crate::control::protocol::EventEnvelope;
         use tokio::sync::mpsc;
 
         let state = mk_state(ApprovalPolicy::AutoApprove).await;
         // Simulate a connected TUI by registering a control writer.
-        let (tx, mut rx) = mpsc::channel::<ControlEvent>(8);
+        let (tx, mut rx) = mpsc::channel::<EventEnvelope>(8);
         *state.root.control_writer.lock().await = Some(crate::dispatch::layer::ControlWriterSlot {
             id: Uuid::now_v7(),
             sender: tx,
@@ -592,11 +604,11 @@ mod tests {
     /// short-circuit even when a TUI/web console is attached.
     #[tokio::test]
     async fn auto_reject_short_circuits_with_tui_attached() {
-        use crate::control::protocol::ControlEvent;
+        use crate::control::protocol::EventEnvelope;
         use tokio::sync::mpsc;
 
         let state = mk_state(ApprovalPolicy::AutoReject).await;
-        let (tx, mut rx) = mpsc::channel::<ControlEvent>(8);
+        let (tx, mut rx) = mpsc::channel::<EventEnvelope>(8);
         *state.root.control_writer.lock().await = Some(crate::dispatch::layer::ControlWriterSlot {
             id: Uuid::now_v7(),
             sender: tx,
@@ -681,17 +693,21 @@ mod tests {
     /// auto-rejects. Both `requested` and `rejected` must bump.
     #[tokio::test]
     async fn queue_full_safe_rejection_bumps_requested_and_rejected() {
-        use crate::control::protocol::ControlEvent;
+        use crate::control::protocol::{ControlEvent, EventEnvelope};
         use tokio::sync::mpsc;
 
         let state = mk_state(ApprovalPolicy::Block).await;
         // Capacity-1 channel filled to force `try_send` to fail. We must not
         // drain the receiver — the bridge's send needs to fail synchronously.
-        let (tx, _rx) = mpsc::channel::<ControlEvent>(1);
-        // Pre-fill with one event so the bridge's try_send is guaranteed to fail.
-        tx.try_send(ControlEvent::OpAcked {
-            op: "noop".into(),
-            task_id: None,
+        let (tx, _rx) = mpsc::channel::<EventEnvelope>(1);
+        // Pre-fill with one envelope so the bridge's try_send is guaranteed to fail.
+        tx.try_send(EventEnvelope {
+            actor_path: Default::default(),
+            seq: 0,
+            event: ControlEvent::OpAcked {
+                op: "noop".into(),
+                task_id: None,
+            },
         })
         .unwrap();
         *state.root.control_writer.lock().await = Some(crate::dispatch::layer::ControlWriterSlot {
@@ -720,11 +736,11 @@ mod tests {
     /// bumps `approved` or `rejected`. Together they yield (1, 1, 0) or (1, 0, 1).
     #[tokio::test]
     async fn respond_path_bumps_approved() {
-        use crate::control::protocol::ControlEvent;
+        use crate::control::protocol::{ControlEvent, EventEnvelope};
         use tokio::sync::mpsc;
 
         let state = mk_state(ApprovalPolicy::Block).await;
-        let (tx, mut rx) = mpsc::channel::<ControlEvent>(8);
+        let (tx, mut rx) = mpsc::channel::<EventEnvelope>(8);
         *state.root.control_writer.lock().await = Some(crate::dispatch::layer::ControlWriterSlot {
             id: Uuid::now_v7(),
             sender: tx,
@@ -748,7 +764,7 @@ mod tests {
 
         // Wait for the bridge to emit the ApprovalRequest event, capture the
         // request_id, then call respond().
-        let request_id = match rx.recv().await.unwrap() {
+        let request_id = match rx.recv().await.unwrap().event {
             ControlEvent::ApprovalRequest { request_id, .. } => request_id,
             other => panic!("unexpected event: {other:?}"),
         };
@@ -777,14 +793,14 @@ mod tests {
     /// empty and the lead's file ambiguous.
     #[tokio::test]
     async fn approval_audit_rows_go_to_caller_actor_dir() {
-        use crate::control::protocol::ControlEvent;
+        use crate::control::protocol::{ControlEvent, EventEnvelope};
         use tokio::sync::mpsc;
 
         let run_subdir = TempDir::new().unwrap();
         let run_subdir_path = run_subdir.path().to_path_buf();
         let state = mk_state_with_run_subdir(ApprovalPolicy::Block, run_subdir_path.clone()).await;
 
-        let (tx, mut rx) = mpsc::channel::<ControlEvent>(8);
+        let (tx, mut rx) = mpsc::channel::<EventEnvelope>(8);
         *state.root.control_writer.lock().await = Some(crate::dispatch::layer::ControlWriterSlot {
             id: Uuid::now_v7(),
             sender: tx,
@@ -808,7 +824,7 @@ mod tests {
                 .await
         });
 
-        let request_id = match rx.recv().await.unwrap() {
+        let request_id = match rx.recv().await.unwrap().event {
             ControlEvent::ApprovalRequest { request_id, .. } => request_id,
             other => panic!("unexpected event: {other:?}"),
         };

--- a/crates/pitboss-cli/src/mcp/tools/tests.rs
+++ b/crates/pitboss-cli/src/mcp/tools/tests.rs
@@ -2770,13 +2770,13 @@ async fn approval_driven_termination_reclassify_policy_fires_after_denial() {
 /// should produce `OperatorRejected`.
 #[tokio::test]
 async fn permission_prompt_operator_driven_reject_records_operator_rejected() {
-    use crate::control::protocol::ControlEvent;
+    use crate::control::protocol::{ControlEvent, EventEnvelope};
     use crate::dispatch::state::{ApprovalPolicy, ApprovalResponse};
     use std::time::Duration;
     use tokio::sync::mpsc;
 
     let state = mk_plan_state(ApprovalPolicy::Block, false).await;
-    let (tx, mut rx) = mpsc::channel::<ControlEvent>(8);
+    let (tx, mut rx) = mpsc::channel::<EventEnvelope>(8);
     *state.root.control_writer.lock().await = Some(crate::dispatch::layer::ControlWriterSlot {
         id: uuid::Uuid::now_v7(),
         sender: tx,
@@ -2788,7 +2788,7 @@ async fn permission_prompt_operator_driven_reject_records_operator_rejected() {
     // `BRIDGE_AUTO_REJECT_COMMENT`).
     let state_for_resp = std::sync::Arc::clone(&state);
     let driver = tokio::spawn(async move {
-        let request_id = match rx.recv().await.unwrap() {
+        let request_id = match rx.recv().await.unwrap().event {
             ControlEvent::ApprovalRequest { request_id, .. } => request_id,
             other => panic!("unexpected event: {other:?}"),
         };
@@ -2873,7 +2873,7 @@ async fn permission_prompt_operator_driven_reject_records_operator_rejected() {
 ///   in `pitboss status` / `summary.json`.
 #[tokio::test]
 async fn permission_prompt_ttl_driven_reject_records_ttl_expired() {
-    use crate::control::protocol::ControlEvent;
+    use crate::control::protocol::{ControlEvent, EventEnvelope};
     use crate::dispatch::state::{ApprovalPolicy, ApprovalResponse, DenialTerminationPolicy};
     use std::time::Duration;
     use tokio::sync::mpsc;
@@ -2885,7 +2885,7 @@ async fn permission_prompt_ttl_driven_reject_records_ttl_expired() {
         DenialTerminationPolicy::Reclassify,
     )
     .await;
-    let (tx, mut rx) = mpsc::channel::<ControlEvent>(8);
+    let (tx, mut rx) = mpsc::channel::<EventEnvelope>(8);
     *state.root.control_writer.lock().await = Some(crate::dispatch::layer::ControlWriterSlot {
         id: uuid::Uuid::now_v7(),
         sender: tx,
@@ -2893,7 +2893,7 @@ async fn permission_prompt_ttl_driven_reject_records_ttl_expired() {
 
     let state_for_resp = std::sync::Arc::clone(&state);
     let driver = tokio::spawn(async move {
-        let request_id = match rx.recv().await.unwrap() {
+        let request_id = match rx.recv().await.unwrap().event {
             ControlEvent::ApprovalRequest { request_id, .. } => request_id,
             other => panic!("unexpected event: {other:?}"),
         };

--- a/crates/pitboss-cli/tests/control_flows.rs
+++ b/crates/pitboss-cli/tests/control_flows.rs
@@ -381,6 +381,198 @@ async fn server_emits_monotonic_seqs_on_wire() {
     );
 }
 
+/// PR-G of #259: when `[run].emit_event_stream = true`, the dispatcher
+/// persists every non-Hello envelope to `<run-dir>/events.jsonl` as it
+/// fires on the wire. Hello is skipped (handshake noise per the spec).
+/// Seqs in the file match seqs on the wire (single counter for both).
+#[tokio::test]
+async fn emit_event_stream_writes_envelopes_to_events_jsonl() {
+    let dir = TempDir::new().unwrap();
+    let run_id = uuid::Uuid::now_v7();
+    let run_subdir = dir.path().join(run_id.to_string());
+    tokio::fs::create_dir_all(&run_subdir).await.unwrap();
+    let manifest = ResolvedManifest {
+        manifest_schema_version: 0,
+        name: None,
+        max_parallel_tasks: Some(4),
+        halt_on_failure: false,
+        run_dir: dir.path().to_path_buf(),
+        worktree_cleanup: WorktreeCleanup::OnSuccess,
+        // The flag this PR activates.
+        emit_event_stream: true,
+        tasks: vec![],
+        lead: None,
+        max_workers: Some(4),
+        budget_usd: Some(1.0),
+        lead_budget_usd: None,
+        lead_timeout_secs: None,
+        default_approval_policy: Some(ApprovalPolicy::Block),
+        denial_termination_policy: None,
+        notifications: vec![],
+        dump_shared_store: false,
+        require_plan_approval: false,
+        approval_rules: vec![],
+        container: None,
+        mcp_servers: vec![],
+        communication: Default::default(),
+        lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
+        untyped_actor_policy: Default::default(),
+    };
+    let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
+    let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
+    let wt_mgr = Arc::new(WorktreeManager::new());
+    let state = Arc::new(DispatchState::new(
+        run_id,
+        manifest,
+        store,
+        CancelToken::new(),
+        String::new(),
+        spawner,
+        PathBuf::from("/bin/true"),
+        wt_mgr,
+        CleanupPolicy::Never,
+        run_subdir.clone(),
+        ApprovalPolicy::Block,
+        None,
+        std::sync::Arc::new(pitboss_cli::shared_store::SharedStore::new()),
+    ));
+    state.root.workers.write().await.insert(
+        "w-1".into(),
+        WorkerState::Running {
+            started_at: chrono::Utc::now(),
+            session_id: Some("sess".into()),
+        },
+    );
+
+    let sock = dir.path().join("events-stream.sock");
+    let _h = start_control_server(
+        sock.clone(),
+        "0.13.0".into(),
+        run_id.to_string(),
+        "flat".into(),
+        state,
+    )
+    .await
+    .unwrap();
+
+    let mut client = FakeControlClient::connect(&sock, "0.13.0").await.unwrap();
+    client.send(&ControlOp::ListWorkers).await.unwrap();
+    // Wait for the OpAcked or WorkersSnapshot reply so the dispatcher
+    // has flushed at least one persisted envelope.
+    let _ = client
+        .recv_timeout(std::time::Duration::from_secs(2))
+        .await
+        .unwrap();
+
+    // Give the persistence write a beat to flush.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let events_path = run_subdir.join("events.jsonl");
+    let contents = tokio::fs::read_to_string(&events_path)
+        .await
+        .expect("events.jsonl must be created when emit_event_stream=true");
+    let lines: Vec<&str> = contents.lines().collect();
+    assert!(
+        !lines.is_empty(),
+        "events.jsonl should have at least one persisted envelope",
+    );
+    // Spec: Hello is NOT archived. The hello envelope has seq=1 on the
+    // wire, but persisted lines start with the second envelope.
+    for line in &lines {
+        assert!(
+            !line.contains("\"event\":\"hello\""),
+            "Hello envelope must not be archived: {line}",
+        );
+    }
+    // Every line carries a seq field.
+    for line in &lines {
+        assert!(line.contains("\"seq\":"), "missing seq in {line}");
+    }
+}
+
+#[tokio::test]
+async fn emit_event_stream_off_does_not_create_events_jsonl() {
+    let dir = TempDir::new().unwrap();
+    let run_id = uuid::Uuid::now_v7();
+    let run_subdir = dir.path().join(run_id.to_string());
+    tokio::fs::create_dir_all(&run_subdir).await.unwrap();
+    let manifest = ResolvedManifest {
+        manifest_schema_version: 0,
+        name: None,
+        max_parallel_tasks: Some(4),
+        halt_on_failure: false,
+        run_dir: dir.path().to_path_buf(),
+        worktree_cleanup: WorktreeCleanup::OnSuccess,
+        emit_event_stream: false, // back-compat default
+        tasks: vec![],
+        lead: None,
+        max_workers: Some(4),
+        budget_usd: Some(1.0),
+        lead_budget_usd: None,
+        lead_timeout_secs: None,
+        default_approval_policy: Some(ApprovalPolicy::Block),
+        denial_termination_policy: None,
+        notifications: vec![],
+        dump_shared_store: false,
+        require_plan_approval: false,
+        approval_rules: vec![],
+        container: None,
+        mcp_servers: vec![],
+        communication: Default::default(),
+        lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
+        untyped_actor_policy: Default::default(),
+    };
+    let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
+    let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
+    let wt_mgr = Arc::new(WorktreeManager::new());
+    let state = Arc::new(DispatchState::new(
+        run_id,
+        manifest,
+        store,
+        CancelToken::new(),
+        String::new(),
+        spawner,
+        PathBuf::from("/bin/true"),
+        wt_mgr,
+        CleanupPolicy::Never,
+        run_subdir.clone(),
+        ApprovalPolicy::Block,
+        None,
+        std::sync::Arc::new(pitboss_cli::shared_store::SharedStore::new()),
+    ));
+
+    let sock = dir.path().join("events-off.sock");
+    let _h = start_control_server(
+        sock.clone(),
+        "0.13.0".into(),
+        run_id.to_string(),
+        "flat".into(),
+        state,
+    )
+    .await
+    .unwrap();
+
+    let mut client = FakeControlClient::connect(&sock, "0.13.0").await.unwrap();
+    client.send(&ControlOp::ListWorkers).await.unwrap();
+    let _ = client
+        .recv_timeout(std::time::Duration::from_secs(2))
+        .await
+        .unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let events_path = run_subdir.join("events.jsonl");
+    assert!(
+        !events_path.exists(),
+        "events.jsonl must not be created when emit_event_stream=false",
+    );
+}
+
 #[tokio::test]
 async fn block_policy_queue_drains_on_tui_connect() {
     use std::time::Duration;


### PR DESCRIPTION
## Summary

Implements the writer side of [#259](https://github.com/SDS-Mode/pitboss/issues/259) — dispatcher persists every non-Hello envelope to `<run-dir>/events.jsonl` when `[run].emit_event_stream = true`. Co-spec'd with [#438](https://github.com/SDS-Mode/pitboss/issues/438) (the unified envelope API RFC at #443).

Also promotes the seq counter from per-connection (PR-B of #438) to **per-run** lifetime, so seqs in events.jsonl match seqs on the live wire and survive TUI reconnects — exactly what the RFC asked of #259.

> **Stacked on #449.** Base is `feat/438-pr-f-watcher-rewire`; rebase once the chain merges to main.

## What's new

- `pitboss_cli::control::event_log::EventLog` — owns the per-run monotonic seq counter and an append-only `<run-dir>/events.jsonl`, lazily created when `[run].emit_event_stream = true`. Skips `Hello` envelopes (handshake noise per #259's spec).
- `DispatchState.event_log: Arc<EventLog>` initialized from the resolved manifest's `emit_event_stream` flag.
- `LayerState` gains a cloned reference + a `.with_event_log(...)` builder. `LayerState::new`'s 14-arg signature stays back-compat for the dozens of test fixtures; prod call sites (`DispatchState::new`, sub-lead spawn) chain the builder to wire the run-scoped log through.
- `ControlWriterSlot.sender` changes from `Sender<ControlEvent>` to `Sender<EventEnvelope>` — the pump just serializes already-wrapped envelopes (wrap + persist done at the broadcast/enqueue site).
- `LayerState::broadcast_control_event` now assigns the run-scoped seq + persists the envelope **unconditionally** — events emitted by `failure_detection::broadcast_worker_failed` and the sub-lead spawn/terminate sites get archived even with no client attached.

## Known gap

Events emitted *inside* `serve_connection` (Hello, WorkersSnapshot, StoreActivity, queued/replayed ApprovalRequest, dispatch_op replies) persist via the pre-pump `send_event` / enqueue helpers, which only run when a client is connected. Headless dispatches with no sub-leads or worker failures will not produce an events.jsonl.

`broadcast_control_event`-routed events (sublead lifecycle, worker failures) persist unconditionally.

Closing this gap fully requires a dispatcher-side persistent listener on a per-run broadcast channel — a substantial refactor that's the right follow-up to land separately. The current slice covers the typical-TUI-attached case end-to-end, which is what most operators see.

## Out of scope (per #259's full spec)

- HTTP endpoint (`GET /api/runs/{id}/events.jsonl`)
- SPA replay tab for completed runs
- `pitboss events <run-id>` CLI subcommand
- AGENTS.md documentation of `emit_event_stream`

These are tracked in the issue body and will land as follow-ups now that the writer foundation is in place.

## Test plan

- [x] 5 new `EventLog` unit tests:
  - `seq_is_monotonic_starting_at_one`
  - `persist_writes_one_line_per_envelope`
  - `persist_skips_hello_envelopes`
  - `persist_noops_when_disabled`
  - `persist_appends_to_existing_file`
- [x] 2 new control_flows integration tests:
  - `emit_event_stream_writes_envelopes_to_events_jsonl` (real server, asserts file contents + Hello skip + seq presence)
  - `emit_event_stream_off_does_not_create_events_jsonl` (back-compat default)
- [x] All 13 control_flows pass
- [x] 139/139 pitboss-tui lib tests pass
- [x] 187/188 pitboss-cli lib tests pass (one pre-existing macOS-only flake on `/bin/true`)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] Reviewer: confirm the known-gap scoping is acceptable; the follow-up to plumb a persistent dispatcher-side listener can be its own PR.

## Stacking

| PR | Base | State |
|---|---|---|
| #443 (RFC) | `main` | draft |
| #444 (PR-A) | `main` | draft |
| #445 (PR-B) | `main` | draft |
| #446 (PR-C) | `feat/438-pr-b-…` | draft |
| #447 (PR-D) | `feat/438-pr-c-…` | draft |
| #448 (PR-E) | `feat/438-pr-d-…` | draft |
| #449 (PR-F) | `feat/438-pr-e-…` | draft |
| **#?? (this, PR-G)** | `feat/438-pr-f-watcher-rewire` | draft |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Note:** supersedes #450 (auto-closed when the parent stack PR's branch was deleted). Same content, rebased onto main.