### PR TITLE
chore: ignore /pb_manifests/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,10 @@ NOTES-*.md
 # session doesn't accidentally promote them to a commit.
 /work.md
 /CLAUDE.md
+
+# Local-only manifest scratch — operators keep their own
+# `pitboss dispatch` / `container-dispatch` manifests here so they're
+# reachable from the working tree (relative paths in launcher scripts,
+# easier `pitboss validate <path>` invocation) without polluting git
+# history. Anchored to the repo root.
+/pb_manifests/


### PR DESCRIPTION
Reserves a root-anchored directory for operators' local-only `pitboss dispatch` / `container-dispatch` manifests. Mirrors the pattern already established for `/work.md`, `/CLAUDE.md`, `/pitboss_proj`, `/angrylarry`, and `NOTES-*.md` at the bottom of the file: **tracked by rule, never tracked by content**.

Surfaced while staging an in-container codebase-review manifest at `/pb_manifests/codebase-review.toml`. Anchored with leading `/` so it doesn't accidentally suppress same-named directories inside `crates/`.

Verified:
- `git check-ignore -v pb_manifests/codebase-review.toml` → `.gitignore:80:/pb_manifests/	pb_manifests/codebase-review.toml`.
- `git status` shows only `.gitignore` in the dirty set (the directory itself is untracked + ignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)