### PR TITLE
feat(web): web SSE bridge cutover to unified envelope API (#438, PR-Q)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -847,10 +847,13 @@ Wire shape:
 **What's in the log:** every envelope produced by the dispatcher's
 `broadcast_control_event` path — `sublead_spawned`,
 `sublead_terminated`, `worker_failed`, run-wide `approval_request`
-(including ones queued before any client connected). Also
-connection-scoped envelopes that ran during an attached session:
-`approval_request` replay, `op_acked` / `op_failed`,
-`store_activity` ticks, `superseded`.
+(including ones queued before any client connected). As of v0.14
+(PR-Q of #438) this also includes **op replies** — `op_acked`,
+`op_failed`, `op_unknown_state`, `workers_snapshot` — which were
+previously connection-scoped. The log now records every accepted
+control op alongside what the dispatcher did with it (audit trail).
+Also connection-scoped envelopes that ran during an attached session:
+`approval_request` replay, `store_activity` ticks, `superseded`.
 
 **What's not in the log:**
 
@@ -859,8 +862,8 @@ connection-scoped envelopes that ran during an attached session:
 - Connection-scoped envelopes that fired during periods when no
   client was attached (e.g. `store_activity` ticks only run while
   a TUI / web bridge is connected). The bus-routed events
-  (sub-lead lifecycle, worker failures, approvals) persist
-  unconditionally.
+  (sub-lead lifecycle, worker failures, approvals, op replies)
+  persist unconditionally.
 
 Three ways to consume the log:
 
@@ -994,9 +997,17 @@ PR-N); every other op returns `OpFailed`.
 
 The dispatcher fans out broadcast envelopes (`broadcast_control_event`)
 to every connected client — writer and all subscribers — via the
-per-run `events_tx: broadcast::Sender<EventEnvelope>`. Connection-scoped
-envelopes (op replies, `store_activity` ticks, queued-approval drain)
-go only to the originating connection.
+per-run `events_tx: broadcast::Sender<EventEnvelope>`. As of v0.14
+(PR-Q of #438) this includes **op replies** (`OpAcked`, `OpFailed`,
+`OpUnknownState`, `WorkersSnapshot`) — they're routed through the bus
+so multi-viewer SSE bridges and unified-API consumers all see the same
+reply stream, and the replies persist in `events.jsonl` when
+`emit_event_stream = true`. Connection-scoped envelopes that remain
+direct: server `Hello` (per-connection bootstrap), `Superseded`
+(targeted at the displaced writer), `StoreActivity` ticks
+(per-connection ticker), and the queued-approval drain / bridge replay
+(a reconnecting TUI needs its own re-delivery, but a fresh subscriber
+doesn't).
 
 ---
 

--- a/book/src/architecture/unified-envelope-api.md
+++ b/book/src/architecture/unified-envelope-api.md
@@ -30,8 +30,8 @@ This is a research/design issue. Landing it produces:
 - PR-A–PR-F shipped the disk-side foundation and the TUI cutover.
 - **PR-N (#464) shipped the live-socket transport** for `StreamMode::LiveOnly` and `StreamMode::ReplayThenLive`, plus the `Subscribe { since_seq }` op.
 - **PR-M (#463) shipped the CLI cold-path migration** for `status` and `diff`.
-- **PR-P shipped subscriber-mode client handshakes** — `ControlOp::Hello` gained a `mode: ClientMode` field. Subscriber connections coexist with one writer instead of displacing it, unblocking the web SSE bridge migration.
-- The actual web SSE bridge cutover is tracked as the PR-Q follow-on — the constraint that gated it is resolved; the migration itself is the remaining work.
+- **PR-P (#466) shipped subscriber-mode client handshakes** — `ControlOp::Hello` gained a `mode: ClientMode` field. Subscriber connections coexist with one writer instead of displacing it.
+- **PR-Q shipped the web SSE bridge cutover.** The dispatcher's read loop now broadcasts op replies (`OpAcked` / `OpFailed` / `OpUnknownState` / `WorkersSnapshot`) onto `events_tx` instead of writing them per-connection. `pitboss-web::control_bridge` runs two dispatcher connections per run: a writer-mode `UnixStream` for `send_op`, and a `pitboss_core::stream::open_run_stream(ReplayThenLive)`-driven subscriber pump for SSE fan-out. The on-the-wire SSE shape (`event: control` + envelope JSON) is unchanged.
 
 ## Sum type: `RunStreamItem`
 
@@ -236,15 +236,20 @@ The TUI slice keeps the ad-hoc reader for per-actor `tasks/<id>/events.jsonl` (d
 
 ### 2. Web (`pitboss-web`)
 
-`control_bridge.rs` becomes a `ReplayThenLive` consumer per run, fanning out to SSE clients. The historical readers in `api/runs.rs`, `api/events.rs`, and `insights/aggregator.rs` become `ReplayOnly` consumers. The on-the-wire SSE shape is unchanged — the migration is internal.
+Shipped in **PR-Q**. The on-the-wire SSE shape (`event: control` + envelope JSON) is unchanged — the migration is internal.
 
-The single-`control_writer`-slot constraint that originally blocked this migration (`serve_connection` superseding the previous client on every accept) is resolved by **PR-P**. `ControlOp::Hello` now carries an optional `mode: ClientMode` field; subscriber-mode clients skip the writer-slot install, the approval-queue drain, and the bridge replay. Multiple subscribers coexist with one writer over the broadcast bus — exactly the topology this migration needs. `pitboss-core::stream::drive_live` already announces `"mode":"subscriber"` in its Hello, so any `open_run_stream(LiveOnly | ReplayThenLive)` consumer is non-displacing by construction.
+`control_bridge.rs` now holds two dispatcher connections per run:
 
-The remaining work (PR-Q) is the actual web cutover:
+- A **writer-mode `UnixStream`** for `send_op`. Owns the write half; a drain task on the read half reads-and-discards (the subscriber arm covers SSE delivery; the drain just prevents kernel-buffer backpressure).
+- A **subscriber-mode pump** driven by `pitboss_core::stream::open_run_stream(run_dir, StreamMode::ReplayThenLive)`. Filters `RunStreamPayload::Event` items and forwards the inner envelope into the existing `broadcast::Sender<EventEnvelope>` that SSE clients subscribe to. `Task` and `Lifecycle` payloads are dropped — disk-replay items belong to the dedicated Replay tab via `/api/runs/:id/events-jsonl`, not the live SSE feed.
 
-- The SSE handler reads from `open_run_stream(ReplayThenLive)` per run, fan-out unchanged.
-- `control_bridge.rs` shrinks to a writer-only single-connection shim for `send_op` (still in `Writer` mode — only one writer is needed per run).
-- The historical readers in `api/runs.rs` are short-circuit reads of single files (manifest, resolved, summary) and don't benefit from `open_run_stream` — they stay on `read_run_snapshot`. `insights/aggregator.rs` was evaluated; the per-run overhead of spawning a tokio task and draining an mpsc channel for what is otherwise a sync `read_run_snapshot` call makes it a perf regression at the scale the aggregator runs (hundreds of run dirs). The migration there is correct but unprofitable, and is deferred.
+Op replies (`OpAcked` / `OpFailed` / `OpUnknownState` / `WorkersSnapshot`) reach SSE clients via the dispatcher's broadcast bus rather than the writer's read half. PR-Q changed `serve_connection`'s read loop to route the `dispatch_op` result through `broadcast_control_event` instead of `send_event`. Every connected client's `bus_bridge` picks the envelope up, including the writer's own bus_bridge — so the writer still sees its own replies. Side effects of the routing change: op replies become run-wide observable (multi-viewer parity), and they appear in `events.jsonl` when `[run].emit_event_stream = true` (richer audit log).
+
+Subscriber-mode rejection (writer ops on a subscriber connection) and parse errors continue to use direct `send_event` — they're feedback specifically to the misbehaving connection, not broadcast-worthy.
+
+Cold-run 404 contract preserved: `ensure_connected` checks for socket existence before opening the unified stream. `open_run_stream(ReplayThenLive)` on a finalized run would otherwise replay disk events.jsonl over the SSE feed, which the SPA expects not to happen.
+
+The historical readers in `api/runs.rs` are short-circuit reads of single files (manifest, resolved, summary) and don't benefit from `open_run_stream` — they stay on `read_run_snapshot`. `insights/aggregator.rs` was evaluated; the per-run overhead of spawning a tokio task and draining an mpsc channel for what is otherwise a sync `read_run_snapshot` call makes it a perf regression at the scale the aggregator runs (hundreds of run dirs). The migration there is correct but unprofitable, and is deferred.
 
 ### 3. CLI one-shots (`status`, `diff`, `list`, dispatch finalize)
 

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -498,8 +498,25 @@ async fn serve_connection(
     });
 
     // Read loop.
+    //
+    // Op-reply routing (PR-Q of #438):
+    //
+    // - **Writer's `dispatch_op` result** (`OpAcked` / `OpFailed` /
+    //   `OpUnknown` / `OpUnknownState` / `WorkersSnapshot`) is broadcast
+    //   via `events_tx`. Every connected client's `bus_bridge` picks it
+    //   up — including THIS writer's own bus_bridge, which forwards the
+    //   envelope to this connection's pump as before. Subscribers see
+    //   the reply too, which is exactly what `pitboss-web`'s SSE bridge
+    //   needs after its read side switched to the unified API.
+    //
+    // - **Subscriber-mode rejection** (writer op sent by a subscriber
+    //   client) and **parse errors** stay per-connection via
+    //   `send_event`: they're feedback specifically to the misbehaving
+    //   connection, not run-wide events worth broadcasting to every
+    //   subscriber.
     while let Ok(Some(line)) = reader.next_line().await {
-        let reply = match serde_json::from_str::<ControlOp>(&line) {
+        let parsed = serde_json::from_str::<ControlOp>(&line);
+        match parsed {
             Ok(op) => {
                 // PR-P of #438: subscriber-mode clients are read-only. Reject
                 // writer ops at the front gate with a typed `OpFailed` rather
@@ -508,16 +525,27 @@ async fn serve_connection(
                 // already past the handshake (a duplicate is a no-op ack) and
                 // Subscribe is the consumer-side advisory ack from PR-N.
                 if client_mode == ClientMode::Subscriber && !is_subscriber_safe_op(&op) {
-                    ControlEvent::OpFailed {
+                    let reply = ControlEvent::OpFailed {
                         op: op_tag(&op).into(),
                         task_id: None,
                         error: "subscriber mode forbids writer ops".into(),
+                    };
+                    if send_event(&writer, &event_log, &reply).await.is_err() {
+                        break;
                     }
                 } else {
-                    dispatch_op(&state, op).await
+                    let reply = dispatch_op(&state, op).await;
+                    state
+                        .root
+                        .broadcast_control_event(EventEnvelope {
+                            actor_path: ActorPath::default(),
+                            seq: 0, // overwritten by broadcast_control_event
+                            event: reply,
+                        })
+                        .await;
                 }
             }
-            Err(e) => ControlEvent::OpFailed {
+            Err(e) => {
                 // Best-effort: extract the `op` string from the raw JSON
                 // so the TUI can correlate the failure with the request
                 // that triggered it. Falls back to a `parse_error`
@@ -525,13 +553,15 @@ async fn serve_connection(
                 // JSON or the `op` discriminator is missing. The empty
                 // string used to be the only signal here, leaving the
                 // TUI no way to attribute the failure. (#152 L4)
-                op: extract_op_tag_from_raw(&line),
-                task_id: None,
-                error: format!("parse error: {e}"),
-            },
-        };
-        if send_event(&writer, &event_log, &reply).await.is_err() {
-            break;
+                let reply = ControlEvent::OpFailed {
+                    op: extract_op_tag_from_raw(&line),
+                    task_id: None,
+                    error: format!("parse error: {e}"),
+                };
+                if send_event(&writer, &event_log, &reply).await.is_err() {
+                    break;
+                }
+            }
         }
     }
 

--- a/crates/pitboss-cli/tests/control_flows.rs
+++ b/crates/pitboss-cli/tests/control_flows.rs
@@ -1640,3 +1640,93 @@ async fn legacy_hello_without_mode_defaults_to_writer() {
         "legacy Hello (no mode field) must still take the writer slot",
     );
 }
+
+/// PR-Q of #438: writer-mode op replies (`OpAcked`, `OpFailed`,
+/// `WorkersSnapshot`, etc.) are routed via `events_tx` so every
+/// connected client — writer AND every subscriber — sees them. This
+/// pins the cross-connection visibility the web SSE bridge depends on
+/// after its read side switched to the unified API.
+#[tokio::test]
+async fn op_replies_broadcast_to_subscribers() {
+    let dir = TempDir::new().unwrap();
+    let (state, run_id, _run_subdir) = make_subscriber_test_state(&dir).await;
+
+    // Install a worker so ListWorkers has a non-empty snapshot to return.
+    state.root.workers.write().await.insert(
+        "w-1".into(),
+        WorkerState::Running {
+            started_at: chrono::Utc::now(),
+            session_id: Some("sess".into()),
+        },
+    );
+    state
+        .root
+        .worker_prompts
+        .write()
+        .await
+        .insert("w-1".into(), "investigate failure".into());
+
+    let sock = dir.path().join("op-reply-broadcast.sock");
+    let _h = start_control_server(
+        sock.clone(),
+        "0.4.0".into(),
+        run_id.to_string(),
+        "flat".into(),
+        state,
+    )
+    .await
+    .unwrap();
+
+    // Writer attaches first.
+    let mut writer = FakeControlClient::connect(&sock, "writer/0.0.0")
+        .await
+        .unwrap();
+    // Subscriber attaches second; PR-P guarantees it does not displace
+    // the writer.
+    let mut subscriber = FakeControlClient::connect_subscriber(&sock, "pitboss-core/0.14.0")
+        .await
+        .unwrap();
+
+    // Writer sends ListWorkers. The reply is broadcast on the bus, so
+    // both clients should see it.
+    writer.send(&ControlOp::ListWorkers).await.unwrap();
+
+    let mut writer_saw = false;
+    for _ in 0..6 {
+        let ev = writer
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .await
+            .unwrap()
+            .expect("writer envelope");
+        if let ControlEvent::WorkersSnapshot { workers } = &ev {
+            assert!(
+                workers.iter().any(|w| w.task_id == "w-1"),
+                "writer snapshot must include w-1: {workers:?}",
+            );
+            writer_saw = true;
+            break;
+        }
+    }
+    assert!(writer_saw, "writer must see its own ListWorkers reply");
+
+    let mut subscriber_saw = false;
+    for _ in 0..6 {
+        let ev = subscriber
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .await
+            .unwrap()
+            .expect("subscriber envelope");
+        if let ControlEvent::WorkersSnapshot { workers } = &ev {
+            assert!(
+                workers.iter().any(|w| w.task_id == "w-1"),
+                "subscriber snapshot must include w-1: {workers:?}",
+            );
+            subscriber_saw = true;
+            break;
+        }
+    }
+    assert!(
+        subscriber_saw,
+        "subscriber must see the writer's ListWorkers reply via broadcast bus",
+    );
+}

--- a/crates/pitboss-web/src/control_bridge.rs
+++ b/crates/pitboss-web/src/control_bridge.rs
@@ -1,45 +1,54 @@
-//! Per-run control-socket bridge. Each subscribed run gets ONE
-//! `UnixStream` connection to its dispatcher; events are fanned out to N
-//! SSE clients via a `tokio::sync::broadcast` channel and outbound
-//! control ops are serialized through the shared write-half.
+//! Per-run control-socket bridge.
+//!
+//! After PR-Q of #438 each run carries two dispatcher connections:
+//!
+//! - **Writer connection** (writer-mode Hello — `ClientMode::Writer`,
+//!   elided on the wire for byte-identical legacy bytes). Owns the
+//!   single `OwnedWriteHalf` that `send_op` writes through. A drain
+//!   task reads-and-discards from the writer's read half so the
+//!   kernel buffer doesn't backpressure dispatcher fan-out — we don't
+//!   need its envelope stream because the subscriber arm covers SSE.
+//!
+//! - **Subscriber-mode unified-API pump.** Drives
+//!   `pitboss_core::stream::open_run_stream(StreamMode::ReplayThenLive)`,
+//!   filters to `RunStreamPayload::Event(_)` items, and pushes the
+//!   inner envelope into the per-run `broadcast::Sender<EventEnvelope>`
+//!   that SSE clients subscribe to. PR-P's subscriber-mode handshake
+//!   guarantees this connection doesn't displace the writer.
+//!
+//! Op replies (`OpAcked`, `OpFailed`, `OpUnknownState`,
+//! `WorkersSnapshot`) reach SSE clients via the dispatcher's broadcast
+//! bus rather than via the writer's read half — PR-Q changed the
+//! dispatcher's read loop to route them through `events_tx`.
 //!
 //! ## Lifecycle
 //!
-//! 1. First `subscribe(run_id)` (or `send_op(run_id, _)`) opens the
-//!    socket, sends `Hello`, splits the stream, spawns a reader task,
-//!    and registers an `Entry { tx, write }` in the bridge map.
+//! 1. First `subscribe(run_id)` or `send_op(run_id, _)` opens the
+//!    writer socket, spawns the writer-drain task, spawns the unified-API
+//!    pump, and registers an `Entry { tx, write }` in the bridge map.
 //! 2. Subsequent `subscribe(run_id)` calls return additional receivers
-//!    against the same sender — no second connection.
-//! 3. `send_op(run_id, op)` serializes the op as a single JSON line and
+//!    against the same sender — no second connection pair.
+//! 3. `send_op(run_id, op)` serializes the op as one JSON line and
 //!    writes it to the shared write-half under a tokio mutex.
-//! 4. Reader task pumps `EventEnvelope`s from the socket into the
-//!    broadcast channel until the socket EOFs.
-//! 5. On exit, the reader removes the entry from the bridge map; the
-//!    next subscribe/send_op will reconnect.
-//!
-//! ## Single-client constraint
-//!
-//! The dispatcher accepts at-most-one control client at a time. If a TUI
-//! is already connected when the web bridge tries to take the slot, the
-//! dispatcher emits `Superseded` to the TUI and binds us. v1 takes the
-//! slot opportunistically — the SPA surfaces a banner if WE in turn get
-//! superseded by another client (the bridge sees `Superseded` in the
-//! event stream, fans it out, and the reader EOFs shortly after).
+//! 4. The unified-API pump exits when the dispatcher EOFs the
+//!    subscriber socket or `open_run_stream` ends; on exit the entry is
+//!    removed from the map so the next call reconnects.
 //!
 //! ## Lost-wakeup safety
 //!
-//! `broadcast::channel` buffers up to `CHANNEL_CAPACITY` events for each
-//! receiver, so the gap between `subscribe()` returning and the SSE
-//! handler starting to consume cannot lose the dispatcher's initial
-//! `Hello`. If a subscriber falls behind by more than the capacity, the
-//! channel emits `Lagged(n)` — the SSE handler surfaces this as a typed
-//! `lagged` SSE event so the client can resync (re-fetch state).
+//! `broadcast::channel` buffers up to `CHANNEL_CAPACITY` events for
+//! each receiver, so the gap between `subscribe()` returning and the
+//! SSE handler starting to consume cannot lose the dispatcher's
+//! initial `Hello`. If a subscriber falls behind by more than the
+//! capacity, the channel emits `Lagged(n)` — the SSE handler surfaces
+//! this as a typed `lagged` SSE event so the client can resync.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use pitboss_cli::control::protocol::{ControlEvent, ControlOp, EventEnvelope};
+use futures_util::StreamExt;
+use pitboss_cli::control::protocol::{ControlOp, EventEnvelope};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::unix::OwnedWriteHalf;
 use tokio::net::UnixStream;
@@ -84,9 +93,9 @@ impl ControlBridge {
         }
     }
 
-    /// Subscribe to a run's control events. Reuses an existing socket
-    /// connection if one is already established; otherwise opens a new
-    /// one and spawns the reader task.
+    /// Subscribe to a run's control events. Reuses an existing
+    /// connection pair if one is already established; otherwise opens
+    /// a new one and spawns the writer-drain + unified-API pump tasks.
     pub async fn subscribe(
         &self,
         run_id: &str,
@@ -103,8 +112,9 @@ impl ControlBridge {
     ///
     /// Returns `Ok(())` once the bytes are flushed to the socket. The
     /// dispatcher's `OpAcked` / `OpFailed` reply is delivered out-of-band
-    /// over the event stream — callers that need it should subscribe to
-    /// the event stream first.
+    /// over the event stream (PR-Q of #438 routes op replies through the
+    /// broadcast bus, so subscribers see them too) — callers that need
+    /// the reply should subscribe to the event stream first.
     pub async fn send_op(&self, run_id: &str, op: &ControlOp) -> Result<(), BridgeError> {
         // Block server-only handshake variant: clients must not impersonate
         // the dispatcher's Hello; the bridge sends its own client Hello
@@ -125,18 +135,20 @@ impl ControlBridge {
         Ok(())
     }
 
-    /// Returns the per-run `Entry`, opening the socket on first use.
+    /// Returns the per-run `Entry`, opening the writer connection and
+    /// spawning the writer-drain + unified-API pump tasks on first use.
     async fn ensure_connected(&self, run_id: &str) -> Result<Entry, BridgeError> {
         let mut map = self.inner.lock().await;
         if let Some(entry) = map.get(run_id) {
             return Ok(entry.clone());
         }
 
-        // Mirror pitboss_cli::runs::resolve_socket_path: prefer the
-        // XDG_RUNTIME_DIR socket the dispatcher actually publishes to,
-        // and fall back to the in-run-dir path for environments without
-        // an XDG runtime dir (the CLI's `pub`-able resolver should
-        // ultimately replace this duplication — tracked separately).
+        // Resolve the socket path. PR-Q preserves the pre-existing
+        // 404-on-cold-runs contract: if neither the XDG path nor the
+        // run-dir fallback exists, return `NotFound` rather than
+        // silently letting `open_run_stream(ReplayThenLive)` replay
+        // disk events.jsonl over the SSE feed — that's the dedicated
+        // Replay tab's job via `/api/runs/:id/events-jsonl`.
         let socket_path = std::env::var_os("XDG_RUNTIME_DIR")
             .map(|x| {
                 std::path::PathBuf::from(x)
@@ -149,17 +161,14 @@ impl ControlBridge {
             return Err(BridgeError::NotFound);
         }
 
-        let mut stream = match UnixStream::connect(&socket_path).await {
+        // 1. Writer connection: writer-mode Hello, owns the write half.
+        let mut writer_stream = match UnixStream::connect(&socket_path).await {
             Ok(s) => s,
             Err(e) if e.kind() == std::io::ErrorKind::ConnectionRefused => {
                 return Err(BridgeError::Dead);
             }
             Err(e) => return Err(BridgeError::Io(e)),
         };
-
-        // Send the Hello handshake. The dispatcher replies with its own
-        // Hello as the first event on the wire — our reader task picks
-        // it up after we register the broadcast sender.
         let hello = ControlOp::Hello {
             client_version: format!("pitboss-web/{}", env!("CARGO_PKG_VERSION")),
             mode: pitboss_cli::control::protocol::ClientMode::default(),
@@ -167,88 +176,103 @@ impl ControlBridge {
         let mut hello_line =
             serde_json::to_string(&hello).map_err(|e| BridgeError::Handshake(e.to_string()))?;
         hello_line.push('\n');
-        stream.write_all(hello_line.as_bytes()).await?;
+        writer_stream.write_all(hello_line.as_bytes()).await?;
 
-        let (read_half, write_half) = stream.into_split();
+        let (writer_read_half, writer_write_half) = writer_stream.into_split();
         let (tx, _initial_rx) = broadcast::channel::<EventEnvelope>(CHANNEL_CAPACITY);
         let entry = Entry {
             tx: tx.clone(),
-            write: Arc::new(Mutex::new(write_half)),
+            write: Arc::new(Mutex::new(writer_write_half)),
         };
 
-        let tx_for_task = tx.clone();
-        let run_id_for_task = run_id.to_string();
-        let inner_for_task = Arc::clone(&self.inner);
+        // 2. Writer-drain task: read-and-discard envelopes the dispatcher
+        //    sends to this writer connection (its own Hello, broadcast
+        //    fan-out, etc.). The subscriber arm covers SSE delivery; the
+        //    drain just keeps the kernel buffer from filling up and
+        //    backpressuring dispatcher writes.
+        let run_id_drain = run_id.to_string();
         tokio::spawn(async move {
-            reader_loop(read_half, tx_for_task, run_id_for_task, inner_for_task).await;
-        });
-        map.insert(run_id.to_string(), entry.clone());
-        info!(run_id, "control bridge connection opened");
-        Ok(entry)
-    }
-}
-
-async fn reader_loop(
-    read_half: tokio::net::unix::OwnedReadHalf,
-    tx: broadcast::Sender<EventEnvelope>,
-    run_id: String,
-    registry: Arc<Mutex<HashMap<String, Entry>>>,
-) {
-    let mut lines = BufReader::new(read_half).lines();
-
-    loop {
-        match lines.next_line().await {
-            Ok(Some(line)) => {
-                if line.trim().is_empty() {
-                    continue;
+            let mut lines = BufReader::new(writer_read_half).lines();
+            loop {
+                match lines.next_line().await {
+                    Ok(Some(_)) => {} // discard
+                    Ok(None) => {
+                        debug!(run_id = %run_id_drain, "writer-side drain task: socket EOF");
+                        break;
+                    }
+                    Err(e) => {
+                        debug!(run_id = %run_id_drain, error = %e, "writer-side drain task: read error");
+                        break;
+                    }
                 }
-                let envelope = match serde_json::from_str::<EventEnvelope>(&line) {
-                    Ok(e) => e,
-                    Err(_) => match serde_json::from_str::<ControlEvent>(&line) {
-                        // Pre-v0.6 dispatchers wire bare ControlEvent
-                        // without the EventEnvelope wrapper. Lift to
-                        // empty-actor-path envelope for uniformity.
-                        Ok(ev) => EventEnvelope {
-                            actor_path: Default::default(),
-                            // Bare ControlEvent had no seq; treat as
-                            // legacy (seq = 0) per PR-B of #438.
-                            seq: 0,
-                            event: ev,
-                        },
+            }
+        });
+
+        // 3. Unified-API pump: drive `open_run_stream(ReplayThenLive)`
+        //    against the per-run dir, filter to `Event` payloads, and
+        //    forward into the broadcast tx. The unified API opens its own
+        //    subscriber-mode UnixStream internally (PR-P), so this is a
+        //    separate, non-displacing connection.
+        let run_dir = self.runs_dir.join(run_id);
+        let tx_for_pump = tx.clone();
+        let run_id_for_pump = run_id.to_string();
+        let inner_for_pump = Arc::clone(&self.inner);
+        tokio::spawn(async move {
+            let stream = pitboss_core::stream::open_run_stream(
+                &run_dir,
+                pitboss_core::stream::StreamMode::ReplayThenLive,
+            );
+            tokio::pin!(stream);
+            while let Some(item) = stream.next().await {
+                if let pitboss_core::stream::RunStreamPayload::Event(env) = item.payload {
+                    // `pitboss_core::control_protocol::EventEnvelope`
+                    // holds the inner event as `serde_json::Value`; the
+                    // SSE handler downstream expects
+                    // `pitboss_cli::control::protocol::EventEnvelope`
+                    // with the typed `ControlEvent`. Re-parse via JSON
+                    // — one alloc per envelope, negligible at SSE rates.
+                    let json = match serde_json::to_string(&*env) {
+                        Ok(s) => s,
                         Err(e) => {
-                            warn!(run_id, error = %e, line = %line, "control event parse failed");
+                            warn!(run_id = %run_id_for_pump, error = %e,
+                                  "control bridge: serialize-then-reparse failed");
                             continue;
                         }
-                    },
-                };
-                // tx.send returns Err(()) only when there are zero
-                // receivers AND zero buffered items. The bridge is
-                // designed to outlive subscriber gaps (a control-only
-                // POST keeps the entry alive without a receiver), so we
-                // tolerate send errors by simply dropping the event —
-                // the entry stays registered until reader EOF.
-                let _ = tx.send(envelope);
+                    };
+                    let typed: EventEnvelope = match serde_json::from_str(&json) {
+                        Ok(e) => e,
+                        Err(e) => {
+                            warn!(run_id = %run_id_for_pump, error = %e, line = %json,
+                                  "control bridge: typed envelope reparse failed");
+                            continue;
+                        }
+                    };
+                    // `tx.send` returns Err only when zero subscribers AND
+                    // zero buffered slots. We tolerate that — a
+                    // control-only POST can keep the entry alive without
+                    // an SSE subscriber.
+                    let _ = tx_for_pump.send(typed);
+                }
             }
-            Ok(None) => {
-                debug!(run_id, "control socket closed by server (EOF)");
-                break;
+            // Stream EOF — either disk replay ran out on a finalized
+            // run, or the live socket dropped. Either way, the entry is
+            // stale; remove so the next subscribe() / send_op() opens a
+            // fresh pair. Race-safe against `ensure_connected`
+            // re-registering: only remove if it's still OUR tx.
+            let mut map = inner_for_pump.lock().await;
+            if let Some(existing) = map.get(&run_id_for_pump) {
+                if existing.tx.same_channel(&tx_for_pump) {
+                    map.remove(&run_id_for_pump);
+                }
             }
-            Err(e) => {
-                warn!(run_id, error = %e, "control socket read error");
-                break;
-            }
-        }
-    }
+            info!(run_id = %run_id_for_pump, "control bridge unified-API pump exited");
+        });
 
-    // Best-effort cleanup; the next subscribe()/send_op() will
-    // re-establish if the dispatcher is back. If the entry has already
-    // been replaced by a newer reader (race on `ensure_connected`
-    // between two callers), only remove our own.
-    let mut map = registry.lock().await;
-    if let Some(existing) = map.get(&run_id) {
-        if existing.tx.same_channel(&tx) {
-            map.remove(&run_id);
-        }
+        map.insert(run_id.to_string(), entry.clone());
+        info!(
+            run_id,
+            "control bridge connection opened (writer + subscriber pump)"
+        );
+        Ok(entry)
     }
-    info!(run_id, "control bridge reader exited");
 }

--- a/crates/pitboss-web/tests/control_bridge_integration.rs
+++ b/crates/pitboss-web/tests/control_bridge_integration.rs
@@ -1,127 +1,191 @@
-//! Integration test for the control-socket → SSE bridge happy path.
+//! Integration tests for the control-socket bridge.
 //!
-//! Spins up a fake dispatcher (UnixListener) at a temp path that mimics
-//! the per-run `<run_id>/control.sock` layout, then drives the bridge
-//! with subscribe → reader → assert-on-receive. No real `pitboss
-//! dispatch` needed.
-//!
-//! The fake dispatcher only implements what the bridge cares about:
-//! - Accept ONE connection.
-//! - Read the client's `Hello` line (and discard it; verifying we sent
-//!   one is sufficient).
-//! - Write a fixed sequence of events as line-delimited JSON.
-//! - Hold the connection open until the bridge drops it.
+//! After PR-Q of #438, the bridge no longer rolls its own UnixStream
+//! reader — the read side is driven by
+//! `pitboss_core::stream::open_run_stream(ReplayThenLive)` (in subscriber
+//! mode), and op replies reach SSE subscribers via the dispatcher's
+//! broadcast bus rather than the writer's read half. Mocking that with
+//! a fake `UnixListener` is no longer practical, so these tests spin up
+//! a real dispatcher via `pitboss_cli::control::server::start_control_server`
+//! and exercise the full path end-to-end.
 
+use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
-use pitboss_cli::control::protocol::{ControlEvent, ControlOp, EventEnvelope};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::net::UnixListener;
+use pitboss_cli::control::protocol::{ControlEvent, ControlOp};
+use pitboss_cli::control::server::start_control_server;
+use pitboss_cli::dispatch::state::{ApprovalPolicy, DispatchState, WorkerState};
+use pitboss_cli::manifest::resolve::ResolvedManifest;
+use pitboss_cli::manifest::schema::WorktreeCleanup;
+use pitboss_core::process::{ProcessSpawner, TokioSpawner};
+use pitboss_core::session::CancelToken;
+use pitboss_core::store::{JsonFileStore, SessionStore};
+use pitboss_core::worktree::{CleanupPolicy, WorktreeManager};
+use tempfile::TempDir;
 use tokio::time::timeout;
 
-// Re-import the bridge from our own crate. Note: this requires
-// `control_bridge` to be a `pub mod` in lib.rs OR a `pub(crate)` mod
-// reachable via a tests-only re-export. We expose it via a tests-only
-// shim to keep the binary surface clean.
-//
-// Bridge is normally a private module of the bin crate; for this
-// integration test we hard-link it via #[path]. Cargo treats `tests/`
-// as separate compilation units that can pull in any module by path.
 #[path = "../src/control_bridge.rs"]
 mod control_bridge;
 
 use control_bridge::{BridgeError, ControlBridge};
 
-#[tokio::test]
-async fn bridge_subscribe_returns_dispatcher_events() {
-    let tmp = tempfile::tempdir().unwrap();
-    let runs_dir = tmp.path().to_path_buf();
-    let run_id = "01950000-0000-7000-8000-000000000001";
-    let run_dir = runs_dir.join(run_id);
-    std::fs::create_dir_all(&run_dir).unwrap();
-    let socket_path = run_dir.join("control.sock");
-
-    let listener = UnixListener::bind(&socket_path).unwrap();
-
-    // Spawn the fake dispatcher.
-    let server_handle = tokio::spawn(async move {
-        let (stream, _) = listener.accept().await.expect("accept");
-        let (read, mut write) = stream.into_split();
-        let mut reader = BufReader::new(read).lines();
-
-        // Read the Hello sent by the bridge — assert non-empty.
-        let hello_line = reader
-            .next_line()
-            .await
-            .expect("read hello")
-            .expect("hello present");
-        assert!(
-            hello_line.contains("\"op\":\"hello\""),
-            "missing hello op: {hello_line}"
-        );
-
-        // Write back a Hello event (pre-v0.6 bare ControlEvent shape).
-        let hello_event = ControlEvent::Hello {
-            server_version: "test-0.0.1".into(),
-            run_id: "01950000-0000-7000-8000-000000000001".into(),
-            run_kind: "flat".into(),
-            workers: vec!["w-1".into()],
-            policy_rules: vec![],
-        };
-        let mut line = serde_json::to_string(&hello_event).unwrap();
-        line.push('\n');
-        write.write_all(line.as_bytes()).await.unwrap();
-
-        // Then a WorkerFailed event for variety.
-        let worker_failed = ControlEvent::WorkerFailed {
-            task_id: "w-1".into(),
-            parent_task_id: None,
-            reason: pitboss_core::store::FailureReason::AuthFailure,
-        };
-        let mut line2 = serde_json::to_string(&worker_failed).unwrap();
-        line2.push('\n');
-        write.write_all(line2.as_bytes()).await.unwrap();
-
-        // Hold the connection until the bridge drops.
-        tokio::time::sleep(Duration::from_secs(5)).await;
-    });
-
-    // Drive the bridge from the client side.
-    let bridge = ControlBridge::new(runs_dir);
-    let mut rx = bridge.subscribe(run_id).await.expect("subscribe");
-
-    // First event should be the Hello.
-    let envelope: EventEnvelope = timeout(Duration::from_secs(2), rx.recv())
-        .await
-        .expect("hello timeout")
-        .expect("hello recv");
-    match envelope.event {
-        ControlEvent::Hello { server_version, .. } => {
-            assert_eq!(server_version, "test-0.0.1");
+/// Wait until the dispatcher's broadcast bus has at least `n` receivers
+/// attached. Tokio `broadcast::Receiver` only sees messages sent after
+/// it subscribed, so tests that broadcast a single envelope after
+/// `bridge.subscribe()` must wait for the bridge's subscriber-mode
+/// pump to attach via its bus_bridge before sending — otherwise the
+/// envelope is delivered only to whoever was attached at send time
+/// (the persistence subscriber alone, which silently drops with
+/// `emit_event_stream = false`).
+///
+/// The initial baseline is 1 (the persistence subscriber spawned by
+/// `DispatchState::new`). Each connected control client adds one. For
+/// the bridge we expect baseline + 1 (the subscriber pump's connection).
+async fn wait_for_bus_receivers(state: &Arc<DispatchState>, target: usize, deadline: Duration) {
+    let start = std::time::Instant::now();
+    while start.elapsed() < deadline {
+        if state.root.events_tx.receiver_count() >= target {
+            return;
         }
-        other => panic!("expected Hello, got {other:?}"),
+        tokio::time::sleep(Duration::from_millis(25)).await;
     }
-
-    // Second event: WorkerFailed.
-    let envelope: EventEnvelope = timeout(Duration::from_secs(2), rx.recv())
-        .await
-        .expect("failure timeout")
-        .expect("failure recv");
-    match envelope.event {
-        ControlEvent::WorkerFailed { task_id, .. } => {
-            assert_eq!(task_id, "w-1");
-        }
-        other => panic!("expected WorkerFailed, got {other:?}"),
-    }
-
-    drop(rx);
-    drop(bridge);
-    let _ = server_handle.await;
+    panic!(
+        "bus receiver count did not reach {target} within {deadline:?} (have {})",
+        state.root.events_tx.receiver_count()
+    );
 }
 
+/// Build a minimal `DispatchState` + run subdir + run id sufficient for
+/// the control-socket lifecycle. The bridge talks to it via the same
+/// per-run socket path it would use in production.
+async fn make_test_state(runs_dir: &TempDir) -> (Arc<DispatchState>, uuid::Uuid, PathBuf) {
+    let run_id = uuid::Uuid::now_v7();
+    let run_subdir = runs_dir.path().join(run_id.to_string());
+    tokio::fs::create_dir_all(&run_subdir).await.unwrap();
+    let manifest = ResolvedManifest {
+        manifest_schema_version: 0,
+        name: None,
+        max_parallel_tasks: Some(4),
+        halt_on_failure: false,
+        run_dir: runs_dir.path().to_path_buf(),
+        worktree_cleanup: WorktreeCleanup::OnSuccess,
+        emit_event_stream: false,
+        tasks: vec![],
+        lead: None,
+        max_workers: Some(4),
+        budget_usd: Some(1.0),
+        lead_budget_usd: None,
+        lead_timeout_secs: None,
+        default_approval_policy: Some(ApprovalPolicy::Block),
+        denial_termination_policy: None,
+        notifications: vec![],
+        dump_shared_store: false,
+        require_plan_approval: false,
+        approval_rules: vec![],
+        container: None,
+        mcp_servers: vec![],
+        communication: Default::default(),
+        lifecycle: None,
+        worker_types: vec![],
+        sublead_types: vec![],
+        require_actor_type: false,
+        untyped_actor_policy: Default::default(),
+    };
+    let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(runs_dir.path().to_path_buf()));
+    let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
+    let wt_mgr = Arc::new(WorktreeManager::new());
+    let state = Arc::new(DispatchState::new(
+        run_id,
+        manifest,
+        store,
+        CancelToken::new(),
+        String::new(),
+        spawner,
+        PathBuf::from("/bin/true"),
+        wt_mgr,
+        CleanupPolicy::Never,
+        run_subdir.clone(),
+        ApprovalPolicy::Block,
+        None,
+        std::sync::Arc::new(pitboss_cli::shared_store::SharedStore::new()),
+    ));
+    (state, run_id, run_subdir)
+}
+
+/// PR-Q regression: the bridge's unified-API pump forwards envelopes
+/// broadcast by `broadcast_control_event` to SSE subscribers.
+#[tokio::test]
+async fn bridge_subscribe_returns_dispatcher_events() {
+    let runs_dir = TempDir::new().unwrap();
+    let (state, run_id, run_subdir) = make_test_state(&runs_dir).await;
+    // Park the socket inside the per-run dir so the bridge's
+    // run-dir-fallback resolver finds it without an XDG_RUNTIME_DIR
+    // shim.
+    let sock = run_subdir.join("control.sock");
+    let _h = start_control_server(
+        sock,
+        "test-0.0.1".into(),
+        run_id.to_string(),
+        "flat".into(),
+        state.clone(),
+    )
+    .await
+    .unwrap();
+
+    let bridge = ControlBridge::new(runs_dir.path().to_path_buf());
+    let mut rx = bridge
+        .subscribe(&run_id.to_string())
+        .await
+        .expect("subscribe");
+
+    // Wait for the bridge's subscriber-mode pump to attach its
+    // bus_bridge inside the dispatcher before we broadcast — otherwise
+    // a Tokio broadcast send would only reach the persistence
+    // subscriber (which is the baseline).
+    // 1 baseline (persistence) + 2 from the bridge's two connections
+    // (writer's bus_bridge + subscriber-mode pump's bus_bridge).
+    wait_for_bus_receivers(&state, 3, Duration::from_secs(3)).await;
+
+    // Broadcast a recognizable event on the dispatcher's bus. The
+    // bridge's unified-API pump receives it via its subscriber-mode
+    // socket and re-broadcasts to SSE clients.
+    let envelope = pitboss_cli::control::protocol::EventEnvelope {
+        actor_path: pitboss_cli::dispatch::actor::ActorPath::default(),
+        seq: 0, // overwritten
+        event: ControlEvent::RunFinished {
+            summary: pitboss_cli::control::protocol::RunFinishedSummary {
+                tasks_total: 3,
+                tasks_failed: 1,
+            },
+        },
+    };
+    state.root.broadcast_control_event(envelope).await;
+
+    // Skim until we find the RunFinished envelope. Tolerate intervening
+    // bus traffic (the dispatcher's own Hello can land here via the
+    // subscriber socket's bus_bridge, and store-activity ticks at 1 s).
+    let mut saw = false;
+    for _ in 0..8 {
+        let env = timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .expect("envelope timeout")
+            .expect("recv");
+        if let ControlEvent::RunFinished { summary } = &env.event {
+            assert_eq!(summary.tasks_total, 3);
+            assert_eq!(summary.tasks_failed, 1);
+            saw = true;
+            break;
+        }
+    }
+    assert!(saw, "subscriber must receive broadcast envelope");
+}
+
+/// Cold runs (no live socket) return 404 — the SSE feed is strictly
+/// live; disk replay belongs to the dedicated Replay tab.
 #[tokio::test]
 async fn bridge_returns_not_found_when_no_socket() {
-    let tmp = tempfile::tempdir().unwrap();
+    let tmp = TempDir::new().unwrap();
     let bridge = ControlBridge::new(tmp.path().to_path_buf());
     let err = bridge
         .subscribe("nonexistent-run-id-12345")
@@ -130,162 +194,173 @@ async fn bridge_returns_not_found_when_no_socket() {
     assert!(matches!(err, BridgeError::NotFound), "got {err:?}");
 }
 
+/// Multiple `subscribe()` callers share one `Entry` (one
+/// writer-mode + one subscriber-mode dispatcher connection regardless
+/// of how many SSE clients attach).
 #[tokio::test]
 async fn bridge_subscribe_shares_connection_for_multiple_subscribers() {
-    let tmp = tempfile::tempdir().unwrap();
-    let runs_dir = tmp.path().to_path_buf();
-    let run_id = "01950000-0000-7000-8000-000000000002";
-    let run_dir = runs_dir.join(run_id);
-    std::fs::create_dir_all(&run_dir).unwrap();
-    let socket_path = run_dir.join("control.sock");
+    let runs_dir = TempDir::new().unwrap();
+    let (state, run_id, run_subdir) = make_test_state(&runs_dir).await;
+    let sock = run_subdir.join("control.sock");
+    let _h = start_control_server(
+        sock,
+        "test-0.0.1".into(),
+        run_id.to_string(),
+        "flat".into(),
+        state.clone(),
+    )
+    .await
+    .unwrap();
 
-    let listener = UnixListener::bind(&socket_path).unwrap();
-
-    // Track how many connections the dispatcher accepts. Should be 1
-    // even though we subscribe twice.
-    let server_handle = tokio::spawn(async move {
-        let mut accepted = 0u32;
-        loop {
-            tokio::select! {
-                accept = listener.accept() => {
-                    if let Ok((stream, _)) = accept {
-                        accepted += 1;
-                        let (_read, mut write) = stream.into_split();
-                        // Single broadcast event so both subscribers see something.
-                        let ev = ControlEvent::Hello {
-                            server_version: "shared".into(),
-                            run_id: "shared".into(),
-                            run_kind: "flat".into(),
-                            workers: vec![],
-                            policy_rules: vec![],
-                        };
-                        let mut line = serde_json::to_string(&ev).unwrap();
-                        line.push('\n');
-                        let _ = write.write_all(line.as_bytes()).await;
-                        // Hold the connection.
-                        tokio::time::sleep(Duration::from_secs(5)).await;
-                    }
-                }
-                _ = tokio::time::sleep(Duration::from_secs(3)) => break accepted,
-            }
-        }
-    });
-
-    let bridge = ControlBridge::new(runs_dir);
-    let mut rx1 = bridge.subscribe(run_id).await.expect("subscribe 1");
-    let mut rx2 = bridge.subscribe(run_id).await.expect("subscribe 2");
-
-    let e1 = timeout(Duration::from_secs(2), rx1.recv())
+    let bridge = ControlBridge::new(runs_dir.path().to_path_buf());
+    let mut rx1 = bridge
+        .subscribe(&run_id.to_string())
         .await
-        .expect("rx1")
-        .expect("rx1 recv");
-    let e2 = timeout(Duration::from_secs(2), rx2.recv())
+        .expect("subscribe 1");
+    let mut rx2 = bridge
+        .subscribe(&run_id.to_string())
         .await
-        .expect("rx2")
-        .expect("rx2 recv");
+        .expect("subscribe 2");
 
-    assert!(matches!(e1.event, ControlEvent::Hello { .. }));
-    assert!(matches!(e2.event, ControlEvent::Hello { .. }));
-
-    drop(rx1);
-    drop(rx2);
-    drop(bridge);
-
-    let accepted = server_handle.await.unwrap();
+    // Same Entry → same bus_bridge → baseline + 1. Two `subscribe()`
+    // calls don't open two dispatcher connections.
+    // 1 baseline (persistence) + 2 from the bridge's two connections
+    // (writer's bus_bridge + subscriber-mode pump's bus_bridge).
+    wait_for_bus_receivers(&state, 3, Duration::from_secs(3)).await;
     assert_eq!(
-        accepted, 1,
-        "bridge must reuse connection across subscribers"
+        state.root.events_tx.receiver_count(),
+        3,
+        "two subscribe() calls must share one dispatcher connection pair \
+         (writer + subscriber + baseline persistence = 3 bus receivers)",
     );
+
+    // Broadcast one envelope; both receivers must observe it via the
+    // shared Entry's broadcast tx.
+    let envelope = pitboss_cli::control::protocol::EventEnvelope {
+        actor_path: pitboss_cli::dispatch::actor::ActorPath::default(),
+        seq: 0,
+        event: ControlEvent::SubleadTerminated {
+            sublead_id: "S1".into(),
+            spent_usd: 0.5,
+            unspent_usd: 0.5,
+            outcome: "success".into(),
+        },
+    };
+    state.root.broadcast_control_event(envelope).await;
+
+    let mut saw1 = false;
+    for _ in 0..8 {
+        let env = timeout(Duration::from_secs(2), rx1.recv())
+            .await
+            .expect("rx1 timeout")
+            .expect("rx1");
+        if matches!(env.event, ControlEvent::SubleadTerminated { .. }) {
+            saw1 = true;
+            break;
+        }
+    }
+    let mut saw2 = false;
+    for _ in 0..8 {
+        let env = timeout(Duration::from_secs(2), rx2.recv())
+            .await
+            .expect("rx2 timeout")
+            .expect("rx2");
+        if matches!(env.event, ControlEvent::SubleadTerminated { .. }) {
+            saw2 = true;
+            break;
+        }
+    }
+    assert!(saw1, "rx1 must see the broadcast event");
+    assert!(saw2, "rx2 must see the broadcast event");
 }
 
+/// PR-Q end-to-end: bridge.send_op writes via the writer-mode
+/// connection, the dispatcher processes the op, the reply is broadcast
+/// via `events_tx`, and the bridge's subscriber-mode pump delivers it
+/// to the SSE receiver.
 #[tokio::test]
 async fn bridge_send_op_round_trips_through_dispatcher() {
-    // End-to-end: subscribe to the bridge, send an op via send_op, the
-    // fake dispatcher echoes an OpAcked, the bridge's reader_loop
-    // delivers the OpAcked envelope to the subscriber. This exercises
-    // the full Phase 3 control-write path without any side-channel
-    // assertions on raw socket bytes (which were flaky under tokio's
-    // current_thread test runtime — the broadcast receiver path is the
-    // one the SPA actually relies on).
-    let tmp = tempfile::tempdir().unwrap();
-    let runs_dir = tmp.path().to_path_buf();
-    let run_id = "01950000-0000-7000-8000-000000000003";
-    let run_dir = runs_dir.join(run_id);
-    std::fs::create_dir_all(&run_dir).unwrap();
-    let socket_path = run_dir.join("control.sock");
+    let runs_dir = TempDir::new().unwrap();
+    let (state, run_id, run_subdir) = make_test_state(&runs_dir).await;
 
-    let listener = UnixListener::bind(&socket_path).unwrap();
+    // Install a worker so ListWorkers returns a non-empty snapshot —
+    // makes the assertion specific.
+    state.root.workers.write().await.insert(
+        "w-1".into(),
+        WorkerState::Running {
+            started_at: chrono::Utc::now(),
+            session_id: Some("sess".into()),
+        },
+    );
+    state
+        .root
+        .worker_prompts
+        .write()
+        .await
+        .insert("w-1".into(), "look into the bug".into());
 
-    let server_handle = tokio::spawn(async move {
-        let (stream, _) = listener.accept().await.expect("accept");
-        let (read, mut write) = stream.into_split();
-        let mut reader = BufReader::new(read).lines();
-        // Read until we see a cancel_worker, then ack it. Dispatcher
-        // implementations always respond to a recognised op with either
-        // OpAcked or OpFailed; we only need the happy path here.
-        while let Ok(Some(line)) = reader.next_line().await {
-            if line.contains("\"op\":\"cancel_worker\"") {
-                let ack = ControlEvent::OpAcked {
-                    op: "cancel_worker".into(),
-                    task_id: Some("w-1".into()),
-                };
-                let mut s = serde_json::to_string(&ack).unwrap();
-                s.push('\n');
-                let _ = write.write_all(s.as_bytes()).await;
-                break;
-            }
-        }
-        // Hold the connection long enough for the bridge's reader to
-        // drain the ack into the broadcast channel before we EOF.
-        tokio::time::sleep(Duration::from_secs(1)).await;
-    });
+    let sock = run_subdir.join("control.sock");
+    let _h = start_control_server(
+        sock,
+        "test-0.0.1".into(),
+        run_id.to_string(),
+        "flat".into(),
+        state.clone(),
+    )
+    .await
+    .unwrap();
 
-    let bridge = ControlBridge::new(runs_dir);
-    // Subscribe FIRST so the dispatcher's OpAcked is visible to the
-    // receiver — tokio broadcast only delivers messages sent after a
-    // receiver is created.
-    let mut rx = bridge.subscribe(run_id).await.expect("subscribe");
+    let bridge = ControlBridge::new(runs_dir.path().to_path_buf());
+    let mut rx = bridge
+        .subscribe(&run_id.to_string())
+        .await
+        .expect("subscribe");
 
+    // Wait for the writer + subscriber connections' bus_bridges to
+    // attach before POSTing the op — otherwise the WorkersSnapshot
+    // broadcast might fire while the subscriber pump is still mid-handshake.
+    wait_for_bus_receivers(&state, 3, Duration::from_secs(3)).await;
+
+    // POST ListWorkers via the bridge's writer connection.
     bridge
-        .send_op(
-            run_id,
-            &ControlOp::CancelWorker {
-                task_id: "w-1".into(),
-            },
-        )
+        .send_op(&run_id.to_string(), &ControlOp::ListWorkers)
         .await
         .expect("send_op");
 
-    let envelope = timeout(Duration::from_secs(3), rx.recv())
-        .await
-        .expect("recv timeout")
-        .expect("recv chan");
-    match envelope.event {
-        ControlEvent::OpAcked { op, task_id } => {
-            assert_eq!(op, "cancel_worker");
-            assert_eq!(task_id.as_deref(), Some("w-1"));
+    let mut saw = false;
+    for _ in 0..8 {
+        let env = timeout(Duration::from_secs(3), rx.recv())
+            .await
+            .expect("recv timeout")
+            .expect("recv");
+        if let ControlEvent::WorkersSnapshot { workers } = &env.event {
+            assert!(
+                workers.iter().any(|w| w.task_id == "w-1"),
+                "snapshot must include w-1: {workers:?}"
+            );
+            saw = true;
+            break;
         }
-        other => panic!("expected OpAcked, got {other:?}"),
     }
-
-    drop(rx);
-    drop(bridge);
-    let _ = server_handle.await;
+    assert!(
+        saw,
+        "WorkersSnapshot must reach the subscriber receiver via the broadcast bus",
+    );
 }
 
+/// The bridge owns the Hello handshake; clients can't smuggle their
+/// own Hello through `send_op`.
 #[tokio::test]
 async fn bridge_send_op_rejects_client_hello() {
-    let tmp = tempfile::tempdir().unwrap();
-    let runs_dir = tmp.path().to_path_buf();
+    let runs_dir = TempDir::new().unwrap();
     let run_id = "01950000-0000-7000-8000-000000000004";
-    let run_dir = runs_dir.join(run_id);
+    let run_dir = runs_dir.path().join(run_id);
     std::fs::create_dir_all(&run_dir).unwrap();
-
     // Bind a listener so the path exists but never accept — Rejected
     // must fire on the up-front variant check before any IO.
-    let _listener = UnixListener::bind(run_dir.join("control.sock")).unwrap();
+    let _listener = tokio::net::UnixListener::bind(run_dir.join("control.sock")).unwrap();
 
-    let bridge = ControlBridge::new(runs_dir);
+    let bridge = ControlBridge::new(runs_dir.path().to_path_buf());
     let err = bridge
         .send_op(
             run_id,


### PR DESCRIPTION
## Summary

Closes out the #438 unified-envelope-API arc by migrating `pitboss-web`'s SSE bridge to consume `pitboss_core::stream::open_run_stream` and shrinking `control_bridge.rs` to a writer-only shim for `send_op`.

Two coupled changes:

**Dispatcher.** `serve_connection`'s read-loop reply path moves from per-connection `send_event` to `broadcast_control_event`. Op replies (`OpAcked` / `OpFailed` / `OpUnknownState` / `WorkersSnapshot`) now reach every connected client via the bus instead of only the originating connection. Writers still see their own replies (via their own `bus_bridge`); subscribers see them too — exactly what the web migration needs after switching to a subscriber-mode read connection. Subscriber-mode rejections and parse errors continue to use direct `send_event` (per-connection feedback). Side benefit: op replies persist in `events.jsonl` for runs with `emit_event_stream = true`.

**Web.** `control_bridge.rs` now opens two dispatcher connections per run:
- Writer-mode `UnixStream` for `send_op` (with a drain task on the read half to prevent kernel-buffer backpressure).
- Subscriber-mode pump driven by `open_run_stream(StreamMode::ReplayThenLive)`, filtering `RunStreamPayload::Event` items and forwarding the inner envelope into the existing per-run broadcast tx.

The SSE handler at `api/events.rs` is unchanged. Wire shape (`event: control` + envelope JSON) is byte-identical. The 404-on-cold-runs contract is preserved.

## Why bundle both changes

During plan exploration I found that op replies are connection-scoped in today's dispatcher (`server.rs:533` writes them via `send_event` to the originator only, comment at `:354–357` makes this explicit). The SPA depends on them (`runs/[id]/+page.svelte:500–514, 544, 611`) — particularly `WorkersSnapshot` which is fire-and-forget-then-await over SSE. A naive "swap the Hello mode and drop the reader_loop" cutover would have lost those frames. Routing op replies through the bus is the architecturally clean fix that aligns with Tokio's canonical single-producer-multi-consumer broadcast pattern (validated via Context7 against `tokio/1.49.0` docs).

## Test plan

- [x] `cargo test -p pitboss-cli --test control_flows` — 20/20 passing, including new `op_replies_broadcast_to_subscribers`.
- [x] `cargo test -p pitboss-web --test control_bridge_integration` — 5/5 (rewritten against a real dispatcher via `start_control_server` since the previous fake-`UnixListener` harness can't simulate the bus_bridge behavior).
- [x] `cargo test -p pitboss-cli --lib control::` — 50/50 passing.
- [x] `cargo test --workspace --features pitboss-core/test-support` — full sweep. Two pre-existing macOS-env failures (`/bin/true` missing on this box; `e2e_lead_request_approval_round_trip` parallel-load flake — passes in isolation) reproduce on `main`; Linux CI is the ground truth.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)