### PR TITLE
Add [[agent_profile]] reusable role preludes with builtin catalog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -402,6 +402,46 @@ The resolved profile id is persisted to each `TaskRecord.actor_type`, surfaced i
 - Synthesized cancellation records on lead-exit cleanup keep `actor_type` from the same map.
 - SQLite-backed runs round-trip `actor_type` (migration v10 adds the column; both backends are now at parity with `JsonFileStore`).
 
+### `[[agent_profile]]` (v0.14+, reusable role preludes)
+
+Reusable role profiles. Each profile carries a **prepended `system_prompt` prelude** plus optional **`model` / `tools` / `env` defaults**. Unlike `[[worker_type]]` (capability *caps*), agent profiles are default-providers — the operator's per-actor config (`[lead]`, `[[task]]`, spawn args) always wins.
+
+Three built-ins ship bundled, listable via `pitboss schema --format=agent-profiles`:
+
+- `pitboss/lead-opus` — root-lead orchestration body on Opus.
+- `pitboss/sublead-sonnet` — sub-tree-lead body on Sonnet.
+- `pitboss/worker-haiku` — leaf-worker publish-ceremony body on Haiku.
+
+A manifest may declare additional profiles and shadow a built-in by matching its id exactly. The `pitboss/` namespace is otherwise reserved (validate rejects novel `pitboss/<other>` ids).
+
+```toml
+[[agent_profile]]
+id            = "review/domain-worker"
+system_prompt = """
+You are a domain reviewer. Publish findings via artifact_put; do not Bash.
+"""
+model = "claude-haiku-4-5"
+tools = ["Read", "Glob", "Grep"]
+env   = { PITBOSS_ACTOR_ROLE = "review-worker" }
+
+[[worker_type]]
+id            = "domain-worker"
+tools         = ["Read", "Glob", "Grep"]
+agent_profile = "review/domain-worker"
+
+[lead]
+id            = "review-lead"
+directory     = "/path/to/repo"
+prompt        = "Review the codebase, then synthesize findings."
+agent_profile = "pitboss/lead-opus"     # built-in
+max_workers   = 4
+budget_usd    = 5.0
+```
+
+**Reference surfaces.** `agent_profile = "<id>"` is accepted on `[lead]`, `[[task]]`, `[[worker_type]]`, and `[[sublead_type]]`. References on `[lead]`/`[[task]]` apply at resolve time (prepended into the resolved prompt); references on `[[worker_type]]`/`[[sublead_type]]` apply at MCP-spawn time (composed before `worker_spawn_args`/`sublead_spawn_args`). Dangling references hard-fail at resolve (`[lead]`/`[[task]]`) or validate (`[[worker_type]]`/`[[sublead_type]]`).
+
+**Precedence (later wins).** `built-in default → profile → [defaults] → per-actor (lead/task/spawn args)`. The `system_prompt` is **prepended** to the operator's prompt with a fixed `\n\n--- TASK ---\n\n` separator (never replaced). The `env` map merges between `[defaults].env` and the per-actor env. The `model` / `tools` defaults fill any slot the operator left unset.
+
 ### `[communication]` (v0.10+, opt-in)
 
 Declares the policy for the Pitboss-owned mailbox + artifact MCP tools.

--- a/crates/pitboss-cli/src/capability_matrix.rs
+++ b/crates/pitboss-cli/src/capability_matrix.rs
@@ -280,6 +280,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         }
     }
 
@@ -311,6 +312,7 @@ mod tests {
             tools: vec![],
             allowed_models: vec![],
             max_timeout_secs: None,
+            agent_profile: None,
         }
     }
 
@@ -321,6 +323,7 @@ mod tests {
             allowed_models: vec![],
             max_timeout_secs: None,
             max_budget_usd: None,
+            agent_profile: None,
         }
     }
 

--- a/crates/pitboss-cli/src/cli.rs
+++ b/crates/pitboss-cli/src/cli.rs
@@ -484,6 +484,12 @@ pub enum Command {
         /// path and exit non-zero if they differ. Otherwise prints to stdout.
         #[arg(long, value_name = "PATH")]
         check: Option<PathBuf>,
+        /// Optional manifest path. Currently only meaningful for
+        /// `--format=agent-profiles`: when set, the renderer merges the
+        /// manifest's `[[agent_profile]]` entries (marked `source=manifest`)
+        /// with the bundled built-ins. Ignored for other formats.
+        #[arg(long, value_name = "PATH")]
+        manifest: Option<PathBuf>,
     },
 }
 
@@ -501,6 +507,11 @@ pub enum SchemaFormat {
     /// the operator customizes `tools`, `allowed_models`, and the
     /// numeric caps to fit their run.
     Migration,
+    /// Reusable role profiles (`[[agent_profile]]`). Lists the bundled
+    /// built-ins (`pitboss/lead-opus`, `pitboss/sublead-sonnet`,
+    /// `pitboss/worker-haiku`); pass `--manifest <path>` to also include
+    /// the manifest-declared profiles.
+    AgentProfiles,
 }
 
 /// Starter templates supported by `pitboss init`.

