### PR TITLE
feat(cli): pitboss events <run-id> (#259, PR-J)

### DIFF
--- a/crates/pitboss-cli/src/cli.rs
+++ b/crates/pitboss-cli/src/cli.rs
@@ -245,6 +245,31 @@ pub enum Command {
         #[arg(long)]
         json: bool,
     },
+    /// Print the persisted control-event stream for a prior run (#259).
+    ///
+    /// Reads `<run-dir>/events.jsonl`, which the dispatcher writes when
+    /// the manifest enables `[run].emit_event_stream = true`. Each line
+    /// is one `EventEnvelope` carrying `seq`, `actor_path`, and a
+    /// flattened `ControlEvent` payload — sub-lead lifecycle, worker
+    /// failures, approval requests, etc.
+    ///
+    /// Default output is a compact one-line-per-envelope summary
+    /// (`seq` · `actor_path` · `event_kind` · key detail). Use
+    /// `--json` for the raw NDJSON suitable for piping into `jq`.
+    Events {
+        /// Run id (full UUID or unique prefix).
+        run_id: String,
+        /// Override runs base directory. Defaults to
+        /// `~/.local/share/pitboss/runs`. Same semantics as `status`,
+        /// `list`, `prune`.
+        #[arg(long)]
+        run_dir: Option<PathBuf>,
+        /// Pass the file through as NDJSON (one envelope per line,
+        /// exactly as written to disk). Default mode renders a
+        /// human-readable summary.
+        #[arg(long)]
+        json: bool,
+    },
     /// Triage a single run or roll up recent runs.
     ///
     /// Single-run mode (`pitboss analyze <run-id>`): produces a

--- a/crates/pitboss-cli/src/events.rs
+++ b/crates/pitboss-cli/src/events.rs
@@ -1,0 +1,372 @@
+//! `pitboss events <run-id>` — print the persisted control-event
+//! stream for a prior run (#259).
+//!
+//! Reads `<run-dir>/events.jsonl`, which the dispatcher writes when
+//! the manifest sets `[run].emit_event_stream = true`. Defaults to a
+//! compact one-line-per-envelope render so an operator can scan a
+//! sub-lead lifecycle / worker-failure / approval trail without
+//! parsing JSON. `--json` passes the file through verbatim (NDJSON)
+//! for piping into `jq`.
+//!
+//! Resolution: the `<run-id>` argument accepts the full UUID or any
+//! unique prefix (same convention as `pitboss status`).
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Result};
+
+use crate::control::protocol::{ControlEvent, EventEnvelope};
+
+/// Entry point for the `events` subcommand.
+pub fn run(run_id_prefix: &str, json: bool, run_dir_override: Option<PathBuf>) -> Result<i32> {
+    let base = run_dir_override.unwrap_or_else(default_runs_dir);
+    let run_dir = crate::runs::resolve_run_dir_by_prefix(&base, run_id_prefix)?;
+    let events_path = run_dir.join("events.jsonl");
+
+    let file = match std::fs::File::open(&events_path) {
+        Ok(f) => f,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            bail!(
+                "no events.jsonl in {}; either the run has not emitted any \
+                 envelopes yet or `[run].emit_event_stream` was not set on the \
+                 manifest. Re-dispatch with the flag enabled to capture the \
+                 control-event stream.",
+                run_dir.display(),
+            );
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    let reader = BufReader::new(file);
+    let mut stdout = std::io::stdout().lock();
+
+    if json {
+        // Passthrough mode: copy the file verbatim. We re-stream
+        // through `BufReader::lines` rather than `std::io::copy` so
+        // an incomplete trailing line (a partial write caught mid-
+        // flush) gets dropped, matching the canonical reader's
+        // semantics elsewhere in the codebase.
+        for line in reader.lines() {
+            let line = line?;
+            stdout.write_all(line.as_bytes())?;
+            stdout.write_all(b"\n")?;
+        }
+        return Ok(0);
+    }
+
+    let mut parsed = 0usize;
+    let mut skipped = 0usize;
+    for line in reader.lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<EventEnvelope>(&line) {
+            Ok(envelope) => {
+                writeln!(stdout, "{}", format_envelope(&envelope))?;
+                parsed += 1;
+            }
+            Err(_) => skipped += 1,
+        }
+    }
+
+    if skipped > 0 {
+        // Don't fail — operators piping into `wc` or grep don't want
+        // an exit code change for a partial-write tail. Log to stderr
+        // so the diagnostic is still visible.
+        eprintln!(
+            "pitboss events: skipped {skipped} malformed line(s); rendered {parsed} envelope(s)",
+        );
+    }
+    Ok(0)
+}
+
+/// Render one envelope as a single fixed-width line. Format:
+///
+/// ```text
+/// seq=NNNN  <actor_path>  <event_kind>  <detail>
+/// ```
+///
+/// Widths are chosen so a typical hierarchical run with a small
+/// number of sub-leads aligns cleanly without forcing word-wrap on
+/// an 80-column terminal. Long detail strings (e.g. approval
+/// summaries) extend past the right edge — same trade-off `pitboss
+/// status` makes for `final_message_preview`.
+fn format_envelope(envelope: &EventEnvelope) -> String {
+    let actor_path = if envelope.actor_path.is_empty() {
+        "/".to_string()
+    } else {
+        // ActorPath has a `Display` impl that uses `→` as the
+        // separator (matches TUI rendering). For a CLI render we
+        // prefer Unix-path-style separators so the output looks
+        // grep-friendly. Walk the inner Vec directly.
+        format!("/{}", envelope.actor_path.0.join("/"))
+    };
+    let (kind, detail) = describe_event(&envelope.event);
+    format!(
+        "seq={:>4}  {:<24}  {:<20}  {}",
+        envelope.seq, actor_path, kind, detail,
+    )
+}
+
+/// Per-variant one-liner. Keep this in lockstep with the
+/// `#[serde(tag = "event", rename_all = "snake_case")]` discriminator
+/// values on `ControlEvent` so the rendered `kind` column matches
+/// what an operator sees in the raw JSON.
+fn describe_event(event: &ControlEvent) -> (&'static str, String) {
+    match event {
+        ControlEvent::Hello { .. } => ("hello", String::new()),
+        ControlEvent::OpAcked { op, task_id } => (
+            "op_acked",
+            match task_id {
+                Some(t) => format!("op={op} task_id={t}"),
+                None => format!("op={op}"),
+            },
+        ),
+        ControlEvent::OpFailed { op, task_id, error } => (
+            "op_failed",
+            match task_id {
+                Some(t) => format!("op={op} task_id={t} error={error}"),
+                None => format!("op={op} error={error}"),
+            },
+        ),
+        ControlEvent::OpUnknown { op } => ("op_unknown", format!("op={op}")),
+        ControlEvent::OpUnknownState {
+            op,
+            task_id,
+            current_state,
+        } => (
+            "op_unknown_state",
+            format!("op={op} task_id={task_id} state={current_state}"),
+        ),
+        ControlEvent::ApprovalRequest {
+            request_id,
+            task_id,
+            summary,
+            kind,
+            ..
+        } => (
+            "approval_request",
+            format!(
+                "request_id={request_id} task_id={task_id} kind={kind:?} summary={:?}",
+                summary,
+            ),
+        ),
+        ControlEvent::WorkersSnapshot { workers } => (
+            "workers_snapshot",
+            format!("worker_count={}", workers.len()),
+        ),
+        ControlEvent::Superseded => ("superseded", String::new()),
+        ControlEvent::RunFinished { summary } => (
+            "run_finished",
+            format!(
+                "tasks_total={} tasks_failed={}",
+                summary.tasks_total, summary.tasks_failed,
+            ),
+        ),
+        ControlEvent::StoreActivity { counters } => {
+            ("store_activity", format!("actor_count={}", counters.len()))
+        }
+        ControlEvent::SubleadSpawned {
+            sublead_id,
+            budget_usd,
+            max_workers,
+            read_down,
+            ..
+        } => (
+            "sublead_spawned",
+            format!(
+                "sublead_id={sublead_id} budget_usd={} max_workers={} read_down={read_down}",
+                budget_usd
+                    .map(|v| format!("{v:.2}"))
+                    .unwrap_or_else(|| "shared".into()),
+                max_workers
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| "shared".into()),
+            ),
+        ),
+        ControlEvent::WorkerFailed {
+            task_id,
+            parent_task_id,
+            reason,
+        } => (
+            "worker_failed",
+            match parent_task_id {
+                Some(p) => format!("task_id={task_id} parent={p} reason={reason:?}"),
+                None => format!("task_id={task_id} reason={reason:?}"),
+            },
+        ),
+        ControlEvent::SubleadTerminated {
+            sublead_id,
+            spent_usd,
+            unspent_usd,
+            ..
+        } => (
+            "sublead_terminated",
+            format!(
+                "sublead_id={sublead_id} spent_usd={spent_usd:.4} unspent_usd={unspent_usd:.4}"
+            ),
+        ),
+    }
+}
+
+fn default_runs_dir() -> PathBuf {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/"))
+        .join(".local/share/pitboss/runs")
+}
+
+/// Test helper exposed so `events::run`-equivalent integration tests
+/// don't have to re-implement the resolve+open+render pipeline. Not
+/// used by `main.rs`.
+#[doc(hidden)]
+pub fn render_to_string(events_path: &Path, json: bool) -> Result<String> {
+    let file = std::fs::File::open(events_path)?;
+    let reader = BufReader::new(file);
+    let mut out = String::new();
+    if json {
+        for line in reader.lines() {
+            let line = line?;
+            out.push_str(&line);
+            out.push('\n');
+        }
+        return Ok(out);
+    }
+    for line in reader.lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<EventEnvelope>(&line) {
+            Ok(envelope) => {
+                out.push_str(&format_envelope(&envelope));
+                out.push('\n');
+            }
+            Err(_) => continue,
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::control::protocol::{ApprovalKind, ControlEvent};
+    use crate::dispatch::actor::ActorPath;
+    use pitboss_core::store::FailureReason;
+    use tempfile::TempDir;
+
+    fn write_events(dir: &Path, envelopes: &[EventEnvelope]) -> PathBuf {
+        let path = dir.join("events.jsonl");
+        let mut content = String::new();
+        for env in envelopes {
+            content.push_str(&serde_json::to_string(env).unwrap());
+            content.push('\n');
+        }
+        std::fs::write(&path, content).unwrap();
+        path
+    }
+
+    #[test]
+    fn render_formats_envelopes_into_columns() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_events(
+            tmp.path(),
+            &[
+                EventEnvelope {
+                    actor_path: ActorPath::default(),
+                    seq: 1,
+                    event: ControlEvent::Superseded,
+                },
+                EventEnvelope {
+                    actor_path: ActorPath::default(),
+                    seq: 2,
+                    event: ControlEvent::SubleadSpawned {
+                        sublead_id: "sub-1".into(),
+                        budget_usd: Some(0.5),
+                        lead_budget_usd: None,
+                        max_workers: Some(2),
+                        read_down: false,
+                    },
+                },
+                EventEnvelope {
+                    actor_path: ActorPath::new(["root", "sub-1"]),
+                    seq: 3,
+                    event: ControlEvent::WorkerFailed {
+                        task_id: "w-1".into(),
+                        parent_task_id: Some("sub-1".into()),
+                        reason: FailureReason::AuthFailure,
+                    },
+                },
+            ],
+        );
+
+        let out = render_to_string(&path, false).unwrap();
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 3, "rendered: {out}");
+        assert!(lines[0].contains("seq=   1"), "first: {}", lines[0]);
+        assert!(lines[0].contains("superseded"));
+        assert!(lines[1].contains("sublead_spawned"));
+        assert!(lines[1].contains("sublead_id=sub-1"));
+        assert!(lines[1].contains("budget_usd=0.50"));
+        assert!(lines[2].contains("worker_failed"));
+        assert!(lines[2].contains("/root/sub-1"));
+        assert!(lines[2].contains("AuthFailure"));
+    }
+
+    #[test]
+    fn json_mode_passes_lines_through_verbatim() {
+        let tmp = TempDir::new().unwrap();
+        let env = EventEnvelope {
+            actor_path: ActorPath::default(),
+            seq: 7,
+            event: ControlEvent::ApprovalRequest {
+                request_id: "r-1".into(),
+                task_id: "t-1".into(),
+                summary: "run cargo test".into(),
+                plan: None,
+                kind: ApprovalKind::Action,
+            },
+        };
+        let raw = serde_json::to_string(&env).unwrap();
+        let path = tmp.path().join("events.jsonl");
+        std::fs::write(&path, format!("{raw}\n")).unwrap();
+
+        let out = render_to_string(&path, true).unwrap();
+        assert_eq!(out, format!("{raw}\n"));
+    }
+
+    #[test]
+    fn render_skips_malformed_lines() {
+        let tmp = TempDir::new().unwrap();
+        let valid = serde_json::to_string(&EventEnvelope {
+            actor_path: ActorPath::default(),
+            seq: 1,
+            event: ControlEvent::Superseded,
+        })
+        .unwrap();
+        let path = tmp.path().join("events.jsonl");
+        // Truncated partial write at the head, valid line at the tail.
+        std::fs::write(&path, format!("{{\"truncated\":\n{valid}\n")).unwrap();
+
+        let out = render_to_string(&path, false).unwrap();
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].contains("superseded"));
+    }
+
+    #[test]
+    fn missing_file_gives_operator_friendly_error() {
+        let tmp = TempDir::new().unwrap();
+        let run_id = uuid::Uuid::now_v7().to_string();
+        std::fs::create_dir_all(tmp.path().join(&run_id)).unwrap();
+        let err = run(&run_id, false, Some(tmp.path().to_path_buf())).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("emit_event_stream"),
+            "error should hint at the manifest flag: {msg}",
+        );
+    }
+}

