### PR TITLE
fix(container): harden extra_args, mount defaults, doc quickstart

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,9 +263,10 @@ To pre-flight a container-mode manifest without dispatching, use `pitboss valida
 |---|---|---|---|
 | `image` | string | `ghcr.io/sds-mode/pitboss-with-claude:latest` | Container image to run. |
 | `runtime` | `"docker"` \| `"podman"` \| `"auto"` | `"auto"` | Runtime selector. `"auto"` prefers podman when available. |
-| `extra_args` | array of string | `[]` | Verbatim flags for `podman run` / `docker run`. The escape hatch for any container-runtime concern: networking (`--network=corp-fw`, `--dns=10.0.0.53`, `--add-host=svc:1.2.3.4`), capabilities (`--cap-add=NET_ADMIN`), security (`--security-opt=…`), resource limits (`--memory=4g`, `--cpus=2`). |
-| `extra_apt` | array of string | `[]` | Debian/Ubuntu packages installed inside the container. Two paths: by default they are installed at dispatch start (~30–90 s per run); after `pitboss container-build`, they are baked into a derived image and dispatch picks up the cached tag automatically. Each entry must match `[a-zA-Z0-9][a-zA-Z0-9.+-]*`; rejected at validate time otherwise. |
+| `extra_args` | array of string | `[]` | Verbatim flags for `podman run` / `docker run`. The escape hatch for any container-runtime concern: networking (`--network=corp-fw`, `--dns=10.0.0.53`, `--add-host=svc:1.2.3.4`), narrow capabilities (`--cap-add=NET_ADMIN`), resource limits (`--memory=4g`, `--cpus=2`). **Validated denylist** (`validate` rejects at parse time): `--privileged`, `--{pid,ipc,uts,userns,cgroupns}=host`, `--cap-add={ALL,SYS_ADMIN,SYS_PTRACE,SYS_MODULE}`, `--security-opt={seccomp,apparmor}=unconfined` / `label=disable`, `--device=…`, `-v` / `--volume` / `--mount` (use `[[container.mount]]`), `-u` / `--user` (UID alignment is pitboss-managed), `--entrypoint`. Each container-dispatch invocation is recorded NDJSON-style at `<runs-base>/container-dispatch.log` for post-facto audit. |
+| `extra_apt` | array of string | `[]` | Debian/Ubuntu packages installed inside the container. Two paths: by default they are installed at dispatch start (~30–90 s per run, **running as UID 0 during the apt phase** before `runuser` drops to `pitboss`); after `pitboss container-build`, they are baked into a derived image and dispatch starts as the unprivileged `pitboss` user. Each entry must match `[a-zA-Z0-9][a-zA-Z0-9.+-]*`; rejected at validate time otherwise. For production, prefer the `pitboss container-build` derived-image path to avoid the apt-phase root window. |
 | `workdir` | string | first mount's container path, else `/home/pitboss` | Working directory inside the container. |
+| `claude_mount_rw` | bool | `false` | Auto-injected `~/.claude` mount mode. `false` (default) = read-only — prevents a buggy/compromised worker from rewriting host credentials or injecting `settings.json` hooks. `true` = read-write, needed only for in-place OAuth token refresh. |
 
 #### `[[container.mount]]`
 
@@ -275,7 +276,7 @@ To pre-flight a container-mode manifest without dispatching, use `pitboss valida
 | `container` | yes | Absolute path inside the container. |
 | `readonly` | no | Default `false`. |
 
-Two mounts are always auto-injected: `~/.claude → /home/pitboss/.claude` (OAuth) and the run artifact directory; the manifest itself is injected at `/run/pitboss.toml` read-only.
+Two mounts are always auto-injected: `~/.claude → /home/pitboss/.claude` (OAuth — **read-only by default**; set `[container].claude_mount_rw = true` to allow OAuth token refresh) and the run artifact directory; the manifest itself is injected at `/run/pitboss.toml` read-only.
 
 #### `[[container.copy]]`
 

--- a/book/src/getting-started/first-dispatch.md
+++ b/book/src/getting-started/first-dispatch.md
@@ -8,7 +8,7 @@ Create `pitboss.toml`:
 
 ```toml
 [run]
-max_parallel = 2
+max_parallel_tasks = 2
 
 [[task]]
 id = "hello-a"
@@ -41,7 +41,7 @@ Exit code 0 means the manifest is valid. Non-zero prints the error and exits.
 pitboss dispatch pitboss.toml
 ```
 
-Pitboss fans out both tasks in parallel (up to `max_parallel = 2`), streams progress to your terminal, and blocks until all tasks finish.
+Pitboss fans out both tasks in parallel (up to `max_parallel_tasks = 2`), streams progress to your terminal, and blocks until all tasks finish.
 
 **Exit codes:**
 - `0` — all tasks succeeded
