### PR TITLE
fix(container): control-bridge TCP forward for macOS+Podman dispatch

### DIFF
--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -9,12 +9,13 @@
 
 #![allow(dead_code)] // Some fields are set by Phase 2 tasks.
 
+use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::Result;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::net::{UnixListener, UnixStream};
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio::net::{TcpListener, UnixListener};
 use tokio::sync::{oneshot, Mutex};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -23,10 +24,35 @@ use tokio_util::task::TaskTracker;
 use crate::control::protocol::{ClientMode, ControlEvent, ControlOp, EventEnvelope};
 use crate::dispatch::actor::ActorPath;
 
+/// Boxed-trait-object read half of a control connection. Both
+/// `UnixStream::OwnedReadHalf` and `TcpStream::OwnedReadHalf` satisfy
+/// the bound, so `serve_connection` is transport-agnostic. (#474)
+type BoxedReader = Box<dyn AsyncRead + Unpin + Send>;
+
+/// Boxed-trait-object write half of a control connection. See
+/// `BoxedReader`. The wire protocol is line-delimited JSON over an
+/// `AsyncWrite` — neither AF_UNIX peer creds nor SCM_CREDS are used, so
+/// TCP is a drop-in transport. (#474)
+type BoxedWriter = Box<dyn AsyncWrite + Unpin + Send>;
+
+/// Optional knobs for `start_control_server_with_options`. The default
+/// matches the historic signature: AF_UNIX only.
+#[derive(Default, Debug, Clone)]
+pub struct ControlServerOptions {
+    /// When `Some(addr)`, the server also binds a TCP listener at `addr`
+    /// alongside the AF_UNIX socket. Used by `pitboss container-dispatch`
+    /// on macOS+Podman where the in-container UNIX socket can't be
+    /// reached from the host through virtiofs. The host publishes the
+    /// port via `-p` and the dispatcher binds the same port on
+    /// `0.0.0.0:<port>` inside the container. (#474)
+    pub tcp_bind: Option<SocketAddr>,
+}
+
 /// Handle returned from `start_control_server`. Drop terminates the accept loop
 /// and removes the socket file.
 pub struct ControlServerHandle {
     socket_path: PathBuf,
+    tcp_addr: Option<SocketAddr>,
     shutdown_tx: Option<oneshot::Sender<()>>,
     join_handle: Option<JoinHandle<()>>,
     tracker: TaskTracker,
@@ -36,6 +62,14 @@ pub struct ControlServerHandle {
 impl ControlServerHandle {
     pub fn socket_path(&self) -> &Path {
         &self.socket_path
+    }
+
+    /// Bound TCP listener address when the server was started with
+    /// `ControlServerOptions::tcp_bind = Some(_)`. Useful for tests that
+    /// pass `127.0.0.1:0` and need the OS-assigned port. (#474)
+    #[must_use]
+    pub fn tcp_addr(&self) -> Option<SocketAddr> {
+        self.tcp_addr
     }
 }
 
@@ -58,8 +92,38 @@ impl Drop for ControlServerHandle {
 /// `server_version`, `run_id`, `run_kind` are embedded in the hello response.
 /// `state` is currently unused in Phase 1 — it threads the `DispatchState`
 /// reference forward so Phase 2 op handlers can operate on it.
+///
+/// This is a thin wrapper over `start_control_server_with_options` that
+/// preserves the historic AF_UNIX-only behavior. Call the
+/// `_with_options` variant directly when you need a TCP listener arm.
 pub async fn start_control_server(
     socket_path: PathBuf,
+    server_version: String,
+    run_id: String,
+    run_kind: String,
+    state: Arc<crate::dispatch::state::DispatchState>,
+) -> Result<ControlServerHandle> {
+    start_control_server_with_options(
+        socket_path,
+        ControlServerOptions::default(),
+        server_version,
+        run_id,
+        run_kind,
+        state,
+    )
+    .await
+}
+
+/// Start the control server with optional extras (TCP listener arm).
+///
+/// When `options.tcp_bind` is `Some(addr)`, a `TcpListener` is bound at
+/// `addr` and shares the same `serve_connection` handler as the
+/// AF_UNIX listener. Used by `pitboss container-dispatch` on macOS to
+/// expose the control bridge to host-side `pitboss-web` despite the
+/// virtiofs `bind()` constraint on AF_UNIX (#474).
+pub async fn start_control_server_with_options(
+    socket_path: PathBuf,
+    options: ControlServerOptions,
     server_version: String,
     run_id: String,
     run_kind: String,
@@ -68,7 +132,17 @@ pub async fn start_control_server(
     if socket_path.exists() {
         let _ = std::fs::remove_file(&socket_path);
     }
-    let listener = UnixListener::bind(&socket_path)?;
+    let unix_listener = UnixListener::bind(&socket_path)?;
+
+    let tcp_listener = match options.tcp_bind {
+        Some(addr) => Some(TcpListener::bind(addr).await?),
+        None => None,
+    };
+    let tcp_addr = match tcp_listener.as_ref() {
+        Some(l) => l.local_addr().ok(),
+        None => None,
+    };
+
     let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();
 
     let tracker = TaskTracker::new();
@@ -78,41 +152,61 @@ pub async fn start_control_server(
     let state_outer = state;
 
     let join_handle = tokio::spawn(async move {
+        // Both accept arms route into the same per-connection spawn.
+        // We share the spawn helper as a closure so the two arms can't
+        // drift on what context they propagate.
+        let spawn_conn = |read_half: BoxedReader, write_half: BoxedWriter| {
+            let cancel_inner = cancel_outer.clone();
+            let server_version = server_version.clone();
+            let run_id = run_id.clone();
+            let run_kind = run_kind.clone();
+            let state_inner = state_outer.clone();
+            // Workers snapshot is deferred to *after* the client Hello
+            // is received (inside `serve_connection`). Taking it here
+            // would miss any worker that spawned in the window between
+            // accept and Hello arrival, leaving the TUI with stale
+            // tiles until the next broadcast.
+            tracker_outer.spawn(async move {
+                tokio::select! {
+                    _ = cancel_inner.cancelled() => {},
+                    _ = serve_connection(
+                        read_half,
+                        write_half,
+                        server_version,
+                        run_id,
+                        run_kind,
+                        state_inner,
+                    ) => {},
+                }
+            });
+        };
+
         loop {
             tokio::select! {
                 biased;
                 _ = &mut shutdown_rx => break,
                 _ = cancel_outer.cancelled() => break,
-                accept = listener.accept() => {
+                accept = unix_listener.accept() => {
                     match accept {
                         Ok((stream, _addr)) => {
-                            let cancel_inner = cancel_outer.clone();
-                            let server_version = server_version.clone();
-                            let run_id = run_id.clone();
-                            let run_kind = run_kind.clone();
-                            let state_inner = state_outer.clone();
-                            // Workers snapshot is deferred to *after* the
-                            // client Hello is received (inside
-                            // `serve_connection`). Taking it here would
-                            // miss any worker that spawned in the window
-                            // between accept and Hello arrival, leaving
-                            // the TUI with stale tiles until the next
-                            // broadcast.
-                            tracker_outer.spawn(async move {
-                                tokio::select! {
-                                    _ = cancel_inner.cancelled() => {},
-                                    _ = serve_connection(
-                                        stream,
-                                        server_version,
-                                        run_id,
-                                        run_kind,
-                                        state_inner,
-                                    ) => {},
-                                }
-                            });
+                            let (rh, wh) = stream.into_split();
+                            spawn_conn(Box::new(rh), Box::new(wh));
                         }
                         Err(e) => {
-                            tracing::debug!("control accept error: {e}");
+                            tracing::debug!("control accept (unix) error: {e}");
+                        }
+                    }
+                }
+                // Pends forever when no TCP listener is bound, so this
+                // arm reduces to a no-op for AF_UNIX-only callers.
+                Some(accept) = maybe_accept_tcp(tcp_listener.as_ref()) => {
+                    match accept {
+                        Ok((stream, _addr)) => {
+                            let (rh, wh) = stream.into_split();
+                            spawn_conn(Box::new(rh), Box::new(wh));
+                        }
+                        Err(e) => {
+                            tracing::debug!("control accept (tcp) error: {e}");
                         }
                     }
                 }
@@ -122,6 +216,7 @@ pub async fn start_control_server(
 
     Ok(ControlServerHandle {
         socket_path,
+        tcp_addr,
         shutdown_tx: Some(shutdown_tx),
         join_handle: Some(join_handle),
         tracker,
@@ -129,18 +224,35 @@ pub async fn start_control_server(
     })
 }
 
+/// `tokio::select!` arm helper: yield the next TCP accept result when a
+/// listener is bound, or pend forever when it isn't. The `Some(_)`
+/// wrapper lets the select macro pattern-match a present accept while
+/// silently ignoring the absent-listener case.
+async fn maybe_accept_tcp(
+    listener: Option<&TcpListener>,
+) -> Option<std::io::Result<(tokio::net::TcpStream, SocketAddr)>> {
+    match listener {
+        Some(l) => Some(l.accept().await),
+        None => std::future::pending().await,
+    }
+}
+
 /// Serve one client: complete hello handshake, install the control_writer,
 /// drain any queued approvals, then concurrently pump outbound events and read
 /// ops from the client. On disconnect clear the control_writer and abort the
 /// pump task.
+///
+/// The reader and writer halves are passed in pre-split and boxed so this
+/// function is transport-agnostic — the same code serves AF_UNIX and TCP
+/// connections (#474).
 async fn serve_connection(
-    stream: UnixStream,
+    read_half: BoxedReader,
+    write_half: BoxedWriter,
     server_version: String,
     run_id: String,
     run_kind: String,
     state: Arc<crate::dispatch::state::DispatchState>,
 ) {
-    let (read_half, write_half) = stream.into_split();
     let writer = Arc::new(Mutex::new(write_half));
     let mut reader = BufReader::new(read_half).lines();
     // Run-scoped monotonic seq counter for the `EventEnvelope.seq`
@@ -759,7 +871,7 @@ fn wrap_with_seq(
 }
 
 async fn send_event(
-    writer: &Arc<Mutex<tokio::net::unix::OwnedWriteHalf>>,
+    writer: &Arc<Mutex<BoxedWriter>>,
     event_log: &crate::control::event_log::EventLog,
     ev: &ControlEvent,
 ) -> Result<()> {
@@ -807,7 +919,7 @@ async fn try_enqueue_envelope(
 /// `flush()`. PR-G: channel carries envelopes (wrap + persist done at
 /// the broadcast/enqueue site), so the pump just writes.
 async fn send_envelopes_batch(
-    writer: &Arc<Mutex<tokio::net::unix::OwnedWriteHalf>>,
+    writer: &Arc<Mutex<BoxedWriter>>,
     batch: &[EventEnvelope],
 ) -> Result<()> {
     if batch.is_empty() {
@@ -1548,6 +1660,126 @@ mod tests {
                 assert_eq!(run_kind, "flat");
             }
             other => panic!("expected Hello, got {other:?}"),
+        }
+        drop(handle);
+    }
+
+    /// #474: the optional TCP listener arm accepts the same Hello
+    /// handshake as the AF_UNIX path and returns the same `Hello`
+    /// reply. Asserts the bound port is exposed via
+    /// `ControlServerHandle::tcp_addr()` so callers that bind to
+    /// `127.0.0.1:0` can discover the OS-assigned port.
+    #[tokio::test]
+    async fn tcp_hello_handshake_roundtrips() {
+        let dir = TempDir::new().unwrap();
+        let run_id = Uuid::now_v7();
+        let state = mk_state(dir.path(), run_id);
+        let sock = dir.path().join("tcp_hello.sock");
+        let handle = start_control_server_with_options(
+            sock.clone(),
+            ControlServerOptions {
+                tcp_bind: Some("127.0.0.1:0".parse().unwrap()),
+            },
+            "0.4.0".into(),
+            run_id.to_string(),
+            "hierarchical".into(),
+            state,
+        )
+        .await
+        .unwrap();
+        let tcp_addr = handle.tcp_addr().expect("tcp_addr surfaced");
+        assert!(sock.exists(), "unix arm still bound alongside tcp arm");
+
+        let mut stream = tokio::net::TcpStream::connect(tcp_addr).await.unwrap();
+        stream
+            .write_all(b"{\"op\":\"hello\",\"client_version\":\"0.4.0\"}\n")
+            .await
+            .unwrap();
+
+        let (r, _w) = stream.split();
+        let mut lines = BufReader::new(r).lines();
+        let hello_line = lines.next_line().await.unwrap().expect("hello line");
+        let ev: ControlEvent = serde_json::from_str(&hello_line).unwrap();
+        match ev {
+            ControlEvent::Hello {
+                server_version,
+                run_id: rid,
+                run_kind,
+                ..
+            } => {
+                assert_eq!(server_version, "0.4.0");
+                assert_eq!(rid, run_id.to_string());
+                assert_eq!(run_kind, "hierarchical");
+            }
+            other => panic!("expected Hello, got {other:?}"),
+        }
+        drop(handle);
+    }
+
+    /// #474: the AF_UNIX and TCP arms share the same `serve_connection`
+    /// handler. A client that connects over TCP, sends Hello + Pause,
+    /// gets the same OpAcked reply as a UNIX client. Pairs with
+    /// `tcp_hello_handshake_roundtrips` to assert the full op-dispatch
+    /// path works over TCP, not just the Hello reply.
+    #[tokio::test]
+    async fn tcp_pause_op_acks() {
+        let dir = TempDir::new().unwrap();
+        let run_id = Uuid::now_v7();
+        let state = mk_state(dir.path(), run_id);
+        let sock = dir.path().join("tcp_pause.sock");
+        let handle = start_control_server_with_options(
+            sock.clone(),
+            ControlServerOptions {
+                tcp_bind: Some("127.0.0.1:0".parse().unwrap()),
+            },
+            "0.4.0".into(),
+            run_id.to_string(),
+            "hierarchical".into(),
+            state,
+        )
+        .await
+        .unwrap();
+        let tcp_addr = handle.tcp_addr().expect("tcp_addr surfaced");
+
+        let mut stream = tokio::net::TcpStream::connect(tcp_addr).await.unwrap();
+        stream
+            .write_all(b"{\"op\":\"hello\",\"client_version\":\"0.4.0\"}\n")
+            .await
+            .unwrap();
+        stream
+            .write_all(b"{\"op\":\"pause_worker\",\"task_id\":\"nope\"}\n")
+            .await
+            .unwrap();
+
+        let (r, _w) = stream.split();
+        let mut lines = BufReader::new(r).lines();
+        // First line: server Hello.
+        let _hello = lines.next_line().await.unwrap().expect("hello line");
+        // Subsequent lines: scan until we see the reply to `pause_worker`.
+        // The dispatcher may interleave StoreActivity ticks (1s cadence)
+        // before the op reply lands.
+        let reply = loop {
+            let line = tokio::time::timeout(std::time::Duration::from_secs(5), lines.next_line())
+                .await
+                .expect("reply arrives before timeout")
+                .unwrap()
+                .expect("not EOF");
+            let envelope: EventEnvelope = serde_json::from_str(&line).unwrap();
+            match envelope.event {
+                ControlEvent::StoreActivity { .. } | ControlEvent::WorkersSnapshot { .. } => {
+                    continue
+                }
+                other => break other,
+            }
+        };
+        match reply {
+            ControlEvent::OpFailed { op, .. } => {
+                assert_eq!(op, "pause_worker");
+            }
+            ControlEvent::OpAcked { op, .. } => {
+                assert_eq!(op, "pause_worker");
+            }
+            other => panic!("expected OpAcked/OpFailed for pause_worker, got {other:?}"),
         }
         drop(handle);
     }

--- a/crates/pitboss-cli/src/diff.rs
+++ b/crates/pitboss-cli/src/diff.rs
@@ -643,6 +643,7 @@ mod tests {
             claude_version: None,
             started_at,
             env: HashMap::new(),
+            control_tcp_addr: None,
         };
         std::fs::write(
             dir.path().join("meta.json"),

--- a/crates/pitboss-cli/src/dispatch/container.rs
+++ b/crates/pitboss-cli/src/dispatch/container.rs
@@ -264,6 +264,30 @@ fn build_run_args(
     args.push("-w".into());
     args.push(workdir.display().to_string());
 
+    // ── Control-bridge TCP forward (#474) ────────────────────────────────────
+    // `pitboss-web` running on the host can't reach the dispatcher's
+    // in-container AF_UNIX control socket on macOS+Podman (virtiofs's
+    // `bind()` returns EINVAL; the `XDG_RUNTIME_DIR=/tmp` workaround
+    // keeps the socket on container-overlay, which is unreachable from
+    // the host). Auto-publish a host-loopback TCP forward instead: pick
+    // a free 127.0.0.1 port, map it to the same port inside the
+    // container, and tell the dispatcher to bind there via
+    // PITBOSS_CONTROL_TCP_PORT. Harmless on Linux — the UNIX socket
+    // continues to work and pitboss-web only consults the TCP arm when
+    // meta.json's `control_tcp_addr` is populated.
+    if let Some(port) = pick_free_loopback_port() {
+        args.push("-p".into());
+        args.push(format!("127.0.0.1:{port}:{port}"));
+        args.push("-e".into());
+        args.push(format!("PITBOSS_CONTROL_TCP_PORT={port}"));
+    } else {
+        eprintln!(
+            "pitboss container-dispatch: warning: could not allocate a host \
+             loopback port for the control bridge TCP forward; pitboss-web \
+             Live/Graph/controls will be unavailable for this run."
+        );
+    }
+
     // ── Extra operator args ───────────────────────────────────────────────────
     // Defense in depth: `validate_extra_args` is also called from
     // `manifest::validate::validate_container`, but a test or
@@ -330,6 +354,24 @@ fn build_run_args(
     }
 
     Ok(args)
+}
+
+/// Pick an unused TCP port on 127.0.0.1 by asking the kernel for one.
+/// Returns `None` on bind failure (e.g., the loopback interface is
+/// somehow unavailable — should not happen in practice).
+///
+/// There is an inherent TOCTOU race between the listener drop and
+/// podman's `-p` bind on the host side, but the window is short and the
+/// alternative (parsing podman's verbose error output to retry) is much
+/// more complex. If a collision does happen, the run starts but the
+/// control-bridge TCP forward is broken — pitboss-web falls back to the
+/// AF_UNIX path (which on macOS will still be unreachable, but that's a
+/// pre-existing limitation we're trying to fix here, not regress). (#474)
+fn pick_free_loopback_port() -> Option<u16> {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .ok()
+        .and_then(|l| l.local_addr().ok())
+        .map(|a| a.port())
 }
 
 /// Reject `extra_args` entries that defeat the container sandbox or

--- a/crates/pitboss-cli/src/dispatch/entrypoint.rs
+++ b/crates/pitboss-cli/src/dispatch/entrypoint.rs
@@ -96,6 +96,16 @@ pub async fn init_run_state(
     }
 
     let started_at = Utc::now();
+    // PITBOSS_CONTROL_TCP_PORT is injected by `pitboss container-dispatch`
+    // on the host (it allocates a free TCP port and publishes it via
+    // `-p 127.0.0.1:<port>:<port>` + `-e PITBOSS_CONTROL_TCP_PORT=<port>`).
+    // When present, record the host-side dial address in meta.json so
+    // pitboss-web can reach the control bridge on platforms where the
+    // in-container AF_UNIX socket isn't visible from the host (#474).
+    let control_tcp_addr = std::env::var("PITBOSS_CONTROL_TCP_PORT")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(|p| format!("127.0.0.1:{p}"));
     let meta = RunMeta {
         run_id,
         manifest_path: manifest_path.to_path_buf(),
@@ -103,6 +113,7 @@ pub async fn init_run_state(
         claude_version,
         started_at,
         env: Default::default(),
+        control_tcp_addr,
     };
     store.init_run(&meta).await.context("init run")?;
 

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -12,7 +12,7 @@ use pitboss_core::session::CancelToken;
 use pitboss_core::store::{JsonFileStore, RunSummary, SessionStore};
 use uuid::Uuid;
 
-use crate::control::{control_socket_path, server::start_control_server};
+use crate::control::control_socket_path;
 use crate::dispatch::state::DispatchState;
 use crate::manifest::resolve::ResolvedManifest;
 use crate::mcp::{socket_path_for_run, McpServer};
@@ -227,9 +227,22 @@ pub async fn run_hierarchical(
     crate::dispatch::runner::install_approval_ttl_watcher(state.clone());
 
     // Bind the control socket for TUI ↔ dispatcher ops.
+    //
+    // PITBOSS_CONTROL_TCP_PORT is injected by `pitboss container-dispatch`
+    // when running on a platform where the in-container AF_UNIX socket
+    // isn't reachable from the host (macOS+Podman virtiofs). When set,
+    // the dispatcher binds an additional TCP listener at
+    // `0.0.0.0:<port>` so podman's `-p` port-forward gives the host
+    // `pitboss-web` a working dial path. The host-side dial address
+    // (`127.0.0.1:<port>`) lands in `meta.json` via the entrypoint. (#474)
+    let tcp_bind = std::env::var("PITBOSS_CONTROL_TCP_PORT")
+        .ok()
+        .and_then(|p| p.parse::<u16>().ok())
+        .map(|p| std::net::SocketAddr::from(([0, 0, 0, 0], p)));
     let control_sock = control_socket_path(run_id, &run_dir);
-    let _control = start_control_server(
+    let _control = crate::control::server::start_control_server_with_options(
         control_sock,
+        crate::control::server::ControlServerOptions { tcp_bind },
         env!("CARGO_PKG_VERSION").to_string(),
         run_id.to_string(),
         "hierarchical".into(),

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -350,9 +350,15 @@ async fn setup_run_harness(
         notification_router,
         shared_store.clone(),
     ));
+    // PITBOSS_CONTROL_TCP_PORT — see hierarchical.rs for the rationale (#474).
+    let tcp_bind = std::env::var("PITBOSS_CONTROL_TCP_PORT")
+        .ok()
+        .and_then(|p| p.parse::<u16>().ok())
+        .map(|p| std::net::SocketAddr::from(([0, 0, 0, 0], p)));
     let control_sock = crate::control::control_socket_path(init.run_id, &resolved.run_dir);
-    let _control = crate::control::server::start_control_server(
+    let _control = crate::control::server::start_control_server_with_options(
         control_sock,
+        crate::control::server::ControlServerOptions { tcp_bind },
         env!("CARGO_PKG_VERSION").to_string(),
         init.run_id.to_string(),
         "flat".into(),

--- a/crates/pitboss-cli/src/prune.rs
+++ b/crates/pitboss-cli/src/prune.rs
@@ -479,6 +479,7 @@ mod tests {
             claude_version: None,
             started_at: Utc::now(),
             env: HashMap::new(),
+            control_tcp_addr: None,
         };
         let bytes = serde_json::to_vec(&meta).unwrap();
         fs::write(run_dir.join("meta.json"), bytes).unwrap();

--- a/crates/pitboss-cli/tests/e2e_sublead_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_sublead_flows.rs
@@ -848,6 +848,7 @@ async fn sublead_session_spawns_runs_and_reconciles() {
             claude_version: None,
             started_at: chrono::Utc::now(),
             env: Default::default(),
+            control_tcp_addr: None,
         })
         .await
         .expect("init run");

--- a/crates/pitboss-core/src/store/json_file.rs
+++ b/crates/pitboss-core/src/store/json_file.rs
@@ -170,6 +170,7 @@ mod iter_runs_tests {
             claude_version: None,
             started_at: started,
             env: HashMap::new(),
+            control_tcp_addr: None,
         }
     }
 

--- a/crates/pitboss-core/src/store/mod.rs
+++ b/crates/pitboss-core/src/store/mod.rs
@@ -32,6 +32,7 @@ mod integration_tests {
             claude_version: Some("1.0.0".into()),
             started_at: Utc::now(),
             env: HashMap::new(),
+            control_tcp_addr: None,
         }
     }
 

--- a/crates/pitboss-core/src/store/record.rs
+++ b/crates/pitboss-core/src/store/record.rs
@@ -129,6 +129,16 @@ pub struct RunMeta {
     pub claude_version: Option<String>,
     pub started_at: DateTime<Utc>,
     pub env: HashMap<String, String>,
+    /// Host-side dial address of the dispatcher's control bridge when
+    /// it is bound on TCP in addition to the UNIX socket. Populated
+    /// only by `pitboss container-dispatch` on platforms where the
+    /// in-container `AF_UNIX` socket is unreachable from the host
+    /// (e.g., `macOS`+Podman virtiofs). Consumers (`pitboss-web`,
+    /// `pitboss-core::stream::drive_live`) prefer this when present and
+    /// fall back to the `AF_UNIX` path otherwise. Format:
+    /// `"127.0.0.1:<port>"`. (#474)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub control_tcp_addr: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/pitboss-core/src/store/sqlite.rs
+++ b/crates/pitboss-core/src/store/sqlite.rs
@@ -1075,6 +1075,10 @@ fn iter_runs_blocking(guard: &rusqlite::Connection) -> Result<Vec<RunMeta>, Stor
             claude_version,
             started_at,
             env,
+            // control_tcp_addr is a transient runtime hint published by
+            // pitboss container-dispatch to meta.json — not persisted
+            // here. Defaults to None for runs read out of sqlite.
+            control_tcp_addr: None,
         });
     }
     Ok(metas)
@@ -1101,6 +1105,7 @@ mod sqlite_tests {
             claude_version: Some("1.0.0".into()),
             started_at: Utc::now(),
             env: HashMap::new(),
+            control_tcp_addr: None,
         }
     }
 
@@ -1517,6 +1522,7 @@ mod sqlite_tests {
             claude_version: None,
             started_at: Utc::now(),
             env,
+            control_tcp_addr: None,
         };
         store.init_run(&m).await.unwrap();
 

--- a/crates/pitboss-core/src/stream.rs
+++ b/crates/pitboss-core/src/stream.rs
@@ -166,11 +166,18 @@ async fn drive_replay(run_dir: &Path, tx: &mpsc::Sender<RunStreamItem>) -> u64 {
 /// the inner `EventEnvelope.seq` and is preserved verbatim for
 /// consumers that care.
 ///
+/// Transport selection (#474):
+/// - If `meta.json` carries `control_tcp_addr`, dial that TCP address
+///   first. This is the path that container-dispatch runs on macOS use
+///   because the in-container `AF_UNIX` socket isn't reachable from the
+///   host through virtiofs.
+/// - Otherwise, fall back to the historical `AF_UNIX` path resolved via
+///   `resolve_control_socket`.
+///
 /// Returns silently when no socket exists or the socket EOFs — the
 /// caller's stream then ends.
 async fn drive_live(run_dir: &Path, tx: &mpsc::Sender<RunStreamItem>, start_seq: u64) {
-    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-    use tokio::net::UnixStream;
+    use tokio::net::{TcpStream, UnixStream};
 
     // Run-id is the run-dir's basename (uuid). Used both for socket
     // resolution and for the `RunStreamItem.run_id` field on emitted
@@ -188,18 +195,47 @@ async fn drive_live(run_dir: &Path, tx: &mpsc::Sender<RunStreamItem>, start_seq:
     };
     let run_id = Uuid::parse_str(&run_id_str).unwrap_or_else(|_| Uuid::nil());
 
+    if let Some(tcp_addr) = read_control_tcp_addr(run_dir) {
+        match TcpStream::connect(&tcp_addr).await {
+            Ok(stream) => {
+                handshake_and_forward(stream, &run_id_str, run_id, tx, start_seq).await;
+            }
+            Err(e) => {
+                tracing::debug!(run_id = %run_id_str, addr = %tcp_addr, error = %e,
+                                "live transport: tcp connect failed");
+            }
+        }
+        return;
+    }
+
     let Some(sock_path) = resolve_control_socket(&run_id_str, run_dir) else {
         tracing::debug!(run_id = %run_id_str, "live transport: no control socket");
         return;
     };
 
-    let mut stream = match UnixStream::connect(&sock_path).await {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::debug!(run_id = %run_id_str, error = %e, "live transport: connect failed");
-            return;
+    match UnixStream::connect(&sock_path).await {
+        Ok(stream) => {
+            handshake_and_forward(stream, &run_id_str, run_id, tx, start_seq).await;
         }
-    };
+        Err(e) => {
+            tracing::debug!(run_id = %run_id_str, error = %e, "live transport: unix connect failed");
+        }
+    }
+}
+
+/// Perform the subscriber-mode Hello + Subscribe handshake, then loop
+/// forwarding envelopes from the stream until EOF or a send error.
+/// Generic over `S` so the same body serves `AF_UNIX` and TCP streams. (#474)
+async fn handshake_and_forward<S>(
+    mut stream: S,
+    run_id_str: &str,
+    run_id: Uuid,
+    tx: &mpsc::Sender<RunStreamItem>,
+    start_seq: u64,
+) where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
     // Client hello. PR-P of #438: send `"mode":"subscriber"` so the
     // dispatcher skips the writer-slot install — any number of unified-API
@@ -221,10 +257,7 @@ async fn drive_live(run_dir: &Path, tx: &mpsc::Sender<RunStreamItem>, start_seq:
     // full-duplex and the dispatcher processes ops in order, so this
     // doesn't race the server-side Hello reply. `since_seq: 0`
     // requests everything; consumer-side reconciliation in
-    // `ReplayThenLive` dedupes against its disk replay. A future PR can
-    // plumb the actual last-seen dispatcher seq and have the server
-    // fast-forward — today the dispatcher just acks and emits new
-    // envelopes onward.
+    // `ReplayThenLive` dedupes against its disk replay.
     let subscribe = "{\"op\":\"subscribe\",\"since_seq\":0}\n";
     if stream.write_all(subscribe.as_bytes()).await.is_err() {
         return;
@@ -233,7 +266,7 @@ async fn drive_live(run_dir: &Path, tx: &mpsc::Sender<RunStreamItem>, start_seq:
         return;
     }
 
-    let (read_half, _write_half) = stream.into_split();
+    let (read_half, _write_half) = tokio::io::split(stream);
     let mut lines = BufReader::new(read_half).lines();
 
     // Forward envelopes.
@@ -249,11 +282,7 @@ async fn drive_live(run_dir: &Path, tx: &mpsc::Sender<RunStreamItem>, start_seq:
                     Err(e) => {
                         // Server may emit non-envelope replies (OpAcked
                         // for the subscribe op, op-replies for future
-                        // ops). Best-effort: keep parsing. A typed
-                        // EventEnvelope with Value-inner parses any
-                        // valid control event, so a parse failure here
-                        // is genuinely malformed JSON or a non-event
-                        // op-reply — log + continue.
+                        // ops). Best-effort: keep parsing.
                         tracing::debug!(
                             run_id = %run_id_str,
                             error = %e,
@@ -288,6 +317,22 @@ async fn drive_live(run_dir: &Path, tx: &mpsc::Sender<RunStreamItem>, start_seq:
             }
         }
     }
+}
+
+/// Read `meta.json` for the run at `run_dir` and return the optional
+/// `control_tcp_addr` field. Returns `None` when meta.json is missing,
+/// unparseable, or doesn't carry the field. Used by `drive_live` to
+/// decide whether to dial TCP or fall back to `AF_UNIX`. (#474)
+fn read_control_tcp_addr(run_dir: &Path) -> Option<String> {
+    #[derive(serde::Deserialize)]
+    struct MetaTcpOnly {
+        #[serde(default)]
+        control_tcp_addr: Option<String>,
+    }
+    let bytes = std::fs::read(run_dir.join("meta.json")).ok()?;
+    serde_json::from_slice::<MetaTcpOnly>(&bytes)
+        .ok()
+        .and_then(|m| m.control_tcp_addr)
 }
 
 /// Polling interval for [`tail_run_stream`]. The current implementation

--- a/crates/pitboss-web/src/control_bridge.rs
+++ b/crates/pitboss-web/src/control_bridge.rs
@@ -49,13 +49,22 @@ use std::sync::Arc;
 
 use futures_util::StreamExt;
 use pitboss_cli::control::protocol::{ControlOp, EventEnvelope};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::net::unix::OwnedWriteHalf;
-use tokio::net::UnixStream;
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio::net::{TcpStream, UnixStream};
 use tokio::sync::{broadcast, Mutex};
 use tracing::{debug, info, warn};
 
 const CHANNEL_CAPACITY: usize = 256;
+
+/// Boxed-trait-object writer half. The bridge connects to either a
+/// `UnixStream` (host-mode runs) or a `TcpStream` (container-dispatch
+/// runs that publish a control_tcp_addr in meta.json — #474). The split
+/// write halves are different concrete types, so they're boxed at the
+/// boundary into a single `AsyncWrite + Unpin + Send` trait object.
+type BoxedWriter = Box<dyn AsyncWrite + Unpin + Send>;
+
+/// Boxed-trait-object reader half. See `BoxedWriter`.
+type BoxedReader = Box<dyn AsyncRead + Unpin + Send>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum BridgeError {
@@ -76,7 +85,7 @@ pub enum BridgeError {
 #[derive(Clone)]
 struct Entry {
     tx: broadcast::Sender<EventEnvelope>,
-    write: Arc<Mutex<OwnedWriteHalf>>,
+    write: Arc<Mutex<BoxedWriter>>,
 }
 
 #[derive(Clone)]
@@ -143,42 +152,74 @@ impl ControlBridge {
             return Ok(entry.clone());
         }
 
-        // Resolve the socket path. PR-Q preserves the pre-existing
-        // 404-on-cold-runs contract: if neither the XDG path nor the
-        // run-dir fallback exists, return `NotFound` rather than
-        // silently letting `open_run_stream(ReplayThenLive)` replay
-        // disk events.jsonl over the SSE feed — that's the dedicated
-        // Replay tab's job via `/api/runs/:id/events-jsonl`.
-        let socket_path = std::env::var_os("XDG_RUNTIME_DIR")
-            .map(|x| {
-                std::path::PathBuf::from(x)
-                    .join("pitboss")
-                    .join(format!("{run_id}.control.sock"))
-            })
-            .filter(|p| p.exists())
-            .unwrap_or_else(|| self.runs_dir.join(run_id).join("control.sock"));
-        if !socket_path.exists() {
-            return Err(BridgeError::NotFound);
-        }
-
-        // 1. Writer connection: writer-mode Hello, owns the write half.
-        let mut writer_stream = match UnixStream::connect(&socket_path).await {
-            Ok(s) => s,
-            Err(e) if e.kind() == std::io::ErrorKind::ConnectionRefused => {
-                return Err(BridgeError::Dead);
+        // Transport selection (#474):
+        //
+        // 1. If meta.json carries `control_tcp_addr`, dial TCP. This is
+        //    populated by `pitboss container-dispatch` on platforms
+        //    where the in-container AF_UNIX socket isn't visible from
+        //    the host (macOS+Podman virtiofs).
+        // 2. Otherwise, resolve the AF_UNIX socket path (XDG runtime
+        //    dir first, then runs-dir fallback) and dial UnixStream.
+        //
+        // PR-Q preserves the pre-existing 404-on-cold-runs contract for
+        // the AF_UNIX path: if the socket doesn't exist, return
+        // `NotFound` rather than silently letting
+        // `open_run_stream(ReplayThenLive)` replay disk events.jsonl
+        // over the SSE feed — that's the dedicated Replay tab's job via
+        // `/api/runs/:id/events-jsonl`.
+        let tcp_addr = read_control_tcp_addr(&self.runs_dir, run_id);
+        let (writer_read_half, writer_write_half): (BoxedReader, BoxedWriter) = match &tcp_addr {
+            Some(addr) => {
+                let mut stream = match TcpStream::connect(addr).await {
+                    Ok(s) => s,
+                    Err(e) if e.kind() == std::io::ErrorKind::ConnectionRefused => {
+                        return Err(BridgeError::Dead);
+                    }
+                    Err(e) => return Err(BridgeError::Io(e)),
+                };
+                let hello = ControlOp::Hello {
+                    client_version: format!("pitboss-web/{}", env!("CARGO_PKG_VERSION")),
+                    mode: pitboss_cli::control::protocol::ClientMode::default(),
+                };
+                let mut hello_line = serde_json::to_string(&hello)
+                    .map_err(|e| BridgeError::Handshake(e.to_string()))?;
+                hello_line.push('\n');
+                stream.write_all(hello_line.as_bytes()).await?;
+                let (rh, wh) = stream.into_split();
+                (Box::new(rh), Box::new(wh))
             }
-            Err(e) => return Err(BridgeError::Io(e)),
+            None => {
+                let socket_path = std::env::var_os("XDG_RUNTIME_DIR")
+                    .map(|x| {
+                        std::path::PathBuf::from(x)
+                            .join("pitboss")
+                            .join(format!("{run_id}.control.sock"))
+                    })
+                    .filter(|p| p.exists())
+                    .unwrap_or_else(|| self.runs_dir.join(run_id).join("control.sock"));
+                if !socket_path.exists() {
+                    return Err(BridgeError::NotFound);
+                }
+                let mut stream = match UnixStream::connect(&socket_path).await {
+                    Ok(s) => s,
+                    Err(e) if e.kind() == std::io::ErrorKind::ConnectionRefused => {
+                        return Err(BridgeError::Dead);
+                    }
+                    Err(e) => return Err(BridgeError::Io(e)),
+                };
+                let hello = ControlOp::Hello {
+                    client_version: format!("pitboss-web/{}", env!("CARGO_PKG_VERSION")),
+                    mode: pitboss_cli::control::protocol::ClientMode::default(),
+                };
+                let mut hello_line = serde_json::to_string(&hello)
+                    .map_err(|e| BridgeError::Handshake(e.to_string()))?;
+                hello_line.push('\n');
+                stream.write_all(hello_line.as_bytes()).await?;
+                let (rh, wh) = stream.into_split();
+                (Box::new(rh), Box::new(wh))
+            }
         };
-        let hello = ControlOp::Hello {
-            client_version: format!("pitboss-web/{}", env!("CARGO_PKG_VERSION")),
-            mode: pitboss_cli::control::protocol::ClientMode::default(),
-        };
-        let mut hello_line =
-            serde_json::to_string(&hello).map_err(|e| BridgeError::Handshake(e.to_string()))?;
-        hello_line.push('\n');
-        writer_stream.write_all(hello_line.as_bytes()).await?;
 
-        let (writer_read_half, writer_write_half) = writer_stream.into_split();
         let (tx, _initial_rx) = broadcast::channel::<EventEnvelope>(CHANNEL_CAPACITY);
         let entry = Entry {
             tx: tx.clone(),
@@ -271,8 +312,26 @@ impl ControlBridge {
         map.insert(run_id.to_string(), entry.clone());
         info!(
             run_id,
+            transport = if tcp_addr.is_some() { "tcp" } else { "unix" },
             "control bridge connection opened (writer + subscriber pump)"
         );
         Ok(entry)
     }
+}
+
+/// Read `meta.json` for a run and return the optional `control_tcp_addr`.
+/// Returns `None` when meta.json doesn't exist, can't be parsed, or
+/// doesn't carry the field (host-mode runs, or container-dispatch runs
+/// from before #474). The bridge falls back to AF_UNIX in those cases.
+fn read_control_tcp_addr(runs_dir: &std::path::Path, run_id: &str) -> Option<String> {
+    #[derive(serde::Deserialize)]
+    struct MetaTcpOnly {
+        #[serde(default)]
+        control_tcp_addr: Option<String>,
+    }
+    let meta_path = runs_dir.join(run_id).join("meta.json");
+    let bytes = std::fs::read(&meta_path).ok()?;
+    serde_json::from_slice::<MetaTcpOnly>(&bytes)
+        .ok()
+        .and_then(|m| m.control_tcp_addr)
 }


### PR DESCRIPTION
## Summary

Auto-publish a host-loopback TCP forward of the dispatcher's control bridge whenever `pitboss container-dispatch` starts a run, so `pitboss-web` on macOS+Podman can reach it despite virtiofs's `AF_UNIX` limitations. Linux runtime is unchanged.

## Why

On macOS+Podman the in-container `AF_UNIX` control socket is unreachable from the host (virtiofs `bind()` returns `EINVAL`; the `XDG_RUNTIME_DIR=/tmp` workaround keeps the socket on container-overlay). pitboss-web renders an inert run-detail page — stat cards stuck at zero, Live/Graph/controls dark — for the full duration of the run.

## How

- **Host** (`crates/pitboss-cli/src/dispatch/container.rs`): allocate a free `127.0.0.1` port, publish via `-p 127.0.0.1:<n>:<n>` + `PITBOSS_CONTROL_TCP_PORT=<n>` env.
- **Container** (`crates/pitboss-cli/src/control/server.rs`): `start_control_server_with_options` adds an optional `TcpListener` that shares the existing `serve_connection` handler. Boxed-trait-object reader/writer types (`AsyncRead + Unpin + Send` / `AsyncWrite + ...`) let the same handler drive both `AF_UNIX` and TCP transports.
- **meta.json** (`crates/pitboss-core/src/store/record.rs`): new optional `control_tcp_addr` field, `#[serde(default, skip_serializing_if = "Option::is_none")]` — old files parse unchanged. SQLite reader sets it to `None` (transient runtime hint, not persisted).
- **Consumers**: `pitboss-web::control_bridge` and `pitboss-core::stream::drive_live` prefer TCP when meta.json carries the field, fall back to `AF_UNIX` otherwise. `handshake_and_forward<S: AsyncRead + AsyncWrite>` extracted as a generic helper so the same subscriber-mode handshake drives both arms.

## Closes

Closes #474

## Test plan

- [x] `cargo lint` clean (`-D warnings`)
- [x] `cargo tidy` clean
- [x] `cargo test --workspace --features pitboss-core/test-support` — 858 pass; one known macOS-only flake (`continue_worker_from_paused_transitions_running`) passes in isolation and is documented in `CLAUDE.md` as pre-existing
- [ ] Manual: macOS+Podman `pitboss container-dispatch <manifest>`, open `pitboss-web`, verify Live/Graph/controls populate during the run
- [ ] Manual regression: native-host `pitboss dispatch <manifest>`, verify `pitboss-web` behavior unchanged (TCP arm not engaged, AF_UNIX path used)
- [ ] Manual regression: Linux container-dispatch — TCP arm engages but AF_UNIX still works; either transport is fine since both reach pitboss-web

🤖 Generated with [Claude Code](https://claude.com/claude-code)