--- a/crates/pitboss-cli/src/communication.rs
+++ b/crates/pitboss-cli/src/communication.rs
@@ -1141,6 +1141,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -1487,6 +1487,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -1971,6 +1972,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         let sub_layer = std::sync::Arc::new(LayerState::new(
             run_id,
@@ -2462,6 +2464,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         let sub_layer = std::sync::Arc::new(LayerState::new(
             run_id,
@@ -2577,6 +2580,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         let sub_layer = std::sync::Arc::new(LayerState::new(
             run_id,
@@ -2707,6 +2711,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         let sub_layer = std::sync::Arc::new(LayerState::new(
             run_id,
@@ -2850,6 +2855,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         let sub_layer = std::sync::Arc::new(LayerState::new(
             run_id,

--- a/crates/pitboss-cli/src/dispatch/budget_watch.rs
+++ b/crates/pitboss-cli/src/dispatch/budget_watch.rs
@@ -357,6 +357,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/src/dispatch/failure_detection.rs
+++ b/crates/pitboss-cli/src/dispatch/failure_detection.rs
@@ -382,6 +382,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         let store: Arc<dyn pitboss_core::store::SessionStore> =
             Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
@@ -479,6 +480,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         let store: Arc<dyn pitboss_core::store::SessionStore> =
             Arc::new(JsonFileStore::new(dir.path().to_path_buf()));

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -1188,6 +1188,7 @@ mod await_drained_tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/src/dispatch/kill_resume.rs
+++ b/crates/pitboss-cli/src/dispatch/kill_resume.rs
@@ -314,6 +314,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         }
     }
 

--- a/crates/pitboss-cli/src/dispatch/layer.rs
+++ b/crates/pitboss-cli/src/dispatch/layer.rs
@@ -584,6 +584,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(FakeSpawner::new(FakeScript::new()));

--- a/crates/pitboss-cli/src/dispatch/resume.rs
+++ b/crates/pitboss-cli/src/dispatch/resume.rs
@@ -714,6 +714,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         std::fs::write(
             run_dir.join("resolved.json"),
@@ -837,6 +838,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         std::fs::write(
             run_dir.join("resolved.json"),
@@ -963,6 +965,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         std::fs::write(
             run_dir.join("resolved.json"),
@@ -1153,6 +1156,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         let json = serde_json::to_string(&m).unwrap();
         assert!(

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -1502,6 +1502,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         }
     }
 
@@ -1654,6 +1655,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
 
         // Script: first call succeeds, second call fails. FakeSpawner is single-shot,
@@ -1755,6 +1757,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
 
         let spawner = Arc::new(CyclingFake(
@@ -1869,6 +1872,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
 
         let spawner = Arc::new(CyclingFake(

--- a/crates/pitboss-cli/src/dispatch/signals.rs
+++ b/crates/pitboss-cli/src/dispatch/signals.rs
@@ -384,6 +384,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -479,6 +480,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -574,6 +576,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -717,6 +717,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -640,22 +640,24 @@ async fn spawn_sublead_session(
     //    blocks like `[defaults.env]` (WORK_DIR/ARTIFACTS_DIR/etc.)
     //    reach subleads automatically; the lead doesn't have to re-pass
     //    them in every spawn_sublead call.
-    let mut lead_env = state
+    let inherited_lead_env = state
         .root
         .manifest
         .lead
         .as_ref()
         .map(|l| l.env.clone())
         .unwrap_or_default();
-    // Merge the agent_profile env (bound via `[[sublead_type]].agent_profile`)
-    // on top of inherited lead env. Profile env wins over inherited lead env
-    // on collision; operator_env (from the spawn_sublead MCP call) wins
-    // over profile env inside `compose_sublead_env`.
-    if let Some(p) = sublead_agent_profile {
-        for (k, v) in &p.env {
-            lead_env.insert(k.clone(), v.clone());
-        }
-    }
+    // Env precedence (later wins, mirroring `resolve_lead`):
+    //   profile.env → inherited [lead.env] → operator_env → pitboss defaults
+    // Start from the profile's env (role default), then layer the
+    // inherited lead env on top so operator-set [lead.env] vars beat
+    // profile defaults on collision. operator_env (the per-spawn override
+    // from the spawn_sublead MCP call) is merged last inside
+    // `compose_sublead_env` and beats everything else.
+    let mut lead_env: HashMap<String, String> = sublead_agent_profile
+        .map(|p| p.env.clone())
+        .unwrap_or_default();
+    lead_env.extend(inherited_lead_env);
     let routing = state
         .root
         .manifest
@@ -793,17 +795,38 @@ async fn spawn_sublead_session(
                     resume_communication_mode,
                     &state_bg.root.manifest.mcp_servers,
                 );
-                // Env precedence: lead → operator → pitboss defaults
-                // (see compose_sublead_env). Same cwd rationale as the
-                // initial spawn: lead.directory (not lead_cwd) — see
-                // the long comment in finalize_sublead_spawn.
-                let lead_env_resume = state_bg
+                // Env precedence on resume mirrors the initial spawn:
+                // profile.env → inherited [lead.env] → operator_env →
+                // pitboss defaults (see compose_sublead_env). Re-applying
+                // the agent_profile env here is what prevents a
+                // sublead_type-bound profile's env vars (e.g.
+                // PITBOSS_ACTOR_ROLE from pitboss/sublead-sonnet) from
+                // vanishing on every reprompt/resume. Same cwd rationale
+                // as the initial spawn: lead.directory (not lead_cwd) —
+                // see the long comment in finalize_sublead_spawn.
+                let resume_profile_env: std::collections::HashMap<String, String> = sublead_type_bg
+                    .as_deref()
+                    .and_then(|t| {
+                        state_bg
+                            .root
+                            .manifest
+                            .sublead_types
+                            .iter()
+                            .find(|st| st.id == t)
+                    })
+                    .and_then(|st| st.agent_profile.as_deref())
+                    .and_then(|id| state_bg.root.manifest.agent_profiles.get(id))
+                    .map(|p| p.env.clone())
+                    .unwrap_or_default();
+                let inherited_lead_env_resume = state_bg
                     .root
                     .manifest
                     .lead
                     .as_ref()
                     .map(|l| l.env.clone())
                     .unwrap_or_default();
+                let mut lead_env_resume = resume_profile_env;
+                lead_env_resume.extend(inherited_lead_env_resume);
                 let resume_env = compose_sublead_env(
                     &lead_env_resume,
                     &operator_env_bg,

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -574,9 +574,26 @@ async fn spawn_sublead_session(
         .as_ref()
         .map(|l| l.permission_routing)
         .unwrap_or_default();
+    // Compose the sub-lead prompt: if the matched `[[sublead_type]]`
+    // binds an `agent_profile`, prepend its `system_prompt` to the
+    // operator-supplied prompt with `\n\n--- TASK ---\n\n` separator.
+    // Untyped spawns / dangling references → operator prompt verbatim.
+    let sublead_type_resolved = sublead_type.as_deref().and_then(|id| {
+        state
+            .root
+            .manifest
+            .sublead_types
+            .iter()
+            .find(|st| st.id == id)
+    });
+    let sublead_agent_profile = crate::manifest::actor_type::sublead_agent_profile(
+        sublead_type_resolved,
+        &state.root.manifest.agent_profiles,
+    );
+    let composed_prompt = crate::manifest::resolve::compose_prompt(sublead_agent_profile, &prompt);
     let args = sublead_spawn_args(
         &sublead_id,
-        &prompt,
+        &composed_prompt,
         &model,
         &mcp_config_path,
         resume_session_id.as_deref(),
@@ -623,13 +640,22 @@ async fn spawn_sublead_session(
     //    blocks like `[defaults.env]` (WORK_DIR/ARTIFACTS_DIR/etc.)
     //    reach subleads automatically; the lead doesn't have to re-pass
     //    them in every spawn_sublead call.
-    let lead_env = state
+    let mut lead_env = state
         .root
         .manifest
         .lead
         .as_ref()
         .map(|l| l.env.clone())
         .unwrap_or_default();
+    // Merge the agent_profile env (bound via `[[sublead_type]].agent_profile`)
+    // on top of inherited lead env. Profile env wins over inherited lead env
+    // on collision; operator_env (from the spawn_sublead MCP call) wins
+    // over profile env inside `compose_sublead_env`.
+    if let Some(p) = sublead_agent_profile {
+        for (k, v) in &p.env {
+            lead_env.insert(k.clone(), v.clone());
+        }
+    }
     let routing = state
         .root
         .manifest

--- a/crates/pitboss-cli/src/main.rs
+++ b/crates/pitboss-cli/src/main.rs
@@ -284,6 +284,25 @@ fn run_schema(
     check: Option<&std::path::Path>,
     manifest_path: Option<&std::path::Path>,
 ) -> i32 {
+    // Reject the combination `--check <path> --manifest <other-path>` for
+    // `--format=agent-profiles`: the renderer's output is a function of
+    // the manifest's `[[agent_profile]]` entries, so wiring `--check`
+    // against a fixed file with `--manifest` set would persistently fail
+    // (or, worse, silently lock the CI to one manifest's state).
+    // `--check` without `--manifest` (built-ins only) is fine, as is
+    // `--manifest` without `--check` (pretty-print only).
+    if matches!(format, cli::SchemaFormat::AgentProfiles)
+        && check.is_some()
+        && manifest_path.is_some()
+    {
+        eprintln!(
+            "pitboss schema --format=agent-profiles: --check and --manifest \
+             are mutually exclusive (the manifest's declared profiles change \
+             the output, so a checked-in snapshot can't be drift-checked \
+             against a specific manifest). Pick one."
+        );
+        return 2;
+    }
     let (generated, format_flag) = match format {
         cli::SchemaFormat::Map => (crate::manifest::map_doc::render(), "map"),
         cli::SchemaFormat::Example => (crate::manifest::example_doc::render(), "example"),

--- a/crates/pitboss-cli/src/main.rs
+++ b/crates/pitboss-cli/src/main.rs
@@ -192,8 +192,12 @@ fn main() -> Result<()> {
             clap_complete::generate(shell, &mut cmd, "pitboss", &mut std::io::stdout());
             std::process::exit(0);
         }
-        Command::Schema { format, check } => {
-            std::process::exit(run_schema(format, check.as_deref()));
+        Command::Schema {
+            format,
+            check,
+            manifest,
+        } => {
+            std::process::exit(run_schema(format, check.as_deref(), manifest.as_deref()));
         }
         Command::Init {
             output,
@@ -275,11 +279,48 @@ fn run_init(
 }
 
 /// Drive `pitboss schema --format=...`. Returns the exit code.
-fn run_schema(format: cli::SchemaFormat, check: Option<&std::path::Path>) -> i32 {
+fn run_schema(
+    format: cli::SchemaFormat,
+    check: Option<&std::path::Path>,
+    manifest_path: Option<&std::path::Path>,
+) -> i32 {
     let (generated, format_flag) = match format {
         cli::SchemaFormat::Map => (crate::manifest::map_doc::render(), "map"),
         cli::SchemaFormat::Example => (crate::manifest::example_doc::render(), "example"),
         cli::SchemaFormat::Migration => (crate::manifest::migration_doc::render(), "migration"),
+        cli::SchemaFormat::AgentProfiles => {
+            // Load the manifest's agent_profiles when --manifest is set.
+            // We deliberately use the raw schema (not resolved) so we
+            // see the operator's declared list, not the merged catalogue
+            // (built-ins are added by the renderer itself).
+            let manifest_profiles: Vec<crate::manifest::schema::AgentProfile> = match manifest_path
+            {
+                Some(p) => match std::fs::read_to_string(p) {
+                    Ok(s) => match toml::from_str::<crate::manifest::schema::Manifest>(&s) {
+                        Ok(m) => m.agent_profiles,
+                        Err(e) => {
+                            eprintln!(
+                                "pitboss schema --format=agent-profiles: cannot parse {}: {e}",
+                                p.display()
+                            );
+                            return 2;
+                        }
+                    },
+                    Err(e) => {
+                        eprintln!(
+                            "pitboss schema --format=agent-profiles: cannot read {}: {e}",
+                            p.display()
+                        );
+                        return 2;
+                    }
+                },
+                None => Vec::new(),
+            };
+            (
+                crate::manifest::agent_profile_doc::render(&manifest_profiles),
+                "agent-profiles",
+            )
+        }
     };
     match check {
         None => {

--- a/crates/pitboss-cli/src/manifest/actor_type.rs
+++ b/crates/pitboss-cli/src/manifest/actor_type.rs
@@ -23,9 +23,11 @@
 //! | false                | Some(unknown)  | —                               | reject ("unknown worker_type")              |
 //! | false                | Some(known)    | —                               | enforce caps                                |
 
+use std::collections::HashMap;
+
 use anyhow::{bail, Result};
 
-use crate::manifest::schema::{SubleadType, WorkerType};
+use crate::manifest::schema::{AgentProfile, SubleadType, WorkerType};
 
 /// The outcome of resolving an actor type against the manifest's
 /// declared profiles.
@@ -188,6 +190,33 @@ pub fn check_model_allowed(
     Ok(())
 }
 
+/// Look up the [`AgentProfile`] (if any) bound to a `[[worker_type]]`
+/// via its `agent_profile` reference. Returns `None` when the worker
+/// is untyped, when the worker_type has no `agent_profile`, or when
+/// the reference fails to resolve in the catalogue (validate-time
+/// should have rejected dangling references, but the runtime treats a
+/// missing entry as "no profile" rather than panicking).
+pub fn worker_agent_profile<'m>(
+    worker_type: Option<&WorkerType>,
+    catalogue: &'m HashMap<String, AgentProfile>,
+) -> Option<&'m AgentProfile> {
+    worker_type
+        .and_then(|wt| wt.agent_profile.as_deref())
+        .and_then(|id| catalogue.get(id))
+}
+
+/// Look up the [`AgentProfile`] (if any) bound to a `[[sublead_type]]`
+/// via its `agent_profile` reference. See [`worker_agent_profile`] for
+/// the resolution rules.
+pub fn sublead_agent_profile<'m>(
+    sublead_type: Option<&SubleadType>,
+    catalogue: &'m HashMap<String, AgentProfile>,
+) -> Option<&'m AgentProfile> {
+    sublead_type
+        .and_then(|st| st.agent_profile.as_deref())
+        .and_then(|id| catalogue.get(id))
+}
+
 /// Clamp `requested` down to `cap` when both are present.
 /// Returns the smaller of the two; preserves `requested` when it's
 /// already within budget.
@@ -218,6 +247,7 @@ mod tests {
             tools: vec!["Read".into(), "Glob".into(), "Grep".into()],
             allowed_models: vec!["claude-haiku-4-5".into()],
             max_timeout_secs: Some(900),
+            agent_profile: None,
         }
     }
 
@@ -228,6 +258,7 @@ mod tests {
             allowed_models: vec!["claude-opus-4-7".into()],
             max_timeout_secs: Some(1800),
             max_budget_usd: Some(2.0),
+            agent_profile: None,
         }
     }
 
@@ -346,5 +377,62 @@ mod tests {
         let profiles = vec![st("planner")];
         let err = resolve_sublead_profile(None, &profiles, true).unwrap_err();
         assert!(err.to_string().contains("require_actor_type"));
+    }
+
+    fn ap(id: &str, prompt: &str) -> AgentProfile {
+        AgentProfile {
+            id: id.to_string(),
+            system_prompt: prompt.to_string(),
+            model: None,
+            env: HashMap::new(),
+            tools: None,
+        }
+    }
+
+    #[test]
+    fn worker_agent_profile_returns_none_when_untyped() {
+        let catalogue: HashMap<String, AgentProfile> = HashMap::new();
+        assert!(worker_agent_profile(None, &catalogue).is_none());
+    }
+
+    #[test]
+    fn worker_agent_profile_returns_none_when_no_reference() {
+        let catalogue: HashMap<String, AgentProfile> = [(String::from("p/x"), ap("p/x", "hi"))]
+            .into_iter()
+            .collect();
+        let wt_no_ref = wt("extraction"); // agent_profile: None
+        assert!(worker_agent_profile(Some(&wt_no_ref), &catalogue).is_none());
+    }
+
+    #[test]
+    fn worker_agent_profile_resolves_via_reference() {
+        let prof = ap("p/worker", "be excellent");
+        let catalogue: HashMap<String, AgentProfile> =
+            [(prof.id.clone(), prof)].into_iter().collect();
+        let mut wt_with_ref = wt("extraction");
+        wt_with_ref.agent_profile = Some("p/worker".to_string());
+        let resolved =
+            worker_agent_profile(Some(&wt_with_ref), &catalogue).expect("should resolve");
+        assert_eq!(resolved.system_prompt, "be excellent");
+    }
+
+    #[test]
+    fn worker_agent_profile_dangling_reference_returns_none() {
+        let catalogue: HashMap<String, AgentProfile> = HashMap::new();
+        let mut wt_with_ref = wt("extraction");
+        wt_with_ref.agent_profile = Some("p/missing".to_string());
+        assert!(worker_agent_profile(Some(&wt_with_ref), &catalogue).is_none());
+    }
+
+    #[test]
+    fn sublead_agent_profile_resolves_via_reference() {
+        let prof = ap("p/sub", "be terse");
+        let catalogue: HashMap<String, AgentProfile> =
+            [(prof.id.clone(), prof)].into_iter().collect();
+        let mut st_with_ref = st("planner");
+        st_with_ref.agent_profile = Some("p/sub".to_string());
+        let resolved =
+            sublead_agent_profile(Some(&st_with_ref), &catalogue).expect("should resolve");
+        assert_eq!(resolved.system_prompt, "be terse");
     }
 }

--- a/crates/pitboss-cli/src/manifest/agent_profile_doc.rs
+++ b/crates/pitboss-cli/src/manifest/agent_profile_doc.rs
@@ -1,0 +1,157 @@
+//! Renderer for `pitboss schema --format=agent-profiles`.
+//!
+//! Lists the bundled built-in [`AgentProfile`] catalogue, optionally
+//! merged with the profiles declared by a specific manifest, in a
+//! human-scannable form. The output is a markdown document with a
+//! summary table + one section per profile.
+//!
+//! Manifest-declared profiles are tagged `source = manifest`; built-ins
+//! are tagged `source = builtin`. A manifest entry that shadows a
+//! built-in id (intentional override) is rendered as `manifest`
+//! (operators see the version that actually wins).
+
+use std::collections::HashSet;
+
+use crate::manifest::schema::AgentProfile;
+
+/// Render the agent-profiles doc.
+///
+/// `manifest_profiles` is empty by default (just the built-ins are
+/// listed); passing a manifest's `agent_profiles` adds them and marks
+/// each with its source.
+pub fn render(manifest_profiles: &[AgentProfile]) -> String {
+    let builtins = crate::manifest::builtin_profiles::load_builtins();
+    let builtin_ids: HashSet<&str> = builtins.iter().map(|p| p.id.as_str()).collect();
+
+    // Manifest entries shadow built-ins; build the effective catalogue
+    // by collecting from built-ins, then overwriting with manifest
+    // entries.
+    let mut effective: Vec<(AgentProfile, &'static str)> =
+        builtins.iter().map(|p| (p.clone(), "builtin")).collect();
+    for mp in manifest_profiles {
+        if let Some(slot) = effective.iter_mut().find(|(p, _)| p.id == mp.id) {
+            *slot = (mp.clone(), "manifest");
+        } else {
+            effective.push((mp.clone(), "manifest"));
+        }
+    }
+    // Stable ordering for deterministic output: built-ins first (in
+    // their declared order), then manifest-only ids alphabetically.
+    let _ = builtin_ids;
+
+    let mut out = String::new();
+    out.push_str("# pitboss schema --format=agent-profiles\n\n");
+    out.push_str(
+        "Reusable role profiles available at resolve / spawn time. Each profile contributes\n\
+         a `system_prompt` prelude prepended to the operator's prompt with a `--- TASK ---`\n\
+         separator, plus optional `model`/`tools`/`env` defaults that the operator's per-actor\n\
+         config can override.\n\n",
+    );
+
+    out.push_str("## Summary\n\n");
+    out.push_str("| id | source | model | tools | env keys |\n");
+    out.push_str("|---|---|---|---|---|\n");
+    for (p, src) in &effective {
+        let model = p.model.as_deref().unwrap_or("—");
+        let tools = match &p.tools {
+            Some(t) if !t.is_empty() => t.join(", "),
+            _ => "—".to_string(),
+        };
+        let env_keys: Vec<&str> = p.env.keys().map(String::as_str).collect();
+        let env_repr = if env_keys.is_empty() {
+            "—".to_string()
+        } else {
+            let mut ks = env_keys.clone();
+            ks.sort();
+            ks.join(", ")
+        };
+        out.push_str(&format!(
+            "| `{}` | {} | `{}` | {} | {} |\n",
+            p.id, src, model, tools, env_repr
+        ));
+    }
+    out.push('\n');
+
+    out.push_str("## Profile bodies\n\n");
+    for (p, src) in &effective {
+        out.push_str(&format!("### `{}` ({})\n\n", p.id, src));
+        out.push_str(&format!(
+            "- **model**: {}\n",
+            p.model.as_deref().unwrap_or("—")
+        ));
+        out.push_str(&format!(
+            "- **tools**: {}\n",
+            match &p.tools {
+                Some(t) if !t.is_empty() => t.join(", "),
+                _ => "—".to_string(),
+            }
+        ));
+        if !p.env.is_empty() {
+            let mut keys: Vec<&String> = p.env.keys().collect();
+            keys.sort();
+            out.push_str("- **env**:\n");
+            for k in keys {
+                out.push_str(&format!("  - `{}` = `{}`\n", k, p.env[k]));
+            }
+        }
+        out.push_str("\n```\n");
+        out.push_str(p.system_prompt.trim_end());
+        out.push_str("\n```\n\n");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_builtins_only_when_manifest_empty() {
+        let out = render(&[]);
+        assert!(out.contains("pitboss/lead-opus"), "{out}");
+        assert!(out.contains("pitboss/sublead-sonnet"), "{out}");
+        assert!(out.contains("pitboss/worker-haiku"), "{out}");
+    }
+
+    #[test]
+    fn marks_manifest_profile_as_manifest_source() {
+        let manifest = vec![AgentProfile {
+            id: "review/domain-worker".into(),
+            system_prompt: "be domain-shaped".into(),
+            model: Some("claude-haiku-4-5".into()),
+            env: Default::default(),
+            tools: Some(vec!["Read".into()]),
+        }];
+        let out = render(&manifest);
+        assert!(out.contains("review/domain-worker"), "{out}");
+        // Source column should call it out.
+        assert!(out.contains("| manifest |"), "{out}");
+    }
+
+    #[test]
+    fn manifest_entry_shadows_builtin_id() {
+        let manifest = vec![AgentProfile {
+            id: "pitboss/worker-haiku".into(),
+            system_prompt: "OVERRIDDEN".into(),
+            model: None,
+            env: Default::default(),
+            tools: None,
+        }];
+        let out = render(&manifest);
+        // The overridden body should appear; the source column should
+        // be "manifest" for the shadowed id.
+        assert!(out.contains("OVERRIDDEN"), "{out}");
+        // Counted once, not twice.
+        let occurrences = out.matches("pitboss/worker-haiku").count();
+        assert!(
+            occurrences == 2, // once in summary table, once in body header
+            "expected 2 occurrences, got {occurrences}:\n{out}"
+        );
+    }
+
+    #[test]
+    fn header_self_identifies_for_drift_checks() {
+        let out = render(&[]);
+        assert!(out.contains("pitboss schema --format=agent-profiles"));
+    }
+}

--- a/crates/pitboss-cli/src/manifest/builtin_profiles.rs
+++ b/crates/pitboss-cli/src/manifest/builtin_profiles.rs
@@ -1,0 +1,206 @@
+//! Built-in [`AgentProfile`] catalogue, compile-time embedded.
+//!
+//! Three profiles ship bundled so the common lead/sublead/worker roles
+//! work zero-config:
+//!
+//! - `pitboss/lead-opus` — root orchestrator on Opus.
+//! - `pitboss/sublead-sonnet` — sub-tree orchestrator on Sonnet.
+//! - `pitboss/worker-haiku` — leaf investigator on Haiku.
+//!
+//! Each bundled file is markdown with a TOML frontmatter block fenced
+//! by `+++`. The frontmatter parses into [`AgentProfile`] fields
+//! (`id`, `model`, `tools`, `env`); the body becomes `system_prompt`.
+//!
+//! ```text
+//! +++
+//! id = "pitboss/worker-haiku"
+//! model = "claude-haiku-4-5"
+//! tools = ["Read", "Glob", "Grep"]
+//! [env]
+//! PITBOSS_ACTOR_ROLE = "worker"
+//! +++
+//! You are a Pitboss worker...
+//! ```
+//!
+//! The catalogue is constructed by [`load_builtins`] at resolve time;
+//! manifest-declared `[[agent_profile]]` entries union with this set
+//! and shadow built-ins by matching id exactly.
+
+use std::collections::HashMap;
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde::Deserialize;
+
+use crate::manifest::schema::AgentProfile;
+
+/// The three bundled profile bodies, embedded at compile time.
+const BUILTIN_SOURCES: &[(&str, &str)] = &[
+    (
+        "lead-opus.md",
+        include_str!("builtin_profiles/lead-opus.md"),
+    ),
+    (
+        "sublead-sonnet.md",
+        include_str!("builtin_profiles/sublead-sonnet.md"),
+    ),
+    (
+        "worker-haiku.md",
+        include_str!("builtin_profiles/worker-haiku.md"),
+    ),
+];
+
+/// TOML frontmatter shape. Mirrors the [`AgentProfile`] fields minus
+/// `system_prompt` (which is the file body, not the frontmatter).
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Frontmatter {
+    id: String,
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    tools: Option<Vec<String>>,
+    #[serde(default)]
+    env: HashMap<String, String>,
+}
+
+/// Parse a single bundled `+++`-fenced markdown source into an
+/// [`AgentProfile`]. Returns an error if the source lacks the fence
+/// pair or the frontmatter doesn't deserialize.
+fn parse_profile(filename: &str, source: &str) -> Result<AgentProfile> {
+    let rest = source
+        .strip_prefix("+++")
+        .ok_or_else(|| anyhow!("{filename}: missing opening `+++` fence"))?;
+    let (frontmatter_raw, body_raw) = rest
+        .split_once("+++")
+        .ok_or_else(|| anyhow!("{filename}: missing closing `+++` fence"))?;
+
+    let fm: Frontmatter = toml::from_str(frontmatter_raw.trim())
+        .with_context(|| format!("{filename}: parsing TOML frontmatter"))?;
+
+    if !fm.id.starts_with("pitboss/") {
+        bail!(
+            "{filename}: built-in profile id {:?} must be in the `pitboss/` namespace",
+            fm.id
+        );
+    }
+
+    let system_prompt = body_raw.trim_start_matches('\n').to_string();
+
+    Ok(AgentProfile {
+        id: fm.id,
+        system_prompt,
+        model: fm.model,
+        env: fm.env,
+        tools: fm.tools,
+    })
+}
+
+/// Return the three bundled profiles. Pure — same output every call.
+/// Panics on a malformed bundled file because that is a build-time
+/// bug, not an operator condition.
+pub fn load_builtins() -> Vec<AgentProfile> {
+    BUILTIN_SOURCES
+        .iter()
+        .map(|(name, src)| {
+            parse_profile(name, src)
+                .unwrap_or_else(|e| panic!("built-in profile {name} failed to parse: {e:?}"))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_builtin_parses() {
+        // Smoke: load_builtins must not panic; every bundled file
+        // must produce an AgentProfile.
+        let profiles = load_builtins();
+        assert_eq!(profiles.len(), BUILTIN_SOURCES.len());
+    }
+
+    #[test]
+    fn every_builtin_id_is_pitboss_namespaced() {
+        for p in load_builtins() {
+            assert!(
+                p.id.starts_with("pitboss/"),
+                "built-in id {:?} not in pitboss/ namespace",
+                p.id
+            );
+        }
+    }
+
+    #[test]
+    fn built_ins_cover_three_roles() {
+        let ids: Vec<String> = load_builtins().into_iter().map(|p| p.id).collect();
+        assert!(ids.contains(&"pitboss/lead-opus".to_string()));
+        assert!(ids.contains(&"pitboss/sublead-sonnet".to_string()));
+        assert!(ids.contains(&"pitboss/worker-haiku".to_string()));
+    }
+
+    #[test]
+    fn worker_haiku_body_mentions_publish_ceremony() {
+        let worker = load_builtins()
+            .into_iter()
+            .find(|p| p.id == "pitboss/worker-haiku")
+            .expect("worker-haiku built-in missing");
+        assert!(
+            worker.system_prompt.contains("artifact_put"),
+            "worker-haiku body should describe artifact_put publish step:\n{}",
+            worker.system_prompt
+        );
+        assert!(
+            worker.system_prompt.contains("message_send"),
+            "worker-haiku body should describe message_send publish step:\n{}",
+            worker.system_prompt
+        );
+    }
+
+    #[test]
+    fn lead_body_mentions_spawn_and_wait() {
+        let lead = load_builtins()
+            .into_iter()
+            .find(|p| p.id == "pitboss/lead-opus")
+            .expect("lead-opus built-in missing");
+        assert!(
+            lead.system_prompt.contains("spawn_worker"),
+            "lead body should describe spawn_worker"
+        );
+        assert!(
+            lead.system_prompt.contains("wait_for_worker")
+                || lead.system_prompt.contains("wait_actor"),
+            "lead body should describe waiting on workers"
+        );
+    }
+
+    #[test]
+    fn frontmatter_carries_role_env() {
+        for p in load_builtins() {
+            assert!(
+                p.env.contains_key("PITBOSS_ACTOR_ROLE"),
+                "{:?} missing PITBOSS_ACTOR_ROLE",
+                p.id
+            );
+        }
+    }
+
+    #[test]
+    fn parser_rejects_missing_opening_fence() {
+        let err = parse_profile("x.md", "no fence\nbody").unwrap_err();
+        assert!(err.to_string().contains("opening `+++`"));
+    }
+
+    #[test]
+    fn parser_rejects_missing_closing_fence() {
+        let err = parse_profile("x.md", "+++\nid = \"pitboss/x\"\n").unwrap_err();
+        assert!(err.to_string().contains("closing `+++`"));
+    }
+
+    #[test]
+    fn parser_rejects_non_pitboss_builtin_id() {
+        let src = "+++\nid = \"x\"\n+++\nbody";
+        let err = parse_profile("x.md", src).unwrap_err();
+        assert!(err.to_string().contains("pitboss/"));
+    }
+}

--- a/crates/pitboss-cli/src/manifest/builtin_profiles/lead-opus.md
+++ b/crates/pitboss-cli/src/manifest/builtin_profiles/lead-opus.md
@@ -1,0 +1,49 @@
++++
+id = "pitboss/lead-opus"
+model = "claude-opus-4-7"
+
+[env]
+PITBOSS_ACTOR_ROLE = "lead"
++++
+You are a Pitboss **lead** — a root orchestrator running under
+`pitboss dispatch`. Your job is to plan, spawn workers, wait on them,
+adapt to results, and synthesize a final answer. You do NOT do the
+investigation yourself.
+
+# Orchestration loop
+
+1. **Plan**: break the operator task into independent worker units.
+2. **Spawn**: call `mcp__pitboss__spawn_worker` (or
+   `mcp__pitboss__spawn_sublead` if the work is deep enough to need its
+   own sub-tree). Pass a focused `prompt`, a `worker_type` if the
+   manifest declares one, and only the `tools` / `model` overrides you
+   need — omit fields to inherit the profile's defaults.
+3. **Wait**: call `mcp__pitboss__wait_for_worker` (or `wait_actor` for
+   subleads). Multiple spawns run in parallel; one `wait_actor` call
+   wakes on the next completion.
+4. **Adapt**: read each worker's `final_message` and any artifacts they
+   published. Decide what to spawn next. Re-spawn on transient failure;
+   give up after one retry on the same root cause.
+5. **Synthesize**: when all workers are done, write a final summary as
+   your own `-p` reply. That last assistant message IS the run's
+   deliverable.
+
+# Cost & cap awareness
+
+- Every spawn reserves estimated cost against `[lead].budget_usd`. If a
+  spawn returns `budget exceeded`, stop spawning and finalize with
+  whatever you have.
+- Respect `max_workers` (concurrent + queued cap) and
+  `max_total_workers` (whole-tree cap). The dispatcher rejects spawns
+  that would breach these — adapt, don't retry.
+- Prefer cheaper models (Haiku) for investigation; reserve Sonnet/Opus
+  for synthesis and reasoning.
+
+# Tool surface (lead-only)
+
+`spawn_worker`, `spawn_sublead`, `cancel_worker`, `wait_for_worker`,
+`wait_actor`, `request_approval`, plus the shared-store KV / mailbox
+tools when `[communication]` is enabled.
+
+Stay tight: short turns, clear spawn arguments, no shell work beyond
+what the orchestration requires.

--- a/crates/pitboss-cli/src/manifest/builtin_profiles/lead-opus.md
+++ b/crates/pitboss-cli/src/manifest/builtin_profiles/lead-opus.md
@@ -18,9 +18,10 @@ investigation yourself.
    own sub-tree). Pass a focused `prompt`, a `worker_type` if the
    manifest declares one, and only the `tools` / `model` overrides you
    need — omit fields to inherit the profile's defaults.
-3. **Wait**: call `mcp__pitboss__wait_for_worker` (or `wait_actor` for
-   subleads). Multiple spawns run in parallel; one `wait_actor` call
-   wakes on the next completion.
+3. **Wait**: call `mcp__pitboss__wait_for_worker` (or
+   `mcp__pitboss__wait_actor` for subleads). Multiple spawns run in
+   parallel; one `mcp__pitboss__wait_actor` call wakes on the next
+   completion.
 4. **Adapt**: read each worker's `final_message` and any artifacts they
    published. Decide what to spawn next. Re-spawn on transient failure;
    give up after one retry on the same root cause.
@@ -41,9 +42,12 @@ investigation yourself.
 
 # Tool surface (lead-only)
 
-`spawn_worker`, `spawn_sublead`, `cancel_worker`, `wait_for_worker`,
-`wait_actor`, `request_approval`, plus the shared-store KV / mailbox
-tools when `[communication]` is enabled.
+`mcp__pitboss__spawn_worker`, `mcp__pitboss__spawn_sublead`,
+`mcp__pitboss__cancel_worker`, `mcp__pitboss__wait_for_worker`,
+`mcp__pitboss__wait_actor`, `mcp__pitboss__request_approval`, plus
+the shared-store KV (`mcp__pitboss__kv_*`) and mailbox
+(`mcp__pitboss__message_*`, `mcp__pitboss__artifact_*`) tools when
+`[communication]` is enabled.
 
 Stay tight: short turns, clear spawn arguments, no shell work beyond
 what the orchestration requires.

--- a/crates/pitboss-cli/src/manifest/builtin_profiles/sublead-sonnet.md
+++ b/crates/pitboss-cli/src/manifest/builtin_profiles/sublead-sonnet.md
@@ -1,0 +1,43 @@
++++
+id = "pitboss/sublead-sonnet"
+model = "claude-sonnet-4-6"
+
+[env]
+PITBOSS_ACTOR_ROLE = "sublead"
++++
+You are a Pitboss **sub-lead** — a sub-tree orchestrator spawned by the
+root lead via `mcp__pitboss__spawn_sublead`. You run with your own
+budget envelope and worker pool, and your own session timeout. The
+operator's prompt tells you what slice of work you own; your job is to
+break it down further, spawn workers, and return a synthesised answer
+to the root lead.
+
+# Parent-child contract
+
+- The root lead reads your `final_message` when you exit. That message
+  IS your reply to the parent. Make it concise and structured —
+  bulleted findings, not chain-of-thought.
+- You inherit caps from the manifest's `[[sublead_type]]` profile (if
+  any): `max_budget_usd`, `max_timeout_secs`, `allowed_models`,
+  `tools`. You cannot widen these. The lead chose them deliberately.
+- You may publish artifacts (`mcp__pitboss__artifact_put`) and send
+  messages to the parent (`mcp__pitboss__message_send`) when
+  `[communication]` is enabled; otherwise rely on the
+  shared-store KV surface.
+
+# Orchestration loop
+
+Same shape as the root lead's: plan → spawn workers → wait → adapt →
+synthesise. The differences:
+
+- `spawn_sublead` is NOT available to you (depth-2 cap). You can only
+  spawn workers, not further sub-trees.
+- Your worker pool is bounded by your own `max_workers`, not the root's.
+- Your budget is independent: budget-exceeded errors come from your own
+  envelope unless `read_down = true` (shared-pool mode).
+
+# When to exit
+
+Exit cleanly with a synthesis message as soon as your slice of work is
+done. Don't drift into adjacent territory just because you have
+budget left — the root lead will spawn another sub-lead for that.

--- a/crates/pitboss-cli/src/manifest/builtin_profiles/sublead-sonnet.md
+++ b/crates/pitboss-cli/src/manifest/builtin_profiles/sublead-sonnet.md
@@ -30,8 +30,9 @@ to the root lead.
 Same shape as the root lead's: plan → spawn workers → wait → adapt →
 synthesise. The differences:
 
-- `spawn_sublead` is NOT available to you (depth-2 cap). You can only
-  spawn workers, not further sub-trees.
+- `mcp__pitboss__spawn_sublead` is NOT available to you (depth-2 cap).
+  You can only spawn workers (`mcp__pitboss__spawn_worker`), not
+  further sub-trees.
 - Your worker pool is bounded by your own `max_workers`, not the root's.
 - Your budget is independent: budget-exceeded errors come from your own
   envelope unless `read_down = true` (shared-pool mode).

--- a/crates/pitboss-cli/src/manifest/builtin_profiles/worker-haiku.md
+++ b/crates/pitboss-cli/src/manifest/builtin_profiles/worker-haiku.md
@@ -1,0 +1,50 @@
++++
+id = "pitboss/worker-haiku"
+model = "claude-haiku-4-5"
+tools = ["Read", "Glob", "Grep", "Bash"]
+
+[env]
+PITBOSS_ACTOR_ROLE = "worker"
++++
+You are a Pitboss **worker** — a leaf actor spawned by a lead or
+sub-lead via `mcp__pitboss__spawn_worker`. Your job is investigation
+and publishing findings, NOT making decisions or spawning further
+work.
+
+# Publish ceremony (when `[communication]` is enabled)
+
+Findings reach your parent through artifacts and messages, never
+through stdout. The parent does NOT see your raw turns; only what you
+publish.
+
+1. Do the investigation the operator asked for.
+2. Call `mcp__pitboss__artifact_put` with the structured result. The
+   parent retrieves it by id.
+3. Call `mcp__pitboss__message_send` to notify the parent the artifact
+   is ready (include the artifact id).
+4. Send a short `final_message` summarising what you published.
+5. Exit.
+
+When `[communication]` is disabled, fall back to writing structured
+output as your `final_message` (the parent reads it from your
+`TaskRecord`). The shared-store KV surface (`kv_set`, `kv_get`,
+`lease_acquire`, etc.) is always available when an mcp-config is
+attached.
+
+# Guard-rails
+
+- **Do not print results to stdout instead of `artifact_put`.** Stdout
+  is logged but not surfaced to the parent.
+- **Do not call `spawn_worker` / `spawn_sublead`.** Those tools are
+  gated to leads/subleads; calls will be rejected.
+- **Do not retry on the same root cause.** If a tool call fails,
+  report it in your final message and exit; the parent decides whether
+  to re-spawn.
+- **Respect your tool allowlist.** Anything outside
+  `--allowedTools` will be denied (Path B) or auto-approved depending
+  on routing — your worker_type's cap is the authority either way.
+
+# When to exit
+
+As soon as you've published. Don't pad turns: every turn costs budget
+the parent has to account for.

--- a/crates/pitboss-cli/src/manifest/builtin_profiles/worker-haiku.md
+++ b/crates/pitboss-cli/src/manifest/builtin_profiles/worker-haiku.md
@@ -27,16 +27,16 @@ publish.
 
 When `[communication]` is disabled, fall back to writing structured
 output as your `final_message` (the parent reads it from your
-`TaskRecord`). The shared-store KV surface (`kv_set`, `kv_get`,
-`lease_acquire`, etc.) is always available when an mcp-config is
-attached.
+`TaskRecord`). The shared-store KV surface (`mcp__pitboss__kv_set`,
+`mcp__pitboss__kv_get`, `mcp__pitboss__lease_acquire`, etc.) is always
+available when an mcp-config is attached.
 
 # Guard-rails
 
-- **Do not print results to stdout instead of `artifact_put`.** Stdout
-  is logged but not surfaced to the parent.
-- **Do not call `spawn_worker` / `spawn_sublead`.** Those tools are
-  gated to leads/subleads; calls will be rejected.
+- **Do not print results to stdout instead of `mcp__pitboss__artifact_put`.**
+  Stdout is logged but not surfaced to the parent.
+- **Do not call `mcp__pitboss__spawn_worker` / `mcp__pitboss__spawn_sublead`.**
+  Those tools are gated to leads/subleads; calls will be rejected.
 - **Do not retry on the same root cause.** If a tool call fails,
   report it in your final message and exit; the parent decides whether
   to re-spawn.

--- a/crates/pitboss-cli/src/manifest/metadata.rs
+++ b/crates/pitboss-cli/src/manifest/metadata.rs
@@ -13,8 +13,9 @@
 use pitboss_schema::SchemaSection;
 
 use super::schema::{
-    ApprovalRuleSpec, CommunicationConfig, ContainerConfig, Defaults, Lead, Lifecycle,
-    McpServerSpec, MountSpec, RunConfig, SubleadDefaults, SubleadType, Task, Template, WorkerType,
+    AgentProfile, ApprovalRuleSpec, CommunicationConfig, ContainerConfig, Defaults, Lead,
+    Lifecycle, McpServerSpec, MountSpec, RunConfig, SubleadDefaults, SubleadType, Task, Template,
+    WorkerType,
 };
 
 /// Walk every section of the v0.9 manifest schema in declaration order.
@@ -88,6 +89,11 @@ pub fn sections() -> Vec<SchemaSection> {
             toml_path: "[[template]]",
             type_name: "Template",
             fields: Template::field_metadata(),
+        },
+        SchemaSection {
+            toml_path: "[[agent_profile]]",
+            type_name: "AgentProfile",
+            fields: AgentProfile::field_metadata(),
         },
         SchemaSection {
             toml_path: "[lifecycle]",

--- a/crates/pitboss-cli/src/manifest/mod.rs
+++ b/crates/pitboss-cli/src/manifest/mod.rs
@@ -1,4 +1,6 @@
 pub mod actor_type;
+pub mod agent_profile_doc;
+pub mod builtin_profiles;
 pub mod error;
 pub mod example_doc;
 pub mod init_template;

--- a/crates/pitboss-cli/src/manifest/resolve.rs
+++ b/crates/pitboss-cli/src/manifest/resolve.rs
@@ -7,8 +7,8 @@ use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
 
 use super::schema::{
-    CommunicationConfig, ContainerConfig, Defaults, Effort, Lead, Manifest, SubleadDefaults, Task,
-    Template, WorktreeCleanup,
+    AgentProfile, CommunicationConfig, ContainerConfig, Defaults, Effort, Lead, Manifest,
+    SubleadDefaults, Task, Template, WorktreeCleanup,
 };
 
 /// Fully resolved task ready for dispatch.
@@ -217,6 +217,15 @@ pub struct ResolvedManifest {
     /// auto-denies via `denied_by_profile`. (#252)
     #[serde(default)]
     pub untyped_actor_policy: crate::manifest::schema::UntypedActorPolicy,
+    /// Effective [`AgentProfile`] catalogue: bundled built-ins union
+    /// with manifest-declared `[[agent_profile]]` entries. Manifest
+    /// entries shadow built-ins by matching id exactly. Looked up at
+    /// MCP-spawn time by `worker_type`/`sublead_type` →
+    /// `agent_profile` references to compose worker/sublead prompts +
+    /// env defaults. Serialised so `resolved.json` round-trips through
+    /// resume.
+    #[serde(default)]
+    pub agent_profiles: HashMap<String, AgentProfile>,
 }
 
 const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
@@ -240,9 +249,64 @@ pub fn resolve(
         .map(|t| (t.id.clone(), t))
         .collect();
 
+    // Reject duplicate manifest-declared agent_profile ids up-front: a
+    // duplicate would silently shadow the earlier entry once we collapse
+    // into a HashMap, matching the dedup posture of [[worker_type]] in
+    // validate.rs.
+    {
+        let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        for p in &manifest.agent_profiles {
+            if !seen.insert(p.id.as_str()) {
+                bail!(
+                    "[[agent_profile]].id {:?}: duplicate; ids must be \
+                     unique within the manifest (catalogue lookup collapses \
+                     duplicates and would silently shadow the earlier entry)",
+                    p.id
+                );
+            }
+        }
+    }
+    // Build the effective agent-profile catalogue: bundled built-ins
+    // first, manifest entries last so a manifest entry sharing a
+    // built-in id shadows it via HashMap::insert's last-wins semantics.
+    let agent_profiles: HashMap<String, AgentProfile> =
+        crate::manifest::builtin_profiles::load_builtins()
+            .into_iter()
+            .chain(manifest.agent_profiles.iter().cloned())
+            .map(|p| (p.id.clone(), p))
+            .collect();
+
+    // Lookup helper: dangling agent_profile references on `[lead]` /
+    // `[[task]]` hard-fail at resolve so a typo doesn't silently fall
+    // back to "no prelude" — operator intent is lost otherwise.
+    let lookup_profile = |surface: &str,
+                          maybe_ref: Option<&str>|
+     -> Result<Option<&AgentProfile>> {
+        match maybe_ref {
+            Some(id) => match agent_profiles.get(id) {
+                Some(p) => Ok(Some(p)),
+                None => {
+                    let mut known: Vec<&str> = agent_profiles.keys().map(String::as_str).collect();
+                    known.sort();
+                    bail!(
+                        "{surface}: agent_profile {id:?} not found. \
+                         Declared profiles (built-ins + manifest): {}. \
+                         See `pitboss schema --format=agent-profiles`.",
+                        known.join(", ")
+                    );
+                }
+            },
+            None => Ok(None),
+        }
+    };
+
     let mut resolved_tasks = Vec::with_capacity(manifest.tasks.len());
     for task in &manifest.tasks {
-        resolved_tasks.push(resolve_task(task, &manifest.defaults, &templates)?);
+        let profile = lookup_profile(
+            &format!("[[task]] id={:?}", task.id),
+            task.agent_profile.as_deref(),
+        )?;
+        resolved_tasks.push(resolve_task(task, &manifest.defaults, &templates, profile)?);
     }
 
     let resolved_sublead_defaults = manifest
@@ -251,10 +315,12 @@ pub fn resolve(
         .map(resolve_sublead_defaults);
 
     let resolved_lead = if let Some(l) = &manifest.lead {
+        let profile = lookup_profile(&format!("[lead] id={:?}", l.id), l.agent_profile.as_deref())?;
         Some(resolve_lead(
             l,
             &manifest.defaults,
             resolved_sublead_defaults.clone(),
+            profile,
         )?)
     } else {
         None
@@ -331,15 +397,39 @@ pub fn resolve(
         sublead_types: manifest.sublead_types,
         require_actor_type: manifest.run.require_actor_type,
         untyped_actor_policy: manifest.run.untyped_actor_policy,
+        agent_profiles,
     })
+}
+
+/// Compose the worker/lead/task prompt by prepending the profile's
+/// `system_prompt` (if any) to the operator's prompt with a fixed
+/// `\n\n--- TASK ---\n\n` separator. Operator content is never
+/// replaced — the profile only contributes the prelude.
+pub fn compose_prompt(profile: Option<&AgentProfile>, operator_prompt: &str) -> String {
+    match profile
+        .map(|p| p.system_prompt.as_str())
+        .filter(|s| !s.is_empty())
+    {
+        Some(prelude) => format!("{prelude}\n\n--- TASK ---\n\n{operator_prompt}"),
+        None => operator_prompt.to_string(),
+    }
 }
 
 fn resolve_lead(
     lead: &Lead,
     defaults: &Defaults,
     sublead_defaults: Option<ResolvedSubleadDefaults>,
+    profile: Option<&AgentProfile>,
 ) -> Result<ResolvedLead> {
+    // Env precedence (later wins): defaults.env → profile.env → lead.env.
+    // Operator-supplied per-actor env beats the profile's role default,
+    // which beats the manifest-wide defaults block.
     let mut env = defaults.env.clone();
+    if let Some(p) = profile {
+        for (k, v) in &p.env {
+            env.insert(k.clone(), v.clone());
+        }
+    }
     env.extend(lead.env.clone());
 
     // Lead timeout cascade: per-lead timeout_secs > lead.lead_timeout_secs
@@ -350,21 +440,30 @@ fn resolve_lead(
         .or(defaults.timeout_secs)
         .unwrap_or(DEFAULT_TIMEOUT_SECS);
 
+    let prompt = compose_prompt(profile, &lead.prompt);
+
     Ok(ResolvedLead {
         id: lead.id.clone(),
         directory: lead.directory.clone(),
-        prompt: lead.prompt.clone(),
+        prompt,
         branch: lead.branch.clone(),
+        // Model precedence: lead.model > defaults.model > profile.model
+        // > DEFAULT_MODEL. The profile is a default-provider, not an
+        // override.
         model: lead
             .model
             .clone()
             .or_else(|| defaults.model.clone())
+            .or_else(|| profile.and_then(|p| p.model.clone()))
             .unwrap_or_else(|| DEFAULT_MODEL.to_string()),
         effort: lead.effort.or(defaults.effort).unwrap_or(DEFAULT_EFFORT),
+        // Tools precedence mirrors model: lead.tools > defaults.tools
+        // > profile.tools > default_tools().
         tools: lead
             .tools
             .clone()
             .or_else(|| defaults.tools.clone())
+            .or_else(|| profile.and_then(|p| p.tools.clone()))
             .unwrap_or_else(default_tools),
         timeout_secs,
         use_worktree: lead.use_worktree.or(defaults.use_worktree).unwrap_or(true),
@@ -383,8 +482,9 @@ fn resolve_task(
     task: &Task,
     defaults: &Defaults,
     templates: &HashMap<String, &Template>,
+    profile: Option<&AgentProfile>,
 ) -> Result<ResolvedTask> {
-    let prompt = match (&task.prompt, &task.template) {
+    let raw_prompt = match (&task.prompt, &task.template) {
         (Some(p), None) => p.clone(),
         (None, Some(tid)) => {
             let tmpl = templates.get(tid).ok_or_else(|| {
@@ -396,8 +496,15 @@ fn resolve_task(
         (Some(_), Some(_)) => bail!("task '{}' sets both prompt and template", task.id),
         (None, None) => bail!("task '{}' has no prompt and no template", task.id),
     };
+    let prompt = compose_prompt(profile, &raw_prompt);
 
+    // Env precedence (later wins): defaults.env → profile.env → task.env.
     let mut env = defaults.env.clone();
+    if let Some(p) = profile {
+        for (k, v) in &p.env {
+            env.insert(k.clone(), v.clone());
+        }
+    }
     env.extend(task.env.clone());
 
     Ok(ResolvedTask {
@@ -405,16 +512,19 @@ fn resolve_task(
         directory: task.directory.clone(),
         prompt,
         branch: task.branch.clone(),
+        // Model/tools precedence: per-task > defaults > profile > built-in.
         model: task
             .model
             .clone()
             .or_else(|| defaults.model.clone())
+            .or_else(|| profile.and_then(|p| p.model.clone()))
             .unwrap_or_else(|| DEFAULT_MODEL.to_string()),
         effort: task.effort.or(defaults.effort).unwrap_or(DEFAULT_EFFORT),
         tools: task
             .tools
             .clone()
             .or_else(|| defaults.tools.clone())
+            .or_else(|| profile.and_then(|p| p.tools.clone()))
             .unwrap_or_else(default_tools),
         timeout_secs: task
             .timeout_secs

--- a/crates/pitboss-cli/src/manifest/resolve.rs
+++ b/crates/pitboss-cli/src/manifest/resolve.rs
@@ -224,6 +224,15 @@ pub struct ResolvedManifest {
     /// `agent_profile` references to compose worker/sublead prompts +
     /// env defaults. Serialised so `resolved.json` round-trips through
     /// resume.
+    ///
+    /// Note: this is the *merged* catalogue. To distinguish
+    /// manifest-declared from built-in entries (used by
+    /// `validate_agent_profiles` for namespace-squatting detection),
+    /// re-load the built-in id set via
+    /// `builtin_profiles::load_builtins()` and diff — the duplicate
+    /// load is cheap (3 `include_str!` parses) and avoids carrying a
+    /// second `agent_profiles_manifest: Vec<AgentProfile>` field whose
+    /// only consumer is validate.
     #[serde(default)]
     pub agent_profiles: HashMap<String, AgentProfile>,
 }

--- a/crates/pitboss-cli/src/manifest/schema.rs
+++ b/crates/pitboss-cli/src/manifest/schema.rs
@@ -25,6 +25,7 @@
 //! | `[[notification]]`        | `NotificationConfig`  | no       | Notification sinks                                   |
 //! | `[[approval_policy]]`     | `ApprovalRuleSpec`    | no       | Declarative approval rules (matched in order)        |
 //! | `[[template]]`            | `Template`            | no       | Prompt templates referenced by `[[task]]`            |
+//! | `[[agent_profile]]`       | `AgentProfile`        | no       | Reusable role prelude + env/model/tools defaults     |
 //!
 //! ## Migration from v0.8 → v0.9
 //!
@@ -362,6 +363,14 @@ pub struct Manifest {
     pub defaults: Defaults,
     #[serde(default, rename = "template")]
     pub templates: Vec<Template>,
+    /// Reusable role profiles (`[[agent_profile]]`). The effective
+    /// catalogue at resolve time is the union of bundled built-ins
+    /// (`pitboss/lead-opus`, `pitboss/sublead-sonnet`,
+    /// `pitboss/worker-haiku`) and these manifest-declared entries;
+    /// manifest entries shadow built-ins by matching id exactly. See
+    /// [`AgentProfile`].
+    #[serde(default, rename = "agent_profile")]
+    pub agent_profiles: Vec<AgentProfile>,
     #[serde(default, rename = "task")]
     pub tasks: Vec<Task>,
     /// Single-table `[lead]` for hierarchical mode. Exactly one is required
@@ -701,6 +710,73 @@ pub enum WorktreeCleanup {
     Never,
 }
 
+/// Reusable role profile (`[[agent_profile]]`). Carries a prepended
+/// system-prompt body plus optional model/tools/env *defaults*. Unlike
+/// [`WorkerType`]/[`SubleadType`] which encode capability **caps**,
+/// agent profiles supply role conventions and fallbacks the operator's
+/// `[lead]`/`[[task]]` config can override.
+///
+/// Referenced by id from `[lead]`, `[[task]]`, `[[worker_type]]`, and
+/// `[[sublead_type]]`. The catalogue is the union of three bundled
+/// built-ins (`pitboss/lead-opus`, `pitboss/sublead-sonnet`,
+/// `pitboss/worker-haiku`) and any manifest-declared profiles; manifest
+/// entries shadow built-ins by matching id exactly.
+///
+/// Precedence (later wins): `DEFAULT_*` → `profile` → `[defaults]` →
+/// per-actor (`[lead]` / `[[task]]` / spawn args). Operator config
+/// always wins; the profile is a default-provider, never an override.
+/// The `system_prompt` is **prepended** to the operator's prompt with a
+/// fixed `\n\n--- TASK ---\n\n` separator (never replaced).
+#[derive(Debug, Clone, Deserialize, Serialize, Default, FieldMetadata)]
+#[serde(deny_unknown_fields)]
+pub struct AgentProfile {
+    /// Unique id. Must match `^[A-Za-z0-9_/-]+$` (validate-time check).
+    /// The `pitboss/` namespace is reserved for built-ins — a manifest
+    /// may shadow a built-in by matching its id exactly, but may not
+    /// introduce novel `pitboss/<other>` ids.
+    #[field(
+        label = "Profile id",
+        help = "Unique id referenced from [lead]/[[task]]/[[worker_type]]/[[sublead_type]] .agent_profile. Match: ^[A-Za-z0-9_/-]+$. The pitboss/ namespace is reserved for built-ins."
+    )]
+    pub id: String,
+    /// Role prelude prepended to the operator's prompt with a
+    /// `\n\n--- TASK ---\n\n` separator. Empty (default) means no
+    /// prelude — profile is just an env/model/tools default-provider.
+    #[serde(default)]
+    #[field(
+        label = "System prompt",
+        help = "Role-shared prelude prepended to the operator's prompt with `\\n\\n--- TASK ---\\n\\n` separator.",
+        form_type = "long_text"
+    )]
+    pub system_prompt: String,
+    /// Default model. The operator's `model =` on the actor wins; this
+    /// fills any slot the operator didn't fill. Distinct from
+    /// `[[worker_type]].allowed_models` which is a *cap*.
+    #[serde(default)]
+    #[field(
+        label = "Model",
+        help = "Default Claude model id when the actor's `model =` is unset. Not a cap — operator config wins."
+    )]
+    pub model: Option<String>,
+    /// Env vars merged in between `[defaults].env` and the per-actor
+    /// env. Operator env wins on collision.
+    #[serde(default)]
+    #[field(
+        label = "Env vars",
+        help = "Env merged between [defaults].env and the per-actor env. Operator wins on collision."
+    )]
+    pub env: HashMap<String, String>,
+    /// Default tool allowlist. The operator's `tools =` wins; this
+    /// fills any slot the operator didn't fill. Distinct from
+    /// `[[worker_type]].tools` which is a *cap*.
+    #[serde(default)]
+    #[field(
+        label = "Tools",
+        help = "Default tool allowlist when the actor's `tools =` is unset. Not a cap — operator config wins."
+    )]
+    pub tools: Option<Vec<String>>,
+}
+
 /// Typed worker profile (`[[worker_type]]`). Caps the capability
 /// surface a `spawn_worker(worker_type = "<id>")` call may request.
 /// The lead-supplied `tools` arg must be a subset of `tools`;
@@ -743,6 +819,17 @@ pub struct WorkerType {
         help = "Hard cap on spawn_worker(timeout_secs=...). Lead values clamp DOWN; smaller values pass through."
     )]
     pub max_timeout_secs: Option<u64>,
+    /// Optional reference to an [`AgentProfile`] id (built-in or
+    /// manifest-declared). When set, every `spawn_worker(worker_type =
+    /// "<id>")` call gets the profile's `system_prompt` prepended to its
+    /// operator prompt and inherits the profile's env/model/tools
+    /// defaults for any slot the call didn't fill.
+    #[serde(default)]
+    #[field(
+        label = "Agent profile",
+        help = "Reference to an [[agent_profile]].id. Workers spawned under this worker_type inherit the profile's system_prompt prelude + env/model/tools defaults."
+    )]
+    pub agent_profile: Option<String>,
 }
 
 /// Typed sub-lead profile (`[[sublead_type]]`). Same enforcement model
@@ -786,6 +873,17 @@ pub struct SubleadType {
         help = "Hard cap on spawn_sublead(budget_usd=...). Clamps DOWN."
     )]
     pub max_budget_usd: Option<f64>,
+    /// Optional reference to an [`AgentProfile`] id (built-in or
+    /// manifest-declared). When set, every
+    /// `spawn_sublead(sublead_type = "<id>")` call gets the profile's
+    /// `system_prompt` prepended to its operator prompt and inherits
+    /// the profile's env/model/tools defaults.
+    #[serde(default)]
+    #[field(
+        label = "Agent profile",
+        help = "Reference to an [[agent_profile]].id. Sub-leads spawned under this sublead_type inherit the profile's system_prompt prelude + env/model/tools defaults."
+    )]
+    pub agent_profile: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default, FieldMetadata)]
@@ -909,6 +1007,16 @@ pub struct Task {
         help = "Per-task env vars merged on top of [defaults].env."
     )]
     pub env: HashMap<String, String>,
+    /// Optional reference to an [`AgentProfile`] id (built-in or
+    /// manifest-declared). When set, the profile's `system_prompt` is
+    /// prepended to the task prompt at resolve time, and the profile's
+    /// env/model/tools defaults fill any slot the task didn't fill.
+    #[serde(default)]
+    #[field(
+        label = "Agent profile",
+        help = "Reference to an [[agent_profile]].id. The profile's system_prompt is prepended; its env/model/tools defaults fill any slot the task didn't set."
+    )]
+    pub agent_profile: Option<String>,
 }
 
 /// Single canonical lead shape (v0.9). Replaces the v0.8 `[[lead]]`/`[lead]` split.
@@ -1075,6 +1183,16 @@ pub struct Lead {
         help = "Cap on total live workers across the entire tree (root + sub-trees)."
     )]
     pub max_total_workers: Option<u32>,
+    /// Optional reference to an [`AgentProfile`] id (built-in or
+    /// manifest-declared). When set, the profile's `system_prompt` is
+    /// prepended to `[lead].prompt` at resolve time, and the profile's
+    /// env/model/tools defaults fill any slot the lead didn't fill.
+    #[serde(default)]
+    #[field(
+        label = "Agent profile",
+        help = "Reference to an [[agent_profile]].id. The profile's system_prompt is prepended to [lead].prompt; its env/model/tools defaults fill any slot the lead didn't set."
+    )]
+    pub agent_profile: Option<String>,
 }
 
 /// Top-level `[sublead_defaults]` block (promoted from `[lead.sublead_defaults]`

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -2872,4 +2872,132 @@ mod tests {
         // Default `untyped_actor_policy = Bridge`; no profiles declared.
         validate_skip_dir_check(&r).expect("bridge policy without profiles must pass validate");
     }
+
+    // ── #7: validate_agent_profiles direct coverage ─────────────────────
+
+    fn ap(id: &str, body: &str) -> crate::manifest::schema::AgentProfile {
+        crate::manifest::schema::AgentProfile {
+            id: id.to_string(),
+            system_prompt: body.to_string(),
+            model: None,
+            env: Default::default(),
+            tools: None,
+        }
+    }
+
+    /// Populate the resolved-manifest's agent_profiles catalogue with the
+    /// built-ins, mirroring what `resolve()` does for real manifests.
+    /// `rm_with` constructs `ResolvedManifest` directly and so bypasses
+    /// the resolve-time catalogue build.
+    fn install_builtins(m: &mut ResolvedManifest) {
+        m.agent_profiles = crate::manifest::builtin_profiles::load_builtins()
+            .into_iter()
+            .map(|p| (p.id.clone(), p))
+            .collect();
+    }
+
+    #[test]
+    fn agent_profile_validate_accepts_only_builtins() {
+        let r = rm_with(install_builtins);
+        validate_skip_dir_check(&r).expect("built-in-only catalogue must validate");
+    }
+
+    #[test]
+    fn agent_profile_validate_rejects_pitboss_namespace_squatting() {
+        let r = rm_with(|m| {
+            install_builtins(m);
+            m.agent_profiles.insert(
+                "pitboss/not-a-builtin".to_string(),
+                ap("pitboss/not-a-builtin", "x"),
+            );
+        });
+        let err = validate_skip_dir_check(&r).unwrap_err().to_string();
+        assert!(
+            err.contains("pitboss/") && err.contains("reserved"),
+            "expected namespace-reservation error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn agent_profile_validate_allows_manifest_shadow_of_builtin() {
+        let r = rm_with(|m| {
+            install_builtins(m);
+            // Overwrite the built-in entry with an operator-shadowed version.
+            m.agent_profiles.insert(
+                "pitboss/worker-haiku".to_string(),
+                ap("pitboss/worker-haiku", "OVERRIDDEN"),
+            );
+        });
+        validate_skip_dir_check(&r)
+            .expect("manifest shadowing a built-in by exact id must validate");
+    }
+
+    #[test]
+    fn agent_profile_validate_rejects_invalid_charset_id() {
+        let r = rm_with(|m| {
+            install_builtins(m);
+            m.agent_profiles
+                .insert("has spaces".to_string(), ap("has spaces", "x"));
+        });
+        let err = validate_skip_dir_check(&r).unwrap_err().to_string();
+        assert!(err.contains("^[A-Za-z0-9_/-]+$"), "got: {err}");
+    }
+
+    #[test]
+    fn agent_profile_validate_rejects_unknown_worker_type_reference() {
+        let r = rm_with(|m| {
+            install_builtins(m);
+            m.worker_types = vec![crate::manifest::schema::WorkerType {
+                id: "extractor".into(),
+                tools: vec!["Read".into()],
+                allowed_models: vec![],
+                max_timeout_secs: None,
+                agent_profile: Some("does/not-exist".into()),
+            }];
+        });
+        let err = validate_skip_dir_check(&r).unwrap_err().to_string();
+        assert!(err.contains("does/not-exist"), "got: {err}");
+        assert!(err.contains("worker_type"), "got: {err}");
+    }
+
+    #[test]
+    fn agent_profile_validate_rejects_unknown_sublead_type_reference() {
+        let r = rm_with(|m| {
+            install_builtins(m);
+            m.sublead_types = vec![crate::manifest::schema::SubleadType {
+                id: "planner".into(),
+                tools: vec!["Read".into()],
+                allowed_models: vec![],
+                max_timeout_secs: None,
+                max_budget_usd: None,
+                agent_profile: Some("nope".into()),
+            }];
+        });
+        let err = validate_skip_dir_check(&r).unwrap_err().to_string();
+        assert!(err.contains("nope"), "got: {err}");
+        assert!(err.contains("sublead_type"), "got: {err}");
+    }
+
+    #[test]
+    fn agent_profile_validate_accepts_known_references() {
+        let r = rm_with(|m| {
+            install_builtins(m);
+            m.worker_types = vec![crate::manifest::schema::WorkerType {
+                id: "extractor".into(),
+                tools: vec!["Read".into()],
+                allowed_models: vec![],
+                max_timeout_secs: None,
+                agent_profile: Some("pitboss/worker-haiku".into()),
+            }];
+            m.sublead_types = vec![crate::manifest::schema::SubleadType {
+                id: "planner".into(),
+                tools: vec!["Read".into()],
+                allowed_models: vec![],
+                max_timeout_secs: None,
+                max_budget_usd: None,
+                agent_profile: Some("pitboss/sublead-sonnet".into()),
+            }];
+        });
+        validate_skip_dir_check(&r).expect("known built-in references must validate");
+    }
 }

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -32,6 +32,7 @@ fn validate_inner(resolved: &ResolvedManifest, skip_dir_check: bool) -> Result<(
     validate_mcp_server_scopes(resolved)?;
     validate_mcp_server_tools(resolved)?;
     validate_mcp_tool_consistency(resolved)?;
+    validate_agent_profiles(resolved)?;
     if resolved.lead.is_some() {
         validate_lead(resolved, skip_dir_check)?;
         validate_hierarchical_ranges(resolved)?;
@@ -127,6 +128,89 @@ fn validate_actor_types(r: &ResolvedManifest) -> Result<()> {
         }
     }
 
+    Ok(())
+}
+
+/// Validate `[[agent_profile]]` invariants and references.
+///
+/// - Charset: every id must match `^[A-Za-z0-9_/-]+$`. The id appears
+///   in error messages and in `pitboss schema --format=agent-profiles`
+///   output; restricting the charset keeps quoting/escaping
+///   predictable across both surfaces.
+/// - Namespace: the `pitboss/` prefix is reserved for bundled
+///   built-ins. A manifest may *shadow* a built-in by matching its id
+///   exactly, but may not introduce novel `pitboss/<other>` ids.
+/// - References: every `agent_profile = "<id>"` mention on
+///   `[[worker_type]]` / `[[sublead_type]]` must resolve to a built-in
+///   or a manifest-declared id. Dangling refs on `[lead]` / `[[task]]`
+///   are caught earlier at resolve time (where the lookup happens
+///   inline); the worker_type / sublead_type refs survive in the
+///   resolved manifest and are checked here.
+///
+/// Duplicate manifest ids are caught at resolve time so the catalogue
+/// HashMap can't silently swallow them.
+fn validate_agent_profiles(r: &ResolvedManifest) -> Result<()> {
+    fn is_valid_id(s: &str) -> bool {
+        !s.is_empty()
+            && s.chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '/')
+    }
+
+    let builtin_ids: HashSet<String> = crate::manifest::builtin_profiles::load_builtins()
+        .into_iter()
+        .map(|p| p.id)
+        .collect();
+
+    for id in r.agent_profiles.keys() {
+        if !is_valid_id(id) {
+            bail!(
+                "[[agent_profile]].id {:?}: must match ^[A-Za-z0-9_/-]+$ \
+                 (allowed: ASCII alphanumeric, underscore, hyphen, forward slash)",
+                id
+            );
+        }
+        if id.starts_with("pitboss/") && !builtin_ids.contains(id) {
+            let mut ids: Vec<&str> = builtin_ids.iter().map(String::as_str).collect();
+            ids.sort();
+            bail!(
+                "[[agent_profile]].id {:?}: the `pitboss/` namespace is \
+                 reserved for built-in profiles. A manifest may shadow a \
+                 built-in by matching its id exactly, but may not introduce \
+                 novel `pitboss/<other>` ids. Known built-ins: {}",
+                id,
+                ids.join(", ")
+            );
+        }
+    }
+
+    let known: HashSet<&str> = r.agent_profiles.keys().map(String::as_str).collect();
+    let check_ref = |surface: &str, maybe_ref: Option<&str>| -> Result<()> {
+        let Some(id) = maybe_ref else {
+            return Ok(());
+        };
+        if !known.contains(id) {
+            let mut ids: Vec<&str> = known.iter().copied().collect();
+            ids.sort();
+            bail!(
+                "{surface}: agent_profile {id:?} not found. Declared profiles \
+                 (built-ins + manifest): {}. See `pitboss schema --format=agent-profiles`.",
+                ids.join(", ")
+            );
+        }
+        Ok(())
+    };
+    for wt in &r.worker_types {
+        check_ref(
+            &format!("[[worker_type]] id={:?}", wt.id),
+            wt.agent_profile.as_deref(),
+        )?;
+    }
+    for st in &r.sublead_types {
+        check_ref(
+            &format!("[[sublead_type]] id={:?}", st.id),
+            st.agent_profile.as_deref(),
+        )?;
+    }
     Ok(())
 }
 
@@ -1018,6 +1102,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         }
     }
 
@@ -1054,6 +1139,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         f(&mut m);
         m
@@ -1146,6 +1232,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         let err = validate(&r).unwrap_err().to_string();
         assert!(
@@ -1185,6 +1272,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         assert!(validate(&r).is_err());
     }
@@ -1220,6 +1308,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         assert!(validate(&r).is_err());
     }
@@ -1269,6 +1358,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         }
     }
 
@@ -1370,6 +1460,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         (d, r)
     }
@@ -1496,6 +1587,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         let err = validate(&r).unwrap_err().to_string();
         assert!(err.contains("empty manifest"), "got: {err}");
@@ -1556,6 +1648,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         let err = validate(&r).unwrap_err().to_string();
         assert!(
@@ -1597,6 +1690,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         assert!(validate(&r).is_err());
     }
@@ -1809,6 +1903,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         // Sanity: with skip_dir_check=false the validator rejects (the
         // host-side path is bogus).
@@ -2155,6 +2250,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         validate(&r).expect("path_b must validate (in soak); pre-#368 this bailed");
     }
@@ -2193,6 +2289,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         validate(&r).expect("path_a is the default and must validate");
     }
@@ -2206,6 +2303,7 @@ mod tests {
                 tools: vec!["Read".into()],
                 allowed_models: vec![],
                 max_timeout_secs: None,
+                agent_profile: None,
             }];
         });
         let err = validate(&r).unwrap_err().to_string();