@@ -98,7 +98,7 @@ Follow-mode log viewer for a single task. Run-id is resolved by prefix (first 8 
 
 | Field | Default | Notes |
 |-------|---------|-------|
-| `[run].max_parallel` | 4 | How many tasks run concurrently |
+| `[run].max_parallel_tasks` | 4 | How many tasks run concurrently |
 | `[run].halt_on_failure` | false | Stop remaining tasks if any task fails |
 | `[run].worktree_cleanup` | `"on_success"` | `"always"`, `"on_success"`, `"never"` |
 | `[[task]].use_worktree` | true | Set `false` for read-only analysis (no branch needed) |

--- a/book/src/operator-guide/container-dispatch.md
+++ b/book/src/operator-guide/container-dispatch.md
@@ -47,10 +47,17 @@ Two mounts are always added automatically (unless you declare them yourself):
 
 | Host path | Container path | Notes |
 |-----------|----------------|-------|
-| `~/.claude` | `/home/pitboss/.claude` | OAuth auth; read-write |
+| `~/.claude` | `/home/pitboss/.claude` | OAuth auth; **read-only** by default (set `[container].claude_mount_rw = true` to allow OAuth token refresh) |
 | `~/.local/share/pitboss/runs` | `/home/pitboss/.local/share/pitboss/runs` | Run artifacts; read-write |
 
 The manifest itself is always injected at `/run/pitboss.toml` (read-only).
+
+The `~/.claude` mount holds OAuth credentials and `settings.json` (which
+may include hooks). Defaulting to read-only prevents a buggy or
+compromised worker from rewriting host credentials or injecting hooks
+that would fire the next time `claude` runs on the host. If you rely on
+in-place OAuth token refresh, opt back into the previous read-write
+behaviour via `[container].claude_mount_rw = true`.
 
 ## Running
 

--- a/book/src/operator-guide/flat-vs-hierarchical.md
+++ b/book/src/operator-guide/flat-vs-hierarchical.md
@@ -35,7 +35,7 @@ Pitboss has two dispatch modes. Choosing the right one before writing a manifest
 
 ```toml
 [run]
-max_parallel = 3
+max_parallel_tasks = 3
 
 [defaults]
 model = "claude-haiku-4-5"

--- a/crates/pitboss-cli/src/dispatch/container.rs
+++ b/crates/pitboss-cli/src/dispatch/container.rs
@@ -96,6 +96,7 @@ pub fn run_container_dispatch(
         None
     };
 
+    let audit_runs_base = run_dir_override.clone().unwrap_or_else(default_run_dir);
     let args = build_run_args(
         &runtime,
         container,
@@ -112,6 +113,20 @@ pub fn run_container_dispatch(
             .join(" ");
         println!("{}", cmd_str);
         return Ok(());
+    }
+
+    // Best-effort audit log: write the resolved container argv to
+    // `<runs_base_dir>/container-dispatch.log` (NDJSON, one record per
+    // invocation) before exec replaces the process. This is the only
+    // post-facto trail of what flags the container actually received —
+    // the inner `pitboss dispatch` writes its own run dir, but it
+    // doesn't see the host-side container flags. Failure to write is
+    // logged but does not abort dispatch (the operator's run shouldn't
+    // hinge on the audit log being writable). (#476 / F-SEC-9)
+    if let Err(e) =
+        append_container_dispatch_audit(&audit_runs_base, &runtime, &args, &manifest_abs)
+    {
+        eprintln!("pitboss container-dispatch: warning: could not write argv audit log: {e}");
     }
 
     let err = Command::new(&runtime).args(&args).exec();
@@ -180,15 +195,31 @@ fn build_run_args(
     }
 
     // ── Auto-inject ~/.claude ─────────────────────────────────────────────────
-    // Required for OAuth auth (Linux) unless the operator already declared
-    // a mount targeting /home/pitboss/.claude.
+    // Required for OAuth auth (Linux) unless the operator already
+    // declared a mount targeting /home/pitboss/.claude.
+    //
+    // F-SEC-11: the auto-inject defaults to `ro,z`. The host's
+    // `~/.claude` holds OAuth credentials, `settings.json` (which may
+    // include hooks), and other long-lived state. Mounting it
+    // read-write into every container run means a compromised or
+    // buggy worker can rewrite host credentials or inject malicious
+    // hooks that would fire the next time claude runs on the host.
+    // Default to read-only and provide an opt-in
+    // (`[container].claude_mount_rw = true`) for the OAuth-refresh
+    // scenario. An explicit `[[container.mount]]` for
+    // /home/pitboss/.claude continues to win.
     let claude_container = PathBuf::from("/home/pitboss/.claude");
     if !covered_container_paths.contains(&claude_container) {
         if let Some(home) = home_dir() {
             let host_claude = home.join(".claude");
+            let mode = if container.claude_mount_rw {
+                "rw,z"
+            } else {
+                "ro,z"
+            };
             args.push("-v".into());
             args.push(format!(
-                "{}:{}:rw,z",
+                "{}:{}:{mode}",
                 host_claude.display(),
                 claude_container.display()
             ));
@@ -234,6 +265,11 @@ fn build_run_args(
     args.push(workdir.display().to_string());
 
     // ── Extra operator args ───────────────────────────────────────────────────
+    // Defense in depth: `validate_extra_args` is also called from
+    // `manifest::validate::validate_container`, but a test or
+    // programmatic caller that skipped validate must not be able to
+    // smuggle in `--privileged` (etc.). Validate before extending. (#476)
+    validate_extra_args(&container.extra_args)?;
     args.extend(container.extra_args.clone());
 
     // ── extra_apt: validate + override user to root for the apt step ─────────
@@ -294,6 +330,133 @@ fn build_run_args(
     }
 
     Ok(args)
+}
+
+/// Reject `extra_args` entries that defeat the container sandbox or
+/// override pitboss-managed settings.
+///
+/// Validation runs in two places: at `pitboss validate` time (via
+/// `manifest::validate::validate_container`) and again defensively in
+/// `build_run_args` so a manifest that skipped validate (test fixtures,
+/// programmatic callers) cannot bypass the gate.
+///
+/// The denylist enumerates **specific dangerous tokens** rather than
+/// trying to whitelist the whole `docker run` flag surface. It covers
+/// the four classes that matter:
+///
+/// 1. **Namespace breakouts** — `--pid=host`, `--ipc=host`, `--uts=host`,
+///    `--userns=host`, `--cgroupns=host` and the `--pid=container:<id>`
+///    join form. Each one defeats one of the namespaces the container
+///    runtime is set up to provide.
+/// 2. **Capability / privilege escalation** — `--privileged`,
+///    `--cap-add=ALL`, `--cap-add=SYS_ADMIN`, `--cap-add=SYS_PTRACE`,
+///    `--cap-add=SYS_MODULE` (parsed out of comma-separated lists).
+///    `--security-opt={seccomp,apparmor}=unconfined` and
+///    `--security-opt=label=disable` disable LSM enforcement.
+/// 3. **Pitboss-managed flags** — `-v` / `--volume` / `--mount` go around
+///    the validated `[[container.mount]]` path; `-u` / `--user` overrides
+///    the UID alignment logic that the apt-bootstrap path depends on;
+///    `--entrypoint` bypasses the `pitboss dispatch` entrypoint.
+/// 4. **Host device passthrough** — `--device=…`, `--device-cgroup-rule=…`.
+///
+/// (#476 / F-SEC-9)
+pub(crate) fn validate_extra_args(extra_args: &[String]) -> Result<()> {
+    // (pattern, why) — exact-match denylist. Reasons appear verbatim in
+    // the error so operators see why a flag was rejected.
+    const EXACT: &[(&str, &str)] = &[
+        ("--privileged", "grants the container near-root on the host"),
+        (
+            "-v",
+            "use [[container.mount]] for bind mounts (path-validated)",
+        ),
+        (
+            "--volume",
+            "use [[container.mount]] for bind mounts (path-validated)",
+        ),
+        (
+            "--mount",
+            "use [[container.mount]] for bind mounts (path-validated)",
+        ),
+        (
+            "-u",
+            "pitboss controls UID alignment; do not override -u in extra_args",
+        ),
+        (
+            "--user",
+            "pitboss controls UID alignment; do not override --user in extra_args",
+        ),
+        (
+            "--entrypoint",
+            "the pitboss dispatch entrypoint must remain in place",
+        ),
+        ("--pid=host", "shares the host PID namespace"),
+        ("--ipc=host", "shares the host IPC namespace"),
+        ("--uts=host", "shares the host UTS namespace"),
+        ("--userns=host", "disables UID namespacing"),
+        ("--cgroupns=host", "shares the host cgroup namespace"),
+        (
+            "--security-opt=seccomp=unconfined",
+            "disables seccomp filtering",
+        ),
+        ("--security-opt=apparmor=unconfined", "disables AppArmor"),
+        ("--security-opt=label=disable", "disables SELinux labels"),
+        ("--security-opt=label:disable", "disables SELinux labels"),
+    ];
+    // Prefix-match denylist for flags with attached values.
+    const PREFIX: &[(&str, &str)] = &[
+        (
+            "--pid=container:",
+            "joins another container's PID namespace",
+        ),
+        ("--device=", "exposes a host device into the container"),
+        ("--device-cgroup-rule=", "rewrites the device cgroup rules"),
+        (
+            "--entrypoint=",
+            "the pitboss dispatch entrypoint must remain in place",
+        ),
+        (
+            "--volume=",
+            "use [[container.mount]] for bind mounts (path-validated)",
+        ),
+        (
+            "--user=",
+            "pitboss controls UID alignment; do not override --user in extra_args",
+        ),
+    ];
+    // `--cap-add` accepts comma-separated capability lists. Parse out
+    // the individual caps so `--cap-add=NET_ADMIN,SYS_ADMIN` is caught.
+    const FORBIDDEN_CAPS: &[&str] = &["ALL", "SYS_ADMIN", "SYS_PTRACE", "SYS_MODULE"];
+
+    for arg in extra_args {
+        for (pat, why) in EXACT {
+            if arg == pat {
+                bail!(
+                    "[container].extra_args: {arg:?} is forbidden ({why}). \
+                     If you genuinely need this, invoke docker/podman directly \
+                     rather than through `pitboss container-dispatch`."
+                );
+            }
+        }
+        for (pat, why) in PREFIX {
+            if arg.starts_with(pat) {
+                bail!("[container].extra_args: {arg:?} is forbidden ({why}).");
+            }
+        }
+        if let Some(rest) = arg.strip_prefix("--cap-add=") {
+            for cap in rest.split(',') {
+                let cap = cap.trim();
+                if FORBIDDEN_CAPS.iter().any(|c| c.eq_ignore_ascii_case(cap)) {
+                    bail!(
+                        "[container].extra_args: --cap-add includes {cap:?} \
+                         which is too broad. Forbidden caps: {FORBIDDEN_CAPS:?}. \
+                         Use narrower caps (e.g. NET_ADMIN) or invoke docker/podman \
+                         directly."
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Validate a debian/ubuntu package name for shell-safe interpolation
@@ -423,6 +586,48 @@ fn default_run_dir() -> PathBuf {
         .join(".local/share/pitboss/runs")
 }
 
+/// Append a single NDJSON record to `<runs_base>/container-dispatch.log`
+/// describing the about-to-exec container invocation. Used as a post-facto
+/// audit trail for `extra_args` and other host-side container flags.
+///
+/// Format:
+/// ```jsonc
+/// {"at":"2026-05-14T12:34:56Z","manifest":"/abs/path/pitboss.toml",
+///  "runtime":"podman","argv":["run","--rm",…]}
+/// ```
+fn append_container_dispatch_audit(
+    runs_base: &Path,
+    runtime: &str,
+    args: &[String],
+    manifest_abs: &Path,
+) -> Result<()> {
+    use std::io::Write;
+
+    std::fs::create_dir_all(runs_base).with_context(|| {
+        format!(
+            "creating runs base dir for audit log: {}",
+            runs_base.display()
+        )
+    })?;
+    let log_path = runs_base.join("container-dispatch.log");
+
+    let record = serde_json::json!({
+        "at": chrono::Utc::now().to_rfc3339(),
+        "manifest": manifest_abs.display().to_string(),
+        "runtime": runtime,
+        "argv": args,
+    });
+
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .with_context(|| format!("opening audit log {}", log_path.display()))?;
+    writeln!(f, "{record}")
+        .with_context(|| format!("appending to audit log {}", log_path.display()))?;
+    Ok(())
+}
+
 /// Read `manifest_abs`, remove the `[container]` key, and write the result to
 /// a temp file. Returns the temp file path, which is mounted read-only into the
 /// container in place of the original manifest.
@@ -484,13 +689,8 @@ mod tests {
 
     fn make_config(mounts: Vec<MountSpec>) -> ContainerConfig {
         ContainerConfig {
-            image: None,
-            runtime: None,
-            extra_args: vec![],
-            extra_apt: vec![],
             mounts,
-            copy: vec![],
-            workdir: None,
+            ..ContainerConfig::default()
         }
     }
 
@@ -604,6 +804,45 @@ prompt = "hi"
         assert!(
             joined.contains("/home/pitboss/.claude"),
             "auto-inject claude: {joined}"
+        );
+    }
+
+    #[test]
+    fn auto_inject_claude_defaults_to_read_only() {
+        // F-SEC-11: the auto-injected ~/.claude mount must be read-only
+        // by default. A compromised worker cannot rewrite host
+        // credentials or inject malicious hooks via the rw mount.
+        let cfg = make_config(vec![]);
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None).unwrap();
+        let claude_mount = args
+            .windows(2)
+            .find(|w| w[0] == "-v" && w[1].contains(":/home/pitboss/.claude:"))
+            .expect("auto-injected claude mount must be present");
+        assert!(
+            claude_mount[1].ends_with(":ro,z"),
+            "auto-injected ~/.claude mount must default to ro,z, got: {}",
+            claude_mount[1]
+        );
+    }
+
+    #[test]
+    fn auto_inject_claude_uses_rw_when_opted_in() {
+        // The operator can opt back into the pre-v0.15 rw mount for
+        // OAuth-refresh scenarios via `[container].claude_mount_rw =
+        // true`. This keeps the escape valve documented and testable.
+        let cfg = ContainerConfig {
+            claude_mount_rw: true,
+            ..ContainerConfig::default()
+        };
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None).unwrap();
+        let claude_mount = args
+            .windows(2)
+            .find(|w| w[0] == "-v" && w[1].contains(":/home/pitboss/.claude:"))
+            .expect("auto-injected claude mount must be present");
+        assert!(
+            claude_mount[1].ends_with(":rw,z"),
+            "opt-in must produce rw,z, got: {}",
+            claude_mount[1]
         );
     }
 
@@ -884,6 +1123,194 @@ prompt = "hi"
             .expect("dispatch arg present");
         assert_eq!(args[dispatch_pos - 1], "pitboss");
         assert_eq!(args[dispatch_pos + 1], "/run/pitboss.toml");
