### PR TITLE
fix(container): auto-inject XDG_RUNTIME_DIR=/tmp on macOS, name virtiofs trap in bind errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -278,6 +278,12 @@ To pre-flight a container-mode manifest without dispatching, use `pitboss valida
 
 Two mounts are always auto-injected: `~/.claude → /home/pitboss/.claude` (OAuth — **read-only by default**; set `[container].claude_mount_rw = true` to allow OAuth token refresh) and the run artifact directory; the manifest itself is injected at `/run/pitboss.toml` read-only.
 
+#### macOS+Podman: auto-injected `XDG_RUNTIME_DIR=/tmp` (#550)
+
+On macOS hosts using Podman, the auto-mounted runs directory is virtiofs-backed and rejects AF_UNIX `bind()` with `EINVAL`. To keep the in-container control + MCP sockets bindable, pitboss auto-injects `-e XDG_RUNTIME_DIR=/tmp` into the `podman run` argv, which redirects the per-run socket paths onto container-overlay `/tmp`. Pairs with the control-bridge TCP forward (#474/#546) so host-side `pitboss-web` still reaches the bridge despite the socket being on container-overlay.
+
+The auto-inject is **suppressed** when the operator already sets the variable via `[container].extra_args` (`-e XDG_RUNTIME_DIR=…`, `--env XDG_RUNTIME_DIR=…`, or the `=`-joined forms) — the operator's value wins and only one `-e` lands in the dispatch audit log. Linux dispatches are unaffected — the operator's systemd-provided `$XDG_RUNTIME_DIR` continues to flow through unchanged.
+
 #### `[[container.copy]]`
 
 Files baked into a derived image at `pitboss container-build` time. Unlike `[[container.mount]]`, these are layered into the image — they're available even when no host bind mount is in place, and they require a build step before `container-dispatch` will run.

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -13,7 +13,7 @@ use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, UnixListener};
 use tokio::sync::{oneshot, Mutex};
@@ -132,10 +132,21 @@ pub async fn start_control_server_with_options(
     if socket_path.exists() {
         let _ = std::fs::remove_file(&socket_path);
     }
-    let unix_listener = UnixListener::bind(&socket_path)?;
+    let unix_listener = UnixListener::bind(&socket_path).with_context(|| {
+        format!(
+            "bind control socket at {} (#550: on macOS+Podman the runs dir is virtiofs-backed, \
+             which rejects AF_UNIX bind() with EINVAL — set [container].extra_args = [\"-e\", \
+             \"XDG_RUNTIME_DIR=/tmp\"] or upgrade to a build where this is auto-injected)",
+            socket_path.display()
+        )
+    })?;
 
     let tcp_listener = match options.tcp_bind {
-        Some(addr) => Some(TcpListener::bind(addr).await?),
+        Some(addr) => Some(
+            TcpListener::bind(addr)
+                .await
+                .with_context(|| format!("bind control TCP listener on {addr}"))?,
+        ),
         None => None,
     };
     let tcp_addr = match tcp_listener.as_ref() {

--- a/crates/pitboss-cli/src/dispatch/container.rs
+++ b/crates/pitboss-cli/src/dispatch/container.rs
@@ -407,6 +407,16 @@ fn pick_free_loopback_port() -> Option<u16> {
 /// auto-inject just lays its default before `extra_args`, and Podman's
 /// "last `-e` wins" semantics ensure a later operator-supplied
 /// `-e XDG_RUNTIME_DIR=...` still overrides at runtime.
+///
+/// The function body is platform-agnostic (pure string parsing) and the
+/// unit tests below run on every platform so the helper's behavior is
+/// validated everywhere. Its only **production** caller lives under
+/// `#[cfg(target_os = "macos")]` in `build_run_args`, so on non-macOS
+/// lib builds the function is dead code from clippy's perspective —
+/// silenced narrowly via `cfg_attr` rather than a blanket
+/// `#[allow(dead_code)]` so a future regression on macOS (no remaining
+/// caller) still fires the warning.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 fn extra_args_overrides_env(extra_args: &[String], key: &str) -> bool {
     let prefix = format!("{key}=");
     let mut iter = extra_args.iter();

--- a/crates/pitboss-cli/src/dispatch/container.rs
+++ b/crates/pitboss-cli/src/dispatch/container.rs
@@ -288,6 +288,30 @@ fn build_run_args(
         );
     }
 