@@ -2223,12 +2321,14 @@ mod tests {
                     tools: vec!["Read".into()],
                     allowed_models: vec![],
                     max_timeout_secs: None,
+                    agent_profile: None,
                 },
                 WorkerType {
                     id: "extraction".into(),
                     tools: vec!["Write".into()],
                     allowed_models: vec![],
                     max_timeout_secs: None,
+                    agent_profile: None,
                 },
             ];
         });
@@ -2248,6 +2348,7 @@ mod tests {
                     allowed_models: vec![],
                     max_timeout_secs: None,
                     max_budget_usd: None,
+                    agent_profile: None,
                 },
                 SubleadType {
                     id: "planner".into(),
@@ -2255,6 +2356,7 @@ mod tests {
                     allowed_models: vec![],
                     max_timeout_secs: None,
                     max_budget_usd: None,
+                    agent_profile: None,
                 },
             ];
         });
@@ -2308,6 +2410,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         m.require_actor_type = true;
         m.worker_types = vec![WorkerType {
@@ -2315,6 +2418,7 @@ mod tests {
             tools: vec!["Read".into()],
             allowed_models: vec![],
             max_timeout_secs: None,
+            agent_profile: None,
         }];
         validate(&m).expect("require_actor_type with profile must validate");
     }
@@ -2351,12 +2455,14 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         m.worker_types = vec![WorkerType {
             id: "extraction".into(),
             tools: vec!["Read".into(), "Glob".into()],
             allowed_models: vec!["claude-haiku-4-5".into()],
             max_timeout_secs: Some(900),
+            agent_profile: None,
         }];
         m.sublead_types = vec![SubleadType {
             id: "planner".into(),
@@ -2364,6 +2470,7 @@ mod tests {
             allowed_models: vec!["claude-opus-4-7".into()],
             max_timeout_secs: Some(1800),
             max_budget_usd: Some(2.0),
+            agent_profile: None,
         }];
         validate(&m).expect("declared profiles without require flag must validate");
     }
