### PR TITLE
feat(audit): per-run aggregated audit log + pitboss audit CLI + /api/runs/:id/audit (#414)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -778,9 +778,10 @@ Files in the run dir:
 | `summary.json` | Written on clean finalize. Full structured summary of the run. |
 | `summary.jsonl` | Appended incrementally as tasks finish. Useful for live observation. |
 | `events.jsonl` | **Opt-in** (v0.13+, `[run].emit_event_stream = true`). Run-wide control-event log: every `EventEnvelope` the dispatcher would have sent on the wire, persisted as it fires. Survives headless dispatches (no TUI / web bridge). See [`events.jsonl` structure](#eventsjsonl-structure-v013-opt-in). |
+| `audit.jsonl` | **v0.14+** (#414). Run-wide aggregated audit log: every per-actor `TaskEvent` row (`pause` / `continue` / `reprompt` / `approval_request` / `approval_response` / `notification_failed` / `tool_denied` / `tool_auto_approved`) tee'd from the per-actor file with an explicit `actor_id` field. Always-on, created lazily on first event. Query via `pitboss audit <run-id> [--actor X] [--kind K] [--since T] [--reason-kind R]` or `GET /api/runs/<id>/audit` with the same filters as query params. |
 | `tasks/<id>/stdout.log` | Raw stream-json from the task's claude subprocess. |
 | `tasks/<id>/stderr.log` | Stderr. |
-| `tasks/<id>/events.jsonl` | **Distinct from the run-level file above.** Per-actor audit log: `pause` / `continue` / `reprompt` / `tool_denied` / `tool_auto_approved` / `approval_request` rows. Always-on (created lazily on first append). |
+| `tasks/<id>/events.jsonl` | **Distinct from the run-level file above.** Per-actor audit log: `pause` / `continue` / `reprompt` / `tool_denied` / `tool_auto_approved` / `approval_request` rows. Always-on (created lazily on first append). The same rows are tee'd into the run-wide `audit.jsonl` for chronological cross-actor queries. |
 | `lead-mcp-config.json` | Hierarchical only. The `--mcp-config` file pointed at `pitboss mcp-bridge <socket>`. |
 
 ### `summary.json` structure
@@ -881,6 +882,45 @@ curl -H "Authorization: Bearer $TOKEN" \
 # SPA: the "Replay" tab on the run-detail page (finalized runs only;
 # in-progress runs still use the live SSE Live tab).
 ```
+
+### `audit.jsonl` structure (v0.14+, #414)
+
+Always-on. The dispatcher tees every per-actor `TaskEvent` write into
+this run-wide file with an explicit `actor_id` field, giving operators
+a chronological cross-actor view without walking
+`tasks/*/events.jsonl` by hand.
+
+```json
+{"actor_id":"lead","event":{"kind":"approval_request","at":"2026-05-14T03:42:00Z","request_id":"r-1","summary_preview":"spawn 3 workers"}}
+{"actor_id":"worker-7","event":{"kind":"tool_denied","at":"2026-05-14T03:42:05Z","tool_name":"Bash","actor_id":"worker-7","reason_kind":"denied_by_rule","reason":"shell access denied"}}
+```
+
+Wire shape: `{actor_id, event}` — `actor_id` is the run-wide
+attribution key; `event` carries the existing per-actor `TaskEvent`
+JSON verbatim (the `kind`-discriminated enum with payload fields). The
+per-actor `tasks/<id>/events.jsonl` files remain durable; the audit
+file is the run-wide companion.
+
+Three ways to consume:
+
+```bash
+# CLI: columnar one-line-per-event with filters; --json for raw NDJSON.
+pitboss audit <run-id>
+pitboss audit <run-id> --actor worker-7 --kind tool_denied
+pitboss audit <run-id> --since 2026-05-14T03:00:00Z --reason-kind operator_rejected
+pitboss audit <run-id> --json | jq 'select(.event.kind == "approval_response")'
+
+# HTTP: NDJSON over the web server with the same filter surface as
+# query params (auth-gated).
+curl -H "Authorization: Bearer $TOKEN" \
+     'http://localhost:8080/api/runs/<run-id>/audit?actor=lead&kind=approval_response'
+```
+
+Write semantics: the tee is best-effort — a transient filesystem
+failure on `audit.jsonl` logs a warning but doesn't break the durable
+per-actor write. So a crashed dispatcher might leave the audit file
+slightly stale relative to the per-actor files; the per-actor files
+remain the source of truth.
 
 ---
 

--- a/crates/pitboss-cli/src/audit.rs
+++ b/crates/pitboss-cli/src/audit.rs
@@ -1,0 +1,475 @@
+//! `pitboss audit <run-id>` — print the per-run aggregated audit log
+//! (#414).
+//!
+//! Reads `<run-dir>/audit.jsonl`, which the dispatcher tees from every
+//! `TaskEvent` emission (see [`crate::dispatch::events::append_event`]).
+//! Each line is a [`TaskEvent`] payload plus a leading `actor_id`
+//! field — `pitboss audit` is the run-wide companion to `pitboss
+//! events`, which reads run-wide CONTROL envelopes; this one reads
+//! run-wide TASK / approval / tool-permission events.
+//!
+//! Filters are applied in-memory after the file is read. Audit logs
+//! are small (single-digit-K rows on a busy multi-worker run); a
+//! full-file scan with structured-filter is the right v1 tradeoff for
+//! simplicity.
+//!
+//! Resolution: the `<run-id>` argument accepts the full UUID or any
+//! unique prefix (same convention as `pitboss events` / `pitboss
+//! status`).
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::dispatch::events::TaskEvent;
+
+/// One row of `audit.jsonl`. Mirrors the write-side
+/// `dispatch::events::AuditEntry`: `actor_id` is the run-wide
+/// attribution key, `event` is the nested [`TaskEvent`] payload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditEntry {
+    pub actor_id: String,
+    pub event: TaskEvent,
+}
+
+/// Filter predicate evaluated against each parsed row. `None`-valued
+/// fields are no-op (the row passes that filter dimension).
+#[derive(Debug, Default, Clone)]
+pub struct AuditFilter {
+    pub actor: Option<String>,
+    pub kind: Option<String>,
+    pub since: Option<DateTime<Utc>>,
+    pub reason_kind: Option<String>,
+}
+
+impl AuditFilter {
+    pub fn matches(&self, entry: &AuditEntry) -> bool {
+        if let Some(actor) = &self.actor {
+            if &entry.actor_id != actor {
+                return false;
+            }
+        }
+        if let Some(kind) = &self.kind {
+            if event_kind(&entry.event) != kind.as_str() {
+                return false;
+            }
+        }
+        if let Some(since) = self.since {
+            if event_at(&entry.event) < since {
+                return false;
+            }
+        }
+        if let Some(rk) = &self.reason_kind {
+            match event_reason_kind(&entry.event) {
+                Some(have) if have == rk.as_str() => {}
+                _ => return false,
+            }
+        }
+        true
+    }
+}
+
+/// Entry point for the `audit` subcommand.
+pub fn run(
+    run_id_prefix: &str,
+    filter: AuditFilter,
+    json: bool,
+    run_dir_override: Option<PathBuf>,
+) -> Result<i32> {
+    let base = run_dir_override.unwrap_or_else(default_runs_dir);
+    let run_dir = crate::runs::resolve_run_dir_by_prefix(&base, run_id_prefix)?;
+    let audit_path = run_dir.join("audit.jsonl");
+
+    let file = match std::fs::File::open(&audit_path) {
+        Ok(f) => f,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            bail!(
+                "no audit.jsonl in {}; the run produced no TaskEvent rows \
+                 (no approvals, no pauses, no tool denials). The audit log is \
+                 written live as events flow — if the run is still in progress, \
+                 wait for the first event, or check the per-actor files under \
+                 {}/tasks/<actor>/events.jsonl.",
+                run_dir.display(),
+                run_dir.display(),
+            );
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    render(
+        BufReader::new(file),
+        &filter,
+        json,
+        &mut std::io::stdout().lock(),
+    )
+}
+
+/// Stream + filter + render into `out`. Factored so tests can drive
+/// the render path against an in-memory buffer without touching disk
+/// resolution.
+pub fn render<R: BufRead, W: Write>(
+    reader: R,
+    filter: &AuditFilter,
+    json: bool,
+    out: &mut W,
+) -> Result<i32> {
+    let mut parsed = 0usize;
+    let mut shown = 0usize;
+    let mut skipped = 0usize;
+
+    for line in reader.lines() {
+        let line = line?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<AuditEntry>(trimmed) {
+            Ok(entry) => {
+                parsed += 1;
+                if !filter.matches(&entry) {
+                    continue;
+                }
+                if json {
+                    // Re-serialise from the typed form so passthrough
+                    // and filtered output share the same canonical
+                    // shape. (Alternative: pass `trimmed` through
+                    // verbatim. Re-serialising costs a few µs per row
+                    // and gives a stable wire shape on filter rounds.)
+                    let canonical = serde_json::to_string(&entry)?;
+                    writeln!(out, "{canonical}")?;
+                } else {
+                    writeln!(out, "{}", format_row(&entry))?;
+                }
+                shown += 1;
+            }
+            Err(_) => skipped += 1,
+        }
+    }
+
+    if skipped > 0 {
+        eprintln!(
+            "pitboss audit: skipped {skipped} malformed line(s); rendered {shown} of {parsed} parsed row(s)",
+        );
+    }
+    Ok(0)
+}
+
+/// Render one row as a single fixed-width line:
+///
+/// ```text
+/// <ts>  <actor_id>          <kind>              <detail>
+/// ```
+fn format_row(entry: &AuditEntry) -> String {
+    let ts = event_at(&entry.event).format("%Y-%m-%dT%H:%M:%SZ");
+    let kind = event_kind(&entry.event);
+    let detail = event_detail(&entry.event);
+    format!(
+        "{ts}  {actor_id:<24}  {kind:<18}  {detail}",
+        ts = ts,
+        actor_id = entry.actor_id,
+        kind = kind,
+        detail = detail,
+    )
+}
+
+/// Stable string discriminator. Mirrors `#[serde(tag = "kind",
+/// rename_all = "snake_case")]` on `TaskEvent`. Centralised here so
+/// `--kind` filter values stay in lockstep with what the JSON
+/// shows.
+pub fn event_kind(event: &TaskEvent) -> &'static str {
+    match event {
+        TaskEvent::Pause { .. } => "pause",
+        TaskEvent::Continue { .. } => "continue",
+        TaskEvent::Reprompt { .. } => "reprompt",
+        TaskEvent::ApprovalRequest { .. } => "approval_request",
+        TaskEvent::ApprovalResponse { .. } => "approval_response",
+        TaskEvent::NotificationFailed { .. } => "notification_failed",
+        TaskEvent::ToolDenied { .. } => "tool_denied",
+        TaskEvent::ToolAutoApproved { .. } => "tool_auto_approved",
+    }
+}
+
+fn event_at(event: &TaskEvent) -> DateTime<Utc> {
+    match event {
+        TaskEvent::Pause { at, .. }
+        | TaskEvent::Continue { at, .. }
+        | TaskEvent::Reprompt { at, .. }
+        | TaskEvent::ApprovalRequest { at, .. }
+        | TaskEvent::ApprovalResponse { at, .. }
+        | TaskEvent::NotificationFailed { at, .. }
+        | TaskEvent::ToolDenied { at, .. }
+        | TaskEvent::ToolAutoApproved { at, .. } => *at,
+    }
+}
+
+/// Extract the `reason_kind` value where it exists (only on
+/// `ToolDenied`). Returns `None` for variants without a reason kind;
+/// `--reason-kind` filtering then excludes them entirely.
+fn event_reason_kind(event: &TaskEvent) -> Option<&'static str> {
+    match event {
+        TaskEvent::ToolDenied { reason_kind, .. } => Some(match reason_kind {
+            crate::dispatch::events::DeniedReasonKind::DeniedByRule => "denied_by_rule",
+            crate::dispatch::events::DeniedReasonKind::DeniedByPolicy => "denied_by_policy",
+            crate::dispatch::events::DeniedReasonKind::DeniedByProfile => "denied_by_profile",
+            crate::dispatch::events::DeniedReasonKind::DeniedByMcpServerAllowlist => {
+                "denied_by_mcp_server_allowlist"
+            }
+            crate::dispatch::events::DeniedReasonKind::OperatorRejected => "operator_rejected",
+            crate::dispatch::events::DeniedReasonKind::TtlExpired => "ttl_expired",
+        }),
+        _ => None,
+    }
+}
+
+fn event_detail(event: &TaskEvent) -> String {
+    match event {
+        TaskEvent::Pause { reason, .. } => reason
+            .as_deref()
+            .map(|r| format!("reason={r}"))
+            .unwrap_or_default(),
+        TaskEvent::Continue {
+            new_session_id,
+            prompt_preview,
+            ..
+        } => format!("session={new_session_id} prompt={prompt_preview:?}"),
+        TaskEvent::Reprompt {
+            prompt_preview,
+            prior_session_id,
+            ..
+        } => format!("prior_session={prior_session_id} prompt={prompt_preview:?}"),
+        TaskEvent::ApprovalRequest {
+            request_id,
+            summary_preview,
+            ..
+        } => format!("request_id={request_id} summary={summary_preview:?}"),
+        TaskEvent::ApprovalResponse {
+            request_id,
+            approved,
+            edited,
+            ..
+        } => format!("request_id={request_id} approved={approved} edited={edited}",),
+        TaskEvent::NotificationFailed {
+            sink_id,
+            event_kind,
+            error,
+            ..
+        } => format!("sink={sink_id} event_kind={event_kind} error={error:?}"),
+        TaskEvent::ToolDenied {
+            tool_name,
+            reason_kind,
+            reason,
+            ..
+        } => format!("tool={tool_name} reason_kind={reason_kind:?} reason={reason:?}",),
+        TaskEvent::ToolAutoApproved {
+            tool_name,
+            actor_type,
+            ..
+        } => format!("tool={tool_name} actor_type={actor_type}"),
+    }
+}
+
+fn default_runs_dir() -> PathBuf {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/"))
+        .join(".local/share/pitboss/runs")
+}
+
+/// Test helper exposed so integration tests can drive `render` against
+/// a fixture path without re-implementing the open + render pipeline.
+#[doc(hidden)]
+pub fn render_to_string(audit_path: &Path, filter: &AuditFilter, json: bool) -> Result<String> {
+    let file = std::fs::File::open(audit_path)?;
+    let mut buf = Vec::new();
+    render(BufReader::new(file), filter, json, &mut buf)?;
+    Ok(String::from_utf8(buf)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dispatch::events::DeniedReasonKind;
+    use std::io::Cursor;
+    use tempfile::TempDir;
+
+    fn entry_pause(actor: &str, at: DateTime<Utc>) -> AuditEntry {
+        AuditEntry {
+            actor_id: actor.into(),
+            event: TaskEvent::Pause {
+                at,
+                reason: Some("op".into()),
+            },
+        }
+    }
+
+    fn entry_denied(actor: &str, at: DateTime<Utc>, kind: DeniedReasonKind) -> AuditEntry {
+        AuditEntry {
+            actor_id: actor.into(),
+            event: TaskEvent::ToolDenied {
+                at,
+                tool_name: "Bash".into(),
+                actor_id: actor.into(),
+                reason_kind: kind,
+                reason: "test".into(),
+            },
+        }
+    }
+
+    fn jsonl(entries: &[AuditEntry]) -> String {
+        let mut s = String::new();
+        for e in entries {
+            s.push_str(&serde_json::to_string(e).unwrap());
+            s.push('\n');
+        }
+        s
+    }
+
+    #[test]
+    fn columnar_render_includes_actor_kind_and_ts() {
+        let now = Utc::now();
+        let body = jsonl(&[entry_pause("w-1", now)]);
+        let out = render_to_string_buf(&body, &AuditFilter::default(), false);
+        assert!(out.contains("w-1"), "actor_id present: {out}");
+        assert!(out.contains("pause"), "kind present: {out}");
+        // No `--reason-kind` filter on a pause row → it passes
+        // (event_reason_kind returns None only when the filter is set;
+        // unset filter is always pass).
+        assert!(!out.is_empty());
+    }
+
+    #[test]
+    fn json_mode_round_trips_through_canonical_form() {
+        let now = Utc::now();
+        let body = jsonl(&[entry_pause("lead", now)]);
+        let out = render_to_string_buf(&body, &AuditFilter::default(), true);
+        let parsed: AuditEntry = serde_json::from_str(out.trim()).unwrap();
+        assert_eq!(parsed.actor_id, "lead");
+        assert!(matches!(parsed.event, TaskEvent::Pause { .. }));
+    }
+
+    #[test]
+    fn filter_actor_matches_exact_id_only() {
+        let now = Utc::now();
+        let body = jsonl(&[
+            entry_pause("w-1", now),
+            entry_pause("w-2", now),
+            entry_pause("lead", now),
+        ]);
+        let out = render_to_string_buf(
+            &body,
+            &AuditFilter {
+                actor: Some("w-1".into()),
+                ..Default::default()
+            },
+            false,
+        );
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 1, "filter to w-1 keeps one row: {out}");
+        assert!(lines[0].contains("w-1"));
+    }
+
+    #[test]
+    fn filter_kind_matches_serde_discriminator() {
+        let now = Utc::now();
+        let body = jsonl(&[
+            entry_pause("w-1", now),
+            entry_denied("w-1", now, DeniedReasonKind::DeniedByRule),
+        ]);
+        let out = render_to_string_buf(
+            &body,
+            &AuditFilter {
+                kind: Some("tool_denied".into()),
+                ..Default::default()
+            },
+            false,
+        );
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].contains("tool_denied"));
+    }
+
+    #[test]
+    fn filter_since_drops_earlier_rows() {
+        let early = Utc::now() - chrono::Duration::minutes(5);
+        let late = Utc::now();
+        let body = jsonl(&[entry_pause("w-1", early), entry_pause("w-1", late)]);
+        let cutoff = Utc::now() - chrono::Duration::minutes(2);
+        let out = render_to_string_buf(
+            &body,
+            &AuditFilter {
+                since: Some(cutoff),
+                ..Default::default()
+            },
+            false,
+        );
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 1, "only the late row passes: {out}");
+    }
+
+    #[test]
+    fn filter_reason_kind_only_matches_tool_denied_rows() {
+        let now = Utc::now();
+        let body = jsonl(&[
+            entry_denied("w-1", now, DeniedReasonKind::DeniedByRule),
+            entry_denied("w-1", now, DeniedReasonKind::OperatorRejected),
+            entry_pause("w-1", now),
+        ]);
+        let out = render_to_string_buf(
+            &body,
+            &AuditFilter {
+                reason_kind: Some("denied_by_rule".into()),
+                ..Default::default()
+            },
+            false,
+        );
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(
+            lines.len(),
+            1,
+            "denied_by_rule matches exactly one row: {out}"
+        );
+        assert!(lines[0].contains("DeniedByRule"));
+    }
+
+    #[test]
+    fn malformed_lines_are_skipped_not_fatal() {
+        let now = Utc::now();
+        let valid = serde_json::to_string(&entry_pause("w-1", now)).unwrap();
+        let body = format!("{{\"actor_id\":\"truncated\"\n{valid}\n");
+        let out = render_to_string_buf(&body, &AuditFilter::default(), false);
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(
+            lines.len(),
+            1,
+            "valid line renders, torn line skipped: {out}"
+        );
+    }
+
+    #[test]
+    fn missing_file_gives_operator_friendly_error() {
+        let tmp = TempDir::new().unwrap();
+        let run_id = uuid::Uuid::now_v7().to_string();
+        std::fs::create_dir_all(tmp.path().join(&run_id)).unwrap();
+        let err = run(
+            &run_id,
+            AuditFilter::default(),
+            false,
+            Some(tmp.path().to_path_buf()),
+        )
+        .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("audit.jsonl"),
+            "error should reference the file: {msg}",
+        );
+    }
+
+    fn render_to_string_buf(body: &str, filter: &AuditFilter, json: bool) -> String {
+        let mut out = Vec::new();
+        render(Cursor::new(body), filter, json, &mut out).unwrap();
+        String::from_utf8(out).unwrap()
+    }
+}

--- a/crates/pitboss-cli/src/cli.rs
+++ b/crates/pitboss-cli/src/cli.rs
@@ -270,6 +270,49 @@ pub enum Command {
         #[arg(long)]
         json: bool,
     },
+    /// Print the per-run aggregated audit log (#414).
+    ///
+    /// Reads `<run-dir>/audit.jsonl`, which the dispatcher tees from
+    /// every per-actor `tasks/<actor>/events.jsonl` write — every
+    /// pause, continue, reprompt, approval request/response,
+    /// notification failure, and tool-permission decision across the
+    /// entire actor tree, in chronological order, attributed to its
+    /// actor.
+    ///
+    /// Default output is a fixed-width columnar render (ts · actor_id
+    /// · kind · detail). Use `--json` for the raw NDJSON suitable for
+    /// piping into `jq`. Filters compose: `--actor`, `--kind`,
+    /// `--since`, `--reason-kind` all narrow the rendered rows
+    /// independently.
+    Audit {
+        /// Run id (full UUID or unique prefix).
+        run_id: String,
+        /// Override runs base directory. Defaults to
+        /// `~/.local/share/pitboss/runs`.
+        #[arg(long)]
+        run_dir: Option<PathBuf>,
+        /// Keep only rows whose `actor_id` exactly matches this value.
+        #[arg(long)]
+        actor: Option<String>,
+        /// Keep only rows whose `event.kind` matches (one of:
+        /// `pause`, `continue`, `reprompt`, `approval_request`,
+        /// `approval_response`, `notification_failed`, `tool_denied`,
+        /// `tool_auto_approved`).
+        #[arg(long)]
+        kind: Option<String>,
+        /// Keep only rows with `event.at >= <RFC3339>`. Example:
+        /// `--since 2026-05-14T03:00:00Z`.
+        #[arg(long)]
+        since: Option<String>,
+        /// Keep only `tool_denied` rows with the given `reason_kind`
+        /// (e.g. `denied_by_rule`, `operator_rejected`). Implicitly
+        /// filters out every other variant.
+        #[arg(long = "reason-kind")]
+        reason_kind: Option<String>,
+        /// Emit raw NDJSON instead of the columnar render.
+        #[arg(long)]
+        json: bool,
+    },
     /// Triage a single run or roll up recent runs.
     ///
     /// Single-run mode (`pitboss analyze <run-id>`): produces a

--- a/crates/pitboss-cli/src/dispatch/events.rs
+++ b/crates/pitboss-cli/src/dispatch/events.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
 
@@ -23,7 +23,7 @@ use tokio::io::AsyncWriteExt;
 /// #370 (item 4) since the duplication couldn't actually diverge:
 /// adding a variant on either side broke the `From` impl at compile
 /// time.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DeniedReasonKind {
     /// An operator-declared `[[approval_policy]]` rule with
@@ -112,7 +112,7 @@ impl DeniedReasonKind {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum TaskEvent {
     Pause {
@@ -183,20 +183,77 @@ pub enum TaskEvent {
     },
 }
 
+/// Wrapper for a row in `<run_subdir>/audit.jsonl` (#414).
+///
+/// `actor_id` is the run-wide attribution key; `event` carries the
+/// existing [`TaskEvent`] payload verbatim.
+///
+/// (A `#[serde(flatten)]` design was rejected because the
+/// `ToolDenied` and `ToolAutoApproved` variants already carry an
+/// inner `actor_id` field — flatten would consume the wrapper's
+/// `actor_id` and leave the variant unable to deserialize its
+/// required payload field. The nested `event` shape avoids the
+/// collision and round-trips cleanly through serde.)
+#[derive(Debug, Serialize)]
+struct AuditEntry<'a> {
+    actor_id: &'a str,
+    event: &'a TaskEvent,
+}
+
 /// Append one event to `<run_subdir>/tasks/<task_id>/events.jsonl`.
 /// Creates the directory if absent.
+///
+/// PR #414 of issue #414 also tees a wrapped record to
+/// `<run_subdir>/audit.jsonl` so operators can query a single run-wide
+/// audit trail without walking the per-actor tree. The tee is
+/// best-effort: a failure on the run-wide write logs and falls
+/// through; the per-actor record (the durable per-task audit source
+/// used by the TUI denial counter and `pitboss status`) is still
+/// written.
 pub async fn append_event(run_subdir: &Path, task_id: &str, event: &TaskEvent) -> Result<()> {
     let dir = run_subdir.join("tasks").join(task_id);
     tokio::fs::create_dir_all(&dir).await?;
     let path = dir.join("events.jsonl");
+    let mut line = serde_json::to_string(event)?;
+    line.push('\n');
+    write_jsonl_line(&path, line.as_bytes()).await?;
+
+    // #414: run-wide audit log tee. Logged-and-swallowed so a
+    // transient failure on the aggregated file doesn't break the
+    // per-actor record. Re-serialise rather than re-using `line`
+    // because the audit row has the extra `actor_id` field.
+    let audit_path = run_subdir.join("audit.jsonl");
+    match serde_json::to_string(&AuditEntry {
+        actor_id: task_id,
+        event,
+    }) {
+        Ok(mut audit_line) => {
+            audit_line.push('\n');
+            if let Err(e) = write_jsonl_line(&audit_path, audit_line.as_bytes()).await {
+                tracing::warn!(
+                    error = %e,
+                    path = %audit_path.display(),
+                    "audit.jsonl: tee append failed (per-actor record still written)",
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "audit.jsonl: serialize failed; tee skipped");
+        }
+    }
+    Ok(())
+}
+
+/// Open-create-append + flush. Single-shot write of an already-serialised
+/// JSONL line (caller supplies the trailing newline). Factored so the
+/// per-actor write and the #414 audit tee share one syscall sequence.
+async fn write_jsonl_line(path: &Path, bytes: &[u8]) -> Result<()> {
     let mut f = OpenOptions::new()
         .create(true)
         .append(true)
-        .open(&path)
+        .open(path)
         .await?;
-    let mut line = serde_json::to_string(event)?;
-    line.push('\n');
-    f.write_all(line.as_bytes()).await?;
+    f.write_all(bytes).await?;
     f.flush().await?;
     Ok(())
 }
@@ -247,5 +304,67 @@ mod tests {
         let path = dir.path().join("tasks").join("w-2").join("events.jsonl");
         let content = tokio::fs::read_to_string(path).await.unwrap();
         assert_eq!(content.lines().count(), 2);
+    }
+
+    /// #414: `append_event` writes the per-actor file (durable trail
+    /// the TUI / `pitboss status` already consume) AND tees a wrapped
+    /// row with explicit `actor_id` into the run-wide audit log.
+    #[tokio::test]
+    async fn append_tees_into_run_wide_audit_log() {
+        let dir = TempDir::new().unwrap();
+        let now = Utc::now();
+        append_event(
+            dir.path(),
+            "lead",
+            &TaskEvent::Pause {
+                at: now,
+                reason: Some("operator".into()),
+            },
+        )
+        .await
+        .unwrap();
+        append_event(
+            dir.path(),
+            "worker-7",
+            &TaskEvent::ToolDenied {
+                at: now,
+                tool_name: "Bash".into(),
+                actor_id: "worker-7".into(),
+                reason_kind: DeniedReasonKind::DeniedByRule,
+                reason: "shell access denied".into(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let audit = tokio::fs::read_to_string(dir.path().join("audit.jsonl"))
+            .await
+            .unwrap();
+        let lines: Vec<&str> = audit.lines().collect();
+        assert_eq!(lines.len(), 2, "tee'd into two rows: {audit}");
+        assert!(
+            lines[0].contains("\"actor_id\":\"lead\""),
+            "first row must carry lead actor_id: {}",
+            lines[0]
+        );
+        assert!(lines[0].contains("\"event\":{\"kind\":\"pause\""));
+        assert!(
+            lines[1].starts_with("{\"actor_id\":\"worker-7\""),
+            "second row must lead with worker-7 actor_id: {}",
+            lines[1]
+        );
+        assert!(lines[1].contains("\"event\":{\"kind\":\"tool_denied\""));
+        assert!(lines[1].contains("\"reason_kind\":\"denied_by_rule\""));
+
+        // Per-actor files still got their copy (the tee doesn't replace
+        // them; both writes are durable).
+        let lead_per_actor = dir.path().join("tasks").join("lead").join("events.jsonl");
+        assert!(lead_per_actor.exists());
+        let worker_per_actor = dir
+            .path()
+            .join("tasks")
+            .join("worker-7")
+            .join("events.jsonl");
+        assert!(worker_per_actor.exists());
     }
 }

--- a/crates/pitboss-cli/src/lib.rs
+++ b/crates/pitboss-cli/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod agents_md;
 pub mod analyze;
 pub mod attach;
+pub mod audit;
 pub mod capability_matrix;
 pub mod cli;
 pub mod communication;

--- a/crates/pitboss-cli/src/main.rs
+++ b/crates/pitboss-cli/src/main.rs
@@ -2,8 +2,8 @@ use anyhow::Result;
 use clap::Parser;
 
 use pitboss_cli::{
-    agents_md, analyze, attach, capability_matrix, cli, diff, dispatch, events, list, manifest,
-    mcp, prune, status, tree,
+    agents_md, analyze, attach, audit, capability_matrix, cli, diff, dispatch, events, list,
+    manifest, mcp, prune, status, tree,
 };
 
 use cli::{Cli, Command};
@@ -100,6 +100,31 @@ fn main() -> Result<()> {
             json,
         } => {
             std::process::exit(events::run(&run_id, json, run_dir)?);
+        }
+        Command::Audit {
+            run_id,
+            run_dir,
+            actor,
+            kind,
+            since,
+            reason_kind,
+            json,
+        } => {
+            let since_parsed = match since {
+                None => None,
+                Some(s) => Some(
+                    chrono::DateTime::parse_from_rfc3339(&s)
+                        .map(|dt| dt.with_timezone(&chrono::Utc))
+                        .map_err(|e| anyhow::anyhow!("--since must be RFC3339: {e}"))?,
+                ),
+            };
+            let filter = audit::AuditFilter {
+                actor,
+                kind,
+                since: since_parsed,
+                reason_kind,
+            };
+            std::process::exit(audit::run(&run_id, filter, json, run_dir)?);
         }
         Command::Analyze {
             run_id,

--- a/crates/pitboss-web/src/api/audit.rs
+++ b/crates/pitboss-web/src/api/audit.rs
@@ -1,0 +1,268 @@
+//! `GET /api/runs/:id/audit` — per-run aggregated audit log (#414).
+//!
+//! Reads `<run-dir>/audit.jsonl`, filters by query-string parameters,
+//! and streams the result as NDJSON. Symmetric with the CLI
+//! (`pitboss audit`) — same filter surface, same wire shape.
+//!
+//! Filter dimensions (all optional; combine multiplicatively):
+//! - `actor` — exact match on `actor_id`.
+//! - `kind` — exact match on the inner `event.kind` discriminator.
+//! - `since` — RFC3339 cutoff; rows with `event.at < since` are dropped.
+//! - `reason_kind` — exact match on `event.reason_kind`; implicitly
+//!   filters out variants that lack a `reason_kind` field.
+//!
+//! 404 when the run never produced an audit row (file absent — every
+//! run that runs a worker through Pitboss emits at least one
+//! `tool_auto_approved` row, so this is rare in practice but possible
+//! on freshly-dispatched in-progress runs).
+
+use std::path::PathBuf;
+
+use axum::{
+    body::Body,
+    extract::{Path as AxPath, Query, State},
+    http::{header, StatusCode},
+    response::Response,
+};
+use chrono::{DateTime, Utc};
+use pitboss_cli::audit::{AuditEntry, AuditFilter};
+use serde::Deserialize;
+
+use crate::{
+    error::{ApiError, ApiResult},
+    state::AppState,
+};
+
+#[derive(Debug, Default, Deserialize)]
+pub struct AuditQuery {
+    pub actor: Option<String>,
+    pub kind: Option<String>,
+    /// RFC3339 timestamp. Parsed lazily — a malformed value returns 400.
+    pub since: Option<String>,
+    pub reason_kind: Option<String>,
+}
+
+/// Per-run audit log handler. Reads `<run-dir>/audit.jsonl`, applies
+/// query-string filters, and returns NDJSON.
+pub async fn audit(
+    State(state): State<AppState>,
+    AxPath(run_id): AxPath<String>,
+    Query(q): Query<AuditQuery>,
+) -> ApiResult<Response> {
+    let run_dir = resolve_run_dir(state.runs_dir(), &run_id)?;
+    let audit_path = run_dir.join("audit.jsonl");
+
+    let since: Option<DateTime<Utc>> = match q.since.as_deref() {
+        None => None,
+        Some(s) => Some(
+            DateTime::parse_from_rfc3339(s)
+                .map(|dt| dt.with_timezone(&Utc))
+                .map_err(|e| ApiError::BadRequest(format!("invalid `since` (RFC3339): {e}")))?,
+        ),
+    };
+
+    let filter = AuditFilter {
+        actor: q.actor,
+        kind: q.kind,
+        since,
+        reason_kind: q.reason_kind,
+    };
+
+    let bytes = match tokio::fs::read(&audit_path).await {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Err(ApiError::NotFound),
+        Err(e) => return Err(e.into()),
+    };
+
+    // CPU-light: filter in-process. Audit logs are single-digit-K rows
+    // even on busy runs; a full-file parse is well within request-time
+    // budget. If we ever see a real run that pushes this past ~100ms,
+    // move to `tokio::task::spawn_blocking`.
+    let filtered = filter_ndjson(&bytes, &filter);
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "application/x-ndjson")
+        .body(Body::from(filtered))
+        .expect("ndjson response"))
+}
+
+/// Filter a buffer of NDJSON audit rows down to those matching `filter`.
+/// Re-emits the surviving rows as NDJSON. Malformed lines are skipped
+/// (matches the CLI's tolerance).
+fn filter_ndjson(bytes: &[u8], filter: &AuditFilter) -> Vec<u8> {
+    let text = match std::str::from_utf8(bytes) {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+    let mut out = Vec::with_capacity(bytes.len());
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let entry: AuditEntry = match serde_json::from_str(trimmed) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        if !filter.matches(&entry) {
+            continue;
+        }
+        // Re-serialise from the typed form so the response shape is
+        // canonical even if the on-disk row had whitespace / key
+        // ordering quirks. Matches `audit::render`'s `--json` path.
+        if let Ok(canonical) = serde_json::to_string(&entry) {
+            out.extend_from_slice(canonical.as_bytes());
+            out.push(b'\n');
+        }
+    }
+    out
+}
+
+/// Resolve `<runs_dir>/<run_id>` defensively. Same shape as the
+/// existing `runs::run_dir` helper in `runs.rs` — duplicated here so
+/// this module doesn't depend on a sibling's private fn.
+fn resolve_run_dir(runs_dir: &std::path::Path, run_id: &str) -> ApiResult<PathBuf> {
+    if run_id.is_empty()
+        || run_id.len() > 128
+        || run_id == ".."
+        || run_id == "."
+        || run_id.contains('/')
+        || run_id.contains('\\')
+    {
+        return Err(ApiError::BadRequest("invalid run id".into()));
+    }
+    Ok(runs_dir.join(run_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+    use pitboss_cli::dispatch::events::{DeniedReasonKind, TaskEvent};
+
+    fn entry_pause(actor: &str, at: DateTime<Utc>) -> AuditEntry {
+        AuditEntry {
+            actor_id: actor.into(),
+            event: TaskEvent::Pause {
+                at,
+                reason: Some("op".into()),
+            },
+        }
+    }
+
+    fn entry_denied(actor: &str, at: DateTime<Utc>, kind: DeniedReasonKind) -> AuditEntry {
+        AuditEntry {
+            actor_id: actor.into(),
+            event: TaskEvent::ToolDenied {
+                at,
+                tool_name: "Bash".into(),
+                actor_id: actor.into(),
+                reason_kind: kind,
+                reason: "test".into(),
+            },
+        }
+    }
+
+    fn jsonl(entries: &[AuditEntry]) -> Vec<u8> {
+        let mut s = String::new();
+        for e in entries {
+            s.push_str(&serde_json::to_string(e).unwrap());
+            s.push('\n');
+        }
+        s.into_bytes()
+    }
+
+    #[test]
+    fn no_filters_returns_every_row() {
+        let now = Utc::now();
+        let body = jsonl(&[entry_pause("w-1", now), entry_pause("w-2", now)]);
+        let out = filter_ndjson(&body, &AuditFilter::default());
+        let lines: Vec<&str> = std::str::from_utf8(&out).unwrap().lines().collect();
+        assert_eq!(lines.len(), 2);
+    }
+
+    #[test]
+    fn actor_filter_keeps_only_matching_id() {
+        let now = Utc::now();
+        let body = jsonl(&[entry_pause("w-1", now), entry_pause("w-2", now)]);
+        let out = filter_ndjson(
+            &body,
+            &AuditFilter {
+                actor: Some("w-2".into()),
+                ..Default::default()
+            },
+        );
+        let text = std::str::from_utf8(&out).unwrap();
+        assert!(text.contains("\"actor_id\":\"w-2\""));
+        assert!(!text.contains("\"actor_id\":\"w-1\""));
+    }
+
+    #[test]
+    fn kind_filter_matches_serde_discriminator() {
+        let now = Utc::now();
+        let body = jsonl(&[
+            entry_pause("w-1", now),
+            entry_denied("w-1", now, DeniedReasonKind::DeniedByRule),
+        ]);
+        let out = filter_ndjson(
+            &body,
+            &AuditFilter {
+                kind: Some("tool_denied".into()),
+                ..Default::default()
+            },
+        );
+        let lines: Vec<&str> = std::str::from_utf8(&out).unwrap().lines().collect();
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].contains("tool_denied"));
+    }
+
+    #[test]
+    fn since_filter_drops_earlier_rows() {
+        let early = Utc::now() - Duration::minutes(5);
+        let late = Utc::now();
+        let body = jsonl(&[entry_pause("w-1", early), entry_pause("w-1", late)]);
+        let cutoff = Utc::now() - Duration::minutes(2);
+        let out = filter_ndjson(
+            &body,
+            &AuditFilter {
+                since: Some(cutoff),
+                ..Default::default()
+            },
+        );
+        let lines: Vec<&str> = std::str::from_utf8(&out).unwrap().lines().collect();
+        assert_eq!(lines.len(), 1);
+    }
+
+    #[test]
+    fn reason_kind_filter_excludes_non_denied_variants() {
+        let now = Utc::now();
+        let body = jsonl(&[
+            entry_denied("w-1", now, DeniedReasonKind::OperatorRejected),
+            entry_pause("w-1", now),
+        ]);
+        let out = filter_ndjson(
+            &body,
+            &AuditFilter {
+                reason_kind: Some("operator_rejected".into()),
+                ..Default::default()
+            },
+        );
+        let lines: Vec<&str> = std::str::from_utf8(&out).unwrap().lines().collect();
+        assert_eq!(lines.len(), 1);
+        assert!(
+            lines[0].contains("\"reason_kind\":\"operator_rejected\""),
+            "wire form is snake_case: {}",
+            lines[0]
+        );
+    }
+
+    #[test]
+    fn malformed_lines_skipped_not_fatal() {
+        let now = Utc::now();
+        let valid = serde_json::to_string(&entry_pause("w-1", now)).unwrap();
+        let body = format!("{{\"truncated\":\n{valid}\n").into_bytes();
+        let out = filter_ndjson(&body, &AuditFilter::default());
+        let lines: Vec<&str> = std::str::from_utf8(&out).unwrap().lines().collect();
+        assert_eq!(lines.len(), 1);
+    }
+}

--- a/crates/pitboss-web/src/api/mod.rs
+++ b/crates/pitboss-web/src/api/mod.rs
@@ -12,6 +12,7 @@ use serde::Deserialize;
 
 use crate::{assets, state::AppState};
 
+mod audit;
 mod control;
 mod events;
 mod insights;
@@ -26,6 +27,7 @@ pub fn router(state: AppState) -> Router {
         .route("/runs/{run_id}/resolved", get(runs::resolved))
         .route("/runs/{run_id}/summary-jsonl", get(runs::summary_jsonl))
         .route("/runs/{run_id}/events-jsonl", get(runs::events_jsonl))
+        .route("/runs/{run_id}/audit", get(audit::audit))
         .route("/runs/{run_id}/tasks/{task_id}", get(runs::task_detail))
         .route("/runs/{run_id}/tasks/{task_id}/log", get(runs::task_log))
         .route(


### PR DESCRIPTION
## Summary

Closes #414. Adds a per-run aggregated audit log at `<run_subdir>/audit.jsonl`, plus a `pitboss audit <run-id>` CLI and `GET /api/runs/:id/audit` web endpoint. Operators can now ask "which Bash calls were denied across all 14 workers?" without walking the per-actor tree or piping `tasks/*/events.jsonl` through `jq`.

## Approach

The dispatcher's `dispatch::events::append_event` is the single funnel for every `TaskEvent` emission today (14 call sites). Extended it to write the same row to a run-wide `audit.jsonl` after the per-actor write, wrapped in an `AuditEntry { actor_id, event }` envelope. Zero call-site changes; one funnel touched.

Wire format per row:

```json
{"actor_id":"worker-3","event":{"kind":"tool_denied","at":"2026-05-14T03:42:00Z","tool_name":"Bash","actor_id":"worker-3","reason_kind":"denied_by_rule","reason":"shell access denied"}}
```

A `#[serde(flatten)]` design was tried first but collides with `ToolDenied`/`ToolAutoApproved` — both variants already carry an inner `actor_id` payload, and flatten consumes the outer key, leaving the variant unable to deserialize. The nested `event` shape round-trips cleanly through serde.

The tee is best-effort: a transient I/O failure on `audit.jsonl` logs a warning but doesn't break the per-actor write (which remains the durable per-task audit source).

### CLI

`pitboss audit <run-id> [--actor X] [--kind K] [--since RFC3339] [--reason-kind R] [--json]`. Mirrors `pitboss events` (#259's PR-K): UUID-prefix resolution via `runs::resolve_run_dir_by_prefix`, malformed-line tolerance, fixed-width columnar render by default, raw NDJSON in `--json` mode.

### Web endpoint

`GET /api/runs/:id/audit?actor=...&kind=...&since=...&reason_kind=...`. Same filter surface as the CLI; returns NDJSON. 404 when `audit.jsonl` is absent (matches the events-jsonl handler).

### Out of scope

- **SPA Audit tab.** The endpoint alone unblocks external tooling; the SPA tab is a clean follow-on (~150 LoC of Svelte mirroring the Replay tab).
- **`RunStreamPayload::Audit` unified-API arm.** Future consumer surface in `pitboss-core::stream`; lands when a consumer needs it.
- **Compaction / retention.** Audit logs grow with run activity. v1 relies on `pitboss prune --remove` for cleanup.

## Test plan

- [x] `cargo test -p pitboss-cli --lib audit::tests` — 8 passing (render, JSON passthrough, 4 filters, malformed-line tolerance, missing-file error).
- [x] `cargo test -p pitboss-cli --lib dispatch::events::tests::append_tees_into_run_wide_audit_log` — pins the tee write.
- [x] `cargo test -p pitboss-web api::audit` — 6 passing (no-filter, 4 filters, malformed-line tolerance).
- [x] `cargo test --workspace --features pitboss-core/test-support` — 810 lib tests pass (up 8 from baseline). Pre-existing macOS-env flakes (`terminate_after_exit_is_ok` / `/bin/true`, `e2e_lead_request_approval_round_trip` parallel-load) reproduce on `main`; one additional parallel-load flake (`control::server::tests::continue_worker_from_paused_transitions_running`) confirmed transient — passes in 3 consecutive modular reruns and on isolated invocation. Linux CI is ground truth.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)