+    // ── macOS+Podman virtiofs AF_UNIX EINVAL workaround (#550) ───────────────
+    // On macOS+Podman the auto-mounted runs dir is virtiofs-backed.
+    // `control_socket_path` (and the per-run MCP socket path) fall back
+    // to `<run_dir>/<run-id>/{control,mcp}.sock` when `$XDG_RUNTIME_DIR`
+    // is unset inside the container — and the `pitboss-with-claude`
+    // image doesn't set it. The fallback path is on virtiofs, where
+    // `bind(AF_UNIX)` returns EINVAL. Redirect XDG_RUNTIME_DIR to
+    // container-overlay `/tmp` so the sockets land somewhere bindable.
+    // The TCP-forward auto-inject above (#474/#546) makes the control
+    // bridge reachable from the host despite the socket being on
+    // container-overlay; the MCP socket only needs to be in-container
+    // reachable so this just works.
+    //
+    // Operator can override by setting `-e XDG_RUNTIME_DIR=...` in
+    // `[container].extra_args` — we skip the auto-inject in that case.
+    // Linux dispatches are untouched (host-Linux operators get their
+    // systemd-provided XDG_RUNTIME_DIR forwarded through the runtime
+    // and don't hit the virtiofs trap).
+    #[cfg(target_os = "macos")]
+    if !extra_args_overrides_env(&container.extra_args, "XDG_RUNTIME_DIR") {
+        args.push("-e".into());
+        args.push("XDG_RUNTIME_DIR=/tmp".into());
+    }
+
     // ── Extra operator args ───────────────────────────────────────────────────
     // Defense in depth: `validate_extra_args` is also called from
     // `manifest::validate::validate_container`, but a test or
@@ -372,6 +396,40 @@ fn pick_free_loopback_port() -> Option<u16> {
         .ok()
         .and_then(|l| l.local_addr().ok())
         .map(|a| a.port())
+}
+
+/// Check whether `extra_args` already sets an env var via the common
+/// `-e KEY=VAL` / `-e KEY` / `--env KEY=VAL` / `--env=KEY=VAL` /
+/// `-e=KEY=VAL` shapes. Used by the macOS+Podman `XDG_RUNTIME_DIR=/tmp`
+/// auto-inject (#550) to honour explicit operator overrides without
+/// emitting a duplicate `-e` in the audit log. Exotic forms (`--env-file`,
+/// env vars set indirectly via wrapper shells) are not recognised — the
+/// auto-inject just lays its default before `extra_args`, and Podman's
+/// "last `-e` wins" semantics ensure a later operator-supplied
+/// `-e XDG_RUNTIME_DIR=...` still overrides at runtime.
+fn extra_args_overrides_env(extra_args: &[String], key: &str) -> bool {
+    let prefix = format!("{key}=");
+    let mut iter = extra_args.iter();
+    while let Some(arg) = iter.next() {
+        // `-e KEY=VAL` / `-e KEY` / `--env KEY=VAL` / `--env KEY`
+        if arg == "-e" || arg == "--env" {
+            if let Some(next) = iter.next() {
+                if next == key || next.starts_with(&prefix) {
+                    return true;
+                }
+            }
+            continue;
+        }
+        // `-e=KEY=VAL` / `--env=KEY=VAL`
+        for joined_prefix in ["-e=", "--env="] {
+            if let Some(rest) = arg.strip_prefix(joined_prefix) {
+                if rest == key || rest.starts_with(&prefix) {
+                    return true;
+                }
+            }
+        }
+    }
+    false
 }
 
 /// Reject `extra_args` entries that defeat the container sandbox or
@@ -1376,5 +1434,179 @@ prompt = "hi"
             cmd.contains("libssl3 g++-12 python3.11 pandoc"),
             "expected joined package list, got: {cmd}"
         );