+    }
+
+    #[test]
+    fn extra_args_rejects_privileged() {
+        // F-SEC-9: --privileged is the canonical sandbox-break flag.
+        let cfg = ContainerConfig {
+            extra_args: vec!["--privileged".into()],
+            ..ContainerConfig::default()
+        };
+        let err = build_run_args("podman", &cfg, &temp_manifest(), None, None)
+            .expect_err("--privileged must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--privileged") && msg.contains("forbidden"),
+            "error must name the flag and reason: {msg}"
+        );
+    }
+
+    #[test]
+    fn extra_args_rejects_namespace_host_flags() {
+        // Each namespace-breakout flag rejected independently.
+        for bad in [
+            "--pid=host",
+            "--ipc=host",
+            "--uts=host",
+            "--userns=host",
+            "--cgroupns=host",
+        ] {
+            let cfg = ContainerConfig {
+                extra_args: vec![bad.into()],
+                ..ContainerConfig::default()
+            };
+            let err = build_run_args("podman", &cfg, &temp_manifest(), None, None)
+                .expect_err(&format!("{bad} must be rejected"));
+            assert!(
+                err.to_string().contains(bad),
+                "rejection must name the flag: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn extra_args_rejects_v_mount_in_extra_args() {
+        // -v / --volume / --mount are pitboss-managed via [[container.mount]];
+        // operators may not smuggle a raw mount through extra_args.
+        for bad in ["-v", "--volume", "--mount"] {
+            let cfg = ContainerConfig {
+                extra_args: vec![bad.into(), "/etc:/etc:rw".into()],
+                ..ContainerConfig::default()
+            };
+            let err = build_run_args("podman", &cfg, &temp_manifest(), None, None)
+                .expect_err(&format!("{bad} must be rejected"));
+            assert!(
+                err.to_string().contains("container.mount"),
+                "rejection must point at the [[container.mount]] alternative: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn extra_args_rejects_fused_volume_flag() {
+        // The fused `--volume=src:dst` form is just as dangerous as the
+        // standalone `-v src:dst` form — both must fail closed.
+        let cfg = ContainerConfig {
+            extra_args: vec!["--volume=/etc:/etc:rw".into()],
+            ..ContainerConfig::default()
+        };
+        let err = build_run_args("podman", &cfg, &temp_manifest(), None, None)
+            .expect_err("--volume=src:dst must be rejected");
+        assert!(
+            err.to_string().contains("--volume=/etc:/etc:rw"),
+            "rejection must echo the offending arg: {err}"
+        );
+    }
+
+    #[test]
+    fn extra_args_rejects_dangerous_cap_add() {
+        // --cap-add=SYS_ADMIN gives the container near-root authority.
+        // Validation must split comma-separated lists so a sneaky
+        // `NET_ADMIN,SYS_ADMIN` is caught.
+        for bad in [
+            "--cap-add=ALL",
+            "--cap-add=SYS_ADMIN",
+            "--cap-add=NET_ADMIN,SYS_ADMIN",
+            "--cap-add=sys_admin",
+        ] {
+            let cfg = ContainerConfig {
+                extra_args: vec![bad.into()],
+                ..ContainerConfig::default()
+            };
+            let err = build_run_args("podman", &cfg, &temp_manifest(), None, None)
+                .expect_err(&format!("{bad} must be rejected"));
+            assert!(
+                err.to_string().contains("cap-add"),
+                "rejection must mention cap-add: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn extra_args_rejects_user_override() {
+        // -u / --user overrides the UID alignment that the apt-bootstrap
+        // path depends on. The fused `--user=0:0` form must also fail.
+        for bad in ["-u", "--user"] {
+            let cfg = ContainerConfig {
+                extra_args: vec![bad.into(), "0:0".into()],
+                ..ContainerConfig::default()
+            };
+            assert!(
+                build_run_args("podman", &cfg, &temp_manifest(), None, None).is_err(),
+                "{bad} must be rejected"
+            );
+        }
+        let cfg = ContainerConfig {
+            extra_args: vec!["--user=0:0".into()],
+            ..ContainerConfig::default()
+        };
+        assert!(
+            build_run_args("podman", &cfg, &temp_manifest(), None, None).is_err(),
+            "--user=0:0 must be rejected"
+        );
+    }
+
+    #[test]
+    fn extra_args_rejects_entrypoint_override() {
+        for bad in ["--entrypoint", "--entrypoint=/bin/sh"] {
+            let cfg = ContainerConfig {
+                extra_args: vec![bad.into()],
+                ..ContainerConfig::default()
+            };
+            assert!(
+                build_run_args("podman", &cfg, &temp_manifest(), None, None).is_err(),
+                "{bad} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn extra_args_rejects_security_opt_unconfined() {
+        for bad in [
+            "--security-opt=seccomp=unconfined",
+            "--security-opt=apparmor=unconfined",
+            "--security-opt=label=disable",
+        ] {
+            let cfg = ContainerConfig {
+                extra_args: vec![bad.into()],
+                ..ContainerConfig::default()
+            };
+            assert!(
+                build_run_args("podman", &cfg, &temp_manifest(), None, None).is_err(),
+                "{bad} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn extra_args_rejects_device_passthrough() {
+        for bad in ["--device=/dev/kvm", "--device-cgroup-rule=a *:* rwm"] {
+            let cfg = ContainerConfig {
+                extra_args: vec![bad.into()],
+                ..ContainerConfig::default()
+            };
+            assert!(
+                build_run_args("podman", &cfg, &temp_manifest(), None, None).is_err(),
+                "{bad} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn extra_args_accepts_realistic_safe_flags() {
+        // Common legitimate flags must pass: dns config, narrow caps,
+        // resource limits, network override (commonly required in corp
+        // firewall scenarios — broad but the operator chose this manifest).
+        let cfg = ContainerConfig {
+            extra_args: vec![
+                "--network=host".into(),
+                "--dns=10.0.0.53".into(),
+                "--cap-drop=ALL".into(),
+                "--cap-add=NET_ADMIN".into(),
+                "--memory=4g".into(),
+                "--cpus=2".into(),
+                "--add-host=internal:10.0.0.1".into(),
+            ],
+            ..ContainerConfig::default()
+        };
+        build_run_args("podman", &cfg, &temp_manifest(), None, None)
+            .expect("realistic safe extra_args must pass validation");
     }
 
     #[test]

--- a/crates/pitboss-cli/src/dispatch/container_build.rs
+++ b/crates/pitboss-cli/src/dispatch/container_build.rs
@@ -313,6 +313,8 @@ pub(crate) fn derived_fallback_warning(
     let tag = derived_tag?;
     Some(format!(
         "warning: derived image {tag} not found locally; falling back to apt-at-spin-up.\n\
+         Note: apt-at-spin-up runs the entry process as UID 0 until `runuser` drops to \
+         the unprivileged pitboss user — the derived-image path avoids that root window. \
          Re-run `pitboss container-build {}` to restore the cached fast-path.",
         manifest_path.display()
     ))
@@ -579,6 +581,28 @@ mod tests {
             msg.contains("pitboss container-build /tmp/manifest.toml"),
             "missing rebuild hint with manifest path: {msg}"
         );
+    }
+
+    #[test]
+    fn fallback_warning_mentions_root_window() {
+        // F-SEC-12: the slow-path warning piggybacks a note that the
+        // apt-bootstrap phase runs as UID 0 until runuser drops to the
+        // pitboss user. Operators choosing between the slow path and
+        // the derived-image path should see the security tradeoff
+        // alongside the performance one.
+        let c = ContainerConfig {
+            extra_apt: vec!["mdbook".into()],
+            ..cfg()
+        };
+        let msg = derived_fallback_warning(
+            &c,
+            Some("pitboss-derived-abc123:local"),
+            false,
+            &PathBuf::from("/tmp/manifest.toml"),
+        )
+        .expect("warning should fire");
+        assert!(msg.contains("UID 0"), "missing root-window note: {msg}");
+        assert!(msg.contains("runuser"), "missing runuser-drop note: {msg}");
     }
 
     #[test]

--- a/crates/pitboss-cli/src/manifest/schema.rs
+++ b/crates/pitboss-cli/src/manifest/schema.rs
@@ -135,6 +135,23 @@ pub struct ContainerConfig {
         help = "cwd inside the container; defaults to the first mount's container path."
     )]
     pub workdir: Option<PathBuf>,
+    /// Auto-injected `~/.claude` mount mode. Default `false` mounts the
+    /// host's `~/.claude` as read-only — sufficient for static OAuth
+    /// tokens and `settings.json`-driven configuration, and prevents a
+    /// compromised or buggy worker from writing host credentials or
+    /// injecting `settings.json` hooks. Set `true` to restore the
+    /// pre-v0.15 behaviour (`rw,z`) when claude needs to refresh OAuth
+    /// tokens in-place. (#525 / F-SEC-11)
+    ///
+    /// An explicit `[[container.mount]]` targeting `/home/pitboss/.claude`
+    /// always wins — its `readonly` field controls the mode, this flag
+    /// is consulted only for the auto-inject path.
+    #[serde(default)]
+    #[field(
+        label = "Claude mount rw",
+        help = "Set true to mount the auto-injected ~/.claude as rw (needed for OAuth token refresh). Default false = read-only."
+    )]
+    pub claude_mount_rw: bool,
 }
 
 /// A single host→container bind mount entry.

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -337,6 +337,10 @@ fn validate_container(r: &ResolvedManifest) -> Result<()> {
             );
         }
     }
+    // F-SEC-9: deny dangerous container runtime flags. Same helper that
+    // `build_run_args` re-checks at dispatch time so test fixtures and
+    // programmatic callers cannot bypass.
+    crate::dispatch::container::validate_extra_args(&container.extra_args)?;
     for spec in &container.copy {
         if !spec.container.is_absolute() {
             bail!(
@@ -353,6 +357,83 @@ fn validate_container(r: &ResolvedManifest) -> Result<()> {
             bail!(
                 "[[container.copy]].host must be an absolute or tilde-prefixed path, got {:?}",
                 spec.host
+            );
+        }
+    }
+    // F-SEC-10: validate [[container.mount]] entries the same way as
+    // [[container.copy]] above. The previous code only validated copy.
+    for spec in &container.mounts {
+        if !spec.container.is_absolute() {
+            bail!(
+                "[[container.mount]].container must be an absolute path, got {:?}",
+                spec.container
+            );
+        }
+        // Host: same rule as copy — absolute or tilde-prefixed only.
+        // Relative paths have no canonical anchor in the manifest schema.
+        let host_str = spec.host.to_string_lossy();
+        let is_tilde = host_str.starts_with('~');
+        if !spec.host.is_absolute() && !is_tilde {
+            bail!(
+                "[[container.mount]].host must be an absolute or tilde-prefixed path, got {:?}",
+                spec.host
+            );
+        }
+        // Hard-reject host paths that would defeat the container
+        // sandbox. The denylist is short: each entry is either a known
+        // container-escape vector (docker/podman socket → root on the
+        // host) or a wholesale namespace bypass (/, /proc, /sys).
+        //
+        // /etc, /var/log, /home/<other-user> are NOT in the denylist —
+        // they are sensitive but operators have legitimate use cases
+        // (config reads, log capture, peer-user collaboration). The
+        // line is "would a buggy/malicious worker get host-root or
+        // host-namespace visibility from this mount?".
+        check_mount_host_path(&host_str)?;
+    }
+    Ok(())
+}
+
+/// Reject host paths that defeat container isolation. Called per-mount
+/// from `validate_container`. (#524 / F-SEC-10)
+///
+/// The check is exact-match (after lossy stringification) for socket
+/// paths and full-tree mounts. Substring matching would over-block
+/// legitimate workspace paths like `/data/proc-recordings`.
+fn check_mount_host_path(host: &str) -> Result<()> {
+    // Trim any trailing slash so `/proc` and `/proc/` are equivalent.
+    let trimmed = host.trim_end_matches('/');
+    let denylist: &[(&str, &str)] = &[
+        (
+            "/var/run/docker.sock",
+            "the docker socket grants root on the host",
+        ),
+        (
+            "/run/docker.sock",
+            "the docker socket grants root on the host",
+        ),
+        (
+            "/var/run/podman/podman.sock",
+            "the podman socket grants root on the host",
+        ),
+        (
+            "/run/podman/podman.sock",
+            "the podman socket grants root on the host",
+        ),
+        ("/proc", "exposes the host process namespace"),
+        (
+            "/sys",
+            "exposes host kernel sysfs (a common container-breakout vector)",
+        ),
+        ("/", "mounts the entire host root filesystem"),
+        ("/etc/shadow", "exposes the host root password hashes"),
+    ];
+    for (bad, why) in denylist {
+        if trimmed == *bad || trimmed == bad.trim_end_matches('/') {
+            bail!(
+                "[[container.mount]].host = {host:?} is forbidden ({why}). \
+                 If you genuinely need this mount, run docker/podman \
+                 directly rather than through `pitboss container-dispatch`."
             );
         }
     }
@@ -1825,6 +1906,158 @@ mod tests {
             ..ContainerConfig::default()
         });
         validate(&m).expect("realistic apt package names must validate");
+    }
+
+    #[test]
+    fn extra_args_dangerous_flag_fails_validate() {
+        // F-SEC-9: dangerous container runtime flags must be rejected at
+        // `pitboss validate` time — not deferred to dispatch — so
+        // operators see the gate in their CI / pre-flight checks.
+        use super::super::schema::ContainerConfig;
+        for bad in [
+            "--privileged",
+            "--pid=host",
+            "--cap-add=SYS_ADMIN",
+            "-v",
+            "--user",
+            "--security-opt=seccomp=unconfined",
+        ] {
+            let d = with_tmp_repo(true);
+            let mut m = rm(vec![rt("t", d.path().to_path_buf(), false, None)]);
+            m.container = Some(ContainerConfig {
+                extra_args: vec![bad.into()],
+                ..ContainerConfig::default()
+            });
+            let err = validate(&m).expect_err(&format!("{bad} must fail validate"));
+            assert!(
+                err.to_string().contains("extra_args"),
+                "error must reference extra_args: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn mount_relative_container_path_fails_validate() {
+        // F-SEC-10: [[container.mount]].container must be absolute, same
+        // rule as [[container.copy]].container.
+        use super::super::schema::{ContainerConfig, MountSpec};
+        let d = with_tmp_repo(true);
+        let mut m = rm(vec![rt("t", d.path().to_path_buf(), false, None)]);
+        m.container = Some(ContainerConfig {
+            mounts: vec![MountSpec {
+                host: PathBuf::from("/abs/host"),
+                container: PathBuf::from("relative/path"),
+                readonly: false,
+            }],
+            ..ContainerConfig::default()
+        });
+        let err = validate(&m).expect_err("relative container path must fail");
+        assert!(
+            err.to_string()
+                .contains("container.mount]].container must be an absolute path"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn mount_relative_host_path_fails_validate() {
+        use super::super::schema::{ContainerConfig, MountSpec};
+        let d = with_tmp_repo(true);
+        let mut m = rm(vec![rt("t", d.path().to_path_buf(), false, None)]);
+        m.container = Some(ContainerConfig {
+            mounts: vec![MountSpec {
+                host: PathBuf::from("./relative"),
+                container: PathBuf::from("/abs/container"),
+                readonly: false,
+            }],
+            ..ContainerConfig::default()
+        });
+        let err = validate(&m).expect_err("relative host path must fail");
+        assert!(
+            err.to_string()
+                .contains("container.mount]].host must be an absolute or tilde-prefixed path"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn mount_dangerous_host_paths_fail_validate() {
+        // F-SEC-10: catastrophic host paths are hard-rejected.
+        use super::super::schema::{ContainerConfig, MountSpec};
+        for bad in [
+            "/var/run/docker.sock",
+            "/run/docker.sock",
+            "/var/run/podman/podman.sock",
+            "/run/podman/podman.sock",
+            "/proc",
+            "/sys",
+            "/",
+            "/etc/shadow",
+            // Trailing-slash form is canonicalised in the check; must
+            // still fail.
+            "/proc/",
+        ] {
+            let d = with_tmp_repo(true);
+            let mut m = rm(vec![rt("t", d.path().to_path_buf(), false, None)]);
+            m.container = Some(ContainerConfig {
+                mounts: vec![MountSpec {
+                    host: PathBuf::from(bad),
+                    container: PathBuf::from("/mnt/host"),
+                    readonly: false,
+                }],
+                ..ContainerConfig::default()
+            });
+            let err = validate(&m).expect_err(&format!("{bad} must fail validate"));
+            assert!(
+                err.to_string().contains("forbidden"),
+                "rejection must label as forbidden: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn mount_sensitive_but_legitimate_host_paths_pass_validate() {
+        // F-SEC-10: paths that are sensitive-but-have-legitimate-uses
+        // (/etc, /var/log, peer home dirs) are NOT in the denylist —
+        // they pass validation. The line is "would this give the
+        // worker host-root or host-namespace authority?". Sensitive ≠
+        // catastrophic.
+        use super::super::schema::{ContainerConfig, MountSpec};
+        for ok in ["/etc", "/var/log", "/home/alice", "/tmp"] {
+            let d = with_tmp_repo(true);
+            let mut m = rm(vec![rt("t", d.path().to_path_buf(), false, None)]);
+            m.container = Some(ContainerConfig {
+                mounts: vec![MountSpec {
+                    host: PathBuf::from(ok),
+                    container: PathBuf::from("/mnt/host"),
+                    readonly: true,
+                }],
+                ..ContainerConfig::default()
+            });
+            validate(&m).unwrap_or_else(|e| {
+                panic!("{ok} should pass validation: {e}");
+            });
+        }
+    }
+
+    #[test]
+    fn extra_args_safe_flags_pass_validate() {
+        // Common legitimate flags continue to validate. This pins the
+        // boundary: if a future change accidentally over-blocks (e.g.
+        // rejects every --cap-add), this test catches it.
+        use super::super::schema::ContainerConfig;
+        let d = with_tmp_repo(true);
+        let mut m = rm(vec![rt("t", d.path().to_path_buf(), false, None)]);
+        m.container = Some(ContainerConfig {
+            extra_args: vec![
+                "--network=host".into(),
+                "--cap-drop=ALL".into(),
+                "--cap-add=NET_ADMIN".into(),
+                "--memory=4g".into(),
+            ],
+            ..ContainerConfig::default()
+        });
+        validate(&m).expect("realistic safe extra_args must validate");
     }
 
     #[test]

--- a/docs/manifest-map.md
+++ b/docs/manifest-map.md
@@ -14,35 +14,35 @@ The annotated example lives at [`pitboss.example.toml`](../pitboss.example.toml)
 
 ## `[run]` — `RunConfig`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:507`](../crates/pitboss-cli/src/manifest/schema.rs#L507).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:524`](../crates/pitboss-cli/src/manifest/schema.rs#L524).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `name` | text | no | Human-readable label used to group related runs in the console (e.g. "build-db", "nightly-sync"). When unset, the manifest filename is used as fallback. | [`../crates/pitboss-cli/src/manifest/schema.rs#L518`](../crates/pitboss-cli/src/manifest/schema.rs#L518) |
-| `max_parallel_tasks` | integer | no | Flat-mode concurrency cap for [[task]] runs. Default 4. Overridden by ANTHROPIC_MAX_CONCURRENT. | [`../crates/pitboss-cli/src/manifest/schema.rs#L527`](../crates/pitboss-cli/src/manifest/schema.rs#L527) |
-| `halt_on_failure` | boolean | no | Stop remaining flat-mode tasks on first failure. | [`../crates/pitboss-cli/src/manifest/schema.rs#L534`](../crates/pitboss-cli/src/manifest/schema.rs#L534) |
-| `run_dir` | path | no | Where per-run artifacts land. Default ~/.local/share/pitboss/runs. | [`../crates/pitboss-cli/src/manifest/schema.rs#L540`](../crates/pitboss-cli/src/manifest/schema.rs#L540) |
-| `worktree_cleanup` | enum (`always` \| `on_success` \| `never`) | no | What to do with each worker's git worktree after it finishes. | [`../crates/pitboss-cli/src/manifest/schema.rs#L548`](../crates/pitboss-cli/src/manifest/schema.rs#L548) |
-| `emit_event_stream` | boolean | no | Write a JSONL event stream alongside summary.jsonl. | [`../crates/pitboss-cli/src/manifest/schema.rs#L555`](../crates/pitboss-cli/src/manifest/schema.rs#L555) |
-| `default_approval_policy` | enum (`block` \| `auto_approve` \| `auto_reject`) | no | Default action for request_approval / propose_plan when no rule matches. `auto_approve`/`auto_reject` are unconditional; `block` routes to the operator if attached, else queues. | [`../crates/pitboss-cli/src/manifest/schema.rs#L583`](../crates/pitboss-cli/src/manifest/schema.rs#L583) |
-| `denial_termination_policy` | enum (`adapt` \| `reclassify`) | no | How a denied permission_prompt affects the actor's terminal status. `adapt` (default) keeps the actor's exit code as-is; `reclassify` re-labels clean exits within 30s of a denial as ApprovalRejected. | [`../crates/pitboss-cli/src/manifest/schema.rs#L594`](../crates/pitboss-cli/src/manifest/schema.rs#L594) |
-| `dump_shared_store` | boolean | no | Write shared-store.json into the run directory on finalize. | [`../crates/pitboss-cli/src/manifest/schema.rs#L602`](../crates/pitboss-cli/src/manifest/schema.rs#L602) |
-| `require_plan_approval` | boolean | no | When true, spawn_worker is blocked until propose_plan has been approved. | [`../crates/pitboss-cli/src/manifest/schema.rs#L610`](../crates/pitboss-cli/src/manifest/schema.rs#L610) |
-| `require_actor_type` | boolean | no | When true, every spawn_worker and spawn_sublead call must name a declared [[worker_type]]/[[sublead_type]]. Default false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L621`](../crates/pitboss-cli/src/manifest/schema.rs#L621) |
-| `untyped_actor_policy` | enum (`bridge` \| `block`) | no | Path-B-only behavior for un-typed callers reaching permission_prompt. `bridge` (default) routes to the operator queue; `block` auto-denies via a synthesized empty profile. | [`../crates/pitboss-cli/src/manifest/schema.rs#L638`](../crates/pitboss-cli/src/manifest/schema.rs#L638) |
+| `name` | text | no | Human-readable label used to group related runs in the console (e.g. "build-db", "nightly-sync"). When unset, the manifest filename is used as fallback. | [`../crates/pitboss-cli/src/manifest/schema.rs#L535`](../crates/pitboss-cli/src/manifest/schema.rs#L535) |
+| `max_parallel_tasks` | integer | no | Flat-mode concurrency cap for [[task]] runs. Default 4. Overridden by ANTHROPIC_MAX_CONCURRENT. | [`../crates/pitboss-cli/src/manifest/schema.rs#L544`](../crates/pitboss-cli/src/manifest/schema.rs#L544) |
+| `halt_on_failure` | boolean | no | Stop remaining flat-mode tasks on first failure. | [`../crates/pitboss-cli/src/manifest/schema.rs#L551`](../crates/pitboss-cli/src/manifest/schema.rs#L551) |
+| `run_dir` | path | no | Where per-run artifacts land. Default ~/.local/share/pitboss/runs. | [`../crates/pitboss-cli/src/manifest/schema.rs#L557`](../crates/pitboss-cli/src/manifest/schema.rs#L557) |
+| `worktree_cleanup` | enum (`always` \| `on_success` \| `never`) | no | What to do with each worker's git worktree after it finishes. | [`../crates/pitboss-cli/src/manifest/schema.rs#L565`](../crates/pitboss-cli/src/manifest/schema.rs#L565) |
+| `emit_event_stream` | boolean | no | Write a JSONL event stream alongside summary.jsonl. | [`../crates/pitboss-cli/src/manifest/schema.rs#L572`](../crates/pitboss-cli/src/manifest/schema.rs#L572) |
+| `default_approval_policy` | enum (`block` \| `auto_approve` \| `auto_reject`) | no | Default action for request_approval / propose_plan when no rule matches. `auto_approve`/`auto_reject` are unconditional; `block` routes to the operator if attached, else queues. | [`../crates/pitboss-cli/src/manifest/schema.rs#L600`](../crates/pitboss-cli/src/manifest/schema.rs#L600) |
+| `denial_termination_policy` | enum (`adapt` \| `reclassify`) | no | How a denied permission_prompt affects the actor's terminal status. `adapt` (default) keeps the actor's exit code as-is; `reclassify` re-labels clean exits within 30s of a denial as ApprovalRejected. | [`../crates/pitboss-cli/src/manifest/schema.rs#L611`](../crates/pitboss-cli/src/manifest/schema.rs#L611) |
+| `dump_shared_store` | boolean | no | Write shared-store.json into the run directory on finalize. | [`../crates/pitboss-cli/src/manifest/schema.rs#L619`](../crates/pitboss-cli/src/manifest/schema.rs#L619) |
+| `require_plan_approval` | boolean | no | When true, spawn_worker is blocked until propose_plan has been approved. | [`../crates/pitboss-cli/src/manifest/schema.rs#L627`](../crates/pitboss-cli/src/manifest/schema.rs#L627) |
+| `require_actor_type` | boolean | no | When true, every spawn_worker and spawn_sublead call must name a declared [[worker_type]]/[[sublead_type]]. Default false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L638`](../crates/pitboss-cli/src/manifest/schema.rs#L638) |
+| `untyped_actor_policy` | enum (`bridge` \| `block`) | no | Path-B-only behavior for un-typed callers reaching permission_prompt. `bridge` (default) routes to the operator queue; `block` auto-denies via a synthesized empty profile. | [`../crates/pitboss-cli/src/manifest/schema.rs#L655`](../crates/pitboss-cli/src/manifest/schema.rs#L655) |
 
 ## `[defaults]` — `Defaults`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:776`](../crates/pitboss-cli/src/manifest/schema.rs#L776).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:793`](../crates/pitboss-cli/src/manifest/schema.rs#L793).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `model` | text | no | Claude model id (e.g. claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-7). | [`../crates/pitboss-cli/src/manifest/schema.rs#L781`](../crates/pitboss-cli/src/manifest/schema.rs#L781) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Maps to the claude --effort flag. | [`../crates/pitboss-cli/src/manifest/schema.rs#L787`](../crates/pitboss-cli/src/manifest/schema.rs#L787) |
-| `tools` | string list | no | Allowed tool surface. Pitboss auto-appends its MCP tools for leads and workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L792`](../crates/pitboss-cli/src/manifest/schema.rs#L792) |
-| `timeout_secs` | integer | no | Per-task wall-clock cap. No default (no cap). | [`../crates/pitboss-cli/src/manifest/schema.rs#L797`](../crates/pitboss-cli/src/manifest/schema.rs#L797) |
-| `use_worktree` | boolean | no | Isolate each worker in a git worktree. Default true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L802`](../crates/pitboss-cli/src/manifest/schema.rs#L802) |
-| `env` | key-value map | no | Environment variables passed to the claude subprocess. | [`../crates/pitboss-cli/src/manifest/schema.rs#L808`](../crates/pitboss-cli/src/manifest/schema.rs#L808) |
+| `model` | text | no | Claude model id (e.g. claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-7). | [`../crates/pitboss-cli/src/manifest/schema.rs#L798`](../crates/pitboss-cli/src/manifest/schema.rs#L798) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Maps to the claude --effort flag. | [`../crates/pitboss-cli/src/manifest/schema.rs#L804`](../crates/pitboss-cli/src/manifest/schema.rs#L804) |
+| `tools` | string list | no | Allowed tool surface. Pitboss auto-appends its MCP tools for leads and workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L809`](../crates/pitboss-cli/src/manifest/schema.rs#L809) |
+| `timeout_secs` | integer | no | Per-task wall-clock cap. No default (no cap). | [`../crates/pitboss-cli/src/manifest/schema.rs#L814`](../crates/pitboss-cli/src/manifest/schema.rs#L814) |
+| `use_worktree` | boolean | no | Isolate each worker in a git worktree. Default true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L819`](../crates/pitboss-cli/src/manifest/schema.rs#L819) |
+| `env` | key-value map | no | Environment variables passed to the claude subprocess. | [`../crates/pitboss-cli/src/manifest/schema.rs#L825`](../crates/pitboss-cli/src/manifest/schema.rs#L825) |
 
 ## `[container]` — `ContainerConfig`
 
@@ -55,143 +55,144 @@ Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:77`](../crates/pitboss
 | `extra_args` | string list | no | Verbatim podman/docker run flags. Use for networking, capabilities, DNS, resources, etc. Example: ["--network=corp-fw", "--dns=10.0.0.53", "--cap-add=NET_ADMIN"]. | [`../crates/pitboss-cli/src/manifest/schema.rs#L101`](../crates/pitboss-cli/src/manifest/schema.rs#L101) |
 | `extra_apt` | string list | no | Debian/Ubuntu packages installed inside the container before pitboss dispatch starts. Adds 30–90s spin-up per dispatch. Example: ["mdbook", "jq"]. | [`../crates/pitboss-cli/src/manifest/schema.rs#L116`](../crates/pitboss-cli/src/manifest/schema.rs#L116) |
 | `workdir` | path | no | cwd inside the container; defaults to the first mount's container path. | [`../crates/pitboss-cli/src/manifest/schema.rs#L137`](../crates/pitboss-cli/src/manifest/schema.rs#L137) |
+| `claude_mount_rw` | boolean | no | Set true to mount the auto-injected ~/.claude as rw (needed for OAuth token refresh). Default false = read-only. | [`../crates/pitboss-cli/src/manifest/schema.rs#L154`](../crates/pitboss-cli/src/manifest/schema.rs#L154) |
 
 ## `[[container.mount]]` — `MountSpec`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:143`](../crates/pitboss-cli/src/manifest/schema.rs#L143).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:160`](../crates/pitboss-cli/src/manifest/schema.rs#L160).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `host` | path | **yes** | Absolute host path. ~ is expanded. | [`../crates/pitboss-cli/src/manifest/schema.rs#L146`](../crates/pitboss-cli/src/manifest/schema.rs#L146) |
-| `container` | path | **yes** | Absolute path inside the container. | [`../crates/pitboss-cli/src/manifest/schema.rs#L149`](../crates/pitboss-cli/src/manifest/schema.rs#L149) |
-| `readonly` | boolean | no | Mount read-only. | [`../crates/pitboss-cli/src/manifest/schema.rs#L153`](../crates/pitboss-cli/src/manifest/schema.rs#L153) |
+| `host` | path | **yes** | Absolute host path. ~ is expanded. | [`../crates/pitboss-cli/src/manifest/schema.rs#L163`](../crates/pitboss-cli/src/manifest/schema.rs#L163) |
+| `container` | path | **yes** | Absolute path inside the container. | [`../crates/pitboss-cli/src/manifest/schema.rs#L166`](../crates/pitboss-cli/src/manifest/schema.rs#L166) |
+| `readonly` | boolean | no | Mount read-only. | [`../crates/pitboss-cli/src/manifest/schema.rs#L170`](../crates/pitboss-cli/src/manifest/schema.rs#L170) |
 
 ## `[[task]]` — `Task`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:839`](../crates/pitboss-cli/src/manifest/schema.rs#L839).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:856`](../crates/pitboss-cli/src/manifest/schema.rs#L856).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique slug. Alphanumeric + _ + -. Used in logs and worktree names. | [`../crates/pitboss-cli/src/manifest/schema.rs#L844`](../crates/pitboss-cli/src/manifest/schema.rs#L844) |
-| `directory` | path | **yes** | Working directory. Must be inside a git repo if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L849`](../crates/pitboss-cli/src/manifest/schema.rs#L849) |
-| `prompt` | text (multi-line) | no | Prompt body sent to claude via -p. Mutually exclusive with `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L855`](../crates/pitboss-cli/src/manifest/schema.rs#L855) |
-| `template` | text | no | Reference to a [[template]] entry. Mutually exclusive with `prompt`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L860`](../crates/pitboss-cli/src/manifest/schema.rs#L860) |
-| `vars` | key-value map | no | Substitutions for {placeholders} when using `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L866`](../crates/pitboss-cli/src/manifest/schema.rs#L866) |
-| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L871`](../crates/pitboss-cli/src/manifest/schema.rs#L871) |
-| `model` | text | no | Per-task override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L873`](../crates/pitboss-cli/src/manifest/schema.rs#L873) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-task override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L879`](../crates/pitboss-cli/src/manifest/schema.rs#L879) |
-| `tools` | string list | no | Per-task override of [defaults].tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L881`](../crates/pitboss-cli/src/manifest/schema.rs#L881) |
-| `timeout_secs` | integer | no | Per-task wall-clock cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L883`](../crates/pitboss-cli/src/manifest/schema.rs#L883) |
-| `use_worktree` | boolean | no | Per-task override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L888`](../crates/pitboss-cli/src/manifest/schema.rs#L888) |
-| `env` | key-value map | no | Per-task env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L894`](../crates/pitboss-cli/src/manifest/schema.rs#L894) |
+| `id` | text | **yes** | Unique slug. Alphanumeric + _ + -. Used in logs and worktree names. | [`../crates/pitboss-cli/src/manifest/schema.rs#L861`](../crates/pitboss-cli/src/manifest/schema.rs#L861) |
+| `directory` | path | **yes** | Working directory. Must be inside a git repo if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L866`](../crates/pitboss-cli/src/manifest/schema.rs#L866) |
+| `prompt` | text (multi-line) | no | Prompt body sent to claude via -p. Mutually exclusive with `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L872`](../crates/pitboss-cli/src/manifest/schema.rs#L872) |
+| `template` | text | no | Reference to a [[template]] entry. Mutually exclusive with `prompt`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L877`](../crates/pitboss-cli/src/manifest/schema.rs#L877) |
+| `vars` | key-value map | no | Substitutions for {placeholders} when using `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L883`](../crates/pitboss-cli/src/manifest/schema.rs#L883) |
+| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L888`](../crates/pitboss-cli/src/manifest/schema.rs#L888) |
+| `model` | text | no | Per-task override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L890`](../crates/pitboss-cli/src/manifest/schema.rs#L890) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-task override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L896`](../crates/pitboss-cli/src/manifest/schema.rs#L896) |
+| `tools` | string list | no | Per-task override of [defaults].tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L898`](../crates/pitboss-cli/src/manifest/schema.rs#L898) |
+| `timeout_secs` | integer | no | Per-task wall-clock cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L900`](../crates/pitboss-cli/src/manifest/schema.rs#L900) |
+| `use_worktree` | boolean | no | Per-task override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L905`](../crates/pitboss-cli/src/manifest/schema.rs#L905) |
+| `env` | key-value map | no | Per-task env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L911`](../crates/pitboss-cli/src/manifest/schema.rs#L911) |
 
 ## `[lead]` — `Lead`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:904`](../crates/pitboss-cli/src/manifest/schema.rs#L904).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:921`](../crates/pitboss-cli/src/manifest/schema.rs#L921).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique slug used as the TUI tile label and in run artifact paths. | [`../crates/pitboss-cli/src/manifest/schema.rs#L911`](../crates/pitboss-cli/src/manifest/schema.rs#L911) |
-| `directory` | path | **yes** | Working directory for the lead's claude subprocess. Must be a git work-tree if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L918`](../crates/pitboss-cli/src/manifest/schema.rs#L918) |
-| `prompt` | text (multi-line) | **yes** | Operator instructions passed to claude via -p. Must appear before any [lead.X] subtable in the source. | [`../crates/pitboss-cli/src/manifest/schema.rs#L930`](../crates/pitboss-cli/src/manifest/schema.rs#L930) |
-| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L938`](../crates/pitboss-cli/src/manifest/schema.rs#L938) |
-| `model` | text | no | Per-lead override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L941`](../crates/pitboss-cli/src/manifest/schema.rs#L941) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-lead override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L948`](../crates/pitboss-cli/src/manifest/schema.rs#L948) |
-| `tools` | string list | no | Per-lead override of [defaults].tools. Pitboss auto-appends its MCP tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L954`](../crates/pitboss-cli/src/manifest/schema.rs#L954) |
-| `timeout_secs` | integer | no | Per-actor subprocess wall-clock cap (claude --timeout). | [`../crates/pitboss-cli/src/manifest/schema.rs#L960`](../crates/pitboss-cli/src/manifest/schema.rs#L960) |
-| `use_worktree` | boolean | no | Per-lead override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L966`](../crates/pitboss-cli/src/manifest/schema.rs#L966) |
-| `env` | key-value map | no | Per-lead env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L972`](../crates/pitboss-cli/src/manifest/schema.rs#L972) |
-| `max_workers` | integer | no | Hard cap on the lead's concurrent + queued worker pool (1–16). Required when the lead spawns workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L981`](../crates/pitboss-cli/src/manifest/schema.rs#L981) |
-| `budget_usd` | float | no | Soft cap on the run's total spend (workers + lead + sub-leads). spawn_worker fails once total_spent + reserved + next_estimate > budget; the lead is aborted if a reconciled turn drives total_spent past the cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L992`](../crates/pitboss-cli/src/manifest/schema.rs#L992) |
-| `lead_budget_usd` | float | no | Optional separate cap on lead + sub-lead token spend (orchestration cost). Independent of budget_usd. Lead is aborted when reached. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1002`](../crates/pitboss-cli/src/manifest/schema.rs#L1002) |
-| `lead_timeout_secs` | integer | no | Wall-clock cap on the lead session. Default 3600. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1011`](../crates/pitboss-cli/src/manifest/schema.rs#L1011) |
-| `permission_routing` | enum (`path_a` \| `path_b`) | no | path_b (default) routes claude's per-tool gate through pitboss's permission_prompt MCP tool — layered enforcement (mcp_server tools allowlist, operator policy, typed profile). path_a bypasses claude's gate via --dangerously-skip-permissions and makes pitboss the sole authority. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1029`](../crates/pitboss-cli/src/manifest/schema.rs#L1029) |
-| `allow_subleads` | boolean | no | Expose spawn_sublead to the root lead. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1038`](../crates/pitboss-cli/src/manifest/schema.rs#L1038) |
-| `max_subleads` | integer | no | Hard cap on total live sub-leads under this root. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1045`](../crates/pitboss-cli/src/manifest/schema.rs#L1045) |
-| `max_sublead_budget_usd` | float | no | Cap on the per-sub-lead budget envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1052`](../crates/pitboss-cli/src/manifest/schema.rs#L1052) |
-| `max_total_workers` | integer | no | Cap on total live workers across the entire tree (root + sub-trees). | [`../crates/pitboss-cli/src/manifest/schema.rs#L1060`](../crates/pitboss-cli/src/manifest/schema.rs#L1060) |
+| `id` | text | **yes** | Unique slug used as the TUI tile label and in run artifact paths. | [`../crates/pitboss-cli/src/manifest/schema.rs#L928`](../crates/pitboss-cli/src/manifest/schema.rs#L928) |
+| `directory` | path | **yes** | Working directory for the lead's claude subprocess. Must be a git work-tree if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L935`](../crates/pitboss-cli/src/manifest/schema.rs#L935) |
+| `prompt` | text (multi-line) | **yes** | Operator instructions passed to claude via -p. Must appear before any [lead.X] subtable in the source. | [`../crates/pitboss-cli/src/manifest/schema.rs#L947`](../crates/pitboss-cli/src/manifest/schema.rs#L947) |
+| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L955`](../crates/pitboss-cli/src/manifest/schema.rs#L955) |
+| `model` | text | no | Per-lead override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L958`](../crates/pitboss-cli/src/manifest/schema.rs#L958) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-lead override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L965`](../crates/pitboss-cli/src/manifest/schema.rs#L965) |
+| `tools` | string list | no | Per-lead override of [defaults].tools. Pitboss auto-appends its MCP tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L971`](../crates/pitboss-cli/src/manifest/schema.rs#L971) |
+| `timeout_secs` | integer | no | Per-actor subprocess wall-clock cap (claude --timeout). | [`../crates/pitboss-cli/src/manifest/schema.rs#L977`](../crates/pitboss-cli/src/manifest/schema.rs#L977) |
+| `use_worktree` | boolean | no | Per-lead override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L983`](../crates/pitboss-cli/src/manifest/schema.rs#L983) |
+| `env` | key-value map | no | Per-lead env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L989`](../crates/pitboss-cli/src/manifest/schema.rs#L989) |
+| `max_workers` | integer | no | Hard cap on the lead's concurrent + queued worker pool (1–16). Required when the lead spawns workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L998`](../crates/pitboss-cli/src/manifest/schema.rs#L998) |
+| `budget_usd` | float | no | Soft cap on the run's total spend (workers + lead + sub-leads). spawn_worker fails once total_spent + reserved + next_estimate > budget; the lead is aborted if a reconciled turn drives total_spent past the cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1009`](../crates/pitboss-cli/src/manifest/schema.rs#L1009) |
+| `lead_budget_usd` | float | no | Optional separate cap on lead + sub-lead token spend (orchestration cost). Independent of budget_usd. Lead is aborted when reached. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1019`](../crates/pitboss-cli/src/manifest/schema.rs#L1019) |
+| `lead_timeout_secs` | integer | no | Wall-clock cap on the lead session. Default 3600. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1028`](../crates/pitboss-cli/src/manifest/schema.rs#L1028) |
+| `permission_routing` | enum (`path_a` \| `path_b`) | no | path_b (default) routes claude's per-tool gate through pitboss's permission_prompt MCP tool — layered enforcement (mcp_server tools allowlist, operator policy, typed profile). path_a bypasses claude's gate via --dangerously-skip-permissions and makes pitboss the sole authority. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1046`](../crates/pitboss-cli/src/manifest/schema.rs#L1046) |
+| `allow_subleads` | boolean | no | Expose spawn_sublead to the root lead. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1055`](../crates/pitboss-cli/src/manifest/schema.rs#L1055) |
+| `max_subleads` | integer | no | Hard cap on total live sub-leads under this root. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1062`](../crates/pitboss-cli/src/manifest/schema.rs#L1062) |
+| `max_sublead_budget_usd` | float | no | Cap on the per-sub-lead budget envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1069`](../crates/pitboss-cli/src/manifest/schema.rs#L1069) |
+| `max_total_workers` | integer | no | Cap on total live workers across the entire tree (root + sub-trees). | [`../crates/pitboss-cli/src/manifest/schema.rs#L1077`](../crates/pitboss-cli/src/manifest/schema.rs#L1077) |
 
 ## `[sublead_defaults]` — `SubleadDefaults`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:1067`](../crates/pitboss-cli/src/manifest/schema.rs#L1067).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:1084`](../crates/pitboss-cli/src/manifest/schema.rs#L1084).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `budget_usd` | float | no | Per-sub-lead envelope when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1072`](../crates/pitboss-cli/src/manifest/schema.rs#L1072) |
-| `lead_budget_usd` | float | no | Per-sub-lead cap on the sub-lead's own token spend (orchestration cost), independent of budget_usd. Honored when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1077`](../crates/pitboss-cli/src/manifest/schema.rs#L1077) |
-| `max_workers` | integer | no | Per-sub-lead worker pool when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1082`](../crates/pitboss-cli/src/manifest/schema.rs#L1082) |
-| `lead_timeout_secs` | integer | no | Wall-clock cap for the sub-lead session. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1087`](../crates/pitboss-cli/src/manifest/schema.rs#L1087) |
-| `read_down` | boolean | no | When true, sub-lead shares root's budget + worker pool instead of carving its own envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1093`](../crates/pitboss-cli/src/manifest/schema.rs#L1093) |
+| `budget_usd` | float | no | Per-sub-lead envelope when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1089`](../crates/pitboss-cli/src/manifest/schema.rs#L1089) |
+| `lead_budget_usd` | float | no | Per-sub-lead cap on the sub-lead's own token spend (orchestration cost), independent of budget_usd. Honored when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1094`](../crates/pitboss-cli/src/manifest/schema.rs#L1094) |
+| `max_workers` | integer | no | Per-sub-lead worker pool when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1099`](../crates/pitboss-cli/src/manifest/schema.rs#L1099) |
+| `lead_timeout_secs` | integer | no | Wall-clock cap for the sub-lead session. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1104`](../crates/pitboss-cli/src/manifest/schema.rs#L1104) |
+| `read_down` | boolean | no | When true, sub-lead shares root's budget + worker pool instead of carving its own envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1110`](../crates/pitboss-cli/src/manifest/schema.rs#L1110) |
 
 ## `[[approval_policy]]` — `ApprovalRuleSpec`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:457`](../crates/pitboss-cli/src/manifest/schema.rs#L457).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:474`](../crates/pitboss-cli/src/manifest/schema.rs#L474).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `action` | enum (`auto_approve` \| `auto_reject` \| `block`) | **yes** | Action when this rule matches. | [`../crates/pitboss-cli/src/manifest/schema.rs#L468`](../crates/pitboss-cli/src/manifest/schema.rs#L468) |
+| `action` | enum (`auto_approve` \| `auto_reject` \| `block`) | **yes** | Action when this rule matches. | [`../crates/pitboss-cli/src/manifest/schema.rs#L485`](../crates/pitboss-cli/src/manifest/schema.rs#L485) |
 
 ## `[[mcp_server]]` — `McpServerSpec`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:192`](../crates/pitboss-cli/src/manifest/schema.rs#L192).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:209`](../crates/pitboss-cli/src/manifest/schema.rs#L209).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Key under mcpServers in the generated config. | [`../crates/pitboss-cli/src/manifest/schema.rs#L198`](../crates/pitboss-cli/src/manifest/schema.rs#L198) |
-| `command` | text | **yes** | Executable to launch (e.g. npx, uvx, or an absolute path). | [`../crates/pitboss-cli/src/manifest/schema.rs#L204`](../crates/pitboss-cli/src/manifest/schema.rs#L204) |
-| `args` | string list | no | Arguments passed to the command. | [`../crates/pitboss-cli/src/manifest/schema.rs#L208`](../crates/pitboss-cli/src/manifest/schema.rs#L208) |
-| `env` | key-value map | no | Environment variables injected into the MCP server process. | [`../crates/pitboss-cli/src/manifest/schema.rs#L215`](../crates/pitboss-cli/src/manifest/schema.rs#L215) |
-| `scope` | text | no | Optional injection scope. Form: "type:<id>" — narrows this server to actors spawned under that worker_type/sublead_type. Unset = inject into all actors. | [`../crates/pitboss-cli/src/manifest/schema.rs#L228`](../crates/pitboss-cli/src/manifest/schema.rs#L228) |
-| `tools` | string list | no | Optional per-tool allowlist for this MCP server. Path B: enforced at validate + spawn argv + permission_prompt runtime. Path A: no runtime effect (claude bypasses the permission layer). Unset = no restriction. | [`../crates/pitboss-cli/src/manifest/schema.rs#L261`](../crates/pitboss-cli/src/manifest/schema.rs#L261) |
+| `id` | text | **yes** | Key under mcpServers in the generated config. | [`../crates/pitboss-cli/src/manifest/schema.rs#L215`](../crates/pitboss-cli/src/manifest/schema.rs#L215) |
+| `command` | text | **yes** | Executable to launch (e.g. npx, uvx, or an absolute path). | [`../crates/pitboss-cli/src/manifest/schema.rs#L221`](../crates/pitboss-cli/src/manifest/schema.rs#L221) |
+| `args` | string list | no | Arguments passed to the command. | [`../crates/pitboss-cli/src/manifest/schema.rs#L225`](../crates/pitboss-cli/src/manifest/schema.rs#L225) |
+| `env` | key-value map | no | Environment variables injected into the MCP server process. | [`../crates/pitboss-cli/src/manifest/schema.rs#L232`](../crates/pitboss-cli/src/manifest/schema.rs#L232) |
+| `scope` | text | no | Optional injection scope. Form: "type:<id>" — narrows this server to actors spawned under that worker_type/sublead_type. Unset = inject into all actors. | [`../crates/pitboss-cli/src/manifest/schema.rs#L245`](../crates/pitboss-cli/src/manifest/schema.rs#L245) |
+| `tools` | string list | no | Optional per-tool allowlist for this MCP server. Path B: enforced at validate + spawn argv + permission_prompt runtime. Path A: no runtime effect (claude bypasses the permission layer). Unset = no restriction. | [`../crates/pitboss-cli/src/manifest/schema.rs#L278`](../crates/pitboss-cli/src/manifest/schema.rs#L278) |
 
 ## `[[worker_type]]` — `WorkerType`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:697`](../crates/pitboss-cli/src/manifest/schema.rs#L697).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:714`](../crates/pitboss-cli/src/manifest/schema.rs#L714).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique id used in spawn_worker(worker_type = "<id>"). Match: ^[A-Za-z0-9_-]+$. | [`../crates/pitboss-cli/src/manifest/schema.rs#L704`](../crates/pitboss-cli/src/manifest/schema.rs#L704) |
-| `tools` | string list | no | Allowed tool surface for this worker class. Lead's spawn_worker(tools=...) must be a subset; omit means "give me the whole allowlist." | [`../crates/pitboss-cli/src/manifest/schema.rs#L712`](../crates/pitboss-cli/src/manifest/schema.rs#L712) |
-| `allowed_models` | string list | no | When non-empty, spawn_worker(model=...) must be in this list. Empty means any model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L720`](../crates/pitboss-cli/src/manifest/schema.rs#L720) |
-| `max_timeout_secs` | integer | no | Hard cap on spawn_worker(timeout_secs=...). Lead values clamp DOWN; smaller values pass through. | [`../crates/pitboss-cli/src/manifest/schema.rs#L728`](../crates/pitboss-cli/src/manifest/schema.rs#L728) |
+| `id` | text | **yes** | Unique id used in spawn_worker(worker_type = "<id>"). Match: ^[A-Za-z0-9_-]+$. | [`../crates/pitboss-cli/src/manifest/schema.rs#L721`](../crates/pitboss-cli/src/manifest/schema.rs#L721) |
+| `tools` | string list | no | Allowed tool surface for this worker class. Lead's spawn_worker(tools=...) must be a subset; omit means "give me the whole allowlist." | [`../crates/pitboss-cli/src/manifest/schema.rs#L729`](../crates/pitboss-cli/src/manifest/schema.rs#L729) |
+| `allowed_models` | string list | no | When non-empty, spawn_worker(model=...) must be in this list. Empty means any model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L737`](../crates/pitboss-cli/src/manifest/schema.rs#L737) |
+| `max_timeout_secs` | integer | no | Hard cap on spawn_worker(timeout_secs=...). Lead values clamp DOWN; smaller values pass through. | [`../crates/pitboss-cli/src/manifest/schema.rs#L745`](../crates/pitboss-cli/src/manifest/schema.rs#L745) |
 
 ## `[[sublead_type]]` — `SubleadType`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:736`](../crates/pitboss-cli/src/manifest/schema.rs#L736).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:753`](../crates/pitboss-cli/src/manifest/schema.rs#L753).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique id used in spawn_sublead(sublead_type = "<id>"). Match: ^[A-Za-z0-9_-]+$. | [`../crates/pitboss-cli/src/manifest/schema.rs#L743`](../crates/pitboss-cli/src/manifest/schema.rs#L743) |
-| `tools` | string list | no | Allowed tool surface for this sub-lead class. spawn_sublead(tools=...) must be a subset; empty means "give me the whole allowlist." | [`../crates/pitboss-cli/src/manifest/schema.rs#L750`](../crates/pitboss-cli/src/manifest/schema.rs#L750) |
-| `allowed_models` | string list | no | When non-empty, spawn_sublead(model=...) must be in this list. | [`../crates/pitboss-cli/src/manifest/schema.rs#L757`](../crates/pitboss-cli/src/manifest/schema.rs#L757) |
-| `max_timeout_secs` | integer | no | Hard cap on spawn_sublead(lead_timeout_secs=...). Clamps DOWN. | [`../crates/pitboss-cli/src/manifest/schema.rs#L764`](../crates/pitboss-cli/src/manifest/schema.rs#L764) |
-| `max_budget_usd` | float | no | Hard cap on spawn_sublead(budget_usd=...). Clamps DOWN. | [`../crates/pitboss-cli/src/manifest/schema.rs#L771`](../crates/pitboss-cli/src/manifest/schema.rs#L771) |
+| `id` | text | **yes** | Unique id used in spawn_sublead(sublead_type = "<id>"). Match: ^[A-Za-z0-9_-]+$. | [`../crates/pitboss-cli/src/manifest/schema.rs#L760`](../crates/pitboss-cli/src/manifest/schema.rs#L760) |
+| `tools` | string list | no | Allowed tool surface for this sub-lead class. spawn_sublead(tools=...) must be a subset; empty means "give me the whole allowlist." | [`../crates/pitboss-cli/src/manifest/schema.rs#L767`](../crates/pitboss-cli/src/manifest/schema.rs#L767) |
+| `allowed_models` | string list | no | When non-empty, spawn_sublead(model=...) must be in this list. | [`../crates/pitboss-cli/src/manifest/schema.rs#L774`](../crates/pitboss-cli/src/manifest/schema.rs#L774) |
+| `max_timeout_secs` | integer | no | Hard cap on spawn_sublead(lead_timeout_secs=...). Clamps DOWN. | [`../crates/pitboss-cli/src/manifest/schema.rs#L781`](../crates/pitboss-cli/src/manifest/schema.rs#L781) |
+| `max_budget_usd` | float | no | Hard cap on spawn_sublead(budget_usd=...). Clamps DOWN. | [`../crates/pitboss-cli/src/manifest/schema.rs#L788`](../crates/pitboss-cli/src/manifest/schema.rs#L788) |
 
 ## `[communication]` — `CommunicationConfig`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:298`](../crates/pitboss-cli/src/manifest/schema.rs#L298).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:315`](../crates/pitboss-cli/src/manifest/schema.rs#L315).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `mode` | enum (`disabled` \| `parent_child`) | no | Actor communication policy mode. "disabled" hides the message_* and artifact_* tools (conservative default). "parent_child" enables them with parent/sublead/worker authz. | [`../crates/pitboss-cli/src/manifest/schema.rs#L305`](../crates/pitboss-cli/src/manifest/schema.rs#L305) |
-| `max_message_bytes` | integer | no | Maximum UTF-8 body size accepted by message_send. | [`../crates/pitboss-cli/src/manifest/schema.rs#L311`](../crates/pitboss-cli/src/manifest/schema.rs#L311) |
-| `max_artifact_bytes` | integer | no | Maximum decoded artifact payload size accepted by artifact_put. | [`../crates/pitboss-cli/src/manifest/schema.rs#L317`](../crates/pitboss-cli/src/manifest/schema.rs#L317) |
-| `max_artifacts_per_actor` | integer | no | Maximum artifacts one actor may publish in a single run. | [`../crates/pitboss-cli/src/manifest/schema.rs#L323`](../crates/pitboss-cli/src/manifest/schema.rs#L323) |
+| `mode` | enum (`disabled` \| `parent_child`) | no | Actor communication policy mode. "disabled" hides the message_* and artifact_* tools (conservative default). "parent_child" enables them with parent/sublead/worker authz. | [`../crates/pitboss-cli/src/manifest/schema.rs#L322`](../crates/pitboss-cli/src/manifest/schema.rs#L322) |
+| `max_message_bytes` | integer | no | Maximum UTF-8 body size accepted by message_send. | [`../crates/pitboss-cli/src/manifest/schema.rs#L328`](../crates/pitboss-cli/src/manifest/schema.rs#L328) |
+| `max_artifact_bytes` | integer | no | Maximum decoded artifact payload size accepted by artifact_put. | [`../crates/pitboss-cli/src/manifest/schema.rs#L334`](../crates/pitboss-cli/src/manifest/schema.rs#L334) |
+| `max_artifacts_per_actor` | integer | no | Maximum artifacts one actor may publish in a single run. | [`../crates/pitboss-cli/src/manifest/schema.rs#L340`](../crates/pitboss-cli/src/manifest/schema.rs#L340) |
 
 ## `[[template]]` — `Template`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:823`](../crates/pitboss-cli/src/manifest/schema.rs#L823).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:840`](../crates/pitboss-cli/src/manifest/schema.rs#L840).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Slug referenced from [[task]].template. | [`../crates/pitboss-cli/src/manifest/schema.rs#L828`](../crates/pitboss-cli/src/manifest/schema.rs#L828) |
-| `prompt` | text (multi-line) | **yes** | Prompt body. Supports {var} placeholders supplied by [[task]].vars. | [`../crates/pitboss-cli/src/manifest/schema.rs#L834`](../crates/pitboss-cli/src/manifest/schema.rs#L834) |
+| `id` | text | **yes** | Slug referenced from [[task]].template. | [`../crates/pitboss-cli/src/manifest/schema.rs#L845`](../crates/pitboss-cli/src/manifest/schema.rs#L845) |
+| `prompt` | text (multi-line) | **yes** | Prompt body. Supports {var} placeholders supplied by [[task]].vars. | [`../crates/pitboss-cli/src/manifest/schema.rs#L851`](../crates/pitboss-cli/src/manifest/schema.rs#L851) |
 
 ## `[lifecycle]` — `Lifecycle`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:434`](../crates/pitboss-cli/src/manifest/schema.rs#L434).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:451`](../crates/pitboss-cli/src/manifest/schema.rs#L451).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `survive_parent` | boolean | no | Allow this dispatch to outlive its parent process. Requires a notify target. | [`../crates/pitboss-cli/src/manifest/schema.rs#L445`](../crates/pitboss-cli/src/manifest/schema.rs#L445) |
+| `survive_parent` | boolean | no | Allow this dispatch to outlive its parent process. Requires a notify target. | [`../crates/pitboss-cli/src/manifest/schema.rs#L462`](../crates/pitboss-cli/src/manifest/schema.rs#L462) |
 

--- a/docs/manifest-reference.toml
+++ b/docs/manifest-reference.toml
@@ -48,6 +48,7 @@ runtime = "docker"
 extra_args = []
 extra_apt = []
 workdir = "/path/to/value"
+claude_mount_rw = false
 
 [[container.mount]]
 host = "/path/to/value"


### PR DESCRIPTION
## Summary

Bundles five validated findings from the 2026-05-14 codebase review into one coherent container-hardening PR:

- **#476 (F-SEC-9) — extra_args denylist.** \`[container].extra_args\` is now validated against a focused denylist that rejects sandbox-escape flags (\`--privileged\`, \`--pid=host\`, \`--cap-add=SYS_ADMIN\`, \`--security-opt={seccomp,apparmor}=unconfined\`, \`--device=…\`, etc.) and flags that override pitboss-managed settings (\`-v\` / \`--volume\` / \`--mount\` — use \`[[container.mount]]\` instead; \`-u\` / \`--user\` — pitboss controls UID alignment; \`--entrypoint\`). Enforced at both \`pitboss validate\` time AND inside \`build_run_args\` (defense in depth — test fixtures and programmatic callers can't bypass). Plus an NDJSON audit log at \`<runs-base>/container-dispatch.log\` recording every invocation's resolved argv for post-facto incident review.
- **#524 (F-SEC-10) — mount path validation.** \`[[container.mount]]\` entries are now validated the same way \`[[container.copy]]\` already was: container path must be absolute, host path must be absolute or tilde-prefixed. Plus a hard-reject denylist for catastrophic host paths (docker/podman sockets, \`/\`, \`/proc\`, \`/sys\`, \`/etc/shadow\`). Sensitive-but-legitimate paths (\`/etc\`, \`/var/log\`, peer home dirs) still pass — the line is "would this grant host-root or namespace-breakout authority?".
- **#525 (F-SEC-11) — auto-injected \`~/.claude\` defaults to read-only.** Prevents a buggy or compromised worker from rewriting host credentials or injecting \`settings.json\` hooks that would fire the next time \`claude\` runs on the host. New manifest knob \`[container].claude_mount_rw = true\` opts back into the pre-v0.15 rw,z mount for the OAuth-refresh scenario. An explicit \`[[container.mount]]\` covering \`/home/pitboss/.claude\` continues to win.
- **#526 (F-SEC-12) — apt-bootstrap UID 0 documented.** The slow-path stderr advisory operators already see when running without a derived image now piggybacks a security note about the root window. AGENTS.md \`extra_apt\` row spells the same point out. The structural fix (no UID 0 phase) is \`pitboss container-build\`, which we already point operators at for the performance reason.
- **#507 (F-DOCS-5) — book quickstart manifest is parseable again.** v0.9 renamed \`max_parallel\` to \`max_parallel_tasks\`, but the book's quickstart and flat-vs-hierarchical examples still used the old name. \`RunConfig\` has \`#[serde(deny_unknown_fields)]\`, so a first-time operator following the quickstart verbatim hit an immediate parse failure. Fixed 4 occurrences across 2 files; left the 2 intentional references to the old name in the rename migration table.

## Test plan

- [x] \`cargo lint\` — clean across the workspace
- [x] \`cargo tidy\` — clean across the workspace
- [x] \`cargo test -p pitboss-cli --lib\` — 832/832 passing in isolation. New tests: 11 in \`dispatch::container::tests\` (\`extra_args_rejects_*\`, \`auto_inject_claude_defaults_to_read_only\`, \`auto_inject_claude_uses_rw_when_opted_in\`), 5 in \`manifest::validate::tests\` (\`extra_args_*\`, \`mount_*\`), 1 in \`dispatch::container_build::tests\` (\`fallback_warning_mentions_root_window\`).
- [x] \`cargo test --workspace --features pitboss-core/test-support\` — passing; the two pre-existing macOS parallel-load flakes (\`continue_worker_from_paused_transitions_running\`, \`e2e_lead_request_approval_round_trip\`) and the \`/bin/true\` env issue are unaffected (all three pass in isolation, all three were observed flaky before this PR).
- [x] Doc regeneration: \`docs/manifest-reference.toml\` and \`docs/manifest-map.md\` regenerated for the new \`claude_mount_rw\` field (auto-regen-test passes).
- [x] AGENTS.md \`[container]\` table updated with \`claude_mount_rw\` row, expanded \`extra_args\` row (denylist + audit log), \`extra_apt\` row (UID 0 note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)