### PR TITLE
refactor(cli): route status + diff through unified replay stream (#438, PR-M)

### DIFF
--- a/crates/pitboss-cli/src/diff.rs
+++ b/crates/pitboss-cli/src/diff.rs
@@ -41,11 +41,13 @@ pub fn resolve_run_under(base: &Path, id_or_prefix: &str) -> Result<PathBuf> {
 /// `summary.jsonl` and constructing a partial `RunSummary` with
 /// `was_interrupted = true`.
 pub fn load_summary(run_dir: &Path) -> Result<RunSummary> {
-    // Canonical reader (#437): if `summary.json` parsed cleanly, return
-    // it directly. Otherwise reconstruct from the deduped task map +
-    // `meta.json`.
-    let snap = pitboss_core::store::read_run_snapshot(run_dir);
-    if let Some(summary) = snap.run_summary {
+    // Canonical reader (#437 + #438 Step 4): drain the unified replay
+    // stream and bin items back into `(tasks, summary?)`. The Finalized
+    // lifecycle carries the run-wide `RunSummary` when `summary.json`
+    // exists; an absent lifecycle is the in-progress fast-path that
+    // falls through to the meta.json synthesis below.
+    let (tasks, summary) = collect_replay(run_dir)?;
+    if let Some(summary) = summary {
         return Ok(summary);
     }
 
@@ -56,7 +58,6 @@ pub fn load_summary(run_dir: &Path) -> Result<RunSummary> {
             run_dir.display()
         );
     }
-    let tasks: Vec<pitboss_core::store::TaskRecord> = snap.tasks.into_values().collect();
     let tasks_failed = tasks
         .iter()
         .filter(|t| !matches!(t.status, pitboss_core::store::TaskStatus::Success))
@@ -101,6 +102,39 @@ pub fn load_summary(run_dir: &Path) -> Result<RunSummary> {
         tasks,
         spend_breakdown: None,
     })
+}
+
+/// Drain `open_run_stream(ReplayOnly)` into `(tasks, finalized_summary?)`.
+/// Inline adapter — same rationale as `status::collect_replay`. Two
+/// call sites doesn't meet rule-of-three for promoting to
+/// `pitboss-core`.
+fn collect_replay(
+    run_dir: &Path,
+) -> Result<(Vec<pitboss_core::store::TaskRecord>, Option<RunSummary>)> {
+    use futures_util::StreamExt;
+    use pitboss_core::stream::{open_run_stream, LifecycleEvent, RunStreamPayload, StreamMode};
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    let items = rt.block_on(async {
+        open_run_stream(run_dir, StreamMode::ReplayOnly)
+            .collect::<Vec<_>>()
+            .await
+    });
+
+    let mut tasks = Vec::with_capacity(items.len());
+    let mut summary = None;
+    for item in items {
+        match item.payload {
+            RunStreamPayload::Task(t) => tasks.push(*t),
+            RunStreamPayload::Lifecycle(LifecycleEvent::Finalized { summary: s }) => {
+                summary = Some(*s);
+            }
+            RunStreamPayload::Lifecycle(LifecycleEvent::Started { .. }) => {}
+        }
+    }
+    Ok((tasks, summary))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/pitboss-cli/src/status.rs
+++ b/crates/pitboss-cli/src/status.rs
@@ -24,16 +24,13 @@ pub fn run(run_id_prefix: &str, json: bool, run_dir_override: Option<PathBuf>) -
         );
     }
 