+    }
+
+    // ── #550: XDG_RUNTIME_DIR=/tmp auto-inject on macOS ───────────────────
+
+    /// Helper: count occurrences of an env `KEY=VAL` (or any value for
+    /// the key) however it was passed — `-e KEY=VAL`, `--env KEY=VAL`,
+    /// `-e=KEY=VAL`, or `--env=KEY=VAL`. Mirrors the shapes recognised
+    /// by `extra_args_overrides_env` so suppression tests can assert
+    /// "exactly one occurrence reached the final argv" no matter which
+    /// form the operator used.
+    fn count_env_inject(args: &[String], key: &str) -> usize {
+        let prefix = format!("{key}=");
+        let mut count = 0usize;
+        let mut i = 0;
+        while i < args.len() {
+            let arg = &args[i];
+            if arg == "-e" || arg == "--env" {
+                if let Some(next) = args.get(i + 1) {
+                    if next == key || next.starts_with(&prefix) {
+                        count += 1;
+                    }
+                }
+                i += 2;
+                continue;
+            }
+            for joined_prefix in ["-e=", "--env="] {
+                if let Some(rest) = arg.strip_prefix(joined_prefix) {
+                    if rest == key || rest.starts_with(&prefix) {
+                        count += 1;
+                    }
+                }
+            }
+            i += 1;
+        }
+        count
+    }
+
+    /// On macOS hosts, `build_run_args` injects `-e XDG_RUNTIME_DIR=/tmp`
+    /// so the in-container AF_UNIX bind for control + MCP sockets lands
+    /// on container-overlay instead of the virtiofs-mounted runs dir.
+    /// Without this, every default macOS+Podman dispatch fails with bare
+    /// `Invalid argument (os error 22)`. (#550)
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_auto_injects_xdg_runtime_dir() {
+        let cfg = ContainerConfig::default();
+        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None).unwrap();
+        assert_eq!(
+            count_env_inject(&args, "XDG_RUNTIME_DIR"),
+            1,
+            "macOS dispatch must inject exactly one XDG_RUNTIME_DIR=/tmp env to dodge \
+             virtiofs+AF_UNIX EINVAL; argv: {args:?}"
+        );
+        // Land in the right shape, not just the right count.
+        let pos = args
+            .iter()
+            .position(|a| a == "XDG_RUNTIME_DIR=/tmp")
+            .expect("XDG_RUNTIME_DIR=/tmp present");
+        assert_eq!(args[pos - 1], "-e", "must be preceded by `-e`");
+    }
+
+    /// On Linux hosts the same path must NOT inject — the operator
+    /// expects their systemd-provided `$XDG_RUNTIME_DIR` to flow
+    /// through, and Linux+Podman doesn't have the virtiofs trap. Forcing
+    /// `/tmp` would shift the socket location and silently break
+    /// host-side observability tools that look at the canonical path.
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn linux_does_not_auto_inject_xdg_runtime_dir() {
+        let cfg = ContainerConfig::default();
+        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None).unwrap();
+        assert_eq!(
+            count_env_inject(&args, "XDG_RUNTIME_DIR"),
+            0,
+            "Linux dispatch must NOT inject XDG_RUNTIME_DIR — operator's environment wins"
+        );
+    }
+
+    /// An operator-supplied `XDG_RUNTIME_DIR` in `extra_args` wins —
+    /// the auto-inject must not append a duplicate. Honours the
+    /// audit-log expectation (one `-e XDG_RUNTIME_DIR=...` in the
+    /// recorded argv) and prevents the audit reader from being
+    /// surprised by a self-inflicted duplicate.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_auto_inject_respects_extra_args_override() {
+        let cfg = ContainerConfig {
+            extra_args: vec!["-e".into(), "XDG_RUNTIME_DIR=/run/custom".into()],
+            ..ContainerConfig::default()
+        };
+        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None).unwrap();
+        assert_eq!(
+            count_env_inject(&args, "XDG_RUNTIME_DIR"),
+            1,
+            "operator override in extra_args must suppress the auto-inject; argv: {args:?}"
+        );
+        // And the surviving value is the operator's, not our default.
+        assert!(
+            args.iter().any(|a| a == "XDG_RUNTIME_DIR=/run/custom"),
+            "operator value must survive: {args:?}"
+        );
+        assert!(
+            !args.iter().any(|a| a == "XDG_RUNTIME_DIR=/tmp"),
+            "default value must not appear: {args:?}"
+        );
+    }
+
+    /// `--env KEY=VAL` (long form) is recognised by the override-detector.
+    /// Same as the `-e` case — must suppress the auto-inject. Pin all
+    /// the shapes the detector handles so a future shrinkage of the
+    /// detector doesn't silently regress override support.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_auto_inject_respects_long_form_env_override() {
+        let cfg = ContainerConfig {
+            extra_args: vec!["--env".into(), "XDG_RUNTIME_DIR=/x".into()],
+            ..ContainerConfig::default()
+        };
+        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None).unwrap();
+        assert_eq!(count_env_inject(&args, "XDG_RUNTIME_DIR"), 1);
+        assert!(args.iter().any(|a| a == "XDG_RUNTIME_DIR=/x"));
+    }
+
+    /// `-e=KEY=VAL` (joined form, less common but legal) — also
+    /// recognised. Some operators write env this way; the auto-inject
+    /// must not duplicate.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_auto_inject_respects_joined_form_env_override() {
+        let cfg = ContainerConfig {
+            extra_args: vec!["-e=XDG_RUNTIME_DIR=/joined".into()],
+            ..ContainerConfig::default()
+        };
+        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None).unwrap();
+        assert!(
+            !args.iter().any(|a| a == "XDG_RUNTIME_DIR=/tmp"),
+            "default must be suppressed by `-e=` joined override: {args:?}"
+        );
+    }
+
+    /// Unit-test the override detector directly so its specific shape
+    /// recognition is verifiable independent of `build_run_args`. The
+    /// caller's invariant: setting a different env var (not the
+    /// target key) does NOT suppress the auto-inject.
+    #[test]
+    fn extra_args_overrides_env_only_matches_the_target_key() {
+        assert!(extra_args_overrides_env(
+            &["-e".into(), "FOO=bar".into()],
+            "FOO"
+        ));
+        assert!(extra_args_overrides_env(
+            &["--env".into(), "FOO=bar".into()],
+            "FOO"
+        ));
+        assert!(extra_args_overrides_env(&["-e=FOO=bar".into()], "FOO"));
+        assert!(extra_args_overrides_env(&["--env=FOO=bar".into()], "FOO"));
+        // Passthrough form: `-e FOO` (value taken from host env)
+        // is also an override — operator clearly cares about this var.
+        assert!(extra_args_overrides_env(
+            &["-e".into(), "FOO".into()],
+            "FOO"
+        ));
+        // Negative: a different key must not match.
+        assert!(!extra_args_overrides_env(
+            &["-e".into(), "OTHER=v".into()],
+            "FOO"
+        ));
+        // Negative: empty extra_args.
+        assert!(!extra_args_overrides_env(&[], "FOO"));
+        // Negative: prefix collision (`FOOBAR` is not `FOO`).
+        assert!(!extra_args_overrides_env(
+            &["-e".into(), "FOOBAR=v".into()],
+            "FOO"
+        ));
     }
 }

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -1,6 +1,6 @@
 //! Lifecycle of the pitboss MCP server (unix socket transport).
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::oneshot;
@@ -1472,7 +1472,14 @@ impl McpServer {
         if socket_path.exists() {
             let _ = std::fs::remove_file(&socket_path);
         }
-        let listener = tokio::net::UnixListener::bind(&socket_path)?;
+        let listener = tokio::net::UnixListener::bind(&socket_path).with_context(|| {
+            format!(
+                "bind MCP socket at {} (#550: on macOS+Podman the runs dir is virtiofs-backed, \
+                 which rejects AF_UNIX bind() with EINVAL — set [container].extra_args = [\"-e\", \
+                 \"XDG_RUNTIME_DIR=/tmp\"] or upgrade to a build where this is auto-injected)",
+                socket_path.display()
+            )
+        })?;
         // Explicit hardening — inherited umask (e.g. 0022) would leave the
         // socket world-readable, letting any local user connect and inject
         // `actor_role: root_lead` in _meta to call spawn_worker / kv_set.


### PR DESCRIPTION
## Summary

- macOS + Podman `pitboss container-dispatch` fails by default with bare \`Invalid argument (os error 22)\` at the lead-spawn boundary — virtiofs rejects AF_UNIX \`bind()\` on the per-run socket paths.
- Auto-inject \`-e XDG_RUNTIME_DIR=/tmp\` into the macOS \`podman run\` argv so the in-container control + MCP sockets land on container-overlay where they can bind.
- Wrap the failing \`bind()\` call sites with context that names the path **and** the macOS+virtiofs cause + workaround, so future regressions / non-default XDG configurations are self-diagnosing.
- Closes #550.

## Why now

Issue #474 (closed by #546) shipped a host-loopback TCP forward of the dispatcher's control bridge so \`pitboss-web\` can reach it despite virtiofs's AF_UNIX limitations. But #546 didn't auto-inject the \`XDG_RUNTIME_DIR\` workaround — so the bind itself still failed on macOS, and the TCP forward was dead code there until this PR. #474's closing note explicitly flagged this as the remaining diagnostic-improvement filing.

## Before vs after

**Before** (every macOS+Podman dispatch with no manual workaround):

\`\`\`
$ pitboss container-dispatch pb_manifests/minimal-hier-container.toml
…
hierarchical dispatch: Invalid argument (os error 22)
\`\`\`

\`summary.jsonl\` empty, no lead log, no task subdir. Operator gets zero signal.

**After** (zero manifest edits):

\`\`\`
$ pitboss container-dispatch pb_manifests/minimal-hier-container.toml
…  # lead actually spawns; summary.jsonl finalizes
\`\`\`

If a future regression *does* take the EINVAL path (custom \`XDG_RUNTIME_DIR\` that happens to also be virtiofs, etc.), the error chain now reads:

\`\`\`
bind control socket at /home/pitboss/.local/share/pitboss/runs/<id>/control.sock
  (#550: on macOS+Podman the runs dir is virtiofs-backed, which rejects AF_UNIX
  bind() with EINVAL — set [container].extra_args = [\"-e\", \"XDG_RUNTIME_DIR=/tmp\"]
  or upgrade to a build where this is auto-injected): Invalid argument (os error 22)
\`\`\`

Path-named, cause-named, fix-named.

## What changed

| File | Change | LoC |
|---|---|---|
| \`crates/pitboss-cli/src/dispatch/container.rs\` | macOS auto-inject in \`build_run_args\`; new \`extra_args_overrides_env\` helper covering 4 env-flag shapes; 6 new unit tests | +232 |
| \`crates/pitboss-cli/src/control/server.rs\` | \`.with_context(...)\` on UnixListener bind + TCP bind | +14, -3 |
| \`crates/pitboss-cli/src/mcp/server.rs\` | \`.with_context(...)\` on MCP UnixListener bind | +9, -2 |
| \`AGENTS.md\` | Document the macOS auto-inject + override path under \`[container]\` | +6 |
| **Total** | | **+261, -5** |

## Design notes

**Scope of the auto-inject** is \`#[cfg(target_os = \"macos\")]\` — compile-time gated on the host where pitboss was built. Linux operators rely on their systemd-provided \`$XDG_RUNTIME_DIR\` flowing through and would be surprised by a global \`/tmp\` override. Linux+Podman has no virtiofs trap, so the inject is unnecessary there. (See test \`linux_does_not_auto_inject_xdg_runtime_dir\`.)

**Operator override** is honoured before the inject lands in the argv. The helper \`extra_args_overrides_env\` recognises 4 shapes (\`-e KEY=V\`, \`-e KEY\`, \`--env KEY=V\`, \`-e=KEY=V\`/\`--env=KEY=V\`) so the operator's value survives without a duplicate \`-e\` in the dispatch-audit log. A direct unit test pins prefix-collision behaviour (\`FOOBAR\` is not a match for \`FOO\`).

**Error context wrapping** is added at two sites (\`control/server.rs:135\`, \`mcp/server.rs:1475\`); both error messages name the path *and* the platform-specific cause. Even after the auto-inject lands, this guards against future regressions where someone overrides \`XDG_RUNTIME_DIR\` to another virtiofs path or hits a yet-unknown bind failure.

**Why not detect virtiofs at runtime instead?** Considered in the issue body; deferred. \`statfs.f_type == VIRTIOFS_MAGIC\` is Linux-only and adds a syscall dependency. The compile-time \`#[cfg]\` gate is simpler, has zero runtime cost, and covers 100% of the observed reproductions.

## Test plan

- [x] \`cargo test -p pitboss-cli --lib dispatch::container\` — 63/63 pass (6 new).
- [x] \`cargo test -p pitboss-cli --lib control::\` — 54/54 pass (control bind context didn't regress connection tests).
- [x] \`cargo test -p pitboss-cli --lib mcp::server\` — 14/14 pass.
- [x] \`cargo test -p pitboss-cli --lib\` — 866/866 pass.
- [x] \`cargo lint\` — clean.
- [x] \`cargo tidy\` — clean.
- [x] **End-to-end**: cargo install --path crates/pitboss-cli → \`pitboss container-dispatch pb_manifests/minimal-hier-container.toml\` (zero manifest edits, no manual workaround) → dispatch reaches lead spawn and writes finalized \`summary.jsonl\`. EINVAL gone.

Closes #550