--- a/crates/pitboss-cli/src/lib.rs
+++ b/crates/pitboss-cli/src/lib.rs
@@ -13,6 +13,7 @@ pub mod communication;
 pub mod control;
 pub mod diff;
 pub mod dispatch;
+pub mod events;
 pub mod list;
 pub mod manifest;
 pub mod mcp;

--- a/crates/pitboss-cli/src/main.rs
+++ b/crates/pitboss-cli/src/main.rs
@@ -2,8 +2,8 @@ use anyhow::Result;
 use clap::Parser;
 
 use pitboss_cli::{
-    agents_md, analyze, attach, capability_matrix, cli, diff, dispatch, list, manifest, mcp, prune,
-    status, tree,
+    agents_md, analyze, attach, capability_matrix, cli, diff, dispatch, events, list, manifest,
+    mcp, prune, status, tree,
 };
 
 use cli::{Cli, Command};
@@ -93,6 +93,13 @@ fn main() -> Result<()> {
             json,
         } => {
             std::process::exit(status::run(&run_id, json, run_dir)?);
+        }
+        Command::Events {
+            run_id,
+            run_dir,
+            json,
+        } => {
+            std::process::exit(events::run(&run_id, json, run_dir)?);
         }
         Command::Analyze {
             run_id,


### PR DESCRIPTION
## Summary

New \`pitboss events <run-id>\` subcommand to print the persisted control-event stream for a run. Reads \`<run-dir>/events.jsonl\` (written by PR-G/H when \`[run].emit_event_stream = true\`) and renders a compact one-line-per-envelope summary by default. \`--json\` passes the file through as NDJSON for piping into \`jq\`.

\`\`\`
$ pitboss events 01950abc
seq=   1  /                         superseded
seq=   2  /                         sublead_spawned   sublead_id=sub-1 budget_usd=0.50 max_workers=2 read_down=false
seq=   3  /root/sub-1               worker_failed     task_id=w-1 parent=sub-1 reason=AuthFailure
seq=   4  /root/sub-1/lead          approval_request  request_id=r-1 task_id=t-1 kind=Action summary=\"run cargo test\"

$ pitboss events 01950abc --json | jq 'select(.event == \"worker_failed\")'
\`\`\`

### Design notes
- Run-id resolution: full UUID or unique prefix via the existing \`runs::resolve_run_dir_by_prefix\`, same convention as \`status\`/\`list\`/\`prune\`.
- Missing \`events.jsonl\` yields an operator-friendly error that hints at the manifest flag rather than a bare IO error.
- Malformed lines (partial writes caught mid-flush) are skipped with a stderr note; exit code stays 0 so \`grep\`/\`wc\` consumers aren't disrupted.
- Default formatter uses Unix-path actor-path syntax (\`/root/sub-1/lead\`) rather than the TUI's \`→\` separator — grep-friendlier.
- No \`--follow\` mode in this PR; deferred as a follow-up that can build on the existing \`tail_run_stream\` plumbing from #438 PR-E once \`events.jsonl\` joins the unified stream.

## Test plan
- [x] 4 new unit tests in \`events::tests\` — formatted output, \`--json\` passthrough, malformed-line skipping, missing-file friendly error
- [x] \`cargo test --workspace --features pitboss-core/test-support\` — 187/188 core pass (1 pre-existing macOS \`/bin/true\` flake), all CLI/web/tui pass
- [x] \`cargo lint\` clean
- [x] \`cargo tidy\` clean
- [x] Manual smoke (release binary): renders 4-event fixture correctly, \`--json\` passes through, unknown-prefix and missing-file produce the right errors

## Stack position

Sits on top of PR-I (#452) in the #259 sequence. After this lands, the only remaining #259 follow-ups are the SPA replay tab and the AGENTS.md documentation update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Note:** supersedes #453 (auto-closed when the parent stack PR's branch was deleted). Same content, rebased onto main.