@@ -2407,6 +2514,7 @@ mod tests {
                 tools: vec!["Read".into()],
                 allowed_models: vec![],
                 max_timeout_secs: None,
+                agent_profile: None,
             }];
             m.mcp_servers = vec![mcp("ctx", Some("type:rdr"))];
         });
@@ -2424,6 +2532,7 @@ mod tests {
                 tools: vec!["Read".into(), "Write".into()],
                 allowed_models: vec![],
                 max_timeout_secs: None,
+                agent_profile: None,
             }];
             m.mcp_servers = vec![mcp("ctx", Some("type:writer"))];
         });
@@ -2441,6 +2550,7 @@ mod tests {
                 allowed_models: vec![],
                 max_timeout_secs: None,
                 max_budget_usd: None,
+                agent_profile: None,
             }];
             m.mcp_servers = vec![mcp("ctx", Some("type:planner"))];
         });
@@ -2535,6 +2645,7 @@ mod tests {
                 tools: vec!["mcp__fs__write_file".into()],
                 allowed_models: vec![],
                 max_timeout_secs: None,
+                agent_profile: None,
             }];
         });
         let err = validate_skip_dir_check(&r).unwrap_err().to_string();
@@ -2555,6 +2666,7 @@ mod tests {
                 tools: vec!["mcp__fs__write_file".into(), "Read".into()],
                 allowed_models: vec![],
                 max_timeout_secs: None,
+                agent_profile: None,
             }];
         });
         validate_skip_dir_check(&r)
@@ -2578,6 +2690,7 @@ mod tests {
                 tools: vec!["mcp__fs_writer__read_file".into()],
                 allowed_models: vec![],
                 max_timeout_secs: None,
+                agent_profile: None,
             }];
         });
         validate_skip_dir_check(&r).expect(
@@ -2599,6 +2712,7 @@ mod tests {
                 tools: vec!["mcp__fs__anything".into()],
                 allowed_models: vec![],
                 max_timeout_secs: None,
+                agent_profile: None,
             }];
         });
         validate_skip_dir_check(&r)
@@ -2662,6 +2776,7 @@ mod tests {
                 tools: vec!["Read".into()],
                 allowed_models: vec![],
                 max_timeout_secs: None,
+                agent_profile: None,
             }];
         });
         r.lead.as_mut().unwrap().permission_routing =
@@ -2679,6 +2794,7 @@ mod tests {
                 allowed_models: vec![],
                 max_timeout_secs: None,
                 max_budget_usd: None,
+                agent_profile: None,
             }];
         });
         r.lead.as_mut().unwrap().permission_routing =
@@ -2725,6 +2841,7 @@ mod tests {
                 tools: vec!["Read".into()],
                 allowed_models: vec![],
                 max_timeout_secs: None,
+                agent_profile: None,
             }];
         });
         r.untyped_actor_policy = crate::manifest::schema::UntypedActorPolicy::Block;
@@ -2739,6 +2856,7 @@ mod tests {
                 allowed_models: vec![],
                 max_timeout_secs: None,
                 max_budget_usd: None,
+                agent_profile: None,
             }];
         });
         r.untyped_actor_policy = crate::manifest::schema::UntypedActorPolicy::Block;

