### PR TITLE
feat(communication): persist mailbox + activity to messages.jsonl for resume (#282)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -426,6 +426,8 @@ max_artifacts_per_actor = 128               # per-actor publish ceiling per run
 
 **Artifact storage** lands at `<run_dir>/communication/artifacts/<artifact_id>`. Auto-mounted under `pitboss container-dispatch`; cleaned with the run dir by `pitboss prune --remove`.
 
+**Resume persistence (v0.14+, #282).** Every mutating handler (`message_send`, `message_ack`, `artifact_put`, `artifact_grant`) appends a typed JSON record to `<run_dir>/communication/messages.jsonl` after its in-memory write succeeds. `CommunicationStore::new` replays the file at run-start, so `pitboss resume` rehydrates the pre-crash mailbox + artifact metadata + per-actor activity counters. Replay is tolerant of torn trailing writes (warns + skips, same pattern as `summary.jsonl`); artifact bytes on disk under `communication/artifacts/<id>` survive independently. Pre-v0.14 runs have no journal and resume with an empty mailbox as before.
+
 **Disabled mode** (the default) hides the 8 tools from `list_tools` and rejects every handler call with `CommunicationError::Disabled`. Tool names still appear in the lead/sublead/worker `--allowedTools` argv (cosmetic only — Claude does not call tools missing from `list_tools`).
 
 See `examples/communication-parent-child-demo.toml` for a full walkthrough.

--- a/crates/pitboss-cli/src/communication.rs
+++ b/crates/pitboss-cli/src/communication.rs
@@ -5,13 +5,14 @@
 //! Pitboss-managed ids rather than by stuffing serialized blobs into KV.
 
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use base64::Engine;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use tokio::io::AsyncWriteExt;
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
@@ -159,9 +160,51 @@ impl StoredArtifact {
 pub struct CommunicationStore {
     config: CommunicationConfig,
     artifact_dir: PathBuf,
+    /// Append-only journal at `<run_subdir>/communication/messages.jsonl`.
+    /// Every mutating handler writes a typed [`JournalRecord`] after its
+    /// in-memory write succeeds; [`CommunicationStore::new`] replays the
+    /// file on construction so `pitboss resume` rehydrates the mailbox
+    /// + artifact metadata that existed pre-crash. See #282.
+    journal_path: PathBuf,
     messages: RwLock<HashMap<String, StoredMessage>>,
     artifacts: RwLock<HashMap<String, StoredArtifact>>,
     activity: RwLock<HashMap<String, CommunicationActivityCounters>>,
+}
+
+/// One line in the `messages.jsonl` journal (#282). The journal exists so
+/// `pitboss resume` rebuilds in-memory mailbox + artifact metadata after a
+/// crash; artifact bytes are on disk under `communication/artifacts/<id>`
+/// independently.
+///
+/// Each mutating handler emits one record after its in-memory write
+/// succeeds. The variants mirror the four observable state transitions
+/// the handlers perform; `note_message_op` / `note_artifact_op` activity
+/// counters are derived on replay from the records themselves
+/// (`MessageSend`/`MessageAck` → `message_ops`,
+/// `ArtifactPut`/`ArtifactGrant` → `artifact_ops`).
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum JournalRecord {
+    MessageSend {
+        message: Message,
+    },
+    MessageAck {
+        message_id: String,
+        by: String,
+    },
+    ArtifactPut {
+        metadata: ArtifactMetadata,
+    },
+    /// `by` records the grantor so replay can correctly attribute the
+    /// `artifact_ops` counter increment that `note_artifact_op` made
+    /// before the in-memory write. Beyond the original #282 spec, which
+    /// only listed `artifact_id` + `to` — without `by` the grantor's
+    /// counter would silently drop on replay.
+    ArtifactGrant {
+        artifact_id: String,
+        to: String,
+        by: String,
+    },
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -172,17 +215,44 @@ pub struct CommunicationActivityCounters {
 
 impl CommunicationStore {
     pub fn new(config: CommunicationConfig, run_subdir: PathBuf) -> Self {
+        let comm_dir = run_subdir.join("communication");
+        let artifact_dir = comm_dir.join("artifacts");
+        let journal_path = comm_dir.join("messages.jsonl");
+
+        // #282: replay the journal if present so a resumed dispatcher
+        // inherits the pre-crash mailbox + artifact metadata. `new` is
+        // sync (called from `DispatchState::new`) so the replay uses
+        // std::fs; this is one-shot at run start, not a hot path.
+        let mut messages: HashMap<String, StoredMessage> = HashMap::new();
+        let mut artifacts: HashMap<String, StoredArtifact> = HashMap::new();
+        let mut activity: HashMap<String, CommunicationActivityCounters> = HashMap::new();
+        replay_journal(
+            &journal_path,
+            &artifact_dir,
+            &mut messages,
+            &mut artifacts,
+            &mut activity,
+        );
+
         Self {
             config,
-            artifact_dir: run_subdir.join("communication").join("artifacts"),
-            messages: RwLock::new(HashMap::new()),
-            artifacts: RwLock::new(HashMap::new()),
-            activity: RwLock::new(HashMap::new()),
+            artifact_dir,
+            journal_path,
+            messages: RwLock::new(messages),
+            artifacts: RwLock::new(artifacts),
+            activity: RwLock::new(activity),
         }
     }
 
     pub fn config(&self) -> &CommunicationConfig {
         &self.config
+    }
+
+    /// Path to the append-only journal (`<run_subdir>/communication/messages.jsonl`).
+    /// Exposed crate-private so the handler helpers can call
+    /// [`journal_append`] after a successful in-memory write.
+    pub(crate) fn journal_path(&self) -> &Path {
+        &self.journal_path
     }
 
     pub async fn note_message_op(&self, actor_id: &str) {
@@ -209,6 +279,178 @@ impl CommunicationStore {
 
     pub async fn activity_snapshot(&self) -> HashMap<String, CommunicationActivityCounters> {
         self.activity.read().await.clone()
+    }
+}
+
+/// Read the `messages.jsonl` journal (if present) and seed in-memory
+/// state from it. Mirrors `pitboss_core::store::summary::overlay_summary_jsonl`:
+/// tolerant of blank lines and torn trailing writes (`Err → warn + skip`).
+///
+/// Each successfully-parsed record reconstructs both the entity (message
+/// or artifact) AND the activity counter increment the live handler
+/// would have made via `note_message_op` / `note_artifact_op`.
+fn replay_journal(
+    journal_path: &Path,
+    artifact_dir: &Path,
+    messages: &mut HashMap<String, StoredMessage>,
+    artifacts: &mut HashMap<String, StoredArtifact>,
+    activity: &mut HashMap<String, CommunicationActivityCounters>,
+) {
+    let Ok(text) = std::fs::read_to_string(journal_path) else {
+        return;
+    };
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let record: JournalRecord = match serde_json::from_str(trimmed) {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    line = trimmed,
+                    path = %journal_path.display(),
+                    "messages.jsonl: skipping unparseable line",
+                );
+                continue;
+            }
+        };
+        apply_journal_record(record, artifact_dir, messages, artifacts, activity);
+    }
+}
+
+/// Apply a single replayed record to the rebuilt in-memory state.
+/// Split out from `replay_journal` so tests can drive the apply path
+/// directly without touching the filesystem if they need to.
+fn apply_journal_record(
+    record: JournalRecord,
+    artifact_dir: &Path,
+    messages: &mut HashMap<String, StoredMessage>,
+    artifacts: &mut HashMap<String, StoredArtifact>,
+    activity: &mut HashMap<String, CommunicationActivityCounters>,
+) {
+    match record {
+        JournalRecord::MessageSend { message } => {
+            let stored = StoredMessage {
+                message_id: message.message_id.clone(),
+                from: message.from.clone(),
+                to: message.to,
+                subject: message.subject,
+                body: message.body,
+                refs: message.refs,
+                created_at: message.created_at,
+                acked_by: message.acked_by.into_iter().collect(),
+            };
+            if !stored.from.is_empty() {
+                activity.entry(stored.from.clone()).or_default().message_ops += 1;
+            }
+            messages.insert(message.message_id, stored);
+        }
+        JournalRecord::MessageAck { message_id, by } => {
+            if let Some(msg) = messages.get_mut(&message_id) {
+                msg.acked_by.insert(by.clone());
+            }
+            if !by.is_empty() {
+                activity.entry(by).or_default().message_ops += 1;
+            }
+        }
+        JournalRecord::ArtifactPut { metadata } => {
+            if !metadata.owner.is_empty() {
+                activity
+                    .entry(metadata.owner.clone())
+                    .or_default()
+                    .artifact_ops += 1;
+            }
+            let path = artifact_dir.join(&metadata.artifact_id);
+            let grants: HashSet<String> = metadata.grants.iter().cloned().collect();
+            artifacts.insert(
+                metadata.artifact_id.clone(),
+                StoredArtifact {
+                    metadata,
+                    path,
+                    grants,
+                },
+            );
+        }
+        JournalRecord::ArtifactGrant {
+            artifact_id,
+            to,
+            by,
+        } => {
+            if let Some(art) = artifacts.get_mut(&artifact_id) {
+                art.grants.insert(to);
+            }
+            if !by.is_empty() {
+                activity.entry(by).or_default().artifact_ops += 1;
+            }
+        }
+    }
+}
+
+/// Append one [`JournalRecord`] to the messages.jsonl journal. Best-effort:
+/// errors are logged and swallowed so a transient I/O failure can't break
+/// the live mailbox or wedge a handler. The in-memory state is then
+/// briefly ahead of the journal until the next successful append — a
+/// fine recovery trade because the operator sees what happened in
+/// memory, and the next write that succeeds resyncs the journal.
+async fn journal_append(path: &Path, record: &JournalRecord) {
+    // Lazily ensure the parent directory exists. For message-only runs
+    // nothing else creates `<run_subdir>/communication/`; for
+    // artifact-using runs `handle_artifact_put` already creates the
+    // sibling `artifacts/` directory, but we don't take a dependency
+    // on call order.
+    if let Some(parent) = path.parent() {
+        if let Err(e) = tokio::fs::create_dir_all(parent).await {
+            tracing::warn!(
+                error = %e,
+                path = %parent.display(),
+                "messages.jsonl: create_dir_all failed; journal append skipped",
+            );
+            return;
+        }
+    }
+    let mut line = match serde_json::to_vec(record) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(error = %e, "messages.jsonl: serialize failed; journal append skipped");
+            return;
+        }
+    };
+    line.push(b'\n');
+    let mut file = match tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .await
+    {
+        Ok(f) => f,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                path = %path.display(),
+                "messages.jsonl: open failed; journal append skipped",
+            );
+            return;
+        }
+    };
+    if let Err(e) = file.write_all(&line).await {
+        tracing::warn!(
+            error = %e,
+            path = %path.display(),
+            "messages.jsonl: write failed; partial line possible (next replay tolerates)",
+        );
+        return;
+    }
+    // `sync_all` matches `pitboss_core::store::json_file::append_record`'s
+    // durability guarantee — after this returns, the row survives a
+    // power loss / kernel panic.
+    if let Err(e) = file.sync_all().await {
+        tracing::warn!(
+            error = %e,
+            path = %path.display(),
+            "messages.jsonl: sync_all failed",
+        );
     }
 }
 