-    // Canonical reader (#437): summary.json seeds, summary.jsonl
-    // overlays last-wins by task_id. `notify_failures` is only present
-    // on a finalized `summary.json`; in-flight runs report None — that's
-    // correct (the count is only authoritative at finalize), and the
-    // journaled `notifications.jsonl` is still available for live
-    // debugging. Reprompt / cancel / respawn lifecycles no longer
-    // over-count tasks_total (#437).
-    let snap = pitboss_core::store::read_run_snapshot(&run_dir);
-    let notify_failures = snap.run_summary.as_ref().and_then(|s| s.notify_failures);
-    let records: Vec<pitboss_core::store::TaskRecord> = snap.tasks.into_values().collect();
+    // Canonical reader (#437 + #438): consume the unified replay stream
+    // and bin items back into `(records, notify_failures)`. `notify_failures`
+    // only appears on a finalized run (`Finalized` lifecycle); in-flight
+    // runs report None — that's correct (the count is only authoritative
+    // at finalize), and the journaled `notifications.jsonl` is still
+    // available for live debugging.
+    let (records, notify_failures) = collect_replay(&run_dir)?;
 
     if json {
         let out = serde_json::to_string_pretty(&records)?;
@@ -56,6 +53,40 @@ pub fn run(run_id_prefix: &str, json: bool, run_dir_override: Option<PathBuf>) -
     )?;
 
     Ok(0)
+}
+
+/// Drain `open_run_stream(ReplayOnly)` into the snapshot shape this
+/// renderer expects. The unified API replaces the legacy
+/// `read_run_snapshot` call (#438 Step 4): same on-disk reader under
+/// the hood, but routes the data through the consumer-facing stream so
+/// `status` stays API-aligned with the TUI and SPA. Inline rather than
+/// promoted to `pitboss-core` because `diff` is the only other site
+/// and rule-of-three isn't met yet.
+fn collect_replay(run_dir: &Path) -> Result<(Vec<pitboss_core::store::TaskRecord>, Option<u32>)> {
+    use futures_util::StreamExt;
+    use pitboss_core::stream::{open_run_stream, LifecycleEvent, RunStreamPayload, StreamMode};
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    let items = rt.block_on(async {
+        open_run_stream(run_dir, StreamMode::ReplayOnly)
+            .collect::<Vec<_>>()
+            .await
+    });
+
+    let mut records = Vec::with_capacity(items.len());
+    let mut notify_failures = None;
+    for item in items {
+        match item.payload {
+            RunStreamPayload::Task(t) => records.push(*t),
+            RunStreamPayload::Lifecycle(LifecycleEvent::Finalized { summary }) => {
+                notify_failures = summary.notify_failures;
+            }
+            RunStreamPayload::Lifecycle(LifecycleEvent::Started { .. }) => {}
+        }
+    }
+    Ok((records, notify_failures))
 }
 
 /// Count `tool_denied` rows in each task's `<run_dir>/tasks/<id>/events.jsonl`.


### PR DESCRIPTION
## Summary
- `pitboss status` and `pitboss diff` now consume `open_run_stream(StreamMode::ReplayOnly)` instead of calling `read_run_snapshot` directly.
- Same on-disk reader under the hood — this is **API alignment** with the TUI (which already consumes the unified stream via \`tail_run_stream\`), not a behavior change.
- Inline \`collect_replay\` adapters bin items back into the snapshot shape each renderer expects (2 sites; under rule-of-three for a shared helper).
- Closes the CLI half of #438 Step 4. Web migration follows in PR-O after PR-N implements the live-socket transport.

## Deliberately NOT migrated

These were considered and excluded to avoid regressing perf or adding boilerplate for zero gain:

- \`runs.rs::collect_run_entries\` — hot path of \`pitboss list\`; per-run runtime + stream allocation per directory entry would regress.
- \`analyze.rs\` — batch aggregator over many runs; inherits the same perf concern.
- \`attach.rs\` — tails \`tasks/<id>/stdout.log\`, not run-summary data.
- \`dispatch/hierarchical.rs::finalize\` — rare resume-time read.

## Test plan
- [x] \`cargo test -p pitboss-cli --lib status::\` — 13 tests pass
- [x] \`cargo test -p pitboss-cli --lib diff::\` — 6 tests pass
- [x] \`cargo clippy -p pitboss-cli --all-targets --all-features -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [x] Full \`cargo test -p pitboss-cli --features pitboss-core/test-support\` — all targeted tests green; two known macOS parallel-load flakes (\`webhook_dns_failure_surfaces_in_summary_notify_failures\`, \`e2e_lead_request_approval_round_trip\`) pass deterministically when run in isolation. CI on Linux is ground truth per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)