### PR TITLE
fix(web): show in-progress children in graph inspector (#438, PR-Q follow-on)

### DIFF
--- a/crates/pitboss-web/spa/src/lib/components/run-graph-inspector.svelte
+++ b/crates/pitboss-web/spa/src/lib/components/run-graph-inspector.svelte
@@ -33,7 +33,7 @@
     failure,
     sublead,
     activity,
-    allTasks,
+    allActors,
     inProgress,
     onJumpTo
   }: {
@@ -49,9 +49,12 @@
     failure: FailureReason | undefined;
     sublead: SubleadInfo | undefined;
     activity: ActorActivity | undefined;
-    /** Full task list — used to compute parent/children for the
-     *  hierarchy section. Same source the graph already consumes. */
-    allTasks: TaskRecord[];
+    /** Merged actor list (live `WorkersSnapshot` + finalized
+     *  `summary.jsonl`) — same shape the graph consumes. Used to compute
+     *  the Hierarchy section's Parent / Children rows, so in-progress
+     *  children appear under their parent immediately rather than
+     *  only after finalization. */
+    allActors: WorkerEntry[];
     /** Whether the run is still in progress. Drives whether the log
      *  pane auto-tails. Post-run inspectors render a frozen tail. */
     inProgress: boolean;
@@ -211,9 +214,9 @@
 
   const parentId = $derived(task?.parent_task_id ?? worker?.parent_task_id ?? null);
   const childrenIds = $derived(
-    allTasks
-      .filter((t) => t.parent_task_id === selectedTaskId)
-      .map((t) => t.task_id)
+    allActors
+      .filter((a) => a.parent_task_id === selectedTaskId)
+      .map((a) => a.task_id)
   );
 
   const totalTokens = $derived(

--- a/crates/pitboss-web/spa/src/routes/runs/[id]/+page.svelte
+++ b/crates/pitboss-web/spa/src/routes/runs/[id]/+page.svelte
@@ -1319,7 +1319,7 @@
     failure={selectedTaskId ? failures[selectedTaskId] : undefined}
     sublead={selectedTaskId ? subleads[selectedTaskId] : undefined}
     activity={selectedTaskId ? storeActivity[selectedTaskId] : undefined}
-    allTasks={tasksToRender as TaskRecord[]}
+    allActors={allWorkers}
     {inProgress}
     onJumpTo={(id) => (selectedTaskId = id === '' ? null : id)}
   />


### PR DESCRIPTION
## Summary

Follow-on bug fix surfaced during real-claude smoke testing of PR-Q (#467) on a sublead manifest:

- The Graph view's node inspector ("Hierarchy → Children" section) derived from `allTasks` (`TaskRecord[]`), sourced from `summary.jsonl`. That file is append-only at task finalize, so mid-run a parent's still-running children were invisible in the inspector — even though the same children were rendering as connected nodes in the graph itself.
- Routed the inspector's children-derivation through the same `allWorkers` list the graph already consumes (live `WorkersSnapshot` ∪ finalized records).
- Prop renamed `allTasks` → `allActors` with type updated to `WorkerEntry[]`. Only `task_id` and `parent_task_id` are touched by the children query — both fields are present on both shapes.

## Verification

- `cargo fmt --all -- --check` — clean.
- `npm run check` (SPA type-check) — 0 errors, 0 warnings across 4245 files.
- `cargo build --release -p pitboss-web` — clean.
- Manual: ran the real-claude sublead smoke (`/tmp/pitboss-smoke/launch-real-sublead.sh`), confirmed the sublead's two child workers now appear in the inspector's Children section while still in `running` state (previously appeared only after `done_success`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)