@@ -353,12 +595,19 @@ pub async fn handle_message_send(
         created_at: Utc::now(),
         acked_by: HashSet::new(),
     };
+    let journal_record = JournalRecord::MessageSend {
+        message: message.full(),
+    };
     state
         .communication
         .messages
         .write()
         .await
         .insert(message_id.clone(), message);
+    // #282: journal AFTER the in-memory write succeeds. Append errors
+    // are logged + swallowed inside `journal_append` so a transient I/O
+    // failure can't fail the live op.
+    journal_append(state.communication.journal_path(), &journal_record).await;
     Ok(MessageSendResult { message_id })
 }
 
@@ -428,17 +677,26 @@ pub async fn handle_message_ack(
     ensure_enabled(state)?;
     let caller: Caller = args.meta.into();
     state.communication.note_message_op(&caller.id).await;
-    let mut messages = state.communication.messages.write().await;
-    let message = messages
-        .get_mut(&args.message_id)
-        .ok_or_else(|| CommunicationError::NotFound(args.message_id.clone()))?;
-    if !can_read_message(state, &caller, message).await? {
-        return Err(CommunicationError::Forbidden(format!(
-            "{} cannot ack message {}",
-            caller.id, args.message_id
-        )));
-    }
-    message.acked_by.insert(caller.id);
+    let journal_record = {
+        let mut messages = state.communication.messages.write().await;
+        let message = messages
+            .get_mut(&args.message_id)
+            .ok_or_else(|| CommunicationError::NotFound(args.message_id.clone()))?;
+        if !can_read_message(state, &caller, message).await? {
+            return Err(CommunicationError::Forbidden(format!(
+                "{} cannot ack message {}",
+                caller.id, args.message_id
+            )));
+        }
+        message.acked_by.insert(caller.id.clone());
+        JournalRecord::MessageAck {
+            message_id: args.message_id,
+            by: caller.id,
+        }
+    };
+    // #282: journal AFTER the in-memory ack lands. Lock dropped above
+    // so the append doesn't hold the messages-write lock across I/O.
+    journal_append(state.communication.journal_path(), &journal_record).await;
     Ok(OkResult { ok: true })
 }
 