--- a/crates/pitboss-cli/src/mcp/approval.rs
+++ b/crates/pitboss-cli/src/mcp/approval.rs
@@ -513,6 +513,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -1713,6 +1713,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();
@@ -1805,6 +1806,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();
@@ -1891,6 +1893,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();
@@ -2044,6 +2047,7 @@ mod tests {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/src/mcp/tools/spawn.rs
+++ b/crates/pitboss-cli/src/mcp/tools/spawn.rs
@@ -386,7 +386,20 @@ pub async fn handle_spawn_worker(
     let target_layer_bg = Arc::clone(&target_layer);
     let task_id_bg = task_id.clone();
     let lead_id_bg = target_layer.lead_id.clone();
-    let prompt_bg = args.prompt.clone();
+    // Compose the worker prompt: if the matched `[[worker_type]]` binds
+    // an `agent_profile`, prepend the profile's `system_prompt` to the
+    // operator-supplied prompt with `\n\n--- TASK ---\n\n` separator.
+    // Untyped spawns / typeless / dangling references → operator prompt
+    // verbatim.
+    let worker_type_for_profile = match &profile_resolution {
+        crate::manifest::actor_type::WorkerProfileResolution::Typed(p) => Some(*p),
+        crate::manifest::actor_type::WorkerProfileResolution::Untyped => None,
+    };
+    let agent_profile = crate::manifest::actor_type::worker_agent_profile(
+        worker_type_for_profile,
+        &state.root.manifest.agent_profiles,
+    );
+    let prompt_bg = crate::manifest::resolve::compose_prompt(agent_profile, &args.prompt);
 
     let worker_type_id_bg = resolved_worker_type_id.clone();
     tokio::spawn(async move {
@@ -578,13 +591,34 @@ async fn run_worker(
     // though the operator set `[defaults.env]` at the manifest level.
     // Fall back through the root lead (always populated, carries the
     // merged [defaults.env] + [lead.env]) before defaulting to empty.
-    let lead_env_for_worker = layer
+    let mut lead_env_for_worker = layer
         .manifest
         .lead
         .as_ref()
         .map(|l| l.env.clone())
         .or_else(|| state.root.manifest.lead.as_ref().map(|l| l.env.clone()))
         .unwrap_or_default();
+    // Merge the agent_profile env (bound via `[[worker_type]].agent_profile`)
+    // on top of the inherited lead env. Profile env wins over inherited
+    // lead env on collision; pitboss defaults (CLAUDE_CODE_ENTRYPOINT,
+    // etc.) still fill any remaining slot inside `compose_sublead_env`.
+    let agent_profile_env: std::collections::HashMap<String, String> = actor_type
+        .as_deref()
+        .and_then(|t| {
+            state
+                .root
+                .manifest
+                .worker_types
+                .iter()
+                .find(|wt| wt.id == t)
+        })
+        .and_then(|wt| wt.agent_profile.as_deref())
+        .and_then(|id| state.root.manifest.agent_profiles.get(id))
+        .map(|p| p.env.clone())
+        .unwrap_or_default();
+    for (k, v) in agent_profile_env {
+        lead_env_for_worker.insert(k, v);
+    }
     let worker_routing = layer
         .manifest
         .lead

--- a/crates/pitboss-cli/src/mcp/tools/spawn.rs
+++ b/crates/pitboss-cli/src/mcp/tools/spawn.rs
@@ -151,10 +151,27 @@ pub async fn handle_spawn_worker(
     };
 
     // Resolve the worker's model up-front so the budget guard can price it.
+    //
+    // Cascade: args.model > profile.model > lead.model > "claude-haiku-4-5".
+    // The profile's model sits ABOVE lead.model deliberately — when a worker
+    // type binds `agent_profile = "pitboss/worker-haiku"`, the lead's own
+    // model (often Opus for the orchestrator) is incidental inheritance,
+    // not a deliberate override; the profile's role-default should win.
+    // Operator can still force a specific model by passing `args.model`.
     let lead = target_layer.manifest.lead.as_ref();
+    let worker_type_for_profile: Option<&crate::manifest::schema::WorkerType> =
+        match &profile_resolution {
+            crate::manifest::actor_type::WorkerProfileResolution::Typed(p) => Some(*p),
+            crate::manifest::actor_type::WorkerProfileResolution::Untyped => None,
+        };
+    let worker_agent_profile_for_model = crate::manifest::actor_type::worker_agent_profile(
+        worker_type_for_profile,
+        &state.root.manifest.agent_profiles,
+    );
     let worker_model = args
         .model
         .clone()
+        .or_else(|| worker_agent_profile_for_model.and_then(|p| p.model.clone()))
         .or_else(|| lead.map(|l| l.model.clone()))
         .unwrap_or_else(|| "claude-haiku-4-5".to_string());
 
@@ -390,15 +407,9 @@ pub async fn handle_spawn_worker(
     // an `agent_profile`, prepend the profile's `system_prompt` to the
     // operator-supplied prompt with `\n\n--- TASK ---\n\n` separator.
     // Untyped spawns / typeless / dangling references → operator prompt
-    // verbatim.
-    let worker_type_for_profile = match &profile_resolution {
-        crate::manifest::actor_type::WorkerProfileResolution::Typed(p) => Some(*p),
-        crate::manifest::actor_type::WorkerProfileResolution::Untyped => None,
-    };
-    let agent_profile = crate::manifest::actor_type::worker_agent_profile(
-        worker_type_for_profile,
-        &state.root.manifest.agent_profiles,
-    );
+    // verbatim. Reuses `worker_agent_profile_for_model` resolved earlier
+    // for the model cascade — they look up the same profile.
+    let agent_profile = worker_agent_profile_for_model;
     let prompt_bg = crate::manifest::resolve::compose_prompt(agent_profile, &args.prompt);
 
     let worker_type_id_bg = resolved_worker_type_id.clone();
@@ -591,17 +602,19 @@ async fn run_worker(
     // though the operator set `[defaults.env]` at the manifest level.
     // Fall back through the root lead (always populated, carries the
     // merged [defaults.env] + [lead.env]) before defaulting to empty.
-    let mut lead_env_for_worker = layer
+    let inherited_lead_env = layer
         .manifest
         .lead
         .as_ref()
         .map(|l| l.env.clone())
         .or_else(|| state.root.manifest.lead.as_ref().map(|l| l.env.clone()))
         .unwrap_or_default();
-    // Merge the agent_profile env (bound via `[[worker_type]].agent_profile`)
-    // on top of the inherited lead env. Profile env wins over inherited
-    // lead env on collision; pitboss defaults (CLAUDE_CODE_ENTRYPOINT,
-    // etc.) still fill any remaining slot inside `compose_sublead_env`.
+    // Env precedence (later wins, mirroring `resolve_lead`):
+    //   profile.env → inherited [defaults.env] + [lead.env]
+    // Start from the profile's env (the role default), then layer the
+    // inherited lead env on top so operator-set vars beat profile defaults.
+    // pitboss defaults (CLAUDE_CODE_ENTRYPOINT, etc.) fill any remaining
+    // slot inside `compose_sublead_env`.
     let agent_profile_env: std::collections::HashMap<String, String> = actor_type
         .as_deref()
         .and_then(|t| {
@@ -616,9 +629,8 @@ async fn run_worker(
         .and_then(|id| state.root.manifest.agent_profiles.get(id))
         .map(|p| p.env.clone())
         .unwrap_or_default();
-    for (k, v) in agent_profile_env {
-        lead_env_for_worker.insert(k, v);
-    }
+    let mut lead_env_for_worker = agent_profile_env;
+    lead_env_for_worker.extend(inherited_lead_env);
     let worker_routing = layer
         .manifest
         .lead
@@ -1139,14 +1151,35 @@ pub async fn spawn_resume_worker(
 
     // Resume path mirrors the initial spawn: inherit the parent lead's
     // resolved env so `[defaults.env]` and `[lead.env]` survive a
-    // pause/continue or reprompt cycle.
-    let lead_env_for_resume = layer
+    // pause/continue or reprompt cycle. ALSO re-merge the agent_profile
+    // env via the resumed worker's `worker_type` → `agent_profile` ref —
+    // without this, every reprompt/continue silently drops profile-bound
+    // env vars (e.g. `PITBOSS_ACTOR_ROLE` from `pitboss/worker-haiku`).
+    // Precedence matches the initial spawn site in `run_worker`:
+    // profile.env first, then inherited lead env on top (operator wins).
+    let inherited_lead_env_for_resume = layer
         .manifest
         .lead
         .as_ref()
         .map(|l| l.env.clone())
         .or_else(|| state.root.manifest.lead.as_ref().map(|l| l.env.clone()))
         .unwrap_or_default();
+    let resume_profile_env: std::collections::HashMap<String, String> = resumed_actor_type
+        .as_deref()
+        .and_then(|t| {
+            state
+                .root
+                .manifest
+                .worker_types
+                .iter()
+                .find(|wt| wt.id == t)
+        })
+        .and_then(|wt| wt.agent_profile.as_deref())
+        .and_then(|id| state.root.manifest.agent_profiles.get(id))
+        .map(|p| p.env.clone())
+        .unwrap_or_default();
+    let mut lead_env_for_resume = resume_profile_env;
+    lead_env_for_resume.extend(inherited_lead_env_for_resume);
     let resume_env = crate::dispatch::sublead::compose_sublead_env(
         &lead_env_for_resume,
         &std::collections::HashMap::new(),
@@ -1293,5 +1326,86 @@ pub(crate) fn initial_estimate_for(model: &str) -> f64 {
         "claude-opus-4-7" => 2.00,
         "claude-sonnet-4-6" => 0.50,
         _ => 0.10, // haiku or unknown
+    }
+}
+
+#[cfg(test)]
+mod worker_spawn_args_tests {
+    //! End-to-end coverage that the prompt composed via `compose_prompt`
+    //! survives intact through `worker_spawn_args` into the `-p` argv
+    //! position. Lives alongside the (`pub(super)`) builder rather than
+    //! in `tests/agent_profile_flows.rs` because the visibility scope
+    //! doesn't reach integration tests.
+
+    use super::worker_spawn_args;
+    use crate::manifest::schema::{AgentProfile, CommunicationMode, PermissionRouting};
+
+    #[test]
+    fn composed_prompt_appears_verbatim_in_p_argv() {
+        let profile = AgentProfile {
+            id: "pitboss/worker-haiku".into(),
+            system_prompt: "WORKER PRELUDE BODY".into(),
+            model: Some("claude-haiku-4-5".into()),
+            env: Default::default(),
+            tools: None,
+        };
+        let composed =
+            crate::manifest::resolve::compose_prompt(Some(&profile), "the operator's task body");
+
+        let argv = worker_spawn_args(
+            &composed,
+            "claude-haiku-4-5",
+            &["Read".to_string()],
+            None,
+            PermissionRouting::PathA, // mcp_config=None forces Path A degrade
+            CommunicationMode::Disabled,
+            &[],
+        );
+
+        // Find the `-p` and assert the next entry is the composed prompt
+        // verbatim (with the prelude + separator + operator body).
+        let p_idx = argv
+            .iter()
+            .position(|a| a == "-p")
+            .expect("argv must include `-p` flag");
+        let p_value = argv
+            .get(p_idx + 1)
+            .expect("argv must have a prompt arg after -p");
+        assert!(
+            p_value.contains("WORKER PRELUDE BODY"),
+            "-p value missing prelude: {p_value:?}"
+        );
+        assert!(
+            p_value.contains("--- TASK ---"),
+            "-p value missing separator: {p_value:?}"
+        );
+        assert!(
+            p_value.contains("the operator's task body"),
+            "-p value missing operator content: {p_value:?}"
+        );
+        assert_eq!(
+            p_value, &composed,
+            "worker_spawn_args must pass the composed prompt through unchanged"
+        );
+        // Only ONE prelude / separator copy makes it into argv.
+        assert_eq!(p_value.matches("--- TASK ---").count(), 1);
+        assert_eq!(p_value.matches("WORKER PRELUDE BODY").count(), 1);
+    }
+
+    #[test]
+    fn untyped_spawn_prompt_passes_through_unchanged() {
+        let composed = crate::manifest::resolve::compose_prompt(None, "raw operator prompt");
+        let argv = worker_spawn_args(
+            &composed,
+            "claude-haiku-4-5",
+            &[],
+            None,
+            PermissionRouting::PathA,
+            CommunicationMode::Disabled,
+            &[],
+        );
+        let p_idx = argv.iter().position(|a| a == "-p").unwrap();
+        assert_eq!(argv[p_idx + 1], "raw operator prompt");
+        assert!(!argv[p_idx + 1].contains("--- TASK ---"));
     }
 }

--- a/crates/pitboss-cli/src/mcp/tools/tests.rs
+++ b/crates/pitboss-cli/src/mcp/tools/tests.rs
@@ -104,6 +104,7 @@ async fn test_state_with_budget(budget: f64) -> Arc<DispatchState> {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();
@@ -868,6 +869,7 @@ async fn completing_test_state_with_budget(budget: Option<f64>) -> Arc<DispatchS
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();
@@ -1727,6 +1729,7 @@ async fn handle_request_approval_auto_approves() {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let script = FakeScript::new().hold_until_signal();
@@ -1828,6 +1831,7 @@ async fn permission_prompt_auto_approves_and_returns_gate_response() {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let script = FakeScript::new().hold_until_signal();
@@ -1950,6 +1954,7 @@ async fn permission_prompt_denies_mcp_tool_outside_server_allowlist() {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let script = FakeScript::new().hold_until_signal();
@@ -2074,6 +2079,7 @@ async fn permission_prompt_admits_mcp_tool_inside_server_allowlist() {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let script = FakeScript::new().hold_until_signal();
@@ -2201,6 +2207,7 @@ async fn mk_plan_state_with_termination_policy(
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let script = FakeScript::new().hold_until_signal();
@@ -3205,6 +3212,7 @@ async fn test_state_with_worker_types_full(
         sublead_types: vec![],
         require_actor_type,
         untyped_actor_policy,
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();
@@ -3238,6 +3246,7 @@ fn extraction_profile() -> crate::manifest::schema::WorkerType {
         tools: vec!["Read".into(), "Glob".into(), "Grep".into()],
         allowed_models: vec!["claude-haiku-4-5".into()],
         max_timeout_secs: Some(900),
+        agent_profile: None,
     }
 }
 

--- a/crates/pitboss-cli/tests/agent_profile_flows.rs
+++ b/crates/pitboss-cli/tests/agent_profile_flows.rs
@@ -1,0 +1,317 @@
+//! End-to-end flows exercising `[[agent_profile]]` resolution and spawn
+//! composition without booting an actual claude subprocess. Verifies that
+//! the prelude / env / model / tools precedence cascade is observable in
+//! the resolved manifest the dispatcher hands to argv builders.
+
+use std::collections::HashMap;
+
+use pitboss_cli::manifest::resolve::{compose_prompt, resolve};
+use pitboss_cli::manifest::schema::{AgentProfile, Manifest};
+
+fn minimal_manifest_with_lead(lead_prompt: &str, lead_profile: Option<&str>) -> String {
+    let profile_line = match lead_profile {
+        Some(id) => format!("agent_profile = \"{id}\"\n"),
+        None => String::new(),
+    };
+    format!(
+        r#"
+[lead]
+id = "test-lead"
+directory = "/tmp"
+prompt = "{lead_prompt}"
+{profile_line}
+"#
+    )
+}
+
+#[test]
+fn builtin_lead_profile_is_prepended_to_lead_prompt() {
+    let toml_src = minimal_manifest_with_lead("plan the test work", Some("pitboss/lead-opus"));
+    let m: Manifest = toml::from_str(&toml_src).expect("parse");
+    let r = resolve(m, None).expect("resolve");
+    let lead = r.lead.expect("lead present");
+
+    // The composed prompt should contain BOTH the built-in lead body and
+    // the operator's prompt, joined by the canonical separator.
+    assert!(
+        lead.prompt.contains("Pitboss **lead**"),
+        "built-in prelude missing from composed prompt:\n{}",
+        lead.prompt
+    );
+    assert!(
+        lead.prompt.contains("--- TASK ---"),
+        "task separator missing:\n{}",
+        lead.prompt
+    );
+    assert!(
+        lead.prompt.contains("plan the test work"),
+        "operator prompt missing from composed prompt:\n{}",
+        lead.prompt
+    );
+
+    // Operator prompt must appear AFTER the separator, not before.
+    let sep = lead.prompt.find("--- TASK ---").unwrap();
+    let op = lead.prompt.find("plan the test work").unwrap();
+    assert!(
+        op > sep,
+        "operator prompt should follow the separator; prompt:\n{}",
+        lead.prompt
+    );
+}
+
+#[test]
+fn unprofiled_lead_prompt_is_unchanged() {
+    let toml_src = minimal_manifest_with_lead("plain prompt", None);
+    let m: Manifest = toml::from_str(&toml_src).expect("parse");
+    let r = resolve(m, None).expect("resolve");
+    let lead = r.lead.expect("lead present");
+    assert_eq!(lead.prompt, "plain prompt");
+    assert!(!lead.prompt.contains("--- TASK ---"));
+}
+
+#[test]
+fn lead_profile_provides_env_default_without_clobbering_operator_env() {
+    // worker-haiku built-in carries PITBOSS_ACTOR_ROLE=worker; if we
+    // use lead-opus, we'll see PITBOSS_ACTOR_ROLE=lead in the env even
+    // though no manifest field set it.
+    let toml_src = minimal_manifest_with_lead("hi", Some("pitboss/lead-opus"));
+    let m: Manifest = toml::from_str(&toml_src).expect("parse");
+    let r = resolve(m, None).expect("resolve");
+    let lead = r.lead.expect("lead present");
+    assert_eq!(
+        lead.env.get("PITBOSS_ACTOR_ROLE").map(String::as_str),
+        Some("lead"),
+        "profile env should populate role env:\n{:#?}",
+        lead.env
+    );
+}
+
+#[test]
+fn manifest_lead_env_overrides_profile_env() {
+    let toml_src = r#"
+[lead]
+id = "x"
+directory = "/tmp"
+prompt = "hi"
+agent_profile = "pitboss/lead-opus"
+env = { PITBOSS_ACTOR_ROLE = "custom-role" }
+"#;
+    let m: Manifest = toml::from_str(toml_src).expect("parse");
+    let r = resolve(m, None).expect("resolve");
+    let lead = r.lead.expect("lead present");
+    assert_eq!(
+        lead.env.get("PITBOSS_ACTOR_ROLE").map(String::as_str),
+        Some("custom-role"),
+        "operator lead env must win over profile default"
+    );
+}
+
+#[test]
+fn manifest_lead_model_overrides_profile_model() {
+    let toml_src = r#"
+[lead]
+id = "x"
+directory = "/tmp"
+prompt = "hi"
+agent_profile = "pitboss/lead-opus"
+model = "claude-haiku-4-5"
+"#;
+    let m: Manifest = toml::from_str(toml_src).expect("parse");
+    let r = resolve(m, None).expect("resolve");
+    let lead = r.lead.expect("lead present");
+    // Operator wins.
+    assert_eq!(lead.model, "claude-haiku-4-5");
+}
+
+#[test]
+fn profile_model_default_takes_effect_when_lead_omits_it() {
+    let toml_src = r#"
+[lead]
+id = "x"
+directory = "/tmp"
+prompt = "hi"
+agent_profile = "pitboss/lead-opus"
+"#;
+    let m: Manifest = toml::from_str(toml_src).expect("parse");
+    let r = resolve(m, None).expect("resolve");
+    let lead = r.lead.expect("lead present");
+    // Default is Sonnet absent a profile; lead-opus profile contributes
+    // the Opus default.
+    assert_eq!(lead.model, "claude-opus-4-7");
+}
+
+#[test]
+fn dangling_lead_profile_reference_fails_resolve() {
+    let toml_src = r#"
+[lead]
+id = "x"
+directory = "/tmp"
+prompt = "hi"
+agent_profile = "this/does-not-exist"
+"#;
+    let m: Manifest = toml::from_str(toml_src).expect("parse");
+    let err = resolve(m, None).unwrap_err().to_string();
+    assert!(
+        err.contains("this/does-not-exist"),
+        "error should name the bad id: {err}"
+    );
+    assert!(err.contains("[lead]"), "error should name the surface");
+}
+
+#[test]
+fn manifest_profile_shadows_builtin_id() {
+    let toml_src = r#"
+[lead]
+id = "x"
+directory = "/tmp"
+prompt = "go"
+agent_profile = "pitboss/lead-opus"
+
+[[agent_profile]]
+id = "pitboss/lead-opus"
+system_prompt = "SHADOWED LEAD"
+model = "claude-sonnet-4-6"
+"#;
+    let m: Manifest = toml::from_str(toml_src).expect("parse");
+    let r = resolve(m, None).expect("resolve");
+    let lead = r.lead.expect("lead present");
+    assert!(
+        lead.prompt.starts_with("SHADOWED LEAD"),
+        "manifest shadow should win:\n{}",
+        lead.prompt
+    );
+    assert_eq!(lead.model, "claude-sonnet-4-6");
+}
+
+#[test]
+fn task_profile_is_prepended_at_resolve_time() {
+    let toml_src = r#"
+[[agent_profile]]
+id = "custom/role"
+system_prompt = "PROFILE BODY"
+model = "claude-haiku-4-5"
+
+[[task]]
+id = "t1"
+directory = "/tmp"
+prompt = "do work"
+agent_profile = "custom/role"
+"#;
+    let m: Manifest = toml::from_str(toml_src).expect("parse");
+    let r = resolve(m, None).expect("resolve");
+    assert_eq!(r.tasks.len(), 1);
+    let t = &r.tasks[0];
+    assert!(t.prompt.contains("PROFILE BODY"), "{}", t.prompt);
+    assert!(t.prompt.contains("--- TASK ---"), "{}", t.prompt);
+    assert!(t.prompt.contains("do work"), "{}", t.prompt);
+    assert_eq!(t.model, "claude-haiku-4-5");
+}
+
+#[test]
+fn duplicate_manifest_profile_id_rejected_at_resolve() {
+    let toml_src = r#"
+[[agent_profile]]
+id = "x/y"
+system_prompt = "first"
+
+[[agent_profile]]
+id = "x/y"
+system_prompt = "second"
+
+[[task]]
+id = "t"
+directory = "/tmp"
+prompt = "go"
+"#;
+    let m: Manifest = toml::from_str(toml_src).expect("parse");
+    let err = resolve(m, None).unwrap_err().to_string();
+    assert!(err.contains("duplicate"), "{err}");
+    assert!(err.contains("x/y"), "{err}");
+}
+
+#[test]
+fn agent_profiles_catalogue_carries_builtins_and_manifest_entries() {
+    let toml_src = r#"
+[[agent_profile]]
+id = "custom/x"
+system_prompt = "x"
+
+[[task]]
+id = "t"
+directory = "/tmp"
+prompt = "go"
+"#;
+    let m: Manifest = toml::from_str(toml_src).expect("parse");
+    let r = resolve(m, None).expect("resolve");
+    // Three built-ins + one manifest entry.
+    assert!(r.agent_profiles.contains_key("pitboss/lead-opus"));
+    assert!(r.agent_profiles.contains_key("pitboss/sublead-sonnet"));
+    assert!(r.agent_profiles.contains_key("pitboss/worker-haiku"));
+    assert!(r.agent_profiles.contains_key("custom/x"));
+    assert_eq!(r.agent_profiles.len(), 4);
+}
+
+#[test]
+fn compose_prompt_helper_passes_through_when_no_profile() {
+    let out = compose_prompt(None, "raw operator content");
+    assert_eq!(out, "raw operator content");
+}
+
+#[test]
+fn compose_prompt_helper_passes_through_when_profile_has_empty_body() {
+    let p = AgentProfile {
+        id: "empty/x".into(),
+        system_prompt: String::new(),
+        model: None,
+        env: HashMap::new(),
+        tools: None,
+    };
+    let out = compose_prompt(Some(&p), "raw");
+    assert_eq!(out, "raw");
+}
+
+#[test]
+fn validate_rejects_pitboss_namespace_squatting() {
+    use pitboss_cli::manifest::validate::validate;
+    let toml_src = r#"
+[[agent_profile]]
+id = "pitboss/not-real"
+system_prompt = "x"
+
+[[task]]
+id = "t"
+directory = "/tmp"
+prompt = "go"
+"#;
+    let m: Manifest = toml::from_str(toml_src).expect("parse");
+    let r = resolve(m, None).expect("resolve");
+    let err = validate(&r).unwrap_err().to_string();
+    assert!(err.contains("pitboss/"), "{err}");
+    assert!(err.contains("reserved"), "{err}");
+}
+
+#[test]
+fn validate_rejects_unknown_worker_type_profile_ref() {
+    use pitboss_cli::manifest::validate::validate_skip_dir_check;
+    let toml_src = r#"
+[run]
+worktree_cleanup = "never"
+
+[[worker_type]]
+id = "extraction"
+tools = ["Read"]
+agent_profile = "does/not-exist"
+
+[lead]
+id = "x"
+directory = "/tmp"
+prompt = "go"
+max_workers = 1
+budget_usd = 1.0
+"#;
+    let m: Manifest = toml::from_str(toml_src).expect("parse");
+    let r = resolve(m, None).expect("resolve");
+    let err = validate_skip_dir_check(&r).unwrap_err().to_string();
+    assert!(err.contains("does/not-exist"), "{err}");
+    assert!(err.contains("worker_type"), "{err}");
+}

--- a/crates/pitboss-cli/tests/agent_profile_flows.rs
+++ b/crates/pitboss-cli/tests/agent_profile_flows.rs
@@ -291,6 +291,98 @@ prompt = "go"
 }
 
 #[test]
+fn resolved_prompt_round_trips_with_exactly_one_prelude() {
+    // Regression guard for the "no double-prepend on resume" invariant.
+    // The resume path reads ResolvedManifest from resolved.json; if a
+    // future refactor were to ALSO re-apply compose_prompt at resume
+    // time, we'd end up with two copies of the prelude and two
+    // `--- TASK ---` separators. Pin the contract: a resolve →
+    // serialize → deserialize round trip on a profile-using manifest
+    // must show exactly ONE prelude and ONE separator.
+    let toml_src = minimal_manifest_with_lead("task body", Some("pitboss/lead-opus"));
+    let m: Manifest = toml::from_str(&toml_src).expect("parse");
+    let r = resolve(m, None).expect("resolve");
+    let prompt_before = r.lead.as_ref().expect("lead").prompt.clone();
+    assert_eq!(prompt_before.matches("--- TASK ---").count(), 1);
+    assert_eq!(prompt_before.matches("Pitboss **lead**").count(), 1);
+
+    let json = serde_json::to_string(&r).expect("serialize");
+    let r2: pitboss_cli::manifest::resolve::ResolvedManifest =
+        serde_json::from_str(&json).expect("deserialize");
+    let prompt_after = r2.lead.expect("lead present after round-trip").prompt;
+    assert_eq!(prompt_before, prompt_after);
+    assert_eq!(
+        prompt_after.matches("--- TASK ---").count(),
+        1,
+        "resume-shaped round trip must not duplicate the TASK separator"
+    );
+    assert_eq!(
+        prompt_after.matches("Pitboss **lead**").count(),
+        1,
+        "resume-shaped round trip must not duplicate the prelude"
+    );
+}
+
+#[test]
+fn defaults_model_beats_profile_model_at_resolve() {
+    // Precedence pin: [defaults].model fills the model slot BEFORE the
+    // profile's default. An operator with a [defaults] block and a
+    // profile reference gets [defaults].model, not the profile's.
+    let toml_src = r#"
+[defaults]
+model = "claude-sonnet-4-6"
+
+[lead]
+id = "x"
+directory = "/tmp"
+prompt = "go"
+agent_profile = "pitboss/lead-opus"
+"#;
+    let m: Manifest = toml::from_str(toml_src).expect("parse");
+    let r = resolve(m, None).expect("resolve");
+    let lead = r.lead.expect("lead present");
+    assert_eq!(
+        lead.model, "claude-sonnet-4-6",
+        "[defaults].model must beat profile.model"
+    );
+}
+
+#[test]
+fn lead_tools_override_profile_tools_at_resolve() {
+    // [lead].tools (explicit) wins over profile.tools (default).
+    let toml_src = r#"
+[lead]
+id = "x"
+directory = "/tmp"
+prompt = "go"
+agent_profile = "pitboss/worker-haiku"
+tools = ["Bash"]
+"#;
+    let m: Manifest = toml::from_str(toml_src).expect("parse");
+    let r = resolve(m, None).expect("resolve");
+    let lead = r.lead.expect("lead present");
+    assert_eq!(lead.tools, vec!["Bash".to_string()]);
+}
+
+#[test]
+fn defaults_tools_beat_profile_tools_when_lead_omits() {
+    let toml_src = r#"
+[defaults]
+tools = ["Read", "Write"]
+
+[lead]
+id = "x"
+directory = "/tmp"
+prompt = "go"
+agent_profile = "pitboss/worker-haiku"
+"#;
+    let m: Manifest = toml::from_str(toml_src).expect("parse");
+    let r = resolve(m, None).expect("resolve");
+    let lead = r.lead.expect("lead present");
+    assert_eq!(lead.tools, vec!["Read".to_string(), "Write".to_string()]);
+}
+
+#[test]
 fn validate_rejects_unknown_worker_type_profile_ref() {
     use pitboss_cli::manifest::validate::validate_skip_dir_check;
     let toml_src = r#"

--- a/crates/pitboss-cli/tests/cancel_cascade_flows.rs
+++ b/crates/pitboss-cli/tests/cancel_cascade_flows.rs
@@ -125,6 +125,7 @@ fn mk_state() -> (TempDir, Arc<DispatchState>) {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/tests/control_flows.rs
+++ b/crates/pitboss-cli/tests/control_flows.rs
@@ -63,6 +63,7 @@ async fn pause_op_writes_events_jsonl() {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -285,6 +286,7 @@ async fn server_emits_monotonic_seqs_on_wire() {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -421,6 +423,7 @@ async fn emit_event_stream_writes_envelopes_to_events_jsonl() {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -528,6 +531,7 @@ async fn emit_event_stream_off_does_not_create_events_jsonl() {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -615,6 +619,7 @@ async fn headless_broadcast_persists_events_jsonl_without_client() {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -731,6 +736,7 @@ async fn block_policy_queue_drains_on_tui_connect() {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -854,6 +860,7 @@ async fn auto_approve_policy_responds_without_tui() {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -924,6 +931,7 @@ async fn auto_reject_policy_responds_without_tui() {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -1005,6 +1013,7 @@ async fn propose_plan_end_to_end_unblocks_spawn_gate() {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -1194,6 +1203,7 @@ async fn subscribe_op_acks_and_keeps_dispatcher_responsive() {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());
@@ -1332,6 +1342,7 @@ async fn make_subscriber_test_state(dir: &TempDir) -> (Arc<DispatchState>, Uuid,
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());

--- a/crates/pitboss-cli/tests/dogfood_fake_flows.rs
+++ b/crates/pitboss-cli/tests/dogfood_fake_flows.rs
@@ -117,6 +117,7 @@ fn mk_state_with_subleads() -> (TempDir, Arc<DispatchState>) {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();
@@ -1051,6 +1052,7 @@ async fn dogfood_envelope_cap_rejection() {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
         let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/tests/e2e_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_flows.rs
@@ -87,6 +87,7 @@ fn mk_state(
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(run_dir.to_path_buf()));
     // Worker-side spawner: emits a complete stream-json run then exits 0.
@@ -402,6 +403,7 @@ async fn e2e_lead_cancels_worker_mid_flight() {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let hold_script = FakeScript::new().hold_until_signal();
@@ -673,6 +675,7 @@ async fn e2e_lead_reprompts_running_worker() {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     // Worker script emits init+result so session_id gets captured via the
@@ -882,6 +885,7 @@ async fn e2e_lead_propose_plan_gate_unblocks_spawn() {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let worker_script = FakeScript::new()
@@ -1193,6 +1197,7 @@ async fn e2e_freeze_pause_and_continue_real_subprocess_worker() {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(FakeClaudeWorkerSpawner {

--- a/crates/pitboss-cli/tests/e2e_sublead_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_sublead_flows.rs
@@ -102,6 +102,7 @@ fn mk_state(dir: &std::path::Path) -> (Uuid, Arc<DispatchState>) {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.to_path_buf()));
     let worker_script = FakeScript::new()
@@ -181,6 +182,7 @@ fn mk_state_hold_workers(dir: &std::path::Path) -> (Uuid, Arc<DispatchState>) {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.to_path_buf()));
     let hold_script = FakeScript::new().hold_until_signal();
@@ -831,6 +833,7 @@ async fn sublead_session_spawns_runs_and_reconciles() {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
 
     let store: std::sync::Arc<dyn pitboss_core::store::SessionStore> = std::sync::Arc::new(

--- a/crates/pitboss-cli/tests/hierarchical_flows.rs
+++ b/crates/pitboss-cli/tests/hierarchical_flows.rs
@@ -78,6 +78,7 @@ fn mk_state() -> (TempDir, Arc<DispatchState>) {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/tests/live_stream_flows.rs
+++ b/crates/pitboss-cli/tests/live_stream_flows.rs
@@ -83,6 +83,7 @@ fn manifest(run_dir: PathBuf) -> ResolvedManifest {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     }
 }
 

--- a/crates/pitboss-cli/tests/notify_flows.rs
+++ b/crates/pitboss-cli/tests/notify_flows.rs
@@ -264,6 +264,7 @@ async fn approval_pending_notification_fires_on_enqueue() {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());

--- a/crates/pitboss-cli/tests/shared_store_flows.rs
+++ b/crates/pitboss-cli/tests/shared_store_flows.rs
@@ -472,6 +472,7 @@ async fn lease_released_when_mcp_connection_drops() {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store_trait: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().into()));
     let run_id = Uuid::now_v7();
@@ -625,6 +626,7 @@ async fn run_global_lease_released_when_mcp_connection_drops() {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store_trait: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().into()));
     let run_id = Uuid::now_v7();

--- a/crates/pitboss-cli/tests/sublead_flows.rs
+++ b/crates/pitboss-cli/tests/sublead_flows.rs
@@ -86,6 +86,7 @@ fn mk_state_with_subleads() -> (TempDir, Arc<DispatchState>) {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();
@@ -164,6 +165,7 @@ fn mk_state_without_subleads() -> (TempDir, Arc<DispatchState>) {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();
@@ -240,6 +242,7 @@ fn mk_state_with_sublead_budget_cap(cap: f64) -> (TempDir, Arc<DispatchState>) {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(dir.path().to_path_buf()));
     let run_id = Uuid::now_v7();
@@ -2018,6 +2021,7 @@ async fn reconcile_terminated_sublead_marks_self_row_done() {
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let sub_layer = Arc::new(pitboss_cli::dispatch::layer::LayerState::new(
         state.root.run_id,
@@ -2132,6 +2136,7 @@ async fn reconcile_terminated_sublead_outcome_to_status_mapping() {
             sublead_types: vec![],
             require_actor_type: false,
             untyped_actor_policy: Default::default(),
+            agent_profiles: ::std::collections::HashMap::new(),
         };
         Arc::new(pitboss_cli::dispatch::layer::LayerState::new(
             state.root.run_id,

--- a/crates/pitboss-web/tests/control_bridge_integration.rs
+++ b/crates/pitboss-web/tests/control_bridge_integration.rs
@@ -91,6 +91,7 @@ async fn make_test_state(runs_dir: &TempDir) -> (Arc<DispatchState>, uuid::Uuid,
         sublead_types: vec![],
         require_actor_type: false,
         untyped_actor_policy: Default::default(),
+        agent_profiles: ::std::collections::HashMap::new(),
     };
     let store: Arc<dyn SessionStore> = Arc::new(JsonFileStore::new(runs_dir.path().to_path_buf()));
     let spawner: Arc<dyn ProcessSpawner> = Arc::new(TokioSpawner::new());

--- a/docs/manifest-map.md
+++ b/docs/manifest-map.md
@@ -192,6 +192,18 @@ Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:938`](../crates/pitbos
 | `id` | text | **yes** | Slug referenced from [[task]].template. | [`../crates/pitboss-cli/src/manifest/schema.rs#L943`](../crates/pitboss-cli/src/manifest/schema.rs#L943) |
 | `prompt` | text (multi-line) | **yes** | Prompt body. Supports {var} placeholders supplied by [[task]].vars. | [`../crates/pitboss-cli/src/manifest/schema.rs#L949`](../crates/pitboss-cli/src/manifest/schema.rs#L949) |
 
+## `[[agent_profile]]` — `AgentProfile`
+
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:732`](../crates/pitboss-cli/src/manifest/schema.rs#L732).
+
+| Field | Type | Required | Help | Source |
+|---|---|---|---|---|
+| `id` | text | **yes** | Unique id referenced from [lead]/[[task]]/[[worker_type]]/[[sublead_type]] .agent_profile. Match: ^[A-Za-z0-9_/-]+$. The pitboss/ namespace is reserved for built-ins. | [`../crates/pitboss-cli/src/manifest/schema.rs#L741`](../crates/pitboss-cli/src/manifest/schema.rs#L741) |
+| `system_prompt` | text (multi-line) | no | Role-shared prelude prepended to the operator's prompt with `\n\n--- TASK ---\n\n` separator. | [`../crates/pitboss-cli/src/manifest/schema.rs#L751`](../crates/pitboss-cli/src/manifest/schema.rs#L751) |
+| `model` | text | no | Default Claude model id when the actor's `model =` is unset. Not a cap — operator config wins. | [`../crates/pitboss-cli/src/manifest/schema.rs#L760`](../crates/pitboss-cli/src/manifest/schema.rs#L760) |
+| `env` | key-value map | no | Env merged between [defaults].env and the per-actor env. Operator wins on collision. | [`../crates/pitboss-cli/src/manifest/schema.rs#L768`](../crates/pitboss-cli/src/manifest/schema.rs#L768) |
+| `tools` | string list | no | Default tool allowlist when the actor's `tools =` is unset. Not a cap — operator config wins. | [`../crates/pitboss-cli/src/manifest/schema.rs#L777`](../crates/pitboss-cli/src/manifest/schema.rs#L777) |
+
 ## `[lifecycle]` — `Lifecycle`
 
 Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:460`](../crates/pitboss-cli/src/manifest/schema.rs#L460).

--- a/docs/manifest-map.md
+++ b/docs/manifest-map.md
@@ -14,185 +14,189 @@ The annotated example lives at [`pitboss.example.toml`](../pitboss.example.toml)
 
 ## `[run]` — `RunConfig`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:524`](../crates/pitboss-cli/src/manifest/schema.rs#L524).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:533`](../crates/pitboss-cli/src/manifest/schema.rs#L533).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `name` | text | no | Human-readable label used to group related runs in the console (e.g. "build-db", "nightly-sync"). When unset, the manifest filename is used as fallback. | [`../crates/pitboss-cli/src/manifest/schema.rs#L535`](../crates/pitboss-cli/src/manifest/schema.rs#L535) |
-| `max_parallel_tasks` | integer | no | Flat-mode concurrency cap for [[task]] runs. Default 4. Overridden by ANTHROPIC_MAX_CONCURRENT. | [`../crates/pitboss-cli/src/manifest/schema.rs#L544`](../crates/pitboss-cli/src/manifest/schema.rs#L544) |
-| `halt_on_failure` | boolean | no | Stop remaining flat-mode tasks on first failure. | [`../crates/pitboss-cli/src/manifest/schema.rs#L551`](../crates/pitboss-cli/src/manifest/schema.rs#L551) |
-| `run_dir` | path | no | Where per-run artifacts land. Default ~/.local/share/pitboss/runs. | [`../crates/pitboss-cli/src/manifest/schema.rs#L557`](../crates/pitboss-cli/src/manifest/schema.rs#L557) |
-| `worktree_cleanup` | enum (`always` \| `on_success` \| `never`) | no | What to do with each worker's git worktree after it finishes. | [`../crates/pitboss-cli/src/manifest/schema.rs#L565`](../crates/pitboss-cli/src/manifest/schema.rs#L565) |
-| `emit_event_stream` | boolean | no | Write a JSONL event stream alongside summary.jsonl. | [`../crates/pitboss-cli/src/manifest/schema.rs#L572`](../crates/pitboss-cli/src/manifest/schema.rs#L572) |
-| `default_approval_policy` | enum (`block` \| `auto_approve` \| `auto_reject`) | no | Default action for request_approval / propose_plan when no rule matches. `auto_approve`/`auto_reject` are unconditional; `block` routes to the operator if attached, else queues. | [`../crates/pitboss-cli/src/manifest/schema.rs#L600`](../crates/pitboss-cli/src/manifest/schema.rs#L600) |
-| `denial_termination_policy` | enum (`adapt` \| `reclassify`) | no | How a denied permission_prompt affects the actor's terminal status. `adapt` (default) keeps the actor's exit code as-is; `reclassify` re-labels clean exits within 30s of a denial as ApprovalRejected. | [`../crates/pitboss-cli/src/manifest/schema.rs#L611`](../crates/pitboss-cli/src/manifest/schema.rs#L611) |
-| `dump_shared_store` | boolean | no | Write shared-store.json into the run directory on finalize. | [`../crates/pitboss-cli/src/manifest/schema.rs#L619`](../crates/pitboss-cli/src/manifest/schema.rs#L619) |
-| `require_plan_approval` | boolean | no | When true, spawn_worker is blocked until propose_plan has been approved. | [`../crates/pitboss-cli/src/manifest/schema.rs#L627`](../crates/pitboss-cli/src/manifest/schema.rs#L627) |
-| `require_actor_type` | boolean | no | When true, every spawn_worker and spawn_sublead call must name a declared [[worker_type]]/[[sublead_type]]. Default false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L638`](../crates/pitboss-cli/src/manifest/schema.rs#L638) |
-| `untyped_actor_policy` | enum (`bridge` \| `block`) | no | Path-B-only behavior for un-typed callers reaching permission_prompt. `bridge` (default) routes to the operator queue; `block` auto-denies via a synthesized empty profile. | [`../crates/pitboss-cli/src/manifest/schema.rs#L655`](../crates/pitboss-cli/src/manifest/schema.rs#L655) |
+| `name` | text | no | Human-readable label used to group related runs in the console (e.g. "build-db", "nightly-sync"). When unset, the manifest filename is used as fallback. | [`../crates/pitboss-cli/src/manifest/schema.rs#L544`](../crates/pitboss-cli/src/manifest/schema.rs#L544) |
+| `max_parallel_tasks` | integer | no | Flat-mode concurrency cap for [[task]] runs. Default 4. Overridden by ANTHROPIC_MAX_CONCURRENT. | [`../crates/pitboss-cli/src/manifest/schema.rs#L553`](../crates/pitboss-cli/src/manifest/schema.rs#L553) |
+| `halt_on_failure` | boolean | no | Stop remaining flat-mode tasks on first failure. | [`../crates/pitboss-cli/src/manifest/schema.rs#L560`](../crates/pitboss-cli/src/manifest/schema.rs#L560) |
+| `run_dir` | path | no | Where per-run artifacts land. Default ~/.local/share/pitboss/runs. | [`../crates/pitboss-cli/src/manifest/schema.rs#L566`](../crates/pitboss-cli/src/manifest/schema.rs#L566) |
+| `worktree_cleanup` | enum (`always` \| `on_success` \| `never`) | no | What to do with each worker's git worktree after it finishes. | [`../crates/pitboss-cli/src/manifest/schema.rs#L574`](../crates/pitboss-cli/src/manifest/schema.rs#L574) |
+| `emit_event_stream` | boolean | no | Write a JSONL event stream alongside summary.jsonl. | [`../crates/pitboss-cli/src/manifest/schema.rs#L581`](../crates/pitboss-cli/src/manifest/schema.rs#L581) |
+| `default_approval_policy` | enum (`block` \| `auto_approve` \| `auto_reject`) | no | Default action for request_approval / propose_plan when no rule matches. `auto_approve`/`auto_reject` are unconditional; `block` routes to the operator if attached, else queues. | [`../crates/pitboss-cli/src/manifest/schema.rs#L609`](../crates/pitboss-cli/src/manifest/schema.rs#L609) |
+| `denial_termination_policy` | enum (`adapt` \| `reclassify`) | no | How a denied permission_prompt affects the actor's terminal status. `adapt` (default) keeps the actor's exit code as-is; `reclassify` re-labels clean exits within 30s of a denial as ApprovalRejected. | [`../crates/pitboss-cli/src/manifest/schema.rs#L620`](../crates/pitboss-cli/src/manifest/schema.rs#L620) |
+| `dump_shared_store` | boolean | no | Write shared-store.json into the run directory on finalize. | [`../crates/pitboss-cli/src/manifest/schema.rs#L628`](../crates/pitboss-cli/src/manifest/schema.rs#L628) |
+| `require_plan_approval` | boolean | no | When true, spawn_worker is blocked until propose_plan has been approved. | [`../crates/pitboss-cli/src/manifest/schema.rs#L636`](../crates/pitboss-cli/src/manifest/schema.rs#L636) |
+| `require_actor_type` | boolean | no | When true, every spawn_worker and spawn_sublead call must name a declared [[worker_type]]/[[sublead_type]]. Default false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L647`](../crates/pitboss-cli/src/manifest/schema.rs#L647) |
+| `untyped_actor_policy` | enum (`bridge` \| `block`) | no | Path-B-only behavior for un-typed callers reaching permission_prompt. `bridge` (default) routes to the operator queue; `block` auto-denies via a synthesized empty profile. | [`../crates/pitboss-cli/src/manifest/schema.rs#L664`](../crates/pitboss-cli/src/manifest/schema.rs#L664) |
 
 ## `[defaults]` — `Defaults`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:793`](../crates/pitboss-cli/src/manifest/schema.rs#L793).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:891`](../crates/pitboss-cli/src/manifest/schema.rs#L891).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `model` | text | no | Claude model id (e.g. claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-7). | [`../crates/pitboss-cli/src/manifest/schema.rs#L798`](../crates/pitboss-cli/src/manifest/schema.rs#L798) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Maps to the claude --effort flag. | [`../crates/pitboss-cli/src/manifest/schema.rs#L804`](../crates/pitboss-cli/src/manifest/schema.rs#L804) |
-| `tools` | string list | no | Allowed tool surface. Pitboss auto-appends its MCP tools for leads and workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L809`](../crates/pitboss-cli/src/manifest/schema.rs#L809) |
-| `timeout_secs` | integer | no | Per-task wall-clock cap. No default (no cap). | [`../crates/pitboss-cli/src/manifest/schema.rs#L814`](../crates/pitboss-cli/src/manifest/schema.rs#L814) |
-| `use_worktree` | boolean | no | Isolate each worker in a git worktree. Default true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L819`](../crates/pitboss-cli/src/manifest/schema.rs#L819) |
-| `env` | key-value map | no | Environment variables passed to the claude subprocess. | [`../crates/pitboss-cli/src/manifest/schema.rs#L825`](../crates/pitboss-cli/src/manifest/schema.rs#L825) |
+| `model` | text | no | Claude model id (e.g. claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-7). | [`../crates/pitboss-cli/src/manifest/schema.rs#L896`](../crates/pitboss-cli/src/manifest/schema.rs#L896) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Maps to the claude --effort flag. | [`../crates/pitboss-cli/src/manifest/schema.rs#L902`](../crates/pitboss-cli/src/manifest/schema.rs#L902) |
+| `tools` | string list | no | Allowed tool surface. Pitboss auto-appends its MCP tools for leads and workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L907`](../crates/pitboss-cli/src/manifest/schema.rs#L907) |
+| `timeout_secs` | integer | no | Per-task wall-clock cap. No default (no cap). | [`../crates/pitboss-cli/src/manifest/schema.rs#L912`](../crates/pitboss-cli/src/manifest/schema.rs#L912) |
+| `use_worktree` | boolean | no | Isolate each worker in a git worktree. Default true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L917`](../crates/pitboss-cli/src/manifest/schema.rs#L917) |
+| `env` | key-value map | no | Environment variables passed to the claude subprocess. | [`../crates/pitboss-cli/src/manifest/schema.rs#L923`](../crates/pitboss-cli/src/manifest/schema.rs#L923) |
 
 ## `[container]` — `ContainerConfig`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:77`](../crates/pitboss-cli/src/manifest/schema.rs#L77).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:78`](../crates/pitboss-cli/src/manifest/schema.rs#L78).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `image` | text | no | Container image reference. Defaults to ghcr.io/sds-mode/pitboss-with-claude:latest. | [`../crates/pitboss-cli/src/manifest/schema.rs#L83`](../crates/pitboss-cli/src/manifest/schema.rs#L83) |
-| `runtime` | enum (`docker` \| `podman` \| `auto`) | no | Container runtime to invoke. "auto" prefers podman. | [`../crates/pitboss-cli/src/manifest/schema.rs#L90`](../crates/pitboss-cli/src/manifest/schema.rs#L90) |
-| `extra_args` | string list | no | Verbatim podman/docker run flags. Use for networking, capabilities, DNS, resources, etc. Example: ["--network=corp-fw", "--dns=10.0.0.53", "--cap-add=NET_ADMIN"]. | [`../crates/pitboss-cli/src/manifest/schema.rs#L101`](../crates/pitboss-cli/src/manifest/schema.rs#L101) |
-| `extra_apt` | string list | no | Debian/Ubuntu packages installed inside the container before pitboss dispatch starts. Adds 30–90s spin-up per dispatch. Example: ["mdbook", "jq"]. | [`../crates/pitboss-cli/src/manifest/schema.rs#L116`](../crates/pitboss-cli/src/manifest/schema.rs#L116) |
-| `workdir` | path | no | cwd inside the container; defaults to the first mount's container path. | [`../crates/pitboss-cli/src/manifest/schema.rs#L137`](../crates/pitboss-cli/src/manifest/schema.rs#L137) |
-| `claude_mount_rw` | boolean | no | Set true to mount the auto-injected ~/.claude as rw (needed for OAuth token refresh). Default false = read-only. | [`../crates/pitboss-cli/src/manifest/schema.rs#L154`](../crates/pitboss-cli/src/manifest/schema.rs#L154) |
+| `image` | text | no | Container image reference. Defaults to ghcr.io/sds-mode/pitboss-with-claude:latest. | [`../crates/pitboss-cli/src/manifest/schema.rs#L84`](../crates/pitboss-cli/src/manifest/schema.rs#L84) |
+| `runtime` | enum (`docker` \| `podman` \| `auto`) | no | Container runtime to invoke. "auto" prefers podman. | [`../crates/pitboss-cli/src/manifest/schema.rs#L91`](../crates/pitboss-cli/src/manifest/schema.rs#L91) |
+| `extra_args` | string list | no | Verbatim podman/docker run flags. Use for networking, capabilities, DNS, resources, etc. Example: ["--network=corp-fw", "--dns=10.0.0.53", "--cap-add=NET_ADMIN"]. | [`../crates/pitboss-cli/src/manifest/schema.rs#L102`](../crates/pitboss-cli/src/manifest/schema.rs#L102) |
+| `extra_apt` | string list | no | Debian/Ubuntu packages installed inside the container before pitboss dispatch starts. Adds 30–90s spin-up per dispatch. Example: ["mdbook", "jq"]. | [`../crates/pitboss-cli/src/manifest/schema.rs#L117`](../crates/pitboss-cli/src/manifest/schema.rs#L117) |
+| `workdir` | path | no | cwd inside the container; defaults to the first mount's container path. | [`../crates/pitboss-cli/src/manifest/schema.rs#L138`](../crates/pitboss-cli/src/manifest/schema.rs#L138) |
+| `claude_mount_rw` | boolean | no | Set true to mount the auto-injected ~/.claude as rw (needed for OAuth token refresh). Default false = read-only. | [`../crates/pitboss-cli/src/manifest/schema.rs#L155`](../crates/pitboss-cli/src/manifest/schema.rs#L155) |
 
 ## `[[container.mount]]` — `MountSpec`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:160`](../crates/pitboss-cli/src/manifest/schema.rs#L160).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:161`](../crates/pitboss-cli/src/manifest/schema.rs#L161).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `host` | path | **yes** | Absolute host path. ~ is expanded. | [`../crates/pitboss-cli/src/manifest/schema.rs#L163`](../crates/pitboss-cli/src/manifest/schema.rs#L163) |
-| `container` | path | **yes** | Absolute path inside the container. | [`../crates/pitboss-cli/src/manifest/schema.rs#L166`](../crates/pitboss-cli/src/manifest/schema.rs#L166) |
-| `readonly` | boolean | no | Mount read-only. | [`../crates/pitboss-cli/src/manifest/schema.rs#L170`](../crates/pitboss-cli/src/manifest/schema.rs#L170) |
+| `host` | path | **yes** | Absolute host path. ~ is expanded. | [`../crates/pitboss-cli/src/manifest/schema.rs#L164`](../crates/pitboss-cli/src/manifest/schema.rs#L164) |
+| `container` | path | **yes** | Absolute path inside the container. | [`../crates/pitboss-cli/src/manifest/schema.rs#L167`](../crates/pitboss-cli/src/manifest/schema.rs#L167) |
+| `readonly` | boolean | no | Mount read-only. | [`../crates/pitboss-cli/src/manifest/schema.rs#L171`](../crates/pitboss-cli/src/manifest/schema.rs#L171) |
 
 ## `[[task]]` — `Task`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:856`](../crates/pitboss-cli/src/manifest/schema.rs#L856).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:954`](../crates/pitboss-cli/src/manifest/schema.rs#L954).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique slug. Alphanumeric + _ + -. Used in logs and worktree names. | [`../crates/pitboss-cli/src/manifest/schema.rs#L861`](../crates/pitboss-cli/src/manifest/schema.rs#L861) |
-| `directory` | path | **yes** | Working directory. Must be inside a git repo if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L866`](../crates/pitboss-cli/src/manifest/schema.rs#L866) |
-| `prompt` | text (multi-line) | no | Prompt body sent to claude via -p. Mutually exclusive with `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L872`](../crates/pitboss-cli/src/manifest/schema.rs#L872) |
-| `template` | text | no | Reference to a [[template]] entry. Mutually exclusive with `prompt`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L877`](../crates/pitboss-cli/src/manifest/schema.rs#L877) |
-| `vars` | key-value map | no | Substitutions for {placeholders} when using `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L883`](../crates/pitboss-cli/src/manifest/schema.rs#L883) |
-| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L888`](../crates/pitboss-cli/src/manifest/schema.rs#L888) |
-| `model` | text | no | Per-task override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L890`](../crates/pitboss-cli/src/manifest/schema.rs#L890) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-task override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L896`](../crates/pitboss-cli/src/manifest/schema.rs#L896) |
-| `tools` | string list | no | Per-task override of [defaults].tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L898`](../crates/pitboss-cli/src/manifest/schema.rs#L898) |
-| `timeout_secs` | integer | no | Per-task wall-clock cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L900`](../crates/pitboss-cli/src/manifest/schema.rs#L900) |
-| `use_worktree` | boolean | no | Per-task override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L905`](../crates/pitboss-cli/src/manifest/schema.rs#L905) |
-| `env` | key-value map | no | Per-task env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L911`](../crates/pitboss-cli/src/manifest/schema.rs#L911) |
+| `id` | text | **yes** | Unique slug. Alphanumeric + _ + -. Used in logs and worktree names. | [`../crates/pitboss-cli/src/manifest/schema.rs#L959`](../crates/pitboss-cli/src/manifest/schema.rs#L959) |
+| `directory` | path | **yes** | Working directory. Must be inside a git repo if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L964`](../crates/pitboss-cli/src/manifest/schema.rs#L964) |
+| `prompt` | text (multi-line) | no | Prompt body sent to claude via -p. Mutually exclusive with `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L970`](../crates/pitboss-cli/src/manifest/schema.rs#L970) |
+| `template` | text | no | Reference to a [[template]] entry. Mutually exclusive with `prompt`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L975`](../crates/pitboss-cli/src/manifest/schema.rs#L975) |
+| `vars` | key-value map | no | Substitutions for {placeholders} when using `template`. | [`../crates/pitboss-cli/src/manifest/schema.rs#L981`](../crates/pitboss-cli/src/manifest/schema.rs#L981) |
+| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L986`](../crates/pitboss-cli/src/manifest/schema.rs#L986) |
+| `model` | text | no | Per-task override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L988`](../crates/pitboss-cli/src/manifest/schema.rs#L988) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-task override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L994`](../crates/pitboss-cli/src/manifest/schema.rs#L994) |
+| `tools` | string list | no | Per-task override of [defaults].tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L996`](../crates/pitboss-cli/src/manifest/schema.rs#L996) |
+| `timeout_secs` | integer | no | Per-task wall-clock cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L998`](../crates/pitboss-cli/src/manifest/schema.rs#L998) |
+| `use_worktree` | boolean | no | Per-task override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1003`](../crates/pitboss-cli/src/manifest/schema.rs#L1003) |
+| `env` | key-value map | no | Per-task env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1009`](../crates/pitboss-cli/src/manifest/schema.rs#L1009) |
+| `agent_profile` | text | no | Reference to an [[agent_profile]].id. The profile's system_prompt is prepended; its env/model/tools defaults fill any slot the task didn't set. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1019`](../crates/pitboss-cli/src/manifest/schema.rs#L1019) |
 
 ## `[lead]` — `Lead`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:921`](../crates/pitboss-cli/src/manifest/schema.rs#L921).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:1029`](../crates/pitboss-cli/src/manifest/schema.rs#L1029).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique slug used as the TUI tile label and in run artifact paths. | [`../crates/pitboss-cli/src/manifest/schema.rs#L928`](../crates/pitboss-cli/src/manifest/schema.rs#L928) |
-| `directory` | path | **yes** | Working directory for the lead's claude subprocess. Must be a git work-tree if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L935`](../crates/pitboss-cli/src/manifest/schema.rs#L935) |
-| `prompt` | text (multi-line) | **yes** | Operator instructions passed to claude via -p. Must appear before any [lead.X] subtable in the source. | [`../crates/pitboss-cli/src/manifest/schema.rs#L947`](../crates/pitboss-cli/src/manifest/schema.rs#L947) |
-| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L955`](../crates/pitboss-cli/src/manifest/schema.rs#L955) |
-| `model` | text | no | Per-lead override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L958`](../crates/pitboss-cli/src/manifest/schema.rs#L958) |
-| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-lead override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L965`](../crates/pitboss-cli/src/manifest/schema.rs#L965) |
-| `tools` | string list | no | Per-lead override of [defaults].tools. Pitboss auto-appends its MCP tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L971`](../crates/pitboss-cli/src/manifest/schema.rs#L971) |
-| `timeout_secs` | integer | no | Per-actor subprocess wall-clock cap (claude --timeout). | [`../crates/pitboss-cli/src/manifest/schema.rs#L977`](../crates/pitboss-cli/src/manifest/schema.rs#L977) |
-| `use_worktree` | boolean | no | Per-lead override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L983`](../crates/pitboss-cli/src/manifest/schema.rs#L983) |
-| `env` | key-value map | no | Per-lead env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L989`](../crates/pitboss-cli/src/manifest/schema.rs#L989) |
-| `max_workers` | integer | no | Hard cap on the lead's concurrent + queued worker pool (1–16). Required when the lead spawns workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L998`](../crates/pitboss-cli/src/manifest/schema.rs#L998) |
-| `budget_usd` | float | no | Soft cap on the run's total spend (workers + lead + sub-leads). spawn_worker fails once total_spent + reserved + next_estimate > budget; the lead is aborted if a reconciled turn drives total_spent past the cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1009`](../crates/pitboss-cli/src/manifest/schema.rs#L1009) |
-| `lead_budget_usd` | float | no | Optional separate cap on lead + sub-lead token spend (orchestration cost). Independent of budget_usd. Lead is aborted when reached. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1019`](../crates/pitboss-cli/src/manifest/schema.rs#L1019) |
-| `lead_timeout_secs` | integer | no | Wall-clock cap on the lead session. Default 3600. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1028`](../crates/pitboss-cli/src/manifest/schema.rs#L1028) |
-| `permission_routing` | enum (`path_a` \| `path_b`) | no | path_b (default) routes claude's per-tool gate through pitboss's permission_prompt MCP tool — layered enforcement (mcp_server tools allowlist, operator policy, typed profile). path_a bypasses claude's gate via --dangerously-skip-permissions and makes pitboss the sole authority. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1046`](../crates/pitboss-cli/src/manifest/schema.rs#L1046) |
-| `allow_subleads` | boolean | no | Expose spawn_sublead to the root lead. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1055`](../crates/pitboss-cli/src/manifest/schema.rs#L1055) |
-| `max_subleads` | integer | no | Hard cap on total live sub-leads under this root. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1062`](../crates/pitboss-cli/src/manifest/schema.rs#L1062) |
-| `max_sublead_budget_usd` | float | no | Cap on the per-sub-lead budget envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1069`](../crates/pitboss-cli/src/manifest/schema.rs#L1069) |
-| `max_total_workers` | integer | no | Cap on total live workers across the entire tree (root + sub-trees). | [`../crates/pitboss-cli/src/manifest/schema.rs#L1077`](../crates/pitboss-cli/src/manifest/schema.rs#L1077) |
+| `id` | text | **yes** | Unique slug used as the TUI tile label and in run artifact paths. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1036`](../crates/pitboss-cli/src/manifest/schema.rs#L1036) |
+| `directory` | path | **yes** | Working directory for the lead's claude subprocess. Must be a git work-tree if use_worktree = true. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1043`](../crates/pitboss-cli/src/manifest/schema.rs#L1043) |
+| `prompt` | text (multi-line) | **yes** | Operator instructions passed to claude via -p. Must appear before any [lead.X] subtable in the source. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1055`](../crates/pitboss-cli/src/manifest/schema.rs#L1055) |
+| `branch` | text | no | Worktree branch name. Auto-generated if omitted. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1063`](../crates/pitboss-cli/src/manifest/schema.rs#L1063) |
+| `model` | text | no | Per-lead override of [defaults].model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1066`](../crates/pitboss-cli/src/manifest/schema.rs#L1066) |
+| `effort` | enum (`low` \| `medium` \| `high` \| `xhigh` \| `max`) | no | Per-lead override of [defaults].effort. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1073`](../crates/pitboss-cli/src/manifest/schema.rs#L1073) |
+| `tools` | string list | no | Per-lead override of [defaults].tools. Pitboss auto-appends its MCP tools. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1079`](../crates/pitboss-cli/src/manifest/schema.rs#L1079) |
+| `timeout_secs` | integer | no | Per-actor subprocess wall-clock cap (claude --timeout). | [`../crates/pitboss-cli/src/manifest/schema.rs#L1085`](../crates/pitboss-cli/src/manifest/schema.rs#L1085) |
+| `use_worktree` | boolean | no | Per-lead override of [defaults].use_worktree. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1091`](../crates/pitboss-cli/src/manifest/schema.rs#L1091) |
+| `env` | key-value map | no | Per-lead env vars merged on top of [defaults].env. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1097`](../crates/pitboss-cli/src/manifest/schema.rs#L1097) |
+| `max_workers` | integer | no | Hard cap on the lead's concurrent + queued worker pool (1–16). Required when the lead spawns workers. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1106`](../crates/pitboss-cli/src/manifest/schema.rs#L1106) |
+| `budget_usd` | float | no | Soft cap on the run's total spend (workers + lead + sub-leads). spawn_worker fails once total_spent + reserved + next_estimate > budget; the lead is aborted if a reconciled turn drives total_spent past the cap. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1117`](../crates/pitboss-cli/src/manifest/schema.rs#L1117) |
+| `lead_budget_usd` | float | no | Optional separate cap on lead + sub-lead token spend (orchestration cost). Independent of budget_usd. Lead is aborted when reached. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1127`](../crates/pitboss-cli/src/manifest/schema.rs#L1127) |
+| `lead_timeout_secs` | integer | no | Wall-clock cap on the lead session. Default 3600. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1136`](../crates/pitboss-cli/src/manifest/schema.rs#L1136) |
+| `permission_routing` | enum (`path_a` \| `path_b`) | no | path_b (default) routes claude's per-tool gate through pitboss's permission_prompt MCP tool — layered enforcement (mcp_server tools allowlist, operator policy, typed profile). path_a bypasses claude's gate via --dangerously-skip-permissions and makes pitboss the sole authority. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1154`](../crates/pitboss-cli/src/manifest/schema.rs#L1154) |
+| `allow_subleads` | boolean | no | Expose spawn_sublead to the root lead. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1163`](../crates/pitboss-cli/src/manifest/schema.rs#L1163) |
+| `max_subleads` | integer | no | Hard cap on total live sub-leads under this root. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1170`](../crates/pitboss-cli/src/manifest/schema.rs#L1170) |
+| `max_sublead_budget_usd` | float | no | Cap on the per-sub-lead budget envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1177`](../crates/pitboss-cli/src/manifest/schema.rs#L1177) |
+| `max_total_workers` | integer | no | Cap on total live workers across the entire tree (root + sub-trees). | [`../crates/pitboss-cli/src/manifest/schema.rs#L1185`](../crates/pitboss-cli/src/manifest/schema.rs#L1185) |
+| `agent_profile` | text | no | Reference to an [[agent_profile]].id. The profile's system_prompt is prepended to [lead].prompt; its env/model/tools defaults fill any slot the lead didn't set. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1195`](../crates/pitboss-cli/src/manifest/schema.rs#L1195) |
 
 ## `[sublead_defaults]` — `SubleadDefaults`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:1084`](../crates/pitboss-cli/src/manifest/schema.rs#L1084).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:1202`](../crates/pitboss-cli/src/manifest/schema.rs#L1202).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `budget_usd` | float | no | Per-sub-lead envelope when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1089`](../crates/pitboss-cli/src/manifest/schema.rs#L1089) |
-| `lead_budget_usd` | float | no | Per-sub-lead cap on the sub-lead's own token spend (orchestration cost), independent of budget_usd. Honored when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1094`](../crates/pitboss-cli/src/manifest/schema.rs#L1094) |
-| `max_workers` | integer | no | Per-sub-lead worker pool when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1099`](../crates/pitboss-cli/src/manifest/schema.rs#L1099) |
-| `lead_timeout_secs` | integer | no | Wall-clock cap for the sub-lead session. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1104`](../crates/pitboss-cli/src/manifest/schema.rs#L1104) |
-| `read_down` | boolean | no | When true, sub-lead shares root's budget + worker pool instead of carving its own envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1110`](../crates/pitboss-cli/src/manifest/schema.rs#L1110) |
+| `budget_usd` | float | no | Per-sub-lead envelope when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1207`](../crates/pitboss-cli/src/manifest/schema.rs#L1207) |
+| `lead_budget_usd` | float | no | Per-sub-lead cap on the sub-lead's own token spend (orchestration cost), independent of budget_usd. Honored when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1212`](../crates/pitboss-cli/src/manifest/schema.rs#L1212) |
+| `max_workers` | integer | no | Per-sub-lead worker pool when read_down = false. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1217`](../crates/pitboss-cli/src/manifest/schema.rs#L1217) |
+| `lead_timeout_secs` | integer | no | Wall-clock cap for the sub-lead session. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1222`](../crates/pitboss-cli/src/manifest/schema.rs#L1222) |
+| `read_down` | boolean | no | When true, sub-lead shares root's budget + worker pool instead of carving its own envelope. | [`../crates/pitboss-cli/src/manifest/schema.rs#L1228`](../crates/pitboss-cli/src/manifest/schema.rs#L1228) |
 
 ## `[[approval_policy]]` — `ApprovalRuleSpec`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:474`](../crates/pitboss-cli/src/manifest/schema.rs#L474).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:483`](../crates/pitboss-cli/src/manifest/schema.rs#L483).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `action` | enum (`auto_approve` \| `auto_reject` \| `block`) | **yes** | Action when this rule matches. | [`../crates/pitboss-cli/src/manifest/schema.rs#L485`](../crates/pitboss-cli/src/manifest/schema.rs#L485) |
+| `action` | enum (`auto_approve` \| `auto_reject` \| `block`) | **yes** | Action when this rule matches. | [`../crates/pitboss-cli/src/manifest/schema.rs#L494`](../crates/pitboss-cli/src/manifest/schema.rs#L494) |
 
 ## `[[mcp_server]]` — `McpServerSpec`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:209`](../crates/pitboss-cli/src/manifest/schema.rs#L209).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:210`](../crates/pitboss-cli/src/manifest/schema.rs#L210).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Key under mcpServers in the generated config. | [`../crates/pitboss-cli/src/manifest/schema.rs#L215`](../crates/pitboss-cli/src/manifest/schema.rs#L215) |
-| `command` | text | **yes** | Executable to launch (e.g. npx, uvx, or an absolute path). | [`../crates/pitboss-cli/src/manifest/schema.rs#L221`](../crates/pitboss-cli/src/manifest/schema.rs#L221) |
-| `args` | string list | no | Arguments passed to the command. | [`../crates/pitboss-cli/src/manifest/schema.rs#L225`](../crates/pitboss-cli/src/manifest/schema.rs#L225) |
-| `env` | key-value map | no | Environment variables injected into the MCP server process. | [`../crates/pitboss-cli/src/manifest/schema.rs#L232`](../crates/pitboss-cli/src/manifest/schema.rs#L232) |
-| `scope` | text | no | Optional injection scope. Form: "type:<id>" — narrows this server to actors spawned under that worker_type/sublead_type. Unset = inject into all actors. | [`../crates/pitboss-cli/src/manifest/schema.rs#L245`](../crates/pitboss-cli/src/manifest/schema.rs#L245) |
-| `tools` | string list | no | Optional per-tool allowlist for this MCP server. Path B: enforced at validate + spawn argv + permission_prompt runtime. Path A: no runtime effect (claude bypasses the permission layer). Unset = no restriction. | [`../crates/pitboss-cli/src/manifest/schema.rs#L278`](../crates/pitboss-cli/src/manifest/schema.rs#L278) |
+| `id` | text | **yes** | Key under mcpServers in the generated config. | [`../crates/pitboss-cli/src/manifest/schema.rs#L216`](../crates/pitboss-cli/src/manifest/schema.rs#L216) |
+| `command` | text | **yes** | Executable to launch (e.g. npx, uvx, or an absolute path). | [`../crates/pitboss-cli/src/manifest/schema.rs#L222`](../crates/pitboss-cli/src/manifest/schema.rs#L222) |
+| `args` | string list | no | Arguments passed to the command. | [`../crates/pitboss-cli/src/manifest/schema.rs#L226`](../crates/pitboss-cli/src/manifest/schema.rs#L226) |
+| `env` | key-value map | no | Environment variables injected into the MCP server process. | [`../crates/pitboss-cli/src/manifest/schema.rs#L233`](../crates/pitboss-cli/src/manifest/schema.rs#L233) |
+| `scope` | text | no | Optional injection scope. Form: "type:<id>" — narrows this server to actors spawned under that worker_type/sublead_type. Unset = inject into all actors. | [`../crates/pitboss-cli/src/manifest/schema.rs#L246`](../crates/pitboss-cli/src/manifest/schema.rs#L246) |
+| `tools` | string list | no | Optional per-tool allowlist for this MCP server. Path B: enforced at validate + spawn argv + permission_prompt runtime. Path A: no runtime effect (claude bypasses the permission layer). Unset = no restriction. | [`../crates/pitboss-cli/src/manifest/schema.rs#L279`](../crates/pitboss-cli/src/manifest/schema.rs#L279) |
 
 ## `[[worker_type]]` — `WorkerType`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:714`](../crates/pitboss-cli/src/manifest/schema.rs#L714).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:790`](../crates/pitboss-cli/src/manifest/schema.rs#L790).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Unique id used in spawn_worker(worker_type = "<id>"). Match: ^[A-Za-z0-9_-]+$. | [`../crates/pitboss-cli/src/manifest/schema.rs#L721`](../crates/pitboss-cli/src/manifest/schema.rs#L721) |
-| `tools` | string list | no | Allowed tool surface for this worker class. Lead's spawn_worker(tools=...) must be a subset; omit means "give me the whole allowlist." | [`../crates/pitboss-cli/src/manifest/schema.rs#L729`](../crates/pitboss-cli/src/manifest/schema.rs#L729) |
-| `allowed_models` | string list | no | When non-empty, spawn_worker(model=...) must be in this list. Empty means any model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L737`](../crates/pitboss-cli/src/manifest/schema.rs#L737) |
-| `max_timeout_secs` | integer | no | Hard cap on spawn_worker(timeout_secs=...). Lead values clamp DOWN; smaller values pass through. | [`../crates/pitboss-cli/src/manifest/schema.rs#L745`](../crates/pitboss-cli/src/manifest/schema.rs#L745) |
+| `id` | text | **yes** | Unique id used in spawn_worker(worker_type = "<id>"). Match: ^[A-Za-z0-9_-]+$. | [`../crates/pitboss-cli/src/manifest/schema.rs#L797`](../crates/pitboss-cli/src/manifest/schema.rs#L797) |
+| `tools` | string list | no | Allowed tool surface for this worker class. Lead's spawn_worker(tools=...) must be a subset; omit means "give me the whole allowlist." | [`../crates/pitboss-cli/src/manifest/schema.rs#L805`](../crates/pitboss-cli/src/manifest/schema.rs#L805) |
+| `allowed_models` | string list | no | When non-empty, spawn_worker(model=...) must be in this list. Empty means any model. | [`../crates/pitboss-cli/src/manifest/schema.rs#L813`](../crates/pitboss-cli/src/manifest/schema.rs#L813) |
+| `max_timeout_secs` | integer | no | Hard cap on spawn_worker(timeout_secs=...). Lead values clamp DOWN; smaller values pass through. | [`../crates/pitboss-cli/src/manifest/schema.rs#L821`](../crates/pitboss-cli/src/manifest/schema.rs#L821) |
+| `agent_profile` | text | no | Reference to an [[agent_profile]].id. Workers spawned under this worker_type inherit the profile's system_prompt prelude + env/model/tools defaults. | [`../crates/pitboss-cli/src/manifest/schema.rs#L832`](../crates/pitboss-cli/src/manifest/schema.rs#L832) |
 
 ## `[[sublead_type]]` — `SubleadType`
-
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:753`](../crates/pitboss-cli/src/manifest/schema.rs#L753).
-
-| Field | Type | Required | Help | Source |
-|---|---|---|---|---|
-| `id` | text | **yes** | Unique id used in spawn_sublead(sublead_type = "<id>"). Match: ^[A-Za-z0-9_-]+$. | [`../crates/pitboss-cli/src/manifest/schema.rs#L760`](../crates/pitboss-cli/src/manifest/schema.rs#L760) |
-| `tools` | string list | no | Allowed tool surface for this sub-lead class. spawn_sublead(tools=...) must be a subset; empty means "give me the whole allowlist." | [`../crates/pitboss-cli/src/manifest/schema.rs#L767`](../crates/pitboss-cli/src/manifest/schema.rs#L767) |
-| `allowed_models` | string list | no | When non-empty, spawn_sublead(model=...) must be in this list. | [`../crates/pitboss-cli/src/manifest/schema.rs#L774`](../crates/pitboss-cli/src/manifest/schema.rs#L774) |
-| `max_timeout_secs` | integer | no | Hard cap on spawn_sublead(lead_timeout_secs=...). Clamps DOWN. | [`../crates/pitboss-cli/src/manifest/schema.rs#L781`](../crates/pitboss-cli/src/manifest/schema.rs#L781) |
-| `max_budget_usd` | float | no | Hard cap on spawn_sublead(budget_usd=...). Clamps DOWN. | [`../crates/pitboss-cli/src/manifest/schema.rs#L788`](../crates/pitboss-cli/src/manifest/schema.rs#L788) |
-
-## `[communication]` — `CommunicationConfig`
-
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:315`](../crates/pitboss-cli/src/manifest/schema.rs#L315).
-
-| Field | Type | Required | Help | Source |
-|---|---|---|---|---|
-| `mode` | enum (`disabled` \| `parent_child`) | no | Actor communication policy mode. "disabled" hides the message_* and artifact_* tools (conservative default). "parent_child" enables them with parent/sublead/worker authz. | [`../crates/pitboss-cli/src/manifest/schema.rs#L322`](../crates/pitboss-cli/src/manifest/schema.rs#L322) |
-| `max_message_bytes` | integer | no | Maximum UTF-8 body size accepted by message_send. | [`../crates/pitboss-cli/src/manifest/schema.rs#L328`](../crates/pitboss-cli/src/manifest/schema.rs#L328) |
-| `max_artifact_bytes` | integer | no | Maximum decoded artifact payload size accepted by artifact_put. | [`../crates/pitboss-cli/src/manifest/schema.rs#L334`](../crates/pitboss-cli/src/manifest/schema.rs#L334) |
-| `max_artifacts_per_actor` | integer | no | Maximum artifacts one actor may publish in a single run. | [`../crates/pitboss-cli/src/manifest/schema.rs#L340`](../crates/pitboss-cli/src/manifest/schema.rs#L340) |
-
-## `[[template]]` — `Template`
 
 Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:840`](../crates/pitboss-cli/src/manifest/schema.rs#L840).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `id` | text | **yes** | Slug referenced from [[task]].template. | [`../crates/pitboss-cli/src/manifest/schema.rs#L845`](../crates/pitboss-cli/src/manifest/schema.rs#L845) |
-| `prompt` | text (multi-line) | **yes** | Prompt body. Supports {var} placeholders supplied by [[task]].vars. | [`../crates/pitboss-cli/src/manifest/schema.rs#L851`](../crates/pitboss-cli/src/manifest/schema.rs#L851) |
+| `id` | text | **yes** | Unique id used in spawn_sublead(sublead_type = "<id>"). Match: ^[A-Za-z0-9_-]+$. | [`../crates/pitboss-cli/src/manifest/schema.rs#L847`](../crates/pitboss-cli/src/manifest/schema.rs#L847) |
+| `tools` | string list | no | Allowed tool surface for this sub-lead class. spawn_sublead(tools=...) must be a subset; empty means "give me the whole allowlist." | [`../crates/pitboss-cli/src/manifest/schema.rs#L854`](../crates/pitboss-cli/src/manifest/schema.rs#L854) |
+| `allowed_models` | string list | no | When non-empty, spawn_sublead(model=...) must be in this list. | [`../crates/pitboss-cli/src/manifest/schema.rs#L861`](../crates/pitboss-cli/src/manifest/schema.rs#L861) |
+| `max_timeout_secs` | integer | no | Hard cap on spawn_sublead(lead_timeout_secs=...). Clamps DOWN. | [`../crates/pitboss-cli/src/manifest/schema.rs#L868`](../crates/pitboss-cli/src/manifest/schema.rs#L868) |
+| `max_budget_usd` | float | no | Hard cap on spawn_sublead(budget_usd=...). Clamps DOWN. | [`../crates/pitboss-cli/src/manifest/schema.rs#L875`](../crates/pitboss-cli/src/manifest/schema.rs#L875) |
+| `agent_profile` | text | no | Reference to an [[agent_profile]].id. Sub-leads spawned under this sublead_type inherit the profile's system_prompt prelude + env/model/tools defaults. | [`../crates/pitboss-cli/src/manifest/schema.rs#L886`](../crates/pitboss-cli/src/manifest/schema.rs#L886) |
 
-## `[lifecycle]` — `Lifecycle`
+## `[communication]` — `CommunicationConfig`
 
-Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:451`](../crates/pitboss-cli/src/manifest/schema.rs#L451).
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:316`](../crates/pitboss-cli/src/manifest/schema.rs#L316).
 
 | Field | Type | Required | Help | Source |
 |---|---|---|---|---|
-| `survive_parent` | boolean | no | Allow this dispatch to outlive its parent process. Requires a notify target. | [`../crates/pitboss-cli/src/manifest/schema.rs#L462`](../crates/pitboss-cli/src/manifest/schema.rs#L462) |
+| `mode` | enum (`disabled` \| `parent_child`) | no | Actor communication policy mode. "disabled" hides the message_* and artifact_* tools (conservative default). "parent_child" enables them with parent/sublead/worker authz. | [`../crates/pitboss-cli/src/manifest/schema.rs#L323`](../crates/pitboss-cli/src/manifest/schema.rs#L323) |
+| `max_message_bytes` | integer | no | Maximum UTF-8 body size accepted by message_send. | [`../crates/pitboss-cli/src/manifest/schema.rs#L329`](../crates/pitboss-cli/src/manifest/schema.rs#L329) |
+| `max_artifact_bytes` | integer | no | Maximum decoded artifact payload size accepted by artifact_put. | [`../crates/pitboss-cli/src/manifest/schema.rs#L335`](../crates/pitboss-cli/src/manifest/schema.rs#L335) |
+| `max_artifacts_per_actor` | integer | no | Maximum artifacts one actor may publish in a single run. | [`../crates/pitboss-cli/src/manifest/schema.rs#L341`](../crates/pitboss-cli/src/manifest/schema.rs#L341) |
+
+## `[[template]]` — `Template`
+
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:938`](../crates/pitboss-cli/src/manifest/schema.rs#L938).
+
+| Field | Type | Required | Help | Source |
+|---|---|---|---|---|
+| `id` | text | **yes** | Slug referenced from [[task]].template. | [`../crates/pitboss-cli/src/manifest/schema.rs#L943`](../crates/pitboss-cli/src/manifest/schema.rs#L943) |
+| `prompt` | text (multi-line) | **yes** | Prompt body. Supports {var} placeholders supplied by [[task]].vars. | [`../crates/pitboss-cli/src/manifest/schema.rs#L949`](../crates/pitboss-cli/src/manifest/schema.rs#L949) |
+
+## `[lifecycle]` — `Lifecycle`
+
+Defined at [`../crates/pitboss-cli/src/manifest/schema.rs:460`](../crates/pitboss-cli/src/manifest/schema.rs#L460).
+
+| Field | Type | Required | Help | Source |
+|---|---|---|---|---|
+| `survive_parent` | boolean | no | Allow this dispatch to outlive its parent process. Requires a notify target. | [`../crates/pitboss-cli/src/manifest/schema.rs#L471`](../crates/pitboss-cli/src/manifest/schema.rs#L471) |
 

--- a/docs/manifest-reference.toml
+++ b/docs/manifest-reference.toml
@@ -141,6 +141,15 @@ prompt = """
   Replace with the actual prompt body.
 """
 
+[[agent_profile]]
+id = "<value>"
+system_prompt = """
+  Replace with the actual prompt body.
+"""
+model = "<value>"
+env = { EXAMPLE_KEY = "value" }
+tools = []
+
 [lifecycle]
 survive_parent = false
 

--- a/docs/manifest-reference.toml
+++ b/docs/manifest-reference.toml
@@ -70,6 +70,7 @@ tools = []
 timeout_secs = 0
 use_worktree = false
 env = { EXAMPLE_KEY = "value" }
+agent_profile = "<value>"
 
 [lead]
 id = "<value>"
@@ -93,6 +94,7 @@ allow_subleads = false
 max_subleads = 0
 max_sublead_budget_usd = 0.0
 max_total_workers = 0
+agent_profile = "<value>"
 
 [sublead_defaults]
 budget_usd = 0.0
@@ -117,6 +119,7 @@ id = "<value>"
 tools = []
 allowed_models = []
 max_timeout_secs = 0
+agent_profile = "<value>"
 
 [[sublead_type]]
 id = "<value>"
@@ -124,6 +127,7 @@ tools = []
 allowed_models = []
 max_timeout_secs = 0
 max_budget_usd = 0.0
+agent_profile = "<value>"
 
 [communication]
 mode = "disabled"


### PR DESCRIPTION
## Summary

Introduces `[[agent_profile]]` — a new manifest section for reusable role profiles that carry prepended system-prompt preludes plus optional model/tools/env defaults. Three built-in profiles ship bundled (`pitboss/lead-opus`, `pitboss/sublead-sonnet`, `pitboss/worker-haiku`), and manifest-declared profiles can shadow them by matching id exactly.

## Key Changes

- **New `AgentProfile` schema** (`schema.rs`): Defines the profile structure with `id`, `system_prompt`, optional `model`/`tools`/`env` fields. Profiles are default-providers (operator config always wins), never overrides.

- **Built-in profile catalog** (`builtin_profiles.rs`): Three markdown files with TOML frontmatter (`lead-opus.md`, `sublead-sonnet.md`, `worker-haiku.md`) embedded at compile time. Each carries role-specific guidance (lead orchestration, sublead sub-tree management, worker publish ceremony).

- **Prompt composition** (`resolve.rs`): New `compose_prompt()` helper prepends profile `system_prompt` to operator prompt with `\n\n--- TASK ---\n\n` separator. Applied at resolve time for `[lead]`/`[[task]]` and at spawn time for `spawn_worker`/`spawn_sublead` MCP calls.

- **Resolve-time validation**: 
  - Duplicate manifest profile ids rejected (would silently shadow in HashMap)
  - Dangling `agent_profile` references on `[lead]`/`[[task]]` fail hard at resolve
  - Effective catalog built as union of built-ins + manifest entries (manifest shadows by id)

- **Validate-time checks** (`validate.rs`):
  - Profile id charset validation: `^[A-Za-z0-9_/-]+$`
  - Namespace enforcement: `pitboss/` prefix reserved for built-ins; manifest may shadow but not introduce novel `pitboss/<other>` ids
  - Worker/sublead type profile references validated against catalog

- **Actor type integration** (`actor_type.rs`): New `worker_agent_profile()` and `sublead_agent_profile()` helpers to look up profiles bound to `[[worker_type]]`/`[[sublead_type]]` via `agent_profile` field.

- **MCP spawn integration** (`spawn.rs`, `sublead.rs`): Worker and sublead spawns now compose prompts using matched actor type's profile (if any).

- **Schema documentation** (`agent_profile_doc.rs`): New renderer for `pitboss schema --format=agent-profiles` listing bundled + manifest profiles in markdown with summary table and per-profile details.

- **CLI enhancement** (`cli.rs`, `main.rs`): `pitboss schema` now accepts optional `--manifest` flag to merge manifest-declared profiles into the agent-profiles output.

## Implementation Details

- **Precedence cascade**: `DEFAULT_*` → `profile` → `[defaults]` → per-actor config (operator always wins)
- **Serialization**: `agent_profiles` HashMap included in `ResolvedManifest` for round-trip through resume
- **Error messages**: Dangling references name the surface (`[lead]`, `[[task]]`, etc.) and the bad id for clarity
- **Deterministic output**: Profile listings ordered (built-ins first in declaration order, then manifest-only alphabetically)

All existing tests updated to include empty `agent_profiles: HashMap::new()` in test state construction.

https://claude.ai/code/session_01S5sRdM9rbQiwvb8qJPfN35