### PR TITLE
feat(control): subscriber-mode client handshake for multi-consumer streams (#438, PR-P)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -958,6 +958,48 @@ source or debugging connection issues should know the contract.
 
 ---
 
+## Control socket protocol (v0.14+)
+
+Each run also stands up a **control socket** distinct from the MCP
+socket. It's a per-run Unix socket carrying line-delimited JSON ops
+(`ControlOp`) and event envelopes (`EventEnvelope` wrapping
+`ControlEvent`). The TUI, the web SSE bridge, `pitboss-core::stream`'s
+live transport, and any future consumer that wants to read the live
+event stream all attach over this socket.
+
+### Socket
+
+- Path: `$XDG_RUNTIME_DIR/pitboss/<run_id>.control.sock` (preferred),
+  or fallback `<run_dir>/<run_id>/control.sock`. Resolved by
+  `pitboss_cli::control::control_socket_path` (re-exported as
+  `pitboss_core::control_protocol::resolve_control_socket`).
+- Bound by `start_control_server` at dispatch start, removed when the
+  `ControlServerHandle` drops.
+
+### Handshake: `Hello { client_version, mode }`
+
+Every client MUST send `ControlOp::Hello` as its first line. The
+`mode: ClientMode` field selects the connection role:
+
+| `mode` | Role | Behavior |
+|---|---|---|
+| `"writer"` (default, elided on the wire) | TUI / `pitboss-web::control_bridge::send_op` / any client that sends mutating ops | Takes the single `control_writer` slot, displacing any prior writer with a `Superseded` event. Receives the queued-approval drain + bridge replay. |
+| `"subscriber"` | `pitboss-core::stream::drive_live`; any read-only mirror | Does NOT take the writer slot — coexists with one writer + any number of other subscribers. Skips approval-drain / bridge-replay (subscribers can't respond). Writer ops are rejected up-front with `OpFailed { error: "subscriber mode forbids writer ops" }`. |
+
+Pre-v0.14 clients send `Hello` without `mode`; `#[serde(default)]`
+deserializes them as `Writer`, preserving byte-identical wire and
+historical semantics. Subscriber connections may send `Hello` (no-op
+ack) and `Subscribe { since_seq }` (advisory subscribe ack from
+PR-N); every other op returns `OpFailed`.
+
+The dispatcher fans out broadcast envelopes (`broadcast_control_event`)
+to every connected client — writer and all subscribers — via the
+per-run `events_tx: broadcast::Sender<EventEnvelope>`. Connection-scoped
+envelopes (op replies, `store_activity` ticks, queued-approval drain)
+go only to the originating connection.
+
+---
+
 ## The MCP tools the lead has
 
 When running hierarchical, the lead's `--allowedTools` is automatically

--- a/book/src/architecture/unified-envelope-api.md
+++ b/book/src/architecture/unified-envelope-api.md
@@ -30,7 +30,8 @@ This is a research/design issue. Landing it produces:
 - PR-A–PR-F shipped the disk-side foundation and the TUI cutover.
 - **PR-N (#464) shipped the live-socket transport** for `StreamMode::LiveOnly` and `StreamMode::ReplayThenLive`, plus the `Subscribe { since_seq }` op.
 - **PR-M (#463) shipped the CLI cold-path migration** for `status` and `diff`.
-- The web SSE bridge migration is blocked on a dispatcher-side change — see the [Web migration](#2-web-pitboss-web) section for the gap and two unblocking options.
+- **PR-P shipped subscriber-mode client handshakes** — `ControlOp::Hello` gained a `mode: ClientMode` field. Subscriber connections coexist with one writer instead of displacing it, unblocking the web SSE bridge migration.
+- The actual web SSE bridge cutover is tracked as the PR-Q follow-on — the constraint that gated it is resolved; the migration itself is the remaining work.
 
 ## Sum type: `RunStreamItem`
 
@@ -150,9 +151,39 @@ Server behavior (as shipped):
 
 - The dispatcher accepts `Subscribe { since_seq: N }` and replies with `OpAcked { op: "subscribe" }`. The `since_seq` value is **advisory** today — the server does not yet do a fast-forward over its in-memory broadcast tail. New envelopes flow through the existing bus → mpsc → socket pipeline from the moment the subscribe ack is sent.
 - Consumer-side reconciliation handles the small race window between disk-replay-EOF and live subscribe. `ReplayThenLive` clients dedupe arriving live events against what they already saw on disk (via `EventEnvelope.seq`).
-- Single-client slot collision behavior (today's `Superseded`) is unchanged.
 
 Server-side fast-forward is a future optimization. The shape of the op was pinned in PR-N so a future PR can drop in the fast-forward semantics without changing the wire — the protocol field is already there.
+
+## Client-mode handshake: `Hello { mode }`
+
+PR-P of #438 extended `ControlOp::Hello` with a `mode: ClientMode` field:
+
+```rust
+enum ControlOp {
+    Hello {
+        client_version: String,
+        #[serde(default, skip_serializing_if = "is_default_client_mode")]
+        mode: ClientMode,
+    },
+    // ...
+}
+
+enum ClientMode {
+    Writer,      // default; pre-PR-P behavior
+    Subscriber,  // read-only; never displaces a writer
+}
+```
+
+`Writer` is the default; pre-PR-P clients (no `mode` field on the wire) deserialize as `Writer` so the historical single-client-slot behavior — including `Superseded` on displacement — is byte-identical. The field is elided on the wire when `Writer`.
+
+`Subscriber` connections:
+
+- Skip the `control_writer`-slot install entirely (no displacement of a prior writer, no `Superseded` emission, no LOAD-BEARING `writer_id` cleanup).
+- Skip the approval-queue drain and approval-bridge replay (approvals require a responder; subscribers can't `Approve` so there's nothing to replay).
+- Still attach to the per-run `events_tx: broadcast::Sender<EventEnvelope>` bus via the same per-connection bus-bridge writers use — so every `broadcast_control_event` fan-out reaches every subscriber.
+- Reject writer ops in the read loop with a typed `OpFailed { op, error: "subscriber mode forbids writer ops" }` before they reach `dispatch_op`. Only `Hello` (handshake echo) and `Subscribe { since_seq }` are accepted.
+
+`pitboss-core::stream::drive_live` announces `"mode":"subscriber"` in its Hello — every unified-API consumer is non-displacing by construction. Multiple unified-API consumers (TUI, web SSE handler, a CLI `pitboss tail`) can attach to the same run concurrently without touching the writer slot.
 
 ## API surface
 
@@ -207,14 +238,13 @@ The TUI slice keeps the ad-hoc reader for per-actor `tasks/<id>/events.jsonl` (d
 
 `control_bridge.rs` becomes a `ReplayThenLive` consumer per run, fanning out to SSE clients. The historical readers in `api/runs.rs`, `api/events.rs`, and `insights/aggregator.rs` become `ReplayOnly` consumers. The on-the-wire SSE shape is unchanged — the migration is internal.
 
-**Blocked on the single-control_writer constraint (discovered during PR-O implementation, #438 Step 4).** The dispatcher's `serve_connection` binds each accepted client into the `control_writer` slot, displacing any prior client with a `Superseded` event. Today's `control_bridge` holds the slot for the lifetime of the run and fans events out to SSE clients via a broadcast channel; `send_op` reuses the same connection's write half. Cutting the read side over to `open_run_stream(ReplayThenLive)` would make the unified API client a second simultaneous control client — every POST to `/api/runs/:id/control` would supersede it (and vice versa).
+The single-`control_writer`-slot constraint that originally blocked this migration (`serve_connection` superseding the previous client on every accept) is resolved by **PR-P**. `ControlOp::Hello` now carries an optional `mode: ClientMode` field; subscriber-mode clients skip the writer-slot install, the approval-queue drain, and the bridge replay. Multiple subscribers coexist with one writer over the broadcast bus — exactly the topology this migration needs. `pitboss-core::stream::drive_live` already announces `"mode":"subscriber"` in its Hello, so any `open_run_stream(LiveOnly | ReplayThenLive)` consumer is non-displacing by construction.
 
-Two ways to unblock:
+The remaining work (PR-Q) is the actual web cutover:
 
-- **Dispatcher feature**: add a "subscribe-only" client mode that does not bind the writer slot. The unified-API consumer would announce this in its handshake (e.g., a new field on `ControlOp::Hello` or a separate op). Multiple subscribe-only clients can coexist with one writer; the existing single-writer invariant is preserved. This is the cleaner end state.
-- **`pitboss-core::stream` writer support**: lift `pitboss-cli::stream::open_run_session`'s read + write split down into `pitboss-core::stream`, exposing a `RunStreamSession { stream, writer }` with a type-erased writer. `control_bridge.rs` then collapses into a thin fan-out over one session per run. Tracked as adjacent work; doesn't require a dispatcher change.
-
-Until one of these lands, the web SSE bridge stays on `control_bridge.rs`'s direct UnixStream usage. The historical readers in `api/runs.rs` are all already short-circuit reads of single files (manifest, resolved, summary) and don't benefit from `open_run_stream`. `insights/aggregator.rs` was evaluated for migration; the per-run overhead of spawning a tokio task and draining an mpsc channel for what is otherwise a sync `read_run_snapshot` call makes it a perf regression at the scale the aggregator runs (hundreds of run dirs). The migration is correct but unprofitable, and is deferred.
+- The SSE handler reads from `open_run_stream(ReplayThenLive)` per run, fan-out unchanged.
+- `control_bridge.rs` shrinks to a writer-only single-connection shim for `send_op` (still in `Writer` mode — only one writer is needed per run).
+- The historical readers in `api/runs.rs` are short-circuit reads of single files (manifest, resolved, summary) and don't benefit from `open_run_stream` — they stay on `read_run_snapshot`. `insights/aggregator.rs` was evaluated; the per-run overhead of spawning a tokio task and draining an mpsc channel for what is otherwise a sync `read_run_snapshot` call makes it a perf regression at the scale the aggregator runs (hundreds of run dirs). The migration there is correct but unprofitable, and is deferred.
 
 ### 3. CLI one-shots (`status`, `diff`, `list`, dispatch finalize)
 

--- a/crates/pitboss-cli/src/control/protocol.rs
+++ b/crates/pitboss-cli/src/control/protocol.rs
@@ -130,6 +130,29 @@ fn is_zero_u64(v: &u64) -> bool {
     *v == 0
 }
 
+/// Selects whether a control-socket client wants to write ops (default,
+/// pre-v0.14 behavior) or only read the broadcast envelope stream.
+///
+/// Added in PR-P of #438 to unblock multi-consumer access to a run's live
+/// envelope stream. The dispatcher's `control_writer` slot is single-tenant:
+/// every newly-accepted writer client supersedes the previous one with a
+/// `Superseded` event. A second control-plane consumer (the web SSE bridge,
+/// a TUI mirror, etc.) used to be impossible to attach without displacing
+/// the in-use writer. With `Subscriber` mode, the dispatcher skips the
+/// writer-slot install and fans out the broadcast bus to any number of
+/// concurrent subscribers.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ClientMode {
+    #[default]
+    Writer,
+    Subscriber,
+}
+
+fn is_default_client_mode(m: &ClientMode) -> bool {
+    matches!(m, ClientMode::Writer)
+}
+
 /// An operation sent from the TUI (client) to the dispatcher (server).
 ///
 /// Note: `Eq` is NOT derived — `UpdatePolicy` carries `Vec<ApprovalRule>`,
@@ -140,6 +163,13 @@ fn is_zero_u64(v: &u64) -> bool {
 pub enum ControlOp {
     Hello {
         client_version: String,
+        /// Optional client-mode discriminator. Absent on the wire for
+        /// pre-v0.14 clients — `#[serde(default)]` yields `Writer`,
+        /// matching the historical single-client behavior. Subscriber
+        /// mode opts the client out of the dispatcher's writer slot;
+        /// see [`ClientMode`].
+        #[serde(default, skip_serializing_if = "is_default_client_mode")]
+        mode: ClientMode,
     },
     CancelWorker {
         task_id: String,
@@ -366,9 +396,35 @@ mod tests {
         assert_eq!(
             op,
             ControlOp::Hello {
-                client_version: "0.4.0".into()
+                client_version: "0.4.0".into(),
+                mode: ClientMode::Writer,
             }
         );
+    }
+
+    /// PR-P of #438: subscriber-mode hello deserializes and round-trips.
+    #[test]
+    fn hello_op_subscriber_mode_roundtrips() {
+        let op = ControlOp::Hello {
+            client_version: "pitboss-core/0.14.0".into(),
+            mode: ClientMode::Subscriber,
+        };
+        let s = serde_json::to_string(&op).unwrap();
+        assert!(s.contains("\"mode\":\"subscriber\""), "{s}");
+        assert_eq!(roundtrip_op(&op), op);
+    }
+
+    /// PR-P back-compat: default `Writer` mode is elided on the wire, so
+    /// pre-PR-P fixtures (`{"op":"hello","client_version":"0.4.0"}`)
+    /// stay byte-identical.
+    #[test]
+    fn hello_op_writer_mode_elided_on_wire() {
+        let op = ControlOp::Hello {
+            client_version: "0.4.0".into(),
+            mode: ClientMode::Writer,
+        };
+        let s = serde_json::to_string(&op).unwrap();
+        assert_eq!(s, r#"{"op":"hello","client_version":"0.4.0"}"#);
     }
 
     #[test]

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -20,7 +20,7 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 
-use crate::control::protocol::{ControlEvent, ControlOp, EventEnvelope};
+use crate::control::protocol::{ClientMode, ControlEvent, ControlOp, EventEnvelope};
 use crate::dispatch::actor::ActorPath;
 
 /// Handle returned from `start_control_server`. Drop terminates the accept loop
@@ -155,8 +155,8 @@ async fn serve_connection(
         Ok(Some(line)) => line,
         _ => return,
     };
-    match serde_json::from_str::<ControlOp>(&first) {
-        Ok(ControlOp::Hello { .. }) => {}
+    let client_mode = match serde_json::from_str::<ControlOp>(&first) {
+        Ok(ControlOp::Hello { mode, .. }) => mode,
         Ok(other) => {
             let _ = send_event(
                 &writer,
@@ -183,7 +183,7 @@ async fn serve_connection(
             .await;
             return;
         }
-    }
+    };
 
     // Snapshot the current worker set *after* receiving the client Hello,
     // not at accept time. Any worker that spawned between accept and this
@@ -218,125 +218,143 @@ async fn serve_connection(
     )
     .await;
 
-    // Install this connection as the control_writer (displace any prior).
-    //
-    // LOAD-BEARING: the connection-unique `writer_id` is checked by the
-    // disconnect cleanup block at the bottom of this function before it
-    // clears `state.root.control_writer`. Without that id-match guard,
-    // a TUI that reconnects in the narrow window between this read loop
-    // exiting and the cleanup block running would have its own writer
-    // slot silently cleared by the previous connection's cleanup —
-    // leading to a connected TUI that receives no events with no
-    // diagnostic surface. **Do not remove the writer_id field, the slot
-    // assignment, or the id-match check at the disconnect site without
-    // first introducing an equivalent reconnect-safety mechanism.**
-    let writer_id = uuid::Uuid::now_v7();
     // PR-G of #259: channel carries fully-wrapped envelopes (seq +
     // persistence already done at the broadcast site). The pump
-    // serializes; no wrap step.
+    // serializes; no wrap step. Both writer and subscriber connections
+    // need the channel — the bus-bridge / pump / activity-pump all push
+    // through it, and subscribers are exactly read-only consumers of
+    // the same fan-out.
     let (ev_tx, mut ev_rx) = tokio::sync::mpsc::channel::<EventEnvelope>(
         crate::dispatch::layer::CONTROL_EVENT_QUEUE_CAP,
     );
-    {
-        let mut cw = state.root.control_writer.lock().await;
-        if let Some(old) = cw.take() {
-            // `try_send` fails when the prior connection's outbound
-            // queue is already full — its TUI is unresponsive or its
-            // socket is wedged. Log the drop so the silent failure is
-            // observable: the displaced TUI will not learn it was
-            // superseded and may keep rendering stale tiles until its
-            // socket EOFs. (#152 M1)
-            let superseded = wrap_with_seq(&state.event_log, &ControlEvent::Superseded);
-            state.event_log.persist(&superseded).await;
-            if let Err(e) = old.sender.try_send(superseded) {
-                tracing::warn!(
-                    new_writer_id = %writer_id,
-                    error = %e,
-                    "could not deliver Superseded to displaced TUI; \
-                     prior connection's queue full or closed"
+
+    // Writer-mode-only setup. PR-P of #438: subscriber connections skip
+    // the writer-slot install, the approval-queue drain, and the
+    // approval-bridge replay — approvals require a responder, and a
+    // read-only subscriber has no way to act on them.
+    //
+    // `writer_id` is `Some(_)` only for writer connections; the
+    // disconnect cleanup block at the bottom of this function uses that
+    // to decide whether to even contend on `state.root.control_writer`.
+    let writer_id = if client_mode == ClientMode::Writer {
+        // Install this connection as the control_writer (displace any prior).
+        //
+        // LOAD-BEARING: the connection-unique `writer_id` is checked by the
+        // disconnect cleanup block at the bottom of this function before it
+        // clears `state.root.control_writer`. Without that id-match guard,
+        // a TUI that reconnects in the narrow window between this read loop
+        // exiting and the cleanup block running would have its own writer
+        // slot silently cleared by the previous connection's cleanup —
+        // leading to a connected TUI that receives no events with no
+        // diagnostic surface. **Do not remove the writer_id field, the slot
+        // assignment, or the id-match check at the disconnect site without
+        // first introducing an equivalent reconnect-safety mechanism.**
+        let writer_id = uuid::Uuid::now_v7();
+        {
+            let mut cw = state.root.control_writer.lock().await;
+            if let Some(old) = cw.take() {
+                // `try_send` fails when the prior connection's outbound
+                // queue is already full — its TUI is unresponsive or its
+                // socket is wedged. Log the drop so the silent failure is
+                // observable: the displaced TUI will not learn it was
+                // superseded and may keep rendering stale tiles until its
+                // socket EOFs. (#152 M1)
+                let superseded = wrap_with_seq(&state.event_log, &ControlEvent::Superseded);
+                state.event_log.persist(&superseded).await;
+                if let Err(e) = old.sender.try_send(superseded) {
+                    tracing::warn!(
+                        new_writer_id = %writer_id,
+                        error = %e,
+                        "could not deliver Superseded to displaced TUI; \
+                         prior connection's queue full or closed"
+                    );
+                }
+            }
+            *cw = Some(crate::dispatch::layer::ControlWriterSlot {
+                id: writer_id,
+                sender: ev_tx.clone(),
+            });
+        }
+
+        // Drain any queued approvals now that a TUI is connected.
+        {
+            let mut queue = state.root.approval_queue.lock().await;
+            while let Some(q) = queue.pop_front() {
+                // Transfer responder into the bridge map, preserving TTL metadata
+                // and display fields so expire_layer_approvals can still expire
+                // the entry and — per #102 — a subsequent TUI reconnect can
+                // replay pending approvals held by the bridge.
+                state.root.approval_bridge.lock().await.insert(
+                    q.request_id.clone(),
+                    crate::dispatch::state::BridgeEntry {
+                        responder: q.responder,
+                        task_id: q.task_id.clone(),
+                        summary: q.summary.clone(),
+                        plan: q.plan.clone(),
+                        kind: q.kind,
+                        ttl_secs: q.ttl_secs,
+                        fallback: q.fallback,
+                        created_at: q.created_at,
+                    },
                 );
+                // And push the event (wrapped + persisted via the helper).
+                let _ = enqueue_envelope(
+                    &ev_tx,
+                    &event_log,
+                    ControlEvent::ApprovalRequest {
+                        request_id: q.request_id,
+                        task_id: q.task_id,
+                        summary: q.summary,
+                        plan: q.plan.map(crate::mcp::approval::approval_plan_to_wire),
+                        kind: q.kind,
+                    },
+                )
+                .await;
             }
         }
-        *cw = Some(crate::dispatch::layer::ControlWriterSlot {
-            id: writer_id,
-            sender: ev_tx.clone(),
-        });
-    }
 
-    // Drain any queued approvals now that a TUI is connected.
-    {
-        let mut queue = state.root.approval_queue.lock().await;
-        while let Some(q) = queue.pop_front() {
-            // Transfer responder into the bridge map, preserving TTL metadata
-            // and display fields so expire_layer_approvals can still expire
-            // the entry and — per #102 — a subsequent TUI reconnect can
-            // replay pending approvals held by the bridge.
-            state.root.approval_bridge.lock().await.insert(
-                q.request_id.clone(),
-                crate::dispatch::state::BridgeEntry {
-                    responder: q.responder,
-                    task_id: q.task_id.clone(),
-                    summary: q.summary.clone(),
-                    plan: q.plan.clone(),
-                    kind: q.kind,
-                    ttl_secs: q.ttl_secs,
-                    fallback: q.fallback,
-                    created_at: q.created_at,
-                },
-            );
-            // And push the event (wrapped + persisted via the helper).
-            let _ = enqueue_envelope(
-                &ev_tx,
-                &event_log,
-                ControlEvent::ApprovalRequest {
-                    request_id: q.request_id,
-                    task_id: q.task_id,
-                    summary: q.summary,
-                    plan: q.plan.map(crate::mcp::approval::approval_plan_to_wire),
-                    kind: q.kind,
-                },
-            )
-            .await;
+        // Replay any approvals already in the bridge (#102). A bridge entry with
+        // a still-live responder means a prior TUI received the ApprovalRequest
+        // event but died without approving/rejecting (or was displaced by this
+        // new connection). Without this replay, the new TUI sees nothing for the
+        // pending responder — the queue is empty, the bridge holds the responder
+        // but emits no event, and the lead blocks until TTL fallback fires.
+        // The responder oneshot stays in the bridge; a subsequent approve/reject
+        // op still delivers correctly.
+        // Collect live entries into a Vec while holding the lock (no async work),
+        // then drop the guard before calling ev_tx.send().await. Holding the lock
+        // across send() suspends while the channel is full, blocking every other
+        // lock waiter (expire_layer_approvals, the Approve op handler, concurrent
+        // Hello drain) for the full duration of the backpressure stall (#105).
+        let pending: Vec<ControlEvent> = {
+            let bridge = state.root.approval_bridge.lock().await;
+            bridge
+                .iter()
+                .filter(|(_, entry)| !entry.responder.is_closed())
+                // is_closed is the best proxy without racing the receiver; a
+                // concurrent TTL expiry between this filter and the send below
+                // is accepted — the TUI briefly renders a card that vanishes
+                // when the expiry is processed (#109).
+                .map(|(request_id, entry)| ControlEvent::ApprovalRequest {
+                    request_id: request_id.clone(),
+                    task_id: entry.task_id.clone(),
+                    summary: entry.summary.clone(),
+                    plan: entry
+                        .plan
+                        .clone()
+                        .map(crate::mcp::approval::approval_plan_to_wire),
+                    kind: entry.kind,
+                })
+                .collect()
+        }; // lock released here
+        for ev in pending {
+            let _ = enqueue_envelope(&ev_tx, &event_log, ev).await;
         }
-    }
 
-    // Replay any approvals already in the bridge (#102). A bridge entry with
-    // a still-live responder means a prior TUI received the ApprovalRequest
-    // event but died without approving/rejecting (or was displaced by this
-    // new connection). Without this replay, the new TUI sees nothing for the
-    // pending responder — the queue is empty, the bridge holds the responder
-    // but emits no event, and the lead blocks until TTL fallback fires.
-    // The responder oneshot stays in the bridge; a subsequent approve/reject
-    // op still delivers correctly.
-    // Collect live entries into a Vec while holding the lock (no async work),
-    // then drop the guard before calling ev_tx.send().await. Holding the lock
-    // across send() suspends while the channel is full, blocking every other
-    // lock waiter (expire_layer_approvals, the Approve op handler, concurrent
-    // Hello drain) for the full duration of the backpressure stall (#105).
-    let pending: Vec<ControlEvent> = {
-        let bridge = state.root.approval_bridge.lock().await;
-        bridge
-            .iter()
-            .filter(|(_, entry)| !entry.responder.is_closed())
-            // is_closed is the best proxy without racing the receiver; a
-            // concurrent TTL expiry between this filter and the send below
-            // is accepted — the TUI briefly renders a card that vanishes
-            // when the expiry is processed (#109).
-            .map(|(request_id, entry)| ControlEvent::ApprovalRequest {
-                request_id: request_id.clone(),
-                task_id: entry.task_id.clone(),
-                summary: entry.summary.clone(),
-                plan: entry
-                    .plan
-                    .clone()
-                    .map(crate::mcp::approval::approval_plan_to_wire),
-                kind: entry.kind,
-            })
-            .collect()
-    }; // lock released here
-    for ev in pending {
-        let _ = enqueue_envelope(&ev_tx, &event_log, ev).await;
-    }
+        Some(writer_id)
+    } else {
+        None
+    };
 
     // PR-H of #259: bus → mpsc bridge. The per-run events broadcast
     // bus carries every `broadcast_control_event` emission. A
@@ -482,7 +500,23 @@ async fn serve_connection(
     // Read loop.
     while let Ok(Some(line)) = reader.next_line().await {
         let reply = match serde_json::from_str::<ControlOp>(&line) {
-            Ok(op) => dispatch_op(&state, op).await,
+            Ok(op) => {
+                // PR-P of #438: subscriber-mode clients are read-only. Reject
+                // writer ops at the front gate with a typed `OpFailed` rather
+                // than letting them mutate state via `dispatch_op`. The two
+                // no-op ops (Hello, Subscribe) are still allowed — Hello is
+                // already past the handshake (a duplicate is a no-op ack) and
+                // Subscribe is the consumer-side advisory ack from PR-N.
+                if client_mode == ClientMode::Subscriber && !is_subscriber_safe_op(&op) {
+                    ControlEvent::OpFailed {
+                        op: op_tag(&op).into(),
+                        task_id: None,
+                        error: "subscriber mode forbids writer ops".into(),
+                    }
+                } else {
+                    dispatch_op(&state, op).await
+                }
+            }
             Err(e) => ControlEvent::OpFailed {
                 // Best-effort: extract the `op` string from the raw JSON
                 // so the TUI can correlate the failure with the request
@@ -508,7 +542,10 @@ async fn serve_connection(
     // the window between our read loop exiting and this cleanup block
     // running; a blind clear would silently disconnect the reconnected
     // client.
-    {
+    //
+    // Subscriber connections (`writer_id == None`) never took the slot,
+    // so the cleanup is a no-op for them.
+    if let Some(writer_id) = writer_id {
         let mut cw = state.root.control_writer.lock().await;
         if cw.as_ref().is_some_and(|slot| slot.id == writer_id) {
             *cw = None;
@@ -517,6 +554,15 @@ async fn serve_connection(
     pump.abort();
     activity_pump.abort();
     bus_bridge.abort();
+}
+
+/// Whether a `ControlOp` is safe to accept from a subscriber-mode
+/// (read-only) connection. Hello is already past the handshake (a
+/// duplicate is a no-op ack) and Subscribe is the consumer-side
+/// advisory ack from PR-N of #438. Every other op mutates dispatcher
+/// state and is rejected up-front in the read loop.
+fn is_subscriber_safe_op(op: &ControlOp) -> bool {
+    matches!(op, ControlOp::Hello { .. } | ControlOp::Subscribe { .. })
 }
 
 /// Best-effort SIGCONT helper: if `task_id` is currently `Frozen`,

--- a/crates/pitboss-cli/src/stream.rs
+++ b/crates/pitboss-cli/src/stream.rs
@@ -205,6 +205,7 @@ async fn drive_socket(socket_path: PathBuf, tx: mpsc::Sender<LiveStreamItem>) {
 async fn send_hello(w: &mut OwnedWriteHalf) -> Result<()> {
     let hello = ControlOp::Hello {
         client_version: env!("CARGO_PKG_VERSION").to_string(),
+        mode: crate::control::protocol::ClientMode::default(),
     };
     let mut line = serde_json::to_string(&hello)?;
     line.push('\n');

--- a/crates/pitboss-cli/tests/control_flows.rs
+++ b/crates/pitboss-cli/tests/control_flows.rs
@@ -331,6 +331,7 @@ async fn server_emits_monotonic_seqs_on_wire() {
     let mut reader = BufReader::new(r).lines();
     let client_hello = serde_json::to_string(&ControlOp::Hello {
         client_version: "0.4.0".into(),
+        mode: pitboss_cli::control::protocol::ClientMode::Writer,
     })
     .unwrap()
         + "\n";
@@ -1232,6 +1233,7 @@ async fn subscribe_op_acks_and_keeps_dispatcher_responsive() {
     // Hello.
     let client_hello = serde_json::to_string(&ControlOp::Hello {
         client_version: "pitboss-core/test".into(),
+        mode: pitboss_cli::control::protocol::ClientMode::Writer,
     })
     .unwrap()
         + "\n";
@@ -1288,5 +1290,353 @@ async fn subscribe_op_acks_and_keeps_dispatcher_responsive() {
     assert!(
         saw_snapshot,
         "Subscribe must not block subsequent op handling",
+    );
+}
+
+// ----------------------------------------------------------------------
+// PR-P of #438 — subscriber-mode client flows.
+// ----------------------------------------------------------------------
+
+/// Build a minimal `DispatchState` + run id + run subdir for PR-P's
+/// subscriber-mode tests. Manifest fields stay at defaults; the tests
+/// below only need the control-socket lifecycle, not the dispatch loop.
+async fn make_subscriber_test_state(dir: &TempDir) -> (Arc<DispatchState>, Uuid, PathBuf) {
+    let run_id = uuid::Uuid::now_v7();
+    let run_subdir = dir.path().join(run_id.to_string());
+    tokio::fs::create_dir_all(&run_subdir).await.unwrap();
+    let manifest = ResolvedManifest {
+        manifest_schema_version: 0,
+        name: None,
+        max_parallel_tasks: Some(4),
+        halt_on_failure: false,
+        run_dir: dir.path().to_path_buf(),
+        worktree_cleanup: WorktreeCleanup::OnSuccess,
+        emit_event_stream: false,
+        tasks: vec![],
+        lead: None,
+        max_workers: Some(4),
+        budget_usd: Some(1.0),
+        lead_budget_usd: None,
+        lead_timeout_secs: None,
+        default_approval_policy: Some(ApprovalPolicy::Block),
+        denial_termination_policy: None,
+        notifications: vec![],
+        dump_shared_store: false,
+        require_plan_approval: false,
+        approval_rules: vec![],
+        container: None,
+        mcp_servers: vec![],
+        communication: Default::default(),
+        lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
+        untyped_actor_policy: Default::default(),
+    };
+    let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
+    let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
+    let wt_mgr = Arc::new(WorktreeManager::new());
+    let state = Arc::new(DispatchState::new(
+        run_id,
+        manifest,
+        store,
+        CancelToken::new(),
+        String::new(),
+        spawner,
+        PathBuf::from("/bin/true"),
+        wt_mgr,
+        CleanupPolicy::Never,
+        run_subdir.clone(),
+        ApprovalPolicy::Block,
+        None,
+        std::sync::Arc::new(pitboss_cli::shared_store::SharedStore::new()),
+    ));
+    (state, run_id, run_subdir)
+}
+
+/// A second client attaching in subscriber mode must not displace the
+/// connected writer: the dispatcher's `control_writer` slot stays bound
+/// to the first client, no `Superseded` envelope is emitted, and the
+/// writer keeps serving op replies.
+#[tokio::test]
+async fn subscriber_hello_does_not_supersede_writer() {
+    let dir = TempDir::new().unwrap();
+    let (state, run_id, _run_subdir) = make_subscriber_test_state(&dir).await;
+
+    let sock = dir.path().join("subscriber-coexist.sock");
+    let _h = start_control_server(
+        sock.clone(),
+        "0.4.0".into(),
+        run_id.to_string(),
+        "flat".into(),
+        state,
+    )
+    .await
+    .unwrap();
+
+    // Writer attaches first.
+    let mut writer = FakeControlClient::connect(&sock, "writer/0.0.0")
+        .await
+        .unwrap();
+
+    // Subscriber attaches second — historically this would have
+    // displaced the writer.
+    let mut subscriber = FakeControlClient::connect_subscriber(&sock, "pitboss-core/0.14.0")
+        .await
+        .unwrap();
+
+    // The writer must NOT receive a Superseded within a reasonable
+    // window. Drain any incidental traffic (e.g. activity ticks) and
+    // assert no Superseded landed.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(800);
+    while std::time::Instant::now() < deadline {
+        match writer
+            .recv_timeout(std::time::Duration::from_millis(150))
+            .await
+            .unwrap()
+        {
+            Some(ev) => {
+                assert!(
+                    !matches!(ev, ControlEvent::Superseded),
+                    "subscriber attach must not displace writer; got {ev:?}",
+                );
+            }
+            None => break,
+        }
+    }
+
+    // Writer still serves op replies after the subscriber attached.
+    writer.send(&ControlOp::ListWorkers).await.unwrap();
+    let mut saw_snapshot = false;
+    for _ in 0..6 {
+        let ev = writer
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .await
+            .unwrap()
+            .expect("envelope");
+        if matches!(ev, ControlEvent::WorkersSnapshot { .. }) {
+            saw_snapshot = true;
+            break;
+        }
+    }
+    assert!(saw_snapshot, "writer must keep serving ops");
+
+    // Subscriber connection is healthy — drain one envelope so a
+    // dangling task doesn't leak when the server handle drops.
+    let _ = subscriber
+        .recv_timeout(std::time::Duration::from_millis(50))
+        .await;
+}
+
+/// Subscriber connections are read-only: any writer op must come back
+/// as a typed `OpFailed` rather than mutating dispatcher state.
+#[tokio::test]
+async fn subscriber_writer_op_returns_op_failed() {
+    let dir = TempDir::new().unwrap();
+    let (state, run_id, _run_subdir) = make_subscriber_test_state(&dir).await;
+
+    // Install a worker so a misrouted CancelWorker has something to find.
+    // The cancel must NOT fire — we rely on the worker_cancels token
+    // staying un-cancelled to prove the op was rejected before
+    // dispatch_op ran.
+    let worker_token = CancelToken::new();
+    state
+        .root
+        .worker_cancels
+        .write()
+        .await
+        .insert("w-1".into(), worker_token.clone());
+    state.root.workers.write().await.insert(
+        "w-1".into(),
+        WorkerState::Running {
+            started_at: chrono::Utc::now(),
+            session_id: Some("sess".into()),
+        },
+    );
+
+    let sock = dir.path().join("subscriber-readonly.sock");
+    let _h = start_control_server(
+        sock.clone(),
+        "0.4.0".into(),
+        run_id.to_string(),
+        "flat".into(),
+        state,
+    )
+    .await
+    .unwrap();
+
+    let mut sub = FakeControlClient::connect_subscriber(&sock, "pitboss-core/0.14.0")
+        .await
+        .unwrap();
+
+    sub.send(&ControlOp::CancelWorker {
+        task_id: "w-1".into(),
+    })
+    .await
+    .unwrap();
+
+    // Skim envelopes until we hit OpFailed for cancel_worker. Tolerate
+    // intervening activity ticks.
+    let mut saw_failure = false;
+    for _ in 0..6 {
+        let ev = sub
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .await
+            .unwrap()
+            .expect("envelope");
+        if let ControlEvent::OpFailed { op, error, .. } = &ev {
+            if op == "cancel_worker" {
+                assert!(
+                    error.contains("subscriber"),
+                    "error must explain subscriber-mode rejection: {error:?}",
+                );
+                saw_failure = true;
+                break;
+            }
+        }
+    }
+    assert!(
+        saw_failure,
+        "writer op must return OpFailed in subscriber mode"
+    );
+    assert!(
+        !worker_token.is_terminated(),
+        "subscriber-mode op must NOT terminate the worker token",
+    );
+    assert!(
+        !worker_token.is_draining(),
+        "subscriber-mode op must NOT drain the worker token either",
+    );
+}
+
+/// Multiple subscriber clients can coexist: every connection's
+/// bus-bridge subscribes to the run's broadcast bus, so a single
+/// `broadcast_control_event` fan-outs to all of them.
+#[tokio::test]
+async fn multiple_subscribers_coexist() {
+    let dir = TempDir::new().unwrap();
+    let (state, run_id, _run_subdir) = make_subscriber_test_state(&dir).await;
+
+    let sock = dir.path().join("multi-subscriber.sock");
+    let _h = start_control_server(
+        sock.clone(),
+        "0.4.0".into(),
+        run_id.to_string(),
+        "flat".into(),
+        state.clone(),
+    )
+    .await
+    .unwrap();
+
+    let mut subs = Vec::with_capacity(3);
+    for _ in 0..3 {
+        subs.push(
+            FakeControlClient::connect_subscriber(&sock, "pitboss-core/0.14.0")
+                .await
+                .unwrap(),
+        );
+    }
+
+    // Wait briefly for every bus-bridge subscriber to attach before we
+    // publish — `events_tx.subscribe()` is spawned on each connection's
+    // task, so a publish too early can miss a slow subscriber. The 100ms
+    // here is generous for an in-process broadcast bus.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // Publish a recognizable envelope onto the broadcast bus. Using
+    // RunFinished because it's a leaf event with no state dependencies
+    // beyond the wire shape — perfect for fan-out assertions.
+    let envelope = pitboss_cli::control::protocol::EventEnvelope {
+        actor_path: pitboss_cli::dispatch::actor::ActorPath::default(),
+        seq: 0, // overwritten by broadcast_control_event
+        event: ControlEvent::RunFinished {
+            summary: pitboss_cli::control::protocol::RunFinishedSummary {
+                tasks_total: 7,
+                tasks_failed: 1,
+            },
+        },
+    };
+    state.root.broadcast_control_event(envelope).await;
+
+    for (idx, sub) in subs.iter_mut().enumerate() {
+        let mut saw = false;
+        for _ in 0..6 {
+            let ev = sub
+                .recv_timeout(std::time::Duration::from_secs(2))
+                .await
+                .unwrap()
+                .expect("envelope");
+            if let ControlEvent::RunFinished { summary } = &ev {
+                assert_eq!(summary.tasks_total, 7);
+                assert_eq!(summary.tasks_failed, 1);
+                saw = true;
+                break;
+            }
+        }
+        assert!(saw, "subscriber {idx} did not see the broadcast event");
+    }
+}
+
+/// Pre-PR-P clients send `Hello` without a `mode` field. The
+/// dispatcher must continue to install them as the writer (the
+/// historical behavior) — verified by observing that a second
+/// no-mode-field client displaces the first with `Superseded`.
+#[tokio::test]
+async fn legacy_hello_without_mode_defaults_to_writer() {
+    let dir = TempDir::new().unwrap();
+    let (state, run_id, _run_subdir) = make_subscriber_test_state(&dir).await;
+
+    let sock = dir.path().join("legacy-hello.sock");
+    let _h = start_control_server(
+        sock.clone(),
+        "0.4.0".into(),
+        run_id.to_string(),
+        "flat".into(),
+        state,
+    )
+    .await
+    .unwrap();
+
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    // First client: bare legacy Hello (no `mode` field).
+    let stream1 = tokio::net::UnixStream::connect(&sock).await.unwrap();
+    let (r1, mut w1) = stream1.into_split();
+    let mut reader1 = BufReader::new(r1).lines();
+    w1.write_all(b"{\"op\":\"hello\",\"client_version\":\"0.4.0\"}\n")
+        .await
+        .unwrap();
+    w1.flush().await.unwrap();
+    let line = reader1.next_line().await.unwrap().expect("server hello");
+    let env: pitboss_cli::control::protocol::EventEnvelope = serde_json::from_str(&line).unwrap();
+    assert!(matches!(env.event, ControlEvent::Hello { .. }));
+
+    // Second client: same legacy Hello shape. If the first connection
+    // had been classified as a subscriber, no Superseded would fire.
+    let stream2 = tokio::net::UnixStream::connect(&sock).await.unwrap();
+    let (_r2, mut w2) = stream2.into_split();
+    w2.write_all(b"{\"op\":\"hello\",\"client_version\":\"0.4.0\"}\n")
+        .await
+        .unwrap();
+    w2.flush().await.unwrap();
+
+    // First client should now receive Superseded.
+    let mut saw_superseded = false;
+    for _ in 0..6 {
+        let line = tokio::time::timeout(std::time::Duration::from_secs(2), reader1.next_line())
+            .await
+            .unwrap()
+            .unwrap()
+            .expect("envelope");
+        let env: pitboss_cli::control::protocol::EventEnvelope =
+            serde_json::from_str(&line).unwrap();
+        if matches!(env.event, ControlEvent::Superseded) {
+            saw_superseded = true;
+            break;
+        }
+    }
+    assert!(
+        saw_superseded,
+        "legacy Hello (no mode field) must still take the writer slot",
     );
 }

--- a/crates/pitboss-core/src/stream.rs
+++ b/crates/pitboss-core/src/stream.rs
@@ -201,9 +201,12 @@ async fn drive_live(run_dir: &Path, tx: &mpsc::Sender<RunStreamItem>, start_seq:
         }
     };
 
-    // Client hello.
+    // Client hello. PR-P of #438: send `"mode":"subscriber"` so the
+    // dispatcher skips the writer-slot install — any number of unified-API
+    // consumers can attach to a run without displacing each other or a
+    // concurrent writer (e.g. `control_bridge.rs::send_op` from pitboss-web).
     let hello = format!(
-        r#"{{"op":"hello","client_version":"pitboss-core/{}"}}{}"#,
+        r#"{{"op":"hello","client_version":"pitboss-core/{}","mode":"subscriber"}}{}"#,
         crate::VERSION,
         "\n"
     );
@@ -803,6 +806,57 @@ mod tests {
         // Per-stream seq is strictly monotonic across the three items.
         assert!(items[0].seq < items[1].seq);
         assert!(items[1].seq < items[2].seq);
+    }
+
+    /// PR-P of #438: the unified-API client identifies itself as
+    /// `"mode":"subscriber"` so the dispatcher skips the writer-slot
+    /// install — any number of `open_run_stream` consumers can attach
+    /// concurrently without displacing a writer like
+    /// `pitboss-web::control_bridge`. Pins the client-side handshake
+    /// shape so a regression in `drive_live`'s Hello formatting is
+    /// caught here rather than at the (one-way coupled) integration
+    /// boundary.
+    #[tokio::test]
+    async fn live_only_handshake_sends_subscriber_mode() {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+        use tokio::net::UnixListener;
+        use tokio::sync::oneshot;
+
+        let tmp = TempDir::new().unwrap();
+        let run_dir = tmp.path().join("019d-fake-run-id");
+        std::fs::create_dir_all(&run_dir).unwrap();
+        let sock = run_dir.join("control.sock");
+        std::env::set_var("XDG_RUNTIME_DIR", tmp.path().join("xdg-empty"));
+
+        let (hello_tx, hello_rx) = oneshot::channel::<String>();
+        let listener = UnixListener::bind(&sock).expect("bind capture socket");
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept");
+            let (read_half, mut write_half) = stream.into_split();
+            let mut lines = BufReader::new(read_half).lines();
+            let client_hello = lines.next_line().await.ok().flatten().unwrap_or_default();
+            let _ = hello_tx.send(client_hello);
+            let server_hello = "{\"event\":\"hello\",\"server_version\":\"mock\",\"run_id\":\"mock\",\"run_kind\":\"test\",\"workers\":[]}\n";
+            let _ = write_half.write_all(server_hello.as_bytes()).await;
+            let _ = write_half.flush().await;
+            // Eat the Subscribe and exit; closing the write half ends
+            // the consumer's stream so `collect` returns deterministically.
+            let _ = lines.next_line().await;
+        });
+        tokio::task::yield_now().await;
+
+        let _items = collect(&run_dir, StreamMode::LiveOnly).await;
+        std::env::remove_var("XDG_RUNTIME_DIR");
+
+        let captured = hello_rx.await.expect("hello captured");
+        assert!(
+            captured.contains("\"op\":\"hello\""),
+            "missing op tag in hello: {captured}"
+        );
+        assert!(
+            captured.contains("\"mode\":\"subscriber\""),
+            "drive_live must send subscriber mode: {captured}"
+        );
     }
 
     /// `ReplayThenLive` against a connected dispatcher emits the disk

--- a/crates/pitboss-web/src/control_bridge.rs
+++ b/crates/pitboss-web/src/control_bridge.rs
@@ -162,6 +162,7 @@ impl ControlBridge {
         // it up after we register the broadcast sender.
         let hello = ControlOp::Hello {
             client_version: format!("pitboss-web/{}", env!("CARGO_PKG_VERSION")),
+            mode: pitboss_cli::control::protocol::ClientMode::default(),
         };
         let mut hello_line =
             serde_json::to_string(&hello).map_err(|e| BridgeError::Handshake(e.to_string()))?;

--- a/crates/pitboss-web/tests/control_bridge_integration.rs
+++ b/crates/pitboss-web/tests/control_bridge_integration.rs
@@ -291,6 +291,7 @@ async fn bridge_send_op_rejects_client_hello() {
             run_id,
             &ControlOp::Hello {
                 client_version: "spoof/0.0.0".into(),
+                mode: pitboss_cli::control::protocol::ClientMode::default(),
             },
         )
         .await

--- a/tests-support/fake-control-client/src/lib.rs
+++ b/tests-support/fake-control-client/src/lib.rs
@@ -12,7 +12,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::net::UnixStream;
 
-use pitboss_cli::control::protocol::{ControlEvent, ControlOp, EventEnvelope};
+use pitboss_cli::control::protocol::{ClientMode, ControlEvent, ControlOp, EventEnvelope};
 
 pub struct FakeControlClient {
     writer: OwnedWriteHalf,
@@ -20,9 +20,25 @@ pub struct FakeControlClient {
 }
 
 impl FakeControlClient {
-    /// Connect to `socket`, send `hello`, read the server hello, return a ready
-    /// client.
+    /// Connect to `socket` as a writer client, send `hello`, read the
+    /// server hello, return a ready client.
     pub async fn connect(socket: &Path, client_version: &str) -> Result<Self> {
+        Self::connect_with_mode(socket, client_version, ClientMode::Writer).await
+    }
+
+    /// PR-P of #438: connect as a subscriber-mode client. The dispatcher
+    /// skips the writer-slot install + approval-drain / bridge-replay
+    /// and rejects writer ops with `OpFailed`. Tests use this to assert
+    /// the subscriber path without displacing a concurrent writer.
+    pub async fn connect_subscriber(socket: &Path, client_version: &str) -> Result<Self> {
+        Self::connect_with_mode(socket, client_version, ClientMode::Subscriber).await
+    }
+
+    async fn connect_with_mode(
+        socket: &Path,
+        client_version: &str,
+        mode: ClientMode,
+    ) -> Result<Self> {
         let stream = UnixStream::connect(socket)
             .await
             .with_context(|| format!("connect {}", socket.display()))?;
@@ -33,6 +49,7 @@ impl FakeControlClient {
         };
         c.send(&ControlOp::Hello {
             client_version: client_version.into(),
+            mode,
         })
         .await?;
         // Wait for the server hello so the connection is fully established.


### PR DESCRIPTION
## Summary

- Adds a `ClientMode { Writer, Subscriber }` discriminator on `ControlOp::Hello`. Default `Writer` is elided on the wire, so every existing legacy-Hello fixture round-trips byte-identically and pre-v0.14 clients keep the historical writer-slot behavior.
- Subscriber-mode connections in `serve_connection` skip the `control_writer` slot install, the approval-queue drain, and the bridge replay. They still attach to the per-run broadcast bus via the same bus-bridge writers use, so every `broadcast_control_event` fan-outs to every subscriber. Writer ops are pre-rejected with `OpFailed { error: "subscriber mode forbids writer ops" }` before `dispatch_op`.
- `pitboss-core::stream::drive_live` announces `"mode":"subscriber"` in its Hello. This unblocks the web SSE bridge migration — a unified-API consumer can now attach to a run without displacing `control_bridge::send_op`'s writer slot.

## Why

PR-O's docs captured the single-`control_writer` constraint as the gating issue for the unified-API web migration: every newly-accepted client takes the slot and supersedes the previous one, so attaching the SSE reader via `open_run_stream(ReplayThenLive)` would collide with each `POST /api/runs/:id/control` writer connection. Tokio's `broadcast::channel` (already used at `dispatch::layer::events_tx` with `EVENTS_BROADCAST_CAP=1024`) is the canonical SPMC fan-out primitive; the dispatcher already fans envelopes onto it, the supersede behavior is only load-bearing for writers. Subscribe-only mode is a 50-100 LoC dispatcher tweak that aligns with the existing topology.

## Out of scope (PR-Q)

The actual web SSE bridge cutover, server-side fast-forward for `Subscribe { since_seq: N > 0 }`, and any authz beyond the existing Unix-socket permission model.

## Test plan

- [x] `cargo test -p pitboss-cli --test control_flows` — all 19 flows pass, including the four new ones:
  - `subscriber_hello_does_not_supersede_writer`
  - `subscriber_writer_op_returns_op_failed`
  - `multiple_subscribers_coexist`
  - `legacy_hello_without_mode_defaults_to_writer`
- [x] `cargo test -p pitboss-cli --test live_stream_flows` — `pitboss_core_live_only_against_real_dispatcher` continues to pass with the subscriber-mode handshake.
- [x] `cargo test -p pitboss-core --lib stream::` — 14 tests including the new `live_only_handshake_sends_subscriber_mode`.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] Full `cargo test --workspace --features pitboss-core/test-support` sweep. Two pre-existing macOS-environment failures (`/bin/true` missing on this box; `e2e_lead_request_approval_round_trip` parallel-load flake — passes in isolation) reproduce on `main` and are unrelated to this PR; Linux CI is the ground truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)