@@ -491,6 +749,7 @@ pub async fn handle_artifact_put(
         grants: Vec::new(),
     };
 
+    let journal_metadata = metadata.clone();
     {
         let mut artifacts = state.communication.artifacts.write().await;
         let current_count = artifacts
@@ -514,6 +773,18 @@ pub async fn handle_artifact_put(
             },
         );
     }
+
+    // #282: journal AFTER the in-memory insert. The bytes are already
+    // on disk by this point; the journal records the metadata so a
+    // resume rebuilds the in-memory entry without re-reading every
+    // artifact directory entry.
+    journal_append(
+        state.communication.journal_path(),
+        &JournalRecord::ArtifactPut {
+            metadata: journal_metadata,
+        },
+    )
+    .await;
 
     Ok(ArtifactPutResult {
         artifact_id,
@@ -598,17 +869,27 @@ pub async fn handle_artifact_grant(
     state.communication.note_artifact_op(&caller.id).await;
     let to = resolve_recipient(state, &caller, &args.to).await?;
     ensure_can_send(state, &caller, &to).await?;
-    let mut artifacts = state.communication.artifacts.write().await;
-    let artifact = artifacts
-        .get_mut(&args.artifact_id)
-        .ok_or_else(|| CommunicationError::NotFound(args.artifact_id.clone()))?;
-    if !can_read_artifact(state, &caller, artifact).await? {
-        return Err(CommunicationError::Forbidden(format!(
-            "{} cannot grant artifact {}",
-            caller.id, args.artifact_id
-        )));
-    }
-    artifact.grants.insert(to);
+    let journal_record = {
+        let mut artifacts = state.communication.artifacts.write().await;
+        let artifact = artifacts
+            .get_mut(&args.artifact_id)
+            .ok_or_else(|| CommunicationError::NotFound(args.artifact_id.clone()))?;
+        if !can_read_artifact(state, &caller, artifact).await? {
+            return Err(CommunicationError::Forbidden(format!(
+                "{} cannot grant artifact {}",
+                caller.id, args.artifact_id
+            )));
+        }
+        artifact.grants.insert(to.clone());
+        JournalRecord::ArtifactGrant {
+            artifact_id: args.artifact_id,
+            to,
+            by: caller.id,
+        }
+    };
+    // #282: journal AFTER the in-memory grant lands. Lock dropped above
+    // so the append doesn't hold the artifacts-write lock across I/O.
+    journal_append(state.communication.journal_path(), &journal_record).await;
     Ok(OkResult { ok: true })
 }
 
@@ -1384,5 +1665,218 @@ mod tests {
             after_second, 1,
             "rejected put must roll back the orphan file (saw {after_second} files)",
         );
+    }
+
+    // ----------------------------------------------------------------
+    // #282: messages.jsonl journal — persist + replay on resume.
+    // ----------------------------------------------------------------
+
+    /// Send three messages from a worker to its parent, drop the
+    /// `CommunicationStore`, construct a fresh one at the same
+    /// `run_subdir`, and assert that all three reappear in the
+    /// rebuilt mailbox (with parent ↔ child wiring intact).
+    #[tokio::test]
+    async fn journal_round_trip_rehydrates_messages() {
+        let state = test_state(CommunicationConfig {
+            mode: CommunicationMode::ParentChild,
+            ..Default::default()
+        })
+        .await;
+        add_root_worker(&state, "w1").await;
+
+        for i in 0..3 {
+            handle_message_send(
+                &state,
+                MessageSendArgs {
+                    to: "parent".into(),
+                    subject: format!("subject-{i}"),
+                    body: format!("body-{i}"),
+                    refs: vec![],
+                    meta: meta("w1", ActorRole::Worker),
+                },
+            )
+            .await
+            .unwrap();
+        }
+
+        // The journal exists on disk with one line per send.
+        let journal_path = state.communication.journal_path().to_path_buf();
+        let on_disk = std::fs::read_to_string(&journal_path).unwrap();
+        assert_eq!(
+            on_disk.lines().count(),
+            3,
+            "journal should have one line per message_send",
+        );
+
+        // Replay into a fresh store and confirm the messages reappear.
+        let fresh = CommunicationStore::new(
+            state.root.manifest.communication.clone(),
+            state.root.run_subdir.clone(),
+        );
+        let rebuilt = fresh.messages.read().await;
+        assert_eq!(rebuilt.len(), 3);
+        let mut subjects: Vec<String> = rebuilt.values().map(|m| m.subject.clone()).collect();
+        subjects.sort();
+        assert_eq!(subjects, vec!["subject-0", "subject-1", "subject-2"]);
+        for msg in rebuilt.values() {
+            assert_eq!(msg.from, "w1");
+            assert_eq!(msg.to, "lead");
+        }
+    }
+
+    /// Put one artifact, grant it to a sibling, drop, recreate; the
+    /// metadata + grant survive into the rebuilt store so a resumed
+    /// dispatcher can serve `artifact_read` for the grantee without
+    /// re-issuing the original grant call.
+    #[tokio::test]
+    async fn journal_round_trip_rehydrates_artifacts_and_grants() {
+        let state = test_state(CommunicationConfig {
+            mode: CommunicationMode::ParentChild,
+            ..Default::default()
+        })
+        .await;
+        add_root_worker(&state, "w1").await;
+        add_root_worker(&state, "w2").await;
+
+        let put = handle_artifact_put(
+            &state,
+            ArtifactPutArgs {
+                name: "report.bin".into(),
+                mime_type: Some("application/octet-stream".into()),
+                content_base64: base64::engine::general_purpose::STANDARD.encode([1, 2, 3]),
+                meta: meta("w1", ActorRole::Worker),
+            },
+        )
+        .await
+        .unwrap();
+
+        handle_artifact_grant(
+            &state,
+            ArtifactGrantArgs {
+                artifact_id: put.artifact_id.clone(),
+                to: "w2".into(),
+                meta: meta("lead", ActorRole::Lead),
+            },
+        )
+        .await
+        .unwrap();
+
+        let fresh = CommunicationStore::new(
+            state.root.manifest.communication.clone(),
+            state.root.run_subdir.clone(),
+        );
+        let rebuilt = fresh.artifacts.read().await;
+        let artifact = rebuilt
+            .get(&put.artifact_id)
+            .expect("artifact must rehydrate");
+        assert_eq!(artifact.metadata.owner, "w1");
+        assert!(
+            artifact.grants.contains("w2"),
+            "grant to w2 must survive replay: grants={:?}",
+            artifact.grants
+        );
+        // The artifact's on-disk path was reconstructed under the run
+        // subdir's artifact_dir — not stored on the wire, but derived
+        // from `artifact_id`.
+        let expected_path = state
+            .root
+            .run_subdir
+            .join("communication")
+            .join("artifacts")
+            .join(&put.artifact_id);
+        assert_eq!(artifact.path, expected_path);
+    }
+
+    /// A torn trailing write — partial line, no newline — must not
+    /// fail the replay. The store loads everything before the torn
+    /// line and skips the bad row with a warn log. Mirrors
+    /// `pitboss_core::store::summary::overlay_summary_jsonl`'s
+    /// tolerant-tail behavior.
+    #[tokio::test]
+    async fn journal_tolerates_torn_trailing_line() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let run_subdir = dir.path().to_path_buf();
+        let comm_dir = run_subdir.join("communication");
+        std::fs::create_dir_all(&comm_dir).unwrap();
+        let journal = comm_dir.join("messages.jsonl");
+
+        // Two valid records, then a torn partial line with no \n.
+        let valid_rec = JournalRecord::MessageSend {
+            message: Message {
+                message_id: "m1".into(),
+                from: "w1".into(),
+                to: "lead".into(),
+                subject: "s".into(),
+                body: "b".into(),
+                refs: vec![],
+                created_at: Utc::now(),
+                acked_by: vec![],
+            },
+        };
+        let second_rec = JournalRecord::MessageAck {
+            message_id: "m1".into(),
+            by: "lead".into(),
+        };
+        let mut content = serde_json::to_string(&valid_rec).unwrap();
+        content.push('\n');
+        content.push_str(&serde_json::to_string(&second_rec).unwrap());
+        content.push('\n');
+        // Torn: missing the closing brace.
+        content.push_str(r#"{"type":"message_send","message":{"message_id":"m2""#);
+        std::fs::write(&journal, content).unwrap();
+
+        let store = CommunicationStore::new(CommunicationConfig::default(), run_subdir);
+        let rebuilt = store.messages.read().await;
+        // Only m1 survives: it was sent + acked; m2's record was torn.
+        assert_eq!(rebuilt.len(), 1);
+        let m1 = rebuilt.get("m1").expect("m1 must be present");
+        assert!(m1.acked_by.contains("lead"), "ack must be replayed");
+    }
+
+    /// `note_message_op` / `note_artifact_op` bump the activity
+    /// counters BEFORE the in-memory write. The replay re-bumps from
+    /// the journal so the post-resume snapshot matches what the
+    /// pre-crash live snapshot would have shown.
+    #[tokio::test]
+    async fn journal_replay_rebuilds_activity_counters() {
+        let state = test_state(CommunicationConfig {
+            mode: CommunicationMode::ParentChild,
+            ..Default::default()
+        })
+        .await;
+        add_root_worker(&state, "w1").await;
+
+        handle_message_send(
+            &state,
+            MessageSendArgs {
+                to: "parent".into(),
+                subject: "s".into(),
+                body: "b".into(),
+                refs: vec![],
+                meta: meta("w1", ActorRole::Worker),
+            },
+        )
+        .await
+        .unwrap();
+        handle_artifact_put(
+            &state,
+            ArtifactPutArgs {
+                name: "f.bin".into(),
+                mime_type: None,
+                content_base64: base64::engine::general_purpose::STANDARD.encode([0u8]),
+                meta: meta("w1", ActorRole::Worker),
+            },
+        )
+        .await
+        .unwrap();
+
+        let fresh = CommunicationStore::new(
+            state.root.manifest.communication.clone(),
+            state.root.run_subdir.clone(),
+        );
+        let activity = fresh.activity_snapshot().await;
+        let w1 = activity.get("w1").expect("w1 counters must rehydrate");
+        assert_eq!(w1.message_ops, 1, "one message_send → one message_ops");
+        assert_eq!(w1.artifact_ops, 1, "one artifact_put → one artifact_ops");
     }
 }


### PR DESCRIPTION
## Summary

Closes #282. Adds an append-only `<run_subdir>/communication/messages.jsonl` journal symmetric with `summary.jsonl`. Each mutating communication handler writes a typed `JournalRecord` after its in-memory state mutation succeeds; `CommunicationStore::new` replays the file at run start so `pitboss resume` rehydrates the pre-crash mailbox + artifact metadata + per-actor activity counters.

## Why

The `[communication]` plane (introduced in #281) stored everything in-memory only. `pitboss resume` rebuilt an empty mailbox — every parent/child handoff that completed before the crash was lost. Artifact bytes survived on disk but the lead had no record of which artifacts existed or who owned them. Recovery was functionally blind.

## Wire format

Private enum in `communication.rs`:

```rust
#[serde(tag = "type", rename_all = "snake_case")]
enum JournalRecord {
    MessageSend { message: Message },
    MessageAck { message_id: String, by: String },
    ArtifactPut { metadata: ArtifactMetadata },
    ArtifactGrant { artifact_id: String, to: String, by: String },
}
```

The `Message` and `ArtifactMetadata` payloads are already public + `Serialize/Deserialize`, so the journal uses them as wire forms — no need to derive serde on the private `StoredMessage`/`StoredArtifact` internals. On replay, `HashSet<String>` ack/grant sets are reconstructed from the `Vec<String>` wire form, and `StoredArtifact.path` is derived from `artifact_dir.join(&artifact_id)`.

`ArtifactGrant.by` extends the original #282 spec to record the grantor. Without it, the `note_artifact_op` counter increment that ran before the in-memory write is silently dropped on replay. Aligns with `MessageAck.by`.

## Reuse

- `pitboss_core::store::summary::overlay_summary_jsonl` — the tolerant-tail JSONL replay pattern. The new `replay_journal` mirrors it line-for-line (`read_to_string`, trim, skip blanks, `warn + skip` on parse error).
- `pitboss_core::store::json_file::append_record` — the async append-with-fsync pattern. The new `journal_append` mirrors it (`OpenOptions::create.append`, `write_all`, `sync_all`). Append errors are logged and swallowed so a transient I/O failure can't fail the live op.

## Test plan

- [x] `cargo test -p pitboss-cli --lib communication` — 15 passing (11 pre-existing + 4 new):
  - `journal_round_trip_rehydrates_messages` — send 3, drop, recreate, see 3.
  - `journal_round_trip_rehydrates_artifacts_and_grants` — put + grant, drop, recreate, both survive.
  - `journal_tolerates_torn_trailing_line` — partial last line is skipped; valid records before it survive.
  - `journal_replay_rebuilds_activity_counters` — `note_*_op` counters post-resume match what live `note_*_op` produced.
- [x] `cargo test --workspace --features pitboss-core/test-support` — 802 lib tests pass (up 4 from baseline); only failure is the pre-existing macOS-env `process::tokio_impl::tests::terminate_after_exit_is_ok` flake (`/bin/true` missing on this box; passes on Linux CI).
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.

## Out of scope (deferred)

- `RunStreamPayload::Message` arm in `pitboss-core::stream` — turns the journal into a unified-API consumer surface. Co-spec'd in the unified-envelope-API RFC as a future arm; lands after #414 pins the `Audit` shape.
- Pruning / compaction — `pitboss prune --remove` already recursively cleans the run-dir, so a deleted run takes its journal with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)