### PR TITLE
refactor(dispatch): extract WorkerRegistry from LayerState

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -405,7 +405,7 @@ The resolved profile id is persisted to each `TaskRecord.actor_type`, surfaced i
 
 **Phase 1.5 (v0.12, landed):**
 - Per-actor MCP server scoping via `[[mcp_server]].scope = "type:<id>"` — see the `[[mcp_server]]` section above.
-- Resumed workers (`continue_worker` / `reprompt_worker`) preserve `actor_type` on the appended record via the in-memory `worker_actor_types` map populated at spawn.
+- Resumed workers (`continue_worker` / `reprompt_worker`) preserve `actor_type` on the appended record via the in-memory `workers.actor_types` map populated at spawn.
 - Synthesized cancellation records on lead-exit cleanup keep `actor_type` from the same map.
 - SQLite-backed runs round-trip `actor_type` (migration v10 adds the column; both backends are now at parity with `JsonFileStore`).
 

--- a/crates/pitboss-cli/src/communication.rs
+++ b/crates/pitboss-cli/src/communication.rs
@@ -1008,18 +1008,25 @@ async fn worker_parent(
     if let Some(owner) = state.worker_layer_index.read().await.get(actor_id).cloned() {
         return Ok(Some(owner.unwrap_or_else(|| state.root.lead_id.clone())));
     }
-    if state.root.workers.read().await.contains_key(actor_id) {
+    if state
+        .root
+        .workers
+        .states
+        .read()
+        .await
+        .contains_key(actor_id)
+    {
         return Ok(Some(state.root.lead_id.clone()));
     }
     let subleads = state.subleads.read().await;
     for (sublead_id, layer) in subleads.iter() {
-        if layer.workers.read().await.contains_key(actor_id) {
+        if layer.workers.states.read().await.contains_key(actor_id) {
             return Ok(Some(sublead_id.clone()));
         }
     }
     let terminated = state.terminated_sublead_layers.read().await;
     for layer in terminated.iter() {
-        if layer.workers.read().await.contains_key(actor_id) {
+        if layer.workers.states.read().await.contains_key(actor_id) {
             return Ok(Some(layer.lead_id.clone()));
         }
     }
@@ -1030,7 +1037,14 @@ async fn actor_exists(state: &Arc<DispatchState>, actor_id: &str) -> bool {
     if actor_id == state.root.lead_id {
         return true;
     }
-    if state.root.workers.read().await.contains_key(actor_id) {
+    if state
+        .root
+        .workers
+        .states
+        .read()
+        .await
+        .contains_key(actor_id)
+    {
         return true;
     }
     let subleads = state.subleads.read().await;
@@ -1038,13 +1052,13 @@ async fn actor_exists(state: &Arc<DispatchState>, actor_id: &str) -> bool {
         return true;
     }
     for layer in subleads.values() {
-        if layer.workers.read().await.contains_key(actor_id) {
+        if layer.workers.states.read().await.contains_key(actor_id) {
             return true;
         }
     }
     let terminated = state.terminated_sublead_layers.read().await;
     for layer in terminated.iter() {
-        if layer.lead_id == actor_id || layer.workers.read().await.contains_key(actor_id) {
+        if layer.lead_id == actor_id || layer.workers.states.read().await.contains_key(actor_id) {
             return true;
         }
     }
@@ -1103,6 +1117,7 @@ mod tests {
         state
             .root
             .workers
+            .states
             .write()
             .await
             .insert(id.to_string(), WorkerState::Pending);
@@ -1132,6 +1147,7 @@ mod tests {
         ));
         layer
             .workers
+            .states
             .write()
             .await
             .insert(worker.to_string(), WorkerState::Pending);

--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -314,7 +314,7 @@ async fn serve_connection(
     // the previously-observed race where the snapshot was empty but a
     // worker was already registered.
     let workers_names: Vec<String> = {
-        let guard = state.root.workers.read().await;
+        let guard = state.root.workers.states.read().await;
         guard.keys().cloned().collect()
     };
 
@@ -725,14 +725,15 @@ fn is_subscriber_safe_op(op: &ControlOp) -> bool {
 /// fail because of signal cleanup.
 async fn thaw_if_frozen(layer: &Arc<crate::dispatch::layer::LayerState>, task_id: &str) {
     let is_frozen = matches!(
-        layer.workers.read().await.get(task_id),
+        layer.workers.states.read().await.get(task_id),
         Some(crate::dispatch::state::WorkerState::Frozen { .. })
     );
     if !is_frozen {
         return;
     }
     let pid = layer
-        .worker_pids
+        .workers
+        .pids
         .read()
         .await
         .get(task_id)
@@ -767,8 +768,8 @@ async fn collect_layer_workers(
     lead_parent: Option<String>,
     out: &mut Vec<crate::control::protocol::WorkerSnapshotEntry>,
 ) {
-    let workers = layer.workers.read().await;
-    let prompts = layer.worker_prompts.read().await;
+    let workers = layer.workers.states.read().await;
+    let prompts = layer.workers.prompts.read().await;
     let layer_lead_id = layer.lead_id.as_str();
     for (id, w) in workers.iter() {
         let (state_str, started_at, session_id) = match w {
@@ -847,12 +848,12 @@ async fn find_worker_layer(
     state: &Arc<crate::dispatch::state::DispatchState>,
     task_id: &str,
 ) -> Option<Arc<crate::dispatch::layer::LayerState>> {
-    if state.root.workers.read().await.contains_key(task_id) {
+    if state.root.workers.states.read().await.contains_key(task_id) {
         return Some(state.root.clone());
     }
     let subleads = state.subleads.read().await;
     for layer in subleads.values() {
-        if layer.workers.read().await.contains_key(task_id) {
+        if layer.workers.states.read().await.contains_key(task_id) {
             return Some(layer.clone());
         }
     }
@@ -989,7 +990,7 @@ async fn dispatch_op(
         },
         ControlOp::CancelWorker { task_id } => {
             // Search root + all sub-leads for the owning layer (#152 M2).
-            // Pre-fix only consulted state.root.worker_cancels and so
+            // Pre-fix only consulted state.root.workers.cancels and so
             // returned "unknown task_id" for any sub-lead-owned worker.
             let Some(layer) = find_worker_layer(state, &task_id).await else {
                 return ControlEvent::OpFailed {
@@ -1003,7 +1004,7 @@ async fn dispatch_op(
             // deliverable — a stopped process can't drain signals until
             // it's running again. Harmless for non-frozen workers.
             thaw_if_frozen(&layer, &task_id).await;
-            let cancels = layer.worker_cancels.read().await;
+            let cancels = layer.workers.cancels.read().await;
             if let Some(tok) = cancels.get(&task_id) {
                 // #475: name the kill site so the resulting TaskRecord
                 // surfaces "killed by operator request" rather than bare
@@ -1016,7 +1017,7 @@ async fn dispatch_op(
                     task_id: Some(task_id),
                 }
             } else {
-                // Layer's workers map had the entry but worker_cancels
+                // Layer's workers map had the entry but workers.cancels
                 // didn't — a transient state during spawn or completion.
                 ControlEvent::OpFailed {
                     op: "cancel_worker".into(),
@@ -1028,12 +1029,12 @@ async fn dispatch_op(
         ControlOp::CancelRun => {
             // Cascade cancel across the whole dispatch tree:
             //   root lead   → state.root.cancel           (terminal)
-            //   root workers → state.root.worker_cancels  (per-worker tokens)
+            //   root workers → state.root.workers.cancels  (per-worker tokens)
             //   sub-leads   → sub_layer.cancel       (bridged to the
             //                                          sub-lead's claude
             //                                          proc_cancel at
             //                                          sublead.rs:566)
-            //   sub-lead-owned workers → sub_layer.worker_cancels
+            //   sub-lead-owned workers → sub_layer.workers.cancels
             //
             // First phase: DRAIN the root cancel. This flips
             // `state.root.cancel.is_draining()` to true, which
@@ -1050,8 +1051,8 @@ async fn dispatch_op(
             // can't act on a cancel token until SIGCONT'd. Mirrors the
             // CancelWorker handler's behavior; now cascades to all layers.
             {
-                let pids = state.root.worker_pids.read().await;
-                let workers = state.root.workers.read().await;
+                let pids = state.root.workers.pids.read().await;
+                let workers = state.root.workers.states.read().await;
                 for (id, w) in workers.iter() {
                     if matches!(w, crate::dispatch::state::WorkerState::Frozen { .. }) {
                         let pid = pids
@@ -1066,7 +1067,7 @@ async fn dispatch_op(
                 drop(workers);
                 let subleads = state.subleads.read().await;
                 for sub_layer in subleads.values() {
-                    let sub_workers = sub_layer.workers.read().await;
+                    let sub_workers = sub_layer.workers.states.read().await;
                     for (id, w) in sub_workers.iter() {
                         if matches!(w, crate::dispatch::state::WorkerState::Frozen { .. }) {
                             let pid = pids
@@ -1091,7 +1092,7 @@ async fn dispatch_op(
 
             // Root-layer worker tokens.
             {
-                let cancels = state.root.worker_cancels.read().await;
+                let cancels = state.root.workers.cancels.read().await;
                 for tok in cancels.values() {
                     tok.terminate_with_reason(cancel_run_reason());
                 }
@@ -1101,13 +1102,13 @@ async fn dispatch_op(
             // Terminating sub_layer.cancel cascades to the sub-lead's
             // claude subprocess (via the tree_cancel → proc_cancel bridge
             // installed in sublead.rs:566). We also explicitly iterate
-            // the sub-lead's worker_cancels because those workers have
+            // the sub-lead's workers.cancels because those workers have
             // their own sibling tokens that aren't bridged to the
             // sub-lead's cancel.
             {
                 let subleads = state.subleads.read().await;
                 for sub_layer in subleads.values() {
-                    let sub_cancels = sub_layer.worker_cancels.read().await;
+                    let sub_cancels = sub_layer.workers.cancels.read().await;
                     for tok in sub_cancels.values() {
                         tok.terminate_with_reason(cancel_run_reason());
                     }
@@ -1134,7 +1135,7 @@ async fn dispatch_op(
                     error: "unknown task_id".into(),
                 };
             };
-            let mut workers = layer.workers.write().await;
+            let mut workers = layer.workers.states.write().await;
             let Some(entry) = workers.get(&task_id).cloned() else {
                 // Worker disappeared between layer discovery and lock —
                 // treat as unknown.
@@ -1151,7 +1152,7 @@ async fn dispatch_op(
                 } => {
                     match mode {
                         crate::control::protocol::PauseMode::Cancel => {
-                            let cancels = layer.worker_cancels.read().await;
+                            let cancels = layer.workers.cancels.read().await;
                             if let Some(tok) = cancels.get(&task_id) {
                                 // #475: operator pause-by-cancel.
                                 tok.terminate_with_reason(
@@ -1173,7 +1174,8 @@ async fn dispatch_op(
                         }
                         crate::control::protocol::PauseMode::Freeze => {
                             let pid = layer
-                                .worker_pids
+                                .workers
+                                .pids
                                 .read()
                                 .await
                                 .get(&task_id)
@@ -1216,7 +1218,8 @@ async fn dispatch_op(
                     )
                     .await;
                     layer
-                        .worker_counters
+                        .workers
+                        .counters
                         .write()
                         .await
                         .entry(task_id.clone())
@@ -1269,7 +1272,7 @@ async fn dispatch_op(
                     error: "unknown task_id".into(),
                 };
             };
-            let current = layer.workers.read().await.get(&task_id).cloned();
+            let current = layer.workers.states.read().await.get(&task_id).cloned();
             match current {
                 Some(crate::dispatch::state::WorkerState::Paused { session_id, .. }) => {
                     let prompt_text = prompt.unwrap_or_else(|| "continue".into());
@@ -1314,7 +1317,8 @@ async fn dispatch_op(
                     // SIGCONT the frozen process. `prompt` is ignored —
                     // freeze-mode preserves state and has no resume point.
                     let pid = layer
-                        .worker_pids
+                        .workers
+                        .pids
                         .read()
                         .await
                         .get(&task_id)
@@ -1334,7 +1338,7 @@ async fn dispatch_op(
                             error: format!("SIGCONT failed: {e}"),
                         };
                     }
-                    layer.workers.write().await.insert(
+                    layer.workers.states.write().await.insert(
                         task_id.clone(),
                         crate::dispatch::state::WorkerState::Running {
                             started_at,
@@ -1407,13 +1411,13 @@ async fn dispatch_op(
                     error: "unknown task_id".into(),
                 };
             };
-            let current = layer.workers.read().await.get(&task_id).cloned();
+            let current = layer.workers.states.read().await.get(&task_id).cloned();
             let session_id = match current {
                 Some(crate::dispatch::state::WorkerState::Running {
                     session_id: Some(sid),
                     ..
                 }) => {
-                    let cancels = layer.worker_cancels.read().await;
+                    let cancels = layer.workers.cancels.read().await;
                     if let Some(tok) = cancels.get(&task_id) {
                         // #475: reprompt is operator-issued kill+respawn.
                         tok.terminate_with_reason(
@@ -1459,7 +1463,8 @@ async fn dispatch_op(
             {
                 Ok(()) => {
                     layer
-                        .worker_counters
+                        .workers
+                        .counters
                         .write()
                         .await
                         .entry(task_id.clone())
@@ -2098,13 +2103,15 @@ mod tests {
         let worker_token = CancelToken::new();
         state
             .root
-            .worker_cancels
+            .workers
+            .cancels
             .write()
             .await
             .insert("w-1".into(), worker_token.clone());
         state
             .root
             .workers
+            .states
             .write()
             .await
             .insert("w-1".into(), crate::dispatch::state::WorkerState::Pending);
@@ -2147,7 +2154,7 @@ mod tests {
     #[tokio::test]
     async fn cancel_run_op_cascades_to_sublead_layers() {
         // Regression coverage for task #60: CancelRun used to fire only
-        // root.cancel + state.root.worker_cancels. Sub-lead claude
+        // root.cancel + state.root.workers.cancels. Sub-lead claude
         // subprocesses, plus any workers the sub-lead had spawned,
         // stayed alive — their cancel tokens live on the sub-layer,
         // not on root. Observable pre-fix: operator hits cancel, root
@@ -2155,7 +2162,7 @@ mod tests {
         // lead_timeout_secs per sub-lead. Cascade must reach:
         //   - sub_layer.cancel (bridged to the sub-lead's claude proc
         //     via sublead.rs:566)
-        //   - every token in sub_layer.worker_cancels
+        //   - every token in sub_layer.workers.cancels
         //
         // Also: root.cancel.drain() must fire BEFORE the iteration so
         // any sub-lead being spawned synchronously (racing the cancel)
@@ -2220,12 +2227,14 @@ mod tests {
             None,
         ));
         sub_layer
-            .worker_cancels
+            .workers
+            .cancels
             .write()
             .await
             .insert("sub-w-1".into(), sub_w1.clone());
         sub_layer
-            .worker_cancels
+            .workers
+            .cancels
             .write()
             .await
             .insert("sub-w-2".into(), sub_w2.clone());
@@ -2291,7 +2300,7 @@ mod tests {
     #[tokio::test]
     async fn cancel_run_op_cascades_to_every_worker_token() {
         // Regression: `CancelRun` used to only fire state.root.cancel (lead-only
-        // token). Workers have per-task tokens in state.root.worker_cancels;
+        // token). Workers have per-task tokens in state.root.workers.cancels;
         // without cascading, workers stayed alive after a kill-run and the
         // TUI showed the run as dead while `ps` showed live claude procs.
         let dir = TempDir::new().unwrap();
@@ -2302,13 +2311,15 @@ mod tests {
         let w2 = pitboss_core::session::CancelToken::new();
         state
             .root
-            .worker_cancels
+            .workers
+            .cancels
             .write()
             .await
             .insert("w-1".into(), w1.clone());
         state
             .root
-            .worker_cancels
+            .workers
+            .cancels
             .write()
             .await
             .insert("w-2".into(), w2.clone());
@@ -2404,11 +2415,12 @@ mod tests {
         let worker_token = CancelToken::new();
         state
             .root
-            .worker_cancels
+            .workers
+            .cancels
             .write()
             .await
             .insert("w-1".into(), worker_token.clone());
-        state.root.workers.write().await.insert(
+        state.root.workers.states.write().await.insert(
             "w-1".into(),
             crate::dispatch::state::WorkerState::Running {
                 started_at: chrono::Utc::now(),
@@ -2447,7 +2459,7 @@ mod tests {
             ControlEvent::OpAcked { ref op, .. } if op == "pause_worker"
         ));
         assert!(worker_token.is_terminated());
-        let workers = state.root.workers.read().await;
+        let workers = state.root.workers.states.read().await;
         match workers.get("w-1").unwrap() {
             crate::dispatch::state::WorkerState::Paused { session_id, .. } => {
                 assert_eq!(session_id, "sess-xyz");
@@ -2462,7 +2474,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let run_id = Uuid::now_v7();
         let state = mk_state(dir.path(), run_id);
-        state.root.workers.write().await.insert(
+        state.root.workers.states.write().await.insert(
             "w-1".into(),
             crate::dispatch::state::WorkerState::Paused {
                 session_id: "sess-xyz".into(),
@@ -2472,13 +2484,15 @@ mod tests {
         );
         state
             .root
-            .worker_prompts
+            .workers
+            .prompts
             .write()
             .await
             .insert("w-1".into(), "hi".into());
         state
             .root
-            .worker_models
+            .workers
+            .models
             .write()
             .await
             .insert("w-1".into(), "claude-haiku-4-5".into());
@@ -2513,7 +2527,7 @@ mod tests {
             reply,
             ControlEvent::OpAcked { ref op, .. } if op == "continue_worker"
         ));
-        let workers = state.root.workers.read().await;
+        let workers = state.root.workers.states.read().await;
         assert!(matches!(
             workers.get("w-1").unwrap(),
             crate::dispatch::state::WorkerState::Running { .. }
@@ -2529,11 +2543,12 @@ mod tests {
         let worker_token = CancelToken::new();
         state
             .root
-            .worker_cancels
+            .workers
+            .cancels
             .write()
             .await
             .insert("w-1".into(), worker_token.clone());
-        state.root.workers.write().await.insert(
+        state.root.workers.states.write().await.insert(
             "w-1".into(),
             crate::dispatch::state::WorkerState::Running {
                 started_at: chrono::Utc::now(),
@@ -2542,13 +2557,15 @@ mod tests {
         );
         state
             .root
-            .worker_prompts
+            .workers
+            .prompts
             .write()
             .await
             .insert("w-1".into(), "hi".into());
         state
             .root
-            .worker_models
+            .workers
+            .models
             .write()
             .await
             .insert("w-1".into(), "claude-haiku-4-5".into());
@@ -2594,7 +2611,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let run_id = Uuid::now_v7();
         let state = mk_state(dir.path(), run_id);
-        state.root.workers.write().await.insert(
+        state.root.workers.states.write().await.insert(
             "w-1".into(),
             crate::dispatch::state::WorkerState::Running {
                 started_at: chrono::Utc::now(),
@@ -2603,7 +2620,8 @@ mod tests {
         );
         state
             .root
-            .worker_prompts
+            .workers
+            .prompts
             .write()
             .await
             .insert("w-1".into(), "investigate bug".into());
@@ -2657,7 +2675,7 @@ mod tests {
         let state = mk_state(dir.path(), run_id);
 
         // One root-layer worker, one sub-lead with one worker.
-        state.root.workers.write().await.insert(
+        state.root.workers.states.write().await.insert(
             "root-w".into(),
             crate::dispatch::state::WorkerState::Running {
                 started_at: chrono::Utc::now(),
@@ -2712,7 +2730,7 @@ mod tests {
             std::sync::Arc::new(crate::shared_store::SharedStore::new()),
             None,
         ));
-        sub_layer.workers.write().await.insert(
+        sub_layer.workers.states.write().await.insert(
             "sub-w".into(),
             crate::dispatch::state::WorkerState::Running {
                 started_at: chrono::Utc::now(),
@@ -2831,14 +2849,14 @@ mod tests {
         ));
         // The sub-lead inserts itself into its own layer.workers via
         // run_kill_resume_loop in production. Mirror that here.
-        sub_layer.workers.write().await.insert(
+        sub_layer.workers.states.write().await.insert(
             "sublead-S".into(),
             crate::dispatch::state::WorkerState::Running {
                 started_at: chrono::Utc::now(),
                 session_id: Some("sub-sess".into()),
             },
         );
-        sub_layer.workers.write().await.insert(
+        sub_layer.workers.states.write().await.insert(
             "sub-tree-w".into(),
             crate::dispatch::state::WorkerState::Running {
                 started_at: chrono::Utc::now(),
@@ -2966,14 +2984,14 @@ mod tests {
         // directly into `terminated_sublead_layers` (skipping the live
         // `subleads` map) to model post-`reconcile_terminated_sublead`
         // state.
-        sub_layer.workers.write().await.insert(
+        sub_layer.workers.states.write().await.insert(
             "sublead-T".into(),
             crate::dispatch::state::WorkerState::Running {
                 started_at: chrono::Utc::now(),
                 session_id: Some("sub-sess".into()),
             },
         );
-        sub_layer.workers.write().await.insert(
+        sub_layer.workers.states.write().await.insert(
             "sub-w".into(),
             crate::dispatch::state::WorkerState::Done(pitboss_core::store::TaskRecord {
                 task_id: "sub-w".into(),
@@ -3052,7 +3070,7 @@ mod tests {
     }
 
     /// #152 M2 regression: cancel_worker on a sub-lead-owned worker
-    /// must terminate the sub-lead's worker_cancels token, not return
+    /// must terminate the sub-lead's workers.cancels token, not return
     /// "unknown task_id" because the handler only consulted root.
     #[tokio::test]
     async fn cancel_worker_routes_to_sublead_layer() {
@@ -3108,7 +3126,7 @@ mod tests {
             None,
         ));
         let sub_w = pitboss_core::session::CancelToken::new();
-        sub_layer.workers.write().await.insert(
+        sub_layer.workers.states.write().await.insert(
             "sub-w".into(),
             crate::dispatch::state::WorkerState::Running {
                 started_at: chrono::Utc::now(),
@@ -3116,7 +3134,8 @@ mod tests {
             },
         );
         sub_layer
-            .worker_cancels
+            .workers
+            .cancels
             .write()
             .await
             .insert("sub-w".into(), sub_w.clone());

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -408,7 +408,8 @@ pub async fn run_hierarchical(
     // Build lead TaskRecord using the accumulated data from all iterations.
     let lead_counters = state
         .root
-        .worker_counters
+        .workers
+        .counters
         .read()
         .await
         .get(&state.root.lead_id)
@@ -543,11 +544,11 @@ pub async fn run_hierarchical(
         )
         .await;
     }
-    state.root.workers.write().await.insert(
+    state.root.workers.states.write().await.insert(
         lead.id.clone(),
         crate::dispatch::state::WorkerState::Done(lead_record.clone()),
     );
-    let _ = state.root.done_tx.send(lead.id.clone());
+    let _ = state.root.workers.done_tx.send(lead.id.clone());
 
     // 4. Finalize.
     // Capture the ORIGINAL cancel state BEFORE we call terminate() below.
@@ -575,7 +576,7 @@ pub async fn run_hierarchical(
     // The new shape:
     //
     // - **Subscribe first.** `done_rx` is taken before we snapshot or
-    //   trip cancels. Workers send their task_id to `state.root.done_tx`
+    //   trip cancels. Workers send their task_id to `state.root.workers.done_tx`
     //   on every exit (root layer or sub-tree, see `mcp/tools.rs:704`).
     //   Subscribing first guarantees we don't miss a fast-completing
     //   worker that exits between the snapshot and the wait.
@@ -600,11 +601,11 @@ pub async fn run_hierarchical(
     //   signal within that window are still classified Cancelled below
     //   but those are now the cases where the underlying child was
     //   genuinely stuck (the audit's pre-fix concern was real).
-    let mut done_rx = state.root.done_tx.subscribe();
+    let mut done_rx = state.root.workers.done_tx.subscribe();
 
     let mut in_flight: std::collections::HashSet<String> = std::collections::HashSet::new();
     {
-        let workers = state.root.workers.read().await;
+        let workers = state.root.workers.states.read().await;
         for (id, w) in workers.iter() {
             if id != &lead.id && !matches!(w, crate::dispatch::state::WorkerState::Done(_)) {
                 in_flight.insert(id.clone());
@@ -614,7 +615,7 @@ pub async fn run_hierarchical(
     {
         let subleads = state.subleads.read().await;
         for sub in subleads.values() {
-            let workers = sub.workers.read().await;
+            let workers = sub.workers.states.read().await;
             for (id, w) in workers.iter() {
                 if !matches!(w, crate::dispatch::state::WorkerState::Done(_)) {
                     in_flight.insert(id.clone());
@@ -687,7 +688,7 @@ pub async fn run_hierarchical(
                 failure_reason: None,
                 cost_usd,
                 // Preserve the typed-profile attribution on synthesized
-                // cancellations: the in-memory `worker_actor_types` map
+                // cancellations: the in-memory `workers.actor_types` map
                 // still has the original spawn's id even though no
                 // TaskRecord was appended yet. (#252 Phase 1.5)
                 actor_type,
@@ -698,9 +699,9 @@ pub async fn run_hierarchical(
             }
         };
     {
-        let workers = state.root.workers.read().await;
-        let worker_models = state.root.worker_models.read().await;
-        let worker_actor_types = state.root.worker_actor_types.read().await;
+        let workers = state.root.workers.states.read().await;
+        let models = state.root.workers.models.read().await;
+        let actor_types = state.root.workers.actor_types.read().await;
         for (id, w) in workers.iter() {
             if id == &lead.id || existing_ids.contains(id) {
                 continue;
@@ -709,8 +710,8 @@ pub async fn run_hierarchical(
                 cancelled_records.push(make_cancelled(
                     id,
                     &lead.id,
-                    worker_models.get(id).cloned(),
-                    worker_actor_types.get(id).cloned(),
+                    models.get(id).cloned(),
+                    actor_types.get(id).cloned(),
                 ));
             }
         }
@@ -718,9 +719,9 @@ pub async fn run_hierarchical(
     {
         let subleads = state.subleads.read().await;
         for (sublead_id, sub) in subleads.iter() {
-            let workers = sub.workers.read().await;
-            let worker_models = sub.worker_models.read().await;
-            let worker_actor_types = sub.worker_actor_types.read().await;
+            let workers = sub.workers.states.read().await;
+            let models = sub.workers.models.read().await;
+            let actor_types = sub.workers.actor_types.read().await;
             for (id, w) in workers.iter() {
                 // Sub-lead layers register the sub-lead itself as a
                 // "worker" entry (the claude subprocess). Filter by the
@@ -734,8 +735,8 @@ pub async fn run_hierarchical(
                     cancelled_records.push(make_cancelled(
                         id,
                         sublead_id,
-                        worker_models.get(id).cloned(),
-                        worker_actor_types.get(id).cloned(),
+                        models.get(id).cloned(),
+                        actor_types.get(id).cloned(),
                     ));
                 }
             }
@@ -850,7 +851,7 @@ pub async fn run_hierarchical(
 ///
 /// This avoids relying on a non-standard `transport: { type: "unix", ... }`
 /// Wait for `in_flight` worker task-ids to all signal completion via
-/// `state.root.done_tx`, or until `timeout` elapses (#150 M6).
+/// `state.root.workers.done_tx`, or until `timeout` elapses (#150 M6).
 ///
 /// `done_rx` MUST be subscribed to BEFORE the caller takes the
 /// `in_flight` snapshot and trips any cancel signals — otherwise a
@@ -920,7 +921,7 @@ async fn refresh_in_flight_from_maps(
 ) {
     let mut done_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
     {
-        let workers = state.root.workers.read().await;
+        let workers = state.root.workers.states.read().await;
         for (id, w) in workers.iter() {
             if matches!(w, crate::dispatch::state::WorkerState::Done(_)) {
                 done_ids.insert(id.clone());
@@ -930,7 +931,7 @@ async fn refresh_in_flight_from_maps(
     {
         let subleads = state.subleads.read().await;
         for sub in subleads.values() {
-            let workers = sub.workers.read().await;
+            let workers = sub.workers.states.read().await;
             for (id, w) in workers.iter() {
                 if matches!(w, crate::dispatch::state::WorkerState::Done(_)) {
                     done_ids.insert(id.clone());
@@ -1193,7 +1194,7 @@ mod await_drained_tests {
     #[tokio::test]
     async fn drain_returns_true_immediately_for_empty_set() {
         let (_dir, state) = mk_state();
-        let mut rx = state.root.done_tx.subscribe();
+        let mut rx = state.root.workers.done_tx.subscribe();
         let in_flight: HashSet<String> = HashSet::new();
         let start = tokio::time::Instant::now();
         let drained =
@@ -1208,11 +1209,11 @@ mod await_drained_tests {
     #[tokio::test]
     async fn drain_returns_true_when_all_workers_signal_before_deadline() {
         let (_dir, state) = mk_state();
-        let mut rx = state.root.done_tx.subscribe();
+        let mut rx = state.root.workers.done_tx.subscribe();
         let in_flight: HashSet<String> = ["w1", "w2", "w3"].into_iter().map(String::from).collect();
 
         // Spawn a producer that emits done events for each worker.
-        let tx = state.root.done_tx.clone();
+        let tx = state.root.workers.done_tx.clone();
         tokio::spawn(async move {
             for id in ["w1", "w2", "w3"] {
                 tokio::time::sleep(Duration::from_millis(10)).await;
@@ -1240,7 +1241,7 @@ mod await_drained_tests {
     #[tokio::test]
     async fn drain_returns_false_when_worker_never_signals() {
         let (_dir, state) = mk_state();
-        let mut rx = state.root.done_tx.subscribe();
+        let mut rx = state.root.workers.done_tx.subscribe();
         let in_flight: HashSet<String> = ["never-drains".to_string()].into_iter().collect();
         let start = tokio::time::Instant::now();
         let drained =
@@ -1262,12 +1263,12 @@ mod await_drained_tests {
     #[tokio::test]
     async fn drain_ignores_done_events_for_unknown_ids() {
         let (_dir, state) = mk_state();
-        let mut rx = state.root.done_tx.subscribe();
+        let mut rx = state.root.workers.done_tx.subscribe();
         let in_flight: HashSet<String> = ["target-1".to_string(), "target-2".to_string()]
             .into_iter()
             .collect();
 
-        let tx = state.root.done_tx.clone();
+        let tx = state.root.workers.done_tx.clone();
         tokio::spawn(async move {
             // Emit some unrelated events first.
             let _ = tx.send("noise-a".to_string());
@@ -1291,7 +1292,7 @@ mod await_drained_tests {
         let (_dir, state) = mk_state();
         // Insert a Done worker on root and a Running worker on root.
         {
-            let mut workers = state.root.workers.write().await;
+            let mut workers = state.root.workers.states.write().await;
             workers.insert(
                 "done-root".into(),
                 WorkerState::Done(pitboss_core::store::TaskRecord {

--- a/crates/pitboss-cli/src/dispatch/kill_resume.rs
+++ b/crates/pitboss-cli/src/dispatch/kill_resume.rs
@@ -126,7 +126,7 @@ pub async fn run_kill_resume_loop(
     let mut current_cmd = args.initial_cmd;
 
     let overall_started_at = Utc::now();
-    layer.workers.write().await.insert(
+    layer.workers.states.write().await.insert(
         actor_id.clone(),
         WorkerState::Running {
             started_at: overall_started_at,
@@ -181,7 +181,7 @@ pub async fn run_kill_resume_loop(
         // fires on the `system{subtype:"init"}` event so it's available
         // mid-run) or from the final result event.
         if let Ok(sid) = session_id_rx.try_recv() {
-            layer.workers.write().await.insert(
+            layer.workers.states.write().await.insert(
                 actor_id.clone(),
                 WorkerState::Running {
                     started_at: overall_started_at,
@@ -208,7 +208,7 @@ pub async fn run_kill_resume_loop(
                 );
                 reprompt_count += 1;
                 current_cmd = build_resume_cmd(sid, &new_prompt);
-                layer.workers.write().await.insert(
+                layer.workers.states.write().await.insert(
                     actor_id.clone(),
                     WorkerState::Running {
                         started_at: overall_started_at,

--- a/crates/pitboss-cli/src/dispatch/layer.rs
+++ b/crates/pitboss-cli/src/dispatch/layer.rs
@@ -65,20 +65,78 @@ pub struct ControlWriterSlot {
     pub sender: mpsc::Sender<crate::control::protocol::EventEnvelope>,
 }
 
+/// Per-task_id maps + the worker-done broadcast bus.
+///
+/// Split out of `LayerState` (#487) to narrow the access surface: every
+/// piece of state keyed by `task_id` lives here, plus the broadcast
+/// channel that fires when a worker transitions to `Done`. Handlers that
+/// only need worker bookkeeping can take `&WorkerRegistry` instead of
+/// `&LayerState` and physically can't touch budget or approval state.
+pub struct WorkerRegistry {
+    /// Map of task_id → worker state. Lead is also tracked here for convenience.
+    pub states: RwLock<HashMap<String, WorkerState>>,
+    /// Per-worker CancelToken, keyed by task_id.
+    pub cancels: RwLock<HashMap<String, CancelToken>>,
+    /// Per-worker prompt preview (first 80 chars of the worker's prompt).
+    pub prompts: RwLock<HashMap<String, String>>,
+    /// Per-worker resolved model, keyed by task_id.
+    pub models: RwLock<HashMap<String, String>>,
+    /// Per-worker resolved `actor_type` (matches a `[[worker_type]].id` from
+    /// the manifest), keyed by task_id. Populated at spawn time when the
+    /// caller resolves to `WorkerProfileResolution::Typed`. Read on resume
+    /// (continue/reprompt) so the rebuilt `mcp-config.json` can scope MCP
+    /// servers and the appended `TaskRecord` keeps its profile attribution.
+    /// (#252 Phase 1.5)
+    pub actor_types: RwLock<HashMap<String, String>>,
+    /// Per-task event counters.
+    pub counters: RwLock<HashMap<String, WorkerCounters>>,
+    /// Per-worker OS pid.
+    pub pids: RwLock<HashMap<String, std::sync::Arc<std::sync::atomic::AtomicU32>>>,
+    /// Per-worker reserved cost (USD) at spawn time.
+    pub reservations: RwLock<HashMap<String, f64>>,
+    /// Broadcast channel that emits a `task_id` whenever a worker transitions
+    /// to `Done`. Subscribed to by `wait_for_worker` handlers.
+    pub done_tx: broadcast::Sender<String>,
+}
+
+impl WorkerRegistry {
+    /// Construct an empty registry with a fresh 64-slot `done_tx` channel.
+    /// The capacity matches the pre-split `LayerState::new` default; the
+    /// channel is mostly there for `wait_for_worker` consumers and a
+    /// `Lagged` receiver re-syncs from the `states` map.
+    pub fn new() -> Self {
+        let (done_tx, _) = broadcast::channel(64);
+        Self {
+            states: RwLock::new(HashMap::new()),
+            cancels: RwLock::new(HashMap::new()),
+            prompts: RwLock::new(HashMap::new()),
+            models: RwLock::new(HashMap::new()),
+            actor_types: RwLock::new(HashMap::new()),
+            counters: RwLock::new(HashMap::new()),
+            pids: RwLock::new(HashMap::new()),
+            reservations: RwLock::new(HashMap::new()),
+            done_tx,
+        }
+    }
+}
+
+impl Default for WorkerRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// All state owned by a single coordination layer (root layer or a
 /// sub-tree layer).
-///
-/// Field names and types mirror the v0.5 `DispatchState` fields exactly so
-/// that all existing callsites continue to work via `Deref<Target = LayerState>`
-/// on `DispatchState`.
 pub struct LayerState {
     pub run_id: Uuid,
     pub manifest: ResolvedManifest,
     pub store: Arc<dyn SessionStore>,
     pub cancel: CancelToken,
     pub lead_id: String,
-    /// Map of task_id → worker state. Lead is also tracked here for convenience.
-    pub workers: RwLock<HashMap<String, WorkerState>>,
+    /// Worker bookkeeping: per-task_id maps + the `Done` broadcast.
+    /// Split out of this struct in #487.
+    pub workers: WorkerRegistry,
     /// Total USD cost spent so far on completed workers in this layer.
     /// Lead and sub-lead token spend live in their own counters
     /// (`lead_spent_usd`); helpers that compute the total run spend sum
@@ -101,24 +159,6 @@ pub struct LayerState {
     /// `TaskRecord.failure_reason` names the overspend rather than
     /// looking like a generic cancellation. (#253)
     pub budget_abort_reason: std::sync::Mutex<Option<String>>,
-    /// Broadcast channel that emits a `task_id` whenever a worker transitions
-    /// to `Done`. Subscribed to by `wait_for_worker` handlers.
-    pub done_tx: broadcast::Sender<String>,
-    /// Per-worker CancelToken, keyed by task_id.
-    pub worker_cancels: RwLock<HashMap<String, CancelToken>>,
-    /// Per-worker prompt preview (first 80 chars of the worker's prompt).
-    pub worker_prompts: RwLock<HashMap<String, String>>,
-    /// Per-worker resolved model, keyed by task_id.
-    pub worker_models: RwLock<HashMap<String, String>>,
-    /// Per-worker resolved `actor_type` (matches a `[[worker_type]].id` from
-    /// the manifest), keyed by task_id. Populated at spawn time when the
-    /// caller resolves to `WorkerProfileResolution::Typed`. Read on resume
-    /// (continue/reprompt) so the rebuilt `mcp-config.json` can scope MCP
-    /// servers and the appended `TaskRecord` keeps its profile attribution.
-    /// (#252 Phase 1.5)
-    pub worker_actor_types: RwLock<HashMap<String, String>>,
-    /// Per-worker reserved cost (USD) at spawn time.
-    pub worker_reservations: RwLock<HashMap<String, f64>>,
     /// Dependencies needed to actually launch worker subprocesses.
     pub spawner: Arc<dyn ProcessSpawner>,
     pub claude_binary: PathBuf,
@@ -180,14 +220,10 @@ pub struct LayerState {
     /// Shared by clone across the root layer and every sub-tree
     /// layer so the entire run funnels into a single bus.
     pub events_tx: broadcast::Sender<crate::control::protocol::EventEnvelope>,
-    /// Per-task event counters.
-    pub worker_counters: RwLock<HashMap<String, WorkerCounters>>,
     /// v0.4.1: notification router.
     pub notification_router: Option<std::sync::Arc<crate::notify::NotificationRouter>>,
     /// In-memory shared store for hub-mediated lead ↔ worker coordination.
     pub shared_store: std::sync::Arc<crate::shared_store::SharedStore>,
-    /// Per-worker OS pid.
-    pub worker_pids: RwLock<HashMap<String, std::sync::Arc<std::sync::atomic::AtomicU32>>>,
     /// Plan-approval gate.
     pub plan_approved: std::sync::atomic::AtomicBool,
     /// Original reservation amount (USD) at sub-lead spawn time.
@@ -231,10 +267,13 @@ impl std::fmt::Debug for LayerState {
         f.debug_struct("LayerState")
             .field("run_id", &self.run_id)
             .field("lead_id", &self.lead_id)
-            .field("workers", &self.workers.try_read().map(|g| g.len()).ok())
             .field(
-                "worker_cancels",
-                &self.worker_cancels.try_read().map(|g| g.len()).ok(),
+                "workers",
+                &self.workers.states.try_read().map(|g| g.len()).ok(),
+            )
+            .field(
+                "workers.cancels",
+                &self.workers.cancels.try_read().map(|g| g.len()).ok(),
             )
             .finish_non_exhaustive()
     }
@@ -272,7 +311,6 @@ impl LayerState {
             std::path::Path::new("/"),
             false,
         ));
-        let (done_tx, _) = broadcast::channel(64);
         // PR-H of #259: each `LayerState::new` mints its own broadcast
         // bus by default. Prod callers (`DispatchState::new`, sub-lead
         // spawn) override via [`Self::with_events_tx`] to share the
@@ -284,17 +322,11 @@ impl LayerState {
             store,
             cancel,
             lead_id,
-            workers: RwLock::new(HashMap::new()),
+            workers: WorkerRegistry::new(),
             spent_usd: Mutex::new(0.0),
             reserved_usd: Mutex::new(0.0),
             lead_spent_usd: std::sync::Mutex::new(0.0),
             budget_abort_reason: std::sync::Mutex::new(None),
-            done_tx,
-            worker_cancels: RwLock::new(HashMap::new()),
-            worker_prompts: RwLock::new(HashMap::new()),
-            worker_models: RwLock::new(HashMap::new()),
-            worker_actor_types: RwLock::new(HashMap::new()),
-            worker_reservations: RwLock::new(HashMap::new()),
             spawner,
             claude_binary,
             wt_mgr,
@@ -306,10 +338,8 @@ impl LayerState {
             control_writer: Mutex::new(None),
             event_log,
             events_tx,
-            worker_counters: RwLock::new(HashMap::new()),
             notification_router,
             shared_store,
-            worker_pids: RwLock::new(HashMap::new()),
             plan_approved: std::sync::atomic::AtomicBool::new(false),
             original_reservation_usd,
             policy_matcher: Mutex::new(None),
@@ -487,6 +517,7 @@ impl LayerState {
 
     pub async fn active_worker_count(&self) -> usize {
         self.workers
+            .states
             .read()
             .await
             .iter()
@@ -512,7 +543,7 @@ impl LayerState {
     /// Register a worker's `CancelToken` under `task_id` and immediately
     /// propagate any in-flight drain/terminate state from this layer's
     /// `cancel` to the worker's token. Centralizes the previously-inlined
-    /// pattern at `mcp/tools.rs` (insert into `worker_cancels`, then
+    /// pattern at `mcp/tools.rs` (insert into `workers.cancels`, then
     /// check `target_layer.cancel.is_terminated()` / `is_draining()`).
     ///
     /// The eager propagation is what closes the post-register cascade
@@ -521,21 +552,22 @@ impl LayerState {
     /// would otherwise miss the cancel signal. Pinned by the integration
     /// tests in `tests/cancel_cascade_flows.rs`.
     pub async fn register_worker_cancel(&self, task_id: String, token: CancelToken) {
-        self.worker_cancels
+        self.workers
+            .cancels
             .write()
             .await
             .insert(task_id, token.clone());
         self.cancel.cascade_to(&token);
     }
 
-    /// Walk every registered `worker_cancels` entry and cascade this
+    /// Walk every registered `workers.cancels` entry and cascade this
     /// layer's current cancel state to it via `CancelToken::cascade_to`.
     /// Used by the per-sublead watcher tasks installed by
     /// `install_sublead_cancel_watcher` — both the drain and terminate
     /// watchers funnel through this method so the cascade rule
     /// (terminate dominates drain) is encoded in exactly one place.
     pub async fn cascade_to_workers(&self) {
-        let workers = self.worker_cancels.read().await;
+        let workers = self.workers.cancels.read().await;
         for (worker_id, tok) in workers.iter() {
             tracing::debug!(worker_id = %worker_id, "cascading cancel state to sub-tree worker");
             self.cancel.cascade_to(tok);
@@ -556,8 +588,8 @@ mod tests {
     #[tokio::test]
     async fn new_layer_starts_empty() {
         let (_dir, layer) = mk_layer();
-        assert!(layer.workers.read().await.is_empty());
-        assert!(layer.worker_cancels.read().await.is_empty());
+        assert!(layer.workers.states.read().await.is_empty());
+        assert!(layer.workers.cancels.read().await.is_empty());
         assert_eq!(*layer.spent_usd.lock().await, 0.0);
         assert_eq!(*layer.reserved_usd.lock().await, 0.0);
     }

--- a/crates/pitboss-cli/src/dispatch/signals.rs
+++ b/crates/pitboss-cli/src/dispatch/signals.rs
@@ -163,12 +163,12 @@ pub async fn cancel_actor_with_reason(
 /// reason'd because there is no parent to receive the reason).
 ///
 /// Routing strategy is O(1) at every layer:
-/// 1. Root-layer worker → `state.root.worker_cancels` HashMap.
+/// 1. Root-layer worker → `state.root.workers.cancels` HashMap.
 /// 2. Sub-lead itself → `state.subleads` HashMap.
 /// 3. Sub-tree worker → `state.worker_layer_index` HashMap to resolve
-///    the owning sublead id, then the sub-tree's own `worker_cancels`.
+///    the owning sublead id, then the sub-tree's own `workers.cancels`.
 ///
-/// The previous implementation walked every sub-tree's `worker_cancels`
+/// The previous implementation walked every sub-tree's `workers.cancels`
 /// under a held `state.subleads` read lock — O(N) per cancel call,
 /// blocking new sublead registration. The `worker_layer_index` lookup
 /// mirrors `resolve_layer_for_caller`'s routing for KV ops (#150 audit).
@@ -186,7 +186,7 @@ async fn cancel_and_find_parent(
 
     // Root-layer workers: parent = root lead.
     {
-        let cancels = state.root.worker_cancels.read().await;
+        let cancels = state.root.workers.cancels.read().await;
         if let Some(tok) = cancels.get(target) {
             tok.terminate_with_reason(operator_reason());
             return Ok(Some(state.root.clone()));
@@ -203,17 +203,17 @@ async fn cancel_and_find_parent(
     }
 
     // Sub-tree workers: route via worker_layer_index for O(1) lookup
-    // instead of scanning every sub-tree's worker_cancels under the
+    // instead of scanning every sub-tree's workers.cancels under the
     // held subleads lock. `worker_layer_index` is populated by
     // `handle_spawn_worker` immediately before the worker_cancel is
     // registered, so a successful index hit guarantees the target is
     // in the named sub-tree (modulo a brief intra-spawn window where
-    // the index is set but worker_cancels insertion hasn't completed —
+    // the index is set but workers.cancels insertion hasn't completed —
     // same race as the prior linear-scan implementation).
     let layer_idx = state.worker_layer_index.read().await.get(target).cloned();
     if let Some(Some(sublead_id)) = layer_idx {
         if let Some(sub_layer) = subleads.get(&sublead_id) {
-            let cancels = sub_layer.worker_cancels.read().await;
+            let cancels = sub_layer.workers.cancels.read().await;
             if let Some(tok) = cancels.get(target) {
                 tok.terminate_with_reason(operator_reason());
                 return Ok(Some(sub_layer.clone()));
@@ -267,7 +267,7 @@ pub fn install_sublead_cancel_watcher(sub_layer: Arc<crate::dispatch::layer::Lay
 /// Each sub-tree's per-layer watcher (installed via
 /// `install_sublead_cancel_watcher` at spawn time) then cascades to the
 /// sub-tree's workers — `DispatchState` never reaches into
-/// `sub_layer.worker_cancels` directly.
+/// `sub_layer.workers.cancels` directly.
 ///
 /// Same shape as `install_sublead_cancel_watcher` (one task,
 /// drain-then-terminate-aware) — see that function's doc-comment for
@@ -425,7 +425,7 @@ mod tests {
         let w1 = CancelToken::new();
         let w2 = CancelToken::new();
         {
-            let mut cancels = sub_layer.worker_cancels.write().await;
+            let mut cancels = sub_layer.workers.cancels.write().await;
             cancels.insert("w1".into(), w1.clone());
             cancels.insert("w2".into(), w2.clone());
         }
@@ -520,7 +520,7 @@ mod tests {
 
         let w1 = CancelToken::new();
         {
-            let mut cancels = sub_layer.worker_cancels.write().await;
+            let mut cancels = sub_layer.workers.cancels.write().await;
             cancels.insert("w1".into(), w1.clone());
         }
 
@@ -617,7 +617,7 @@ mod tests {
 
         let w1 = CancelToken::new();
         {
-            let mut cancels = sub_layer.worker_cancels.write().await;
+            let mut cancels = sub_layer.workers.cancels.write().await;
             cancels.insert("w1".into(), w1.clone());
         }
 

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -405,7 +405,7 @@ pub struct DispatchState {
     /// by `handle_spawn_sublead` after the sub-lead's `LayerState` is
     /// registered (#252). Run-global (only the root layer hosts
     /// sub-leads — depth-2 cap), so it lives on `DispatchState` rather
-    /// than mirroring the per-layer `worker_actor_types` map.
+    /// than mirroring the per-layer `workers.actor_types` map.
     ///
     /// Read by `handle_permission_prompt` to look up a sub-lead
     /// caller's profile when applying the typed-profile auto-approve /
@@ -759,7 +759,8 @@ mod tests {
         let st = mk_state(None, None);
         let c = st
             .root
-            .worker_counters
+            .workers
+            .counters
             .read()
             .await
             .get("absent")

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -224,12 +224,12 @@ pub async fn resolve_envelope(
 
     // ── Cap: max_total_workers ─────────────────────────────────────────
     if let Some(cap) = lead.and_then(|l| l.max_total_workers) {
-        let root_workers = state.root.workers.read().await.len() as u32;
+        let root_workers = state.root.workers.states.read().await.len() as u32;
         let subleads_guard = state.subleads.read().await;
         let sub_workers: u32 = {
             let mut total = 0u32;
             for sub in subleads_guard.values() {
-                total += sub.workers.read().await.len() as u32;
+                total += sub.workers.states.read().await.len() as u32;
             }
             total
         };
@@ -1086,7 +1086,7 @@ pub async fn reconcile_terminated_sublead(
     // leave it alone rather than clobbering richer data.
     {
         use crate::dispatch::state::WorkerState;
-        let mut workers = sub_layer.workers.write().await;
+        let mut workers = sub_layer.workers.states.write().await;
         let already_done = matches!(workers.get(sublead_id), Some(WorkerState::Done(_)));
         if !already_done {
             let (started_at, claude_session_id) = match workers.get(sublead_id) {
@@ -1209,7 +1209,7 @@ pub async fn reconcile_terminated_sublead(
         .insert(sublead_id.to_string(), record);
 
     // Wake any wait_actor subscribers blocked on this sublead_id.
-    let _ = state.root.done_tx.send(sublead_id.to_string());
+    let _ = state.root.workers.done_tx.send(sublead_id.to_string());
 
     Ok(())
 }

--- a/crates/pitboss-cli/src/mcp/approval.rs
+++ b/crates/pitboss-cli/src/mcp/approval.rs
@@ -85,7 +85,8 @@ pub struct ApprovalBridge {
 pub(crate) async fn bump_approval_requested(state: &Arc<DispatchState>, caller_id: &str) {
     state
         .root
-        .worker_counters
+        .workers
+        .counters
         .write()
         .await
         .entry(caller_id.to_string())
@@ -103,7 +104,7 @@ pub(crate) async fn record_approval_outcome(
     caller_id: &str,
     approved: bool,
 ) {
-    let mut guard = state.root.worker_counters.write().await;
+    let mut guard = state.root.workers.counters.write().await;
     let entry = guard.entry(caller_id.to_string()).or_default();
     if approved {
         entry.approvals_approved += 1;
@@ -617,7 +618,7 @@ mod tests {
     /// response path bumped `approvals_approved`/`approvals_rejected`; every
     /// short-circuit path silently left them at zero.
     async fn counters_for(state: &Arc<DispatchState>, caller: &str) -> (u32, u32, u32) {
-        let guard = state.root.worker_counters.read().await;
+        let guard = state.root.workers.counters.read().await;
         let c = guard.get(caller).cloned().unwrap_or_default();
         (
             c.approvals_requested,

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -376,12 +376,12 @@ pub(super) async fn find_worker_across_layers(
     state: &Arc<DispatchState>,
     task_id: &str,
 ) -> Option<WorkerState> {
-    if let Some(w) = state.root.workers.read().await.get(task_id).cloned() {
+    if let Some(w) = state.root.workers.states.read().await.get(task_id).cloned() {
         return Some(w);
     }
     let subleads = state.subleads.read().await;
     for layer in subleads.values() {
-        if let Some(w) = layer.workers.read().await.get(task_id).cloned() {
+        if let Some(w) = layer.workers.states.read().await.get(task_id).cloned() {
             return Some(w);
         }
     }
@@ -390,8 +390,8 @@ pub(super) async fn find_worker_across_layers(
 
 /// Resolve the `LayerState` that owns `task_id`. Used by mutating
 /// handlers (cancel/pause/continue/reprompt) so they target the correct
-/// layer's `workers` / `worker_cancels` / `worker_pids` /
-/// `worker_counters` maps. Sub-lead-owned workers live in their layer,
+/// layer's `workers` / `workers.cancels` / `workers.pids` /
+/// `workers.counters` maps. Sub-lead-owned workers live in their layer,
 /// NOT root — before this helper, every mutating handler hard-coded
 /// `state.root.*` and silently failed for sub-tree workers (issue #146).
 ///
@@ -407,11 +407,11 @@ pub(super) async fn layer_for_worker(
         Some(None) => Some(state.root.clone()),
         Some(Some(sublead_id)) => state.subleads.read().await.get(&sublead_id).cloned(),
         None => {
-            if state.root.workers.read().await.contains_key(task_id) {
+            if state.root.workers.states.read().await.contains_key(task_id) {
                 return Some(state.root.clone());
             }
             for layer in state.subleads.read().await.values() {
-                if layer.workers.read().await.contains_key(task_id) {
+                if layer.workers.states.read().await.contains_key(task_id) {
                     return Some(layer.clone());
                 }
             }

--- a/crates/pitboss-cli/src/mcp/tools/approval.rs
+++ b/crates/pitboss-cli/src/mcp/tools/approval.rs
@@ -847,7 +847,8 @@ async fn caller_profile(
             let type_id_opt: Option<String> = match layer_opt {
                 None | Some(None) => state
                     .root
-                    .worker_actor_types
+                    .workers
+                    .actor_types
                     .read()
                     .await
                     .get(caller_id)
@@ -864,7 +865,7 @@ async fn caller_profile(
                     };
                     match sub {
                         Some(sub) => {
-                            let map = sub.worker_actor_types.read().await;
+                            let map = sub.workers.actor_types.read().await;
                             map.get(caller_id).cloned()
                         }
                         None => None,

--- a/crates/pitboss-cli/src/mcp/tools/lifecycle.rs
+++ b/crates/pitboss-cli/src/mcp/tools/lifecycle.rs
@@ -22,12 +22,12 @@ pub async fn handle_list_workers(state: &Arc<DispatchState>) -> Vec<WorkerSummar
     // calling `list_workers` got an empty list even when they had their
     // own workers active — the workers were registered in the sub-lead
     // layer's own `workers` map by `handle_spawn_worker`'s
-    // `target_layer.workers.write()`.
+    // `target_layer.workers.states.write()`.
     //
     // Lead id filtering: excludes the root lead id. Sub-lead ids aren't
     // registered as workers so they don't need filtering here.
     let mut summaries: Vec<WorkerSummary> = Vec::new();
-    let prompts = state.root.worker_prompts.read().await;
+    let prompts = state.root.workers.prompts.read().await;
     let render = |id: &String, w: &WorkerState| -> WorkerSummary {
         let (state_str, started_at) = match w {
             WorkerState::Pending => ("Pending".to_string(), None),
@@ -61,14 +61,14 @@ pub async fn handle_list_workers(state: &Arc<DispatchState>) -> Vec<WorkerSummar
             started_at,
         }
     };
-    for (id, w) in state.root.workers.read().await.iter() {
+    for (id, w) in state.root.workers.states.read().await.iter() {
         if id != &state.root.lead_id {
             summaries.push(render(id, w));
         }
     }
     let subleads = state.subleads.read().await;
     for layer in subleads.values() {
-        for (id, w) in layer.workers.read().await.iter() {
+        for (id, w) in layer.workers.states.read().await.iter() {
             // Sub-lead layers hold the sub-lead itself as a "worker" entry
             // (the claude subprocess registered via workers.write() in
             // finalize_sublead_spawn). Filter by layer.lead_id so the
@@ -140,13 +140,14 @@ pub async fn handle_worker_status(
     };
     // #151 L2: read prompt_preview from the *owning* layer, not just
     // root. Sub-tree workers' prompts live in their layer's
-    // `worker_prompts`; pre-fix, `handle_worker_status` only checked
+    // `workers.prompts`; pre-fix, `handle_worker_status` only checked
     // root and so returned an empty prompt_preview for every
     // sub-lead-spawned worker. Falls back to root for compat in case
     // an older record landed there.
     let prompt_preview = if let Some(layer) = layer_for_worker(state, task_id).await {
         layer
-            .worker_prompts
+            .workers
+            .prompts
             .read()
             .await
             .get(task_id)
@@ -155,7 +156,8 @@ pub async fn handle_worker_status(
     } else {
         state
             .root
-            .worker_prompts
+            .workers
+            .prompts
             .read()
             .await
             .get(task_id)
@@ -181,7 +183,7 @@ pub async fn handle_cancel_worker(
     let layer = layer_for_worker(state, task_id)
         .await
         .ok_or_else(|| anyhow::anyhow!("unknown task_id: {task_id}"))?;
-    let cancels = layer.worker_cancels.read().await;
+    let cancels = layer.workers.cancels.read().await;
     let Some(token) = cancels.get(task_id) else {
         anyhow::bail!("unknown task_id: {task_id}");
     };
@@ -204,7 +206,7 @@ pub async fn handle_pause_worker(
     let layer = layer_for_worker(state, task_id)
         .await
         .ok_or_else(|| anyhow::anyhow!("unknown task_id: {task_id}"))?;
-    let mut workers = layer.workers.write().await;
+    let mut workers = layer.workers.states.write().await;
     let Some(entry) = workers.get(task_id).cloned() else {
         anyhow::bail!("unknown task_id: {task_id}");
     };
@@ -214,7 +216,7 @@ pub async fn handle_pause_worker(
             session_id: Some(sid),
         } => match mode {
             PauseMode::Cancel => {
-                let cancels = layer.worker_cancels.read().await;
+                let cancels = layer.workers.cancels.read().await;
                 if let Some(tok) = cancels.get(task_id) {
                     // #475: pause-by-cancel — same kind of kill as
                     // terminate_worker, but issued via the MCP pause
@@ -239,7 +241,8 @@ pub async fn handle_pause_worker(
                 // Read the pid slot. If 0 (subprocess hasn't spawned
                 // yet), fail — freeze is meaningless without a pid.
                 let pid = layer
-                    .worker_pids
+                    .workers
+                    .pids
                     .read()
                     .await
                     .get(task_id)
@@ -278,7 +281,13 @@ pub async fn handle_continue_worker(
     let layer = layer_for_worker(state, &args.task_id)
         .await
         .ok_or_else(|| anyhow::anyhow!("unknown task_id: {}", args.task_id))?;
-    let current = layer.workers.read().await.get(&args.task_id).cloned();
+    let current = layer
+        .workers
+        .states
+        .read()
+        .await
+        .get(&args.task_id)
+        .cloned();
     match current {
         Some(WorkerState::Paused { session_id, .. }) => {
             let prompt = args.prompt.unwrap_or_else(|| "continue".into());
@@ -296,7 +305,8 @@ pub async fn handle_continue_worker(
             // a resume-only concept); clients that want to inject a
             // new prompt should thaw + reprompt as two steps.
             let pid = layer
-                .worker_pids
+                .workers
+                .pids
                 .read()
                 .await
                 .get(&args.task_id)
@@ -311,7 +321,7 @@ pub async fn handle_continue_worker(
             crate::dispatch::signals::resume_stopped(pid)?;
             // Transition back to Running, preserving the ORIGINAL
             // started_at so wall-clock duration stays accurate.
-            layer.workers.write().await.insert(
+            layer.workers.states.write().await.insert(
                 args.task_id.clone(),
                 WorkerState::Running {
                     started_at,
@@ -335,13 +345,19 @@ pub async fn handle_reprompt_worker(
     let layer = layer_for_worker(state, &args.task_id)
         .await
         .ok_or_else(|| anyhow::anyhow!("unknown task_id: {}", args.task_id))?;
-    let current = layer.workers.read().await.get(&args.task_id).cloned();
+    let current = layer
+        .workers
+        .states
+        .read()
+        .await
+        .get(&args.task_id)
+        .cloned();
     let session_id = match current {
         Some(WorkerState::Running {
             session_id: Some(sid),
             ..
         }) => {
-            let cancels = layer.worker_cancels.read().await;
+            let cancels = layer.workers.cancels.read().await;
             if let Some(tok) = cancels.get(&args.task_id) {
                 // #475: reprompt issues an internal kill+spawn-resume; not
                 // operator-initiated in the kill-audit sense, but record
@@ -392,7 +408,8 @@ pub async fn handle_reprompt_worker(
     // doesn't falsely inflate the reprompt count. Bump the counter on
     // the OWNING layer, not root.
     layer
-        .worker_counters
+        .workers
+        .counters
         .write()
         .await
         .entry(args.task_id)

--- a/crates/pitboss-cli/src/mcp/tools/spawn.rs
+++ b/crates/pitboss-cli/src/mcp/tools/spawn.rs
@@ -251,14 +251,15 @@ pub async fn handle_spawn_worker(
         *reserved_guard += estimate;
         drop(reserved_guard);
         target_layer
-            .worker_reservations
+            .workers
+            .reservations
             .write()
             .await
             .insert(task_id.clone(), estimate);
     }
 
     {
-        let mut workers = target_layer.workers.write().await;
+        let mut workers = target_layer.workers.states.write().await;
         workers.insert(task_id.clone(), WorkerState::Pending);
     }
 
@@ -278,7 +279,7 @@ pub async fn handle_spawn_worker(
         .insert(task_id.clone(), layer_index_value);
 
     // Register the worker's CancelToken on the target layer. This both
-    // inserts into `worker_cancels` and eagerly propagates any in-flight
+    // inserts into `workers.cancels` and eagerly propagates any in-flight
     // drain/terminate state from `target_layer.cancel` to the new token —
     // the post-#99 cascade gap fix lives inside `register_worker_cancel`
     // so the watcher / registration paths share one cascade rule
@@ -291,7 +292,8 @@ pub async fn handle_spawn_worker(
     // Record the prompt preview before spawning the background task.
     let prompt_preview: String = args.prompt.chars().take(80).collect();
     target_layer
-        .worker_prompts
+        .workers
+        .prompts
         .write()
         .await
         .insert(task_id.clone(), prompt_preview);
@@ -299,7 +301,8 @@ pub async fn handle_spawn_worker(
     // Track the worker's resolved model so cost estimation can price
     // completed workers at the correct rate.
     target_layer
-        .worker_models
+        .workers
+        .models
         .write()
         .await
         .insert(task_id.clone(), worker_model.clone());
@@ -309,7 +312,8 @@ pub async fn handle_spawn_worker(
     // reattach the type to appended TaskRecords. (#252 Phase 1.5)
     if let Some(t) = resolved_worker_type_id.as_deref() {
         target_layer
-            .worker_actor_types
+            .workers
+            .actor_types
             .write()
             .await
             .insert(task_id.clone(), t.to_string());
@@ -392,7 +396,8 @@ pub async fn handle_spawn_worker(
 
     // Retrieve the per-worker cancel token we inserted above.
     let worker_cancel_bg = target_layer
-        .worker_cancels
+        .workers
+        .cancels
         .read()
         .await
         .get(&task_id)
@@ -523,6 +528,7 @@ async fn run_worker(
                 let _ = layer.store.append_record(layer.run_id, &rec).await;
                 layer
                     .workers
+                    .states
                     .write()
                     .await
                     .insert(task_id.clone(), WorkerState::Done(rec));
@@ -533,9 +539,9 @@ async fn run_worker(
                 // Fan out to root so cross-layer wait_actor subscribers wake
                 // even on early-exit paths like SpawnFailed. Same rationale
                 // as the normal-exit fan-out below.
-                let _ = layer.done_tx.send(task_id.clone());
+                let _ = layer.workers.done_tx.send(task_id.clone());
                 if !std::sync::Arc::ptr_eq(&layer, &state.root) {
-                    let _ = state.root.done_tx.send(task_id);
+                    let _ = state.root.workers.done_tx.send(task_id);
                 }
                 return;
             }
@@ -545,7 +551,7 @@ async fn run_worker(
     };
 
     // Transition Pending → Running.
-    layer.workers.write().await.insert(
+    layer.workers.states.write().await.insert(
         task_id.clone(),
         WorkerState::Running {
             started_at: Utc::now(),
@@ -677,7 +683,7 @@ async fn run_worker(
         let task_id_for_rx = task_id.clone();
         let promote_task = tokio::spawn(async move {
             if let Some(sid) = session_id_rx.recv().await {
-                let mut workers = session_layer.workers.write().await;
+                let mut workers = session_layer.workers.states.write().await;
                 if let Some(WorkerState::Running { started_at, .. }) =
                     workers.get(&task_id_for_rx).cloned()
                 {
@@ -696,7 +702,8 @@ async fn run_worker(
         // `run_to_completion` right after the spawn succeeds.
         let pid_slot = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
         layer
-            .worker_pids
+            .workers
+            .pids
             .write()
             .await
             .insert(task_id.clone(), pid_slot.clone());
@@ -709,7 +716,7 @@ async fn run_worker(
             .await;
         promote_task.abort();
         // Clean up the pid slot — the worker is done, the pid is stale.
-        layer.worker_pids.write().await.remove(&task_id);
+        layer.workers.pids.write().await.remove(&task_id);
         outcome
     };
 
@@ -749,7 +756,8 @@ async fn run_worker(
 
     let worktree_path = if use_worktree { Some(cwd) } else { None };
     let counters = layer
-        .worker_counters
+        .workers
+        .counters
         .read()
         .await
         .get(&task_id)
@@ -825,6 +833,7 @@ async fn run_worker(
     // Transition to Done + broadcast on the layer's done channel.
     layer
         .workers
+        .states
         .write()
         .await
         .insert(task_id.clone(), WorkerState::Done(rec));
@@ -837,15 +846,15 @@ async fn run_worker(
     }
     // Broadcast termination on the worker's own layer AND on root.
     // wait_for_actor_internal (the engine for wait_actor / wait_for_worker)
-    // always subscribes via state.root.done_tx — regardless of which layer
+    // always subscribes via state.root.workers.done_tx — regardless of which layer
     // the caller is in — so a sublead-spawned worker that only fired its
     // own layer's done_tx would be invisible to its parent sub-lead's
     // wait_actor (which subscribes to root). Fan out to root so every
     // wait_actor caller, anywhere in the tree, wakes on every worker
     // completion. Cheap; broadcast.send is O(subscribers).
-    let _ = layer.done_tx.send(task_id.clone());
+    let _ = layer.workers.done_tx.send(task_id.clone());
     if !std::sync::Arc::ptr_eq(&layer, &state.root) {
-        let _ = state.root.done_tx.send(task_id);
+        let _ = state.root.workers.done_tx.send(task_id);
     }
 }
 
@@ -854,7 +863,8 @@ async fn run_worker(
 /// (returns 0 from the map). Clamped at 0.0 to avoid f64 drift going negative.
 async fn release_reservation_for_layer(layer: &Arc<LayerState>, task_id: &str) {
     let reserved_amount = layer
-        .worker_reservations
+        .workers
+        .reservations
         .write()
         .await
         .remove(task_id)
@@ -870,8 +880,8 @@ async fn release_reservation_for_layer(layer: &Arc<LayerState>, task_id: &str) {
 /// both root and sub-tree layers.
 async fn estimate_new_worker_cost_for_layer(layer: &Arc<LayerState>, intended_model: &str) -> f64 {
     use pitboss_core::prices::cost_usd;
-    let workers = layer.workers.read().await;
-    let models = layer.worker_models.read().await;
+    let workers = layer.workers.states.read().await;
+    let models = layer.workers.models.read().await;
     let mut costs: Vec<f64> = Vec::new();
     for (id, w) in workers.iter() {
         if let WorkerState::Done(rec) = w {
@@ -1035,7 +1045,8 @@ pub async fn spawn_resume_worker(
         .await
         .ok_or_else(|| anyhow::anyhow!("unknown task_id: {task_id}"))?;
     let model = layer
-        .worker_models
+        .workers
+        .models
         .read()
         .await
         .get(&task_id)
@@ -1044,8 +1055,13 @@ pub async fn spawn_resume_worker(
     // Resolve the worker's typed-profile id (if any) so the rebuilt
     // mcp-config.json scopes correctly and the appended TaskRecord
     // keeps its profile attribution. (#252 Phase 1.5)
-    let resumed_actor_type: Option<String> =
-        layer.worker_actor_types.read().await.get(&task_id).cloned();
+    let resumed_actor_type: Option<String> = layer
+        .workers
+        .actor_types
+        .read()
+        .await
+        .get(&task_id)
+        .cloned();
     let tools: Vec<String> = layer
         .manifest
         .lead
@@ -1085,11 +1101,12 @@ pub async fn spawn_resume_worker(
         worker_cancel.drain();
     }
     layer
-        .worker_cancels
+        .workers
+        .cancels
         .write()
         .await
         .insert(task_id.clone(), worker_cancel.clone());
-    layer.workers.write().await.insert(
+    layer.workers.states.write().await.insert(
         task_id.clone(),
         WorkerState::Running {
             started_at: Utc::now(),
@@ -1215,7 +1232,8 @@ pub async fn spawn_resume_worker(
     // freeze-pause works across continue_worker boundaries.
     let resume_pid_slot = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
     layer
-        .worker_pids
+        .workers
+        .pids
         .write()
         .await
         .insert(task_id.clone(), resume_pid_slot.clone());
@@ -1236,7 +1254,7 @@ pub async fn spawn_resume_worker(
         )
         .await;
         // Clean up the pid slot when the resumed subprocess exits.
-        layer_bg.worker_pids.write().await.remove(&task_id_bg);
+        layer_bg.workers.pids.write().await.remove(&task_id_bg);
         let mut status = match outcome.final_state {
             pitboss_core::session::SessionState::Completed => TaskStatus::Success,
             pitboss_core::session::SessionState::Failed { .. } => TaskStatus::Failed,
@@ -1259,7 +1277,8 @@ pub async fn spawn_resume_worker(
             }
         }
         let counters = layer_bg
-            .worker_counters
+            .workers
+            .counters
             .read()
             .await
             .get(&task_id_bg)
@@ -1294,7 +1313,7 @@ pub async fn spawn_resume_worker(
             cost_usd,
             // Preserve the typed-profile attribution across resume so the
             // appended record carries the same `actor_type` as the original
-            // spawn — read from the in-memory `worker_actor_types` map at
+            // spawn — read from the in-memory `workers.actor_types` map at
             // resume entry. (#252 Phase 1.5)
             actor_type: resumed_actor_type_bg.clone(),
             // Plumb kill reason from the resumed worker's cancel token.
@@ -1317,6 +1336,7 @@ pub async fn spawn_resume_worker(
         }
         layer_bg
             .workers
+            .states
             .write()
             .await
             .insert(task_id_bg.clone(), WorkerState::Done(rec));
@@ -1328,7 +1348,7 @@ pub async fn spawn_resume_worker(
             .write()
             .await
             .remove(&task_id_bg);
-        let _ = layer_bg.done_tx.send(task_id_bg);
+        let _ = layer_bg.workers.done_tx.send(task_id_bg);
     });
 
     Ok(())

--- a/crates/pitboss-cli/src/mcp/tools/tests.rs
+++ b/crates/pitboss-cli/src/mcp/tools/tests.rs
@@ -369,7 +369,7 @@ async fn list_workers_empty_when_no_spawns() {
 async fn list_workers_shows_pending_and_running() {
     let state = test_state().await;
     {
-        let mut w = state.root.workers.write().await;
+        let mut w = state.root.workers.states.write().await;
         w.insert("w-1".into(), WorkerState::Pending);
         w.insert(
             "w-2".into(),
@@ -407,7 +407,7 @@ async fn spawn_worker_adds_entry_to_state() {
     // The background task may have already transitioned the worker to
     // Running or Done by the time we read, so we just assert the key
     // exists and is in a valid state (Pending / Running / Done).
-    let workers = state.root.workers.read().await;
+    let workers = state.root.workers.states.read().await;
     assert_eq!(workers.len(), 1);
     let entry = workers.get(&result.task_id).unwrap();
     assert!(matches!(
@@ -416,7 +416,7 @@ async fn spawn_worker_adds_entry_to_state() {
     ));
 
     // Verify prompt_preview was recorded.
-    let prompts = state.root.worker_prompts.read().await;
+    let prompts = state.root.workers.prompts.read().await;
     assert_eq!(
         prompts.get(&result.task_id).unwrap(),
         "investigate issue #1"
@@ -609,7 +609,7 @@ async fn wait_for_worker_returns_outcome_on_completion() {
     let state = test_state().await;
     let task_id = "worker-test-1".to_string();
     {
-        let mut w = state.root.workers.write().await;
+        let mut w = state.root.workers.states.write().await;
         w.insert(task_id.clone(), WorkerState::Pending);
     }
 
@@ -643,9 +643,9 @@ async fn wait_for_worker_returns_outcome_on_completion() {
             actor_type: None,
             terminate_reason: None,
         };
-        let mut w = state_clone.root.workers.write().await;
+        let mut w = state_clone.root.workers.states.write().await;
         w.insert(task_id_clone.clone(), WorkerState::Done(rec));
-        let _ = state_clone.root.done_tx.send(task_id_clone);
+        let _ = state_clone.root.workers.done_tx.send(task_id_clone);
     });
 
     let outcome = handle_wait_for_worker(&state, &task_id, Some(5))
@@ -659,7 +659,7 @@ async fn wait_for_worker_times_out() {
     let state = test_state().await;
     let task_id = "worker-stuck".to_string();
     {
-        let mut w = state.root.workers.write().await;
+        let mut w = state.root.workers.states.write().await;
         w.insert(task_id.clone(), WorkerState::Pending);
     }
     let err = handle_wait_for_worker(&state, &task_id, Some(0))
@@ -685,7 +685,7 @@ async fn wait_for_any_returns_first_completed() {
     let state = test_state().await;
     let ids = vec!["w-a".to_string(), "w-b".to_string(), "w-c".to_string()];
     {
-        let mut w = state.root.workers.write().await;
+        let mut w = state.root.workers.states.write().await;
         for id in &ids {
             w.insert(id.clone(), WorkerState::Pending);
         }
@@ -720,9 +720,9 @@ async fn wait_for_any_returns_first_completed() {
             actor_type: None,
             terminate_reason: None,
         };
-        let mut w = state_clone.root.workers.write().await;
+        let mut w = state_clone.root.workers.states.write().await;
         w.insert("w-b".into(), WorkerState::Done(rec));
-        let _ = state_clone.root.done_tx.send("w-b".into());
+        let _ = state_clone.root.workers.done_tx.send("w-b".into());
     });
 
     let (winner_id, _rec) = handle_wait_for_any(&state, &ids, Some(5)).await.unwrap();
@@ -847,7 +847,7 @@ async fn spawn_worker_completes_and_updates_spent_usd_and_parent_task_id() {
     };
 
     // Subscribe to done events BEFORE spawning.
-    let mut rx = state.root.done_tx.subscribe();
+    let mut rx = state.root.workers.done_tx.subscribe();
     let spawn = handle_spawn_worker(&state, args).await.unwrap();
 
     // Wait for the broadcast.
@@ -858,7 +858,7 @@ async fn spawn_worker_completes_and_updates_spent_usd_and_parent_task_id() {
     assert_eq!(id, spawn.task_id, "broadcast id matches spawn id");
 
     // Verify Done state + Success + parent_task_id.
-    let workers = state.root.workers.read().await;
+    let workers = state.root.workers.states.read().await;
     let entry = workers.get(&spawn.task_id).expect("worker recorded");
     match entry {
         WorkerState::Done(rec) => {
@@ -886,7 +886,8 @@ async fn spawn_worker_completes_and_updates_spent_usd_and_parent_task_id() {
     // Verify prompt_preview is present.
     let preview = state
         .root
-        .worker_prompts
+        .workers
+        .prompts
         .read()
         .await
         .get(&spawn.task_id)
@@ -948,7 +949,7 @@ async fn reservation_released_on_worker_completion() {
 
     // Subscribe to done events BEFORE spawning — the completion path is
     // fast (FakeScript exits immediately after emitting the result line).
-    let mut rx = state.root.done_tx.subscribe();
+    let mut rx = state.root.workers.done_tx.subscribe();
 
     let spawn = handle_spawn_worker(
         &state,
@@ -969,7 +970,7 @@ async fn reservation_released_on_worker_completion() {
     // Reservation should be > 0 at some point between spawn and completion;
     // under a very fast FakeSpawner the worker can complete before this
     // read, so we only assert "reservation was initialized to >0". That's
-    // checked indirectly via the `worker_reservations` map having an entry
+    // checked indirectly via the `workers.reservations` map having an entry
     // (or having had one — it's removed on release).
     // The primary assertion is post-completion.
 
@@ -984,7 +985,7 @@ async fn reservation_released_on_worker_completion() {
         reserved_after.abs() < 1e-9,
         "reservation should be released after completion, got {reserved_after}"
     );
-    let reservations = state.root.worker_reservations.read().await;
+    let reservations = state.root.workers.reservations.read().await;
     assert!(
         !reservations.contains_key(&spawn.task_id),
         "reservation entry should be removed on completion"
@@ -1009,7 +1010,7 @@ async fn running_worker_state_gets_session_id_after_init() {
     use std::time::Duration;
 
     let state = completing_test_state().await;
-    let mut rx = state.root.done_tx.subscribe();
+    let mut rx = state.root.workers.done_tx.subscribe();
     let args = SpawnWorkerArgs {
         prompt: "analyze".into(),
         directory: None,
@@ -1028,7 +1029,7 @@ async fn running_worker_state_gets_session_id_after_init() {
 
     // Post-completion, the worker is in Done state. The session_id is
     // preserved on TaskRecord via SessionOutcome. Assert it.
-    let workers = state.root.workers.read().await;
+    let workers = state.root.workers.states.read().await;
     match workers.get(&spawn.task_id).unwrap() {
         WorkerState::Done(rec) => {
             assert_eq!(rec.claude_session_id.as_deref(), Some("sess_ok"));
@@ -1102,11 +1103,12 @@ async fn handle_pause_worker_pauses_running_worker() {
     let worker_token = pitboss_core::session::CancelToken::new();
     state
         .root
-        .worker_cancels
+        .workers
+        .cancels
         .write()
         .await
         .insert("w-1".into(), worker_token.clone());
-    state.root.workers.write().await.insert(
+    state.root.workers.states.write().await.insert(
         "w-1".into(),
         WorkerState::Running {
             started_at: chrono::Utc::now(),
@@ -1118,7 +1120,7 @@ async fn handle_pause_worker_pauses_running_worker() {
         .unwrap();
     assert!(res.ok);
     assert!(worker_token.is_terminated());
-    let workers = state.root.workers.read().await;
+    let workers = state.root.workers.states.read().await;
     assert!(matches!(
         workers.get("w-1").unwrap(),
         WorkerState::Paused { .. }
@@ -1150,17 +1152,19 @@ async fn freeze_and_thaw_transition_via_handler() {
     let slot = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(pid));
     state
         .root
-        .worker_pids
+        .workers
+        .pids
         .write()
         .await
         .insert("w-freeze".into(), slot);
     state
         .root
-        .worker_cancels
+        .workers
+        .cancels
         .write()
         .await
         .insert("w-freeze".into(), pitboss_core::session::CancelToken::new());
-    state.root.workers.write().await.insert(
+    state.root.workers.states.write().await.insert(
         "w-freeze".into(),
         WorkerState::Running {
             started_at: chrono::Utc::now(),
@@ -1174,7 +1178,14 @@ async fn freeze_and_thaw_transition_via_handler() {
         .unwrap();
     assert!(res.ok);
     assert!(matches!(
-        state.root.workers.read().await.get("w-freeze").unwrap(),
+        state
+            .root
+            .workers
+            .states
+            .read()
+            .await
+            .get("w-freeze")
+            .unwrap(),
         WorkerState::Frozen { .. }
     ));
 
@@ -1202,7 +1213,14 @@ async fn freeze_and_thaw_transition_via_handler() {
     .unwrap();
     assert!(cres.ok);
     assert!(matches!(
-        state.root.workers.read().await.get("w-freeze").unwrap(),
+        state
+            .root
+            .workers
+            .states
+            .read()
+            .await
+            .get("w-freeze")
+            .unwrap(),
         WorkerState::Running { .. }
     ));
 
@@ -1215,7 +1233,7 @@ async fn freeze_and_thaw_transition_via_handler() {
 #[tokio::test]
 async fn handle_continue_worker_resumes_paused() {
     let state = test_state().await;
-    state.root.workers.write().await.insert(
+    state.root.workers.states.write().await.insert(
         "w-1".into(),
         WorkerState::Paused {
             session_id: "sess".into(),
@@ -1225,13 +1243,15 @@ async fn handle_continue_worker_resumes_paused() {
     );
     state
         .root
-        .worker_prompts
+        .workers
+        .prompts
         .write()
         .await
         .insert("w-1".into(), "hi".into());
     state
         .root
-        .worker_models
+        .workers
+        .models
         .write()
         .await
         .insert("w-1".into(), "claude-haiku-4-5".into());
@@ -1245,7 +1265,7 @@ async fn handle_continue_worker_resumes_paused() {
     .await
     .unwrap();
     assert!(res.ok);
-    let workers = state.root.workers.read().await;
+    let workers = state.root.workers.states.read().await;
     assert!(matches!(
         workers.get("w-1").unwrap(),
         WorkerState::Running { .. }
@@ -1258,11 +1278,12 @@ async fn handle_reprompt_worker_from_running() {
     let worker_token = pitboss_core::session::CancelToken::new();
     state
         .root
-        .worker_cancels
+        .workers
+        .cancels
         .write()
         .await
         .insert("w-1".into(), worker_token.clone());
-    state.root.workers.write().await.insert(
+    state.root.workers.states.write().await.insert(
         "w-1".into(),
         WorkerState::Running {
             started_at: chrono::Utc::now(),
@@ -1271,13 +1292,15 @@ async fn handle_reprompt_worker_from_running() {
     );
     state
         .root
-        .worker_prompts
+        .workers
+        .prompts
         .write()
         .await
         .insert("w-1".into(), "original".into());
     state
         .root
-        .worker_models
+        .workers
+        .models
         .write()
         .await
         .insert("w-1".into(), "claude-haiku-4-5".into());
@@ -1296,7 +1319,8 @@ async fn handle_reprompt_worker_from_running() {
     // Counter bumps on success.
     let counters = state
         .root
-        .worker_counters
+        .workers
+        .counters
         .read()
         .await
         .get("w-1")
@@ -1316,7 +1340,7 @@ async fn handle_reprompt_worker_from_running() {
         "events.jsonl missing reprompt: {events}"
     );
     // Worker transitioned back to Running via spawn_resume_worker.
-    let workers = state.root.workers.read().await;
+    let workers = state.root.workers.states.read().await;
     assert!(matches!(
         workers.get("w-1").unwrap(),
         WorkerState::Running { .. }
@@ -1355,6 +1379,7 @@ async fn handle_reprompt_worker_from_done_errors() {
     state
         .root
         .workers
+        .states
         .write()
         .await
         .insert("w-done".into(), WorkerState::Done(rec));
@@ -1432,11 +1457,12 @@ async fn handle_pause_worker_targets_sublead_layer() {
 
     let worker_token = pitboss_core::session::CancelToken::new();
     sub_layer
-        .worker_cancels
+        .workers
+        .cancels
         .write()
         .await
         .insert("w-sub".into(), worker_token.clone());
-    sub_layer.workers.write().await.insert(
+    sub_layer.workers.states.write().await.insert(
         "w-sub".into(),
         WorkerState::Running {
             started_at: chrono::Utc::now(),
@@ -1444,14 +1470,21 @@ async fn handle_pause_worker_targets_sublead_layer() {
         },
     );
     // Sanity: root has no entry — pre-fix code would bail here.
-    assert!(state.root.workers.read().await.get("w-sub").is_none());
+    assert!(state
+        .root
+        .workers
+        .states
+        .read()
+        .await
+        .get("w-sub")
+        .is_none());
 
     let res = handle_pause_worker(&state, "w-sub", PauseMode::Cancel)
         .await
         .unwrap();
     assert!(res.ok);
     assert!(worker_token.is_terminated());
-    let workers = sub_layer.workers.read().await;
+    let workers = sub_layer.workers.states.read().await;
     assert!(matches!(
         workers.get("w-sub").unwrap(),
         WorkerState::Paused { .. }
@@ -1466,7 +1499,7 @@ async fn handle_continue_worker_targets_sublead_layer() {
     let sub_layer = register_test_sublead(&state, "sublead-A").await;
     index_worker(&state, "w-sub", Some("sublead-A")).await;
 
-    sub_layer.workers.write().await.insert(
+    sub_layer.workers.states.write().await.insert(
         "w-sub".into(),
         WorkerState::Paused {
             session_id: "sess".into(),
@@ -1475,12 +1508,14 @@ async fn handle_continue_worker_targets_sublead_layer() {
         },
     );
     sub_layer
-        .worker_prompts
+        .workers
+        .prompts
         .write()
         .await
         .insert("w-sub".into(), "hi".into());
     sub_layer
-        .worker_models
+        .workers
+        .models
         .write()
         .await
         .insert("w-sub".into(), "claude-haiku-4-5".into());
@@ -1496,8 +1531,15 @@ async fn handle_continue_worker_targets_sublead_layer() {
     .unwrap();
     assert!(res.ok);
     // The sublead's layer has the resumed worker — root must remain empty.
-    assert!(state.root.workers.read().await.get("w-sub").is_none());
-    let workers = sub_layer.workers.read().await;
+    assert!(state
+        .root
+        .workers
+        .states
+        .read()
+        .await
+        .get("w-sub")
+        .is_none());
+    let workers = sub_layer.workers.states.read().await;
     assert!(matches!(
         workers.get("w-sub").unwrap(),
         WorkerState::Running { .. }
@@ -1515,11 +1557,12 @@ async fn handle_reprompt_worker_targets_sublead_layer() {
 
     let worker_token = pitboss_core::session::CancelToken::new();
     sub_layer
-        .worker_cancels
+        .workers
+        .cancels
         .write()
         .await
         .insert("w-sub".into(), worker_token.clone());
-    sub_layer.workers.write().await.insert(
+    sub_layer.workers.states.write().await.insert(
         "w-sub".into(),
         WorkerState::Running {
             started_at: chrono::Utc::now(),
@@ -1527,12 +1570,14 @@ async fn handle_reprompt_worker_targets_sublead_layer() {
         },
     );
     sub_layer
-        .worker_prompts
+        .workers
+        .prompts
         .write()
         .await
         .insert("w-sub".into(), "original".into());
     sub_layer
-        .worker_models
+        .workers
+        .models
         .write()
         .await
         .insert("w-sub".into(), "claude-haiku-4-5".into());
@@ -1549,7 +1594,8 @@ async fn handle_reprompt_worker_targets_sublead_layer() {
     assert!(res.ok);
     // Counter bumps on the sub-lead's layer (NOT root).
     let counters = sub_layer
-        .worker_counters
+        .workers
+        .counters
         .read()
         .await
         .get("w-sub")
@@ -1559,7 +1605,8 @@ async fn handle_reprompt_worker_targets_sublead_layer() {
     // Root counters should be empty.
     assert!(state
         .root
-        .worker_counters
+        .workers
+        .counters
         .read()
         .await
         .get("w-sub")
@@ -1576,11 +1623,12 @@ async fn handle_cancel_worker_targets_sublead_layer() {
 
     let worker_token = pitboss_core::session::CancelToken::new();
     sub_layer
-        .worker_cancels
+        .workers
+        .cancels
         .write()
         .await
         .insert("w-sub".into(), worker_token.clone());
-    sub_layer.workers.write().await.insert(
+    sub_layer.workers.states.write().await.insert(
         "w-sub".into(),
         WorkerState::Running {
             started_at: chrono::Utc::now(),
@@ -1589,7 +1637,7 @@ async fn handle_cancel_worker_targets_sublead_layer() {
     );
 
     // Pre-fix: this would bail "unknown task_id" because the read was
-    // pinned to state.root.worker_cancels.
+    // pinned to state.root.workers.cancels.
     let res = handle_cancel_worker(&state, "w-sub").await.unwrap();
     assert!(res.ok);
     assert!(worker_token.is_terminated());
@@ -2423,7 +2471,7 @@ async fn permission_prompt_cost_over_rule_denies_when_estimate_exceeds() {
 
     // #367: the rule short-circuit must also record approval state so
     // counters and `approval_driven_termination` work under Path B.
-    let counters = state.root.worker_counters.read().await;
+    let counters = state.root.workers.counters.read().await;
     let entry = counters
         .get("lead")
         .expect("rule-driven deny must bump approval counters for caller");
@@ -2483,7 +2531,7 @@ async fn permission_prompt_rule_auto_approve_records_state_and_counters() {
         "rule-driven approve must yield Allow: {resp:?}"
     );
 
-    let counters = state.root.worker_counters.read().await;
+    let counters = state.root.workers.counters.read().await;
     let entry = counters
         .get("lead")
         .expect("rule-driven approve must bump approval counters for caller");
@@ -2520,7 +2568,7 @@ async fn permission_prompt_default_policy_auto_approve_records_last_response() {
         "bridge AutoApprove must yield Allow: {resp:?}"
     );
 
-    let counters = state.root.worker_counters.read().await;
+    let counters = state.root.workers.counters.read().await;
     let entry = counters
         .get("lead")
         .expect("bridge AutoApprove must bump approval counters");
@@ -2583,7 +2631,7 @@ async fn permission_prompt_default_policy_auto_reject_records_denied_by_policy()
          did (#373): {reason}"
     );
 
-    let counters = state.root.worker_counters.read().await;
+    let counters = state.root.workers.counters.read().await;
     let entry = counters
         .get("lead")
         .expect("bridge AutoReject must bump approval counters");
@@ -2655,7 +2703,7 @@ async fn approval_driven_termination_adapt_policy_returns_none_after_denial() {
     // Sanity: the denial WAS recorded — counters and last_approval_response
     // both fired (the Adapt policy does not silence those signals,
     // only the reclassification).
-    let counters = state.root.worker_counters.read().await;
+    let counters = state.root.workers.counters.read().await;
     let entry = counters
         .get("lead")
         .expect("denial must still bump approvals_rejected");
@@ -3206,7 +3254,8 @@ async fn spawn_worker_typed_persists_actor_type_on_record() {
     for _ in 0..50 {
         if let Some(tok) = state
             .root
-            .worker_cancels
+            .workers
+            .cancels
             .read()
             .await
             .get(&res.task_id)
@@ -3224,7 +3273,9 @@ async fn spawn_worker_typed_persists_actor_type_on_record() {
     let mut found_actor_type: Option<String> = None;
     for _ in 0..50 {
         tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-        if let Some(WorkerState::Done(rec)) = state.root.workers.read().await.get(&res.task_id) {
+        if let Some(WorkerState::Done(rec)) =
+            state.root.workers.states.read().await.get(&res.task_id)
+        {
             found_actor_type = rec.actor_type.clone();
             break;
         }
@@ -3249,13 +3300,14 @@ async fn spawn_worker_typed_persists_actor_type_on_record() {
 // fall through to the bridge unchanged.
 
 /// Helper for the profile tests below: inserts a typed worker entry
-/// into the root layer's `worker_actor_types` map. Mirrors what
+/// into the root layer's `workers.actor_types` map. Mirrors what
 /// `handle_spawn_worker` does on a real spawn, without driving the
 /// FakeSpawner — the approval path only reads the maps.
 async fn insert_typed_worker(state: &Arc<DispatchState>, worker_id: &str, worker_type_id: &str) {
     state
         .root
-        .worker_actor_types
+        .workers
+        .actor_types
         .write()
         .await
         .insert(worker_id.to_string(), worker_type_id.to_string());
@@ -3297,7 +3349,7 @@ async fn permission_prompt_profile_auto_approves_tool_in_allowlist() {
     );
 
     // Counters bumped — symmetric with rule-driven AutoApprove (#367).
-    let counters = state.root.worker_counters.read().await;
+    let counters = state.root.workers.counters.read().await;
     let entry = counters
         .get("worker-1")
         .expect("profile auto-approve must bump approval counters");
@@ -3331,7 +3383,7 @@ async fn permission_prompt_profile_auto_denies_tool_outside_allowlist() {
         "model-facing reason must name the profile so claude can adapt: {message}"
     );
 
-    let counters = state.root.worker_counters.read().await;
+    let counters = state.root.workers.counters.read().await;
     let entry = counters
         .get("worker-1")
         .expect("profile auto-deny must bump approval counters");
@@ -3340,7 +3392,7 @@ async fn permission_prompt_profile_auto_denies_tool_outside_allowlist() {
     assert_eq!(entry.approvals_rejected, 1);
 }
 
-/// Untyped workers (no entry in `worker_actor_types`) MUST fall through
+/// Untyped workers (no entry in `workers.actor_types`) MUST fall through
 /// to the bridge so back-compat with v0.9 manifests is preserved.
 /// Verified by setting the bridge's default policy to AutoApprove and
 /// confirming the call returns Allow — if the profile path had
@@ -3372,7 +3424,7 @@ async fn permission_prompt_untyped_worker_falls_through_to_bridge() {
 /// Lead callers MUST NOT short-circuit on profile, even when typed
 /// `[[worker_type]]` entries exist in the manifest. The root lead is
 /// never typed (#252 Phase 1.5: "Root lead is never typed") and an
-/// off-by-one that wired `worker_actor_types` lookups for `ActorRole::Lead`
+/// off-by-one that wired `workers.actor_types` lookups for `ActorRole::Lead`
 /// would silently apply a worker profile's caps to the lead — which
 /// would forbid orchestration tools the lead must always have.
 #[tokio::test]
@@ -3388,13 +3440,14 @@ async fn permission_prompt_lead_caller_never_uses_profile_path() {
     .await;
     // Typed worker entries exist but the caller's role is Lead — the
     // profile lookup must short-circuit at the `ActorRole::Lead` arm.
-    // If it didn't, looking up `"lead"` in `worker_actor_types` would
+    // If it didn't, looking up `"lead"` in `workers.actor_types` would
     // find the planted "extraction" entry and apply a worker profile
     // to the lead — forbidding orchestration tools the lead must
     // always have.
     state
         .root
-        .worker_actor_types
+        .workers
+        .actor_types
         .write()
         .await
         .insert("lead".into(), "extraction".into());
@@ -3573,7 +3626,7 @@ async fn permission_prompt_synthetic_default_blocks_untyped_worker() {
         "synthetic denial must name the sentinel profile id: {message}"
     );
 
-    let counters = state.root.worker_counters.read().await;
+    let counters = state.root.workers.counters.read().await;
     let entry = counters
         .get("worker-untyped")
         .expect("synthetic auto-deny must bump approval counters");

--- a/crates/pitboss-cli/src/mcp/tools/wait.rs
+++ b/crates/pitboss-cli/src/mcp/tools/wait.rs
@@ -1,6 +1,6 @@
 //! Wait-side MCP handlers: `wait_for_worker`, `wait_for_actor`,
 //! `wait_for_any`. All three share a single internal engine
-//! `wait_for_actor_internal` that subscribes to `state.root.done_tx`
+//! `wait_for_actor_internal` that subscribes to `state.root.workers.done_tx`
 //! before any fast-path check (preventing the cross-layer
 //! subscribe-after-completion race).
 
@@ -32,7 +32,7 @@ async fn wait_for_actor_internal(
     //    broadcast is missed and the wait blocks until either the
     //    timeout fires or the sublead itself is killed by lead_timeout.
     //    Subscribing first guarantees no completion is lost.
-    let mut rx = state.root.done_tx.subscribe();
+    let mut rx = state.root.workers.done_tx.subscribe();
 
     // ── Fast path: already Done ────────────────────────────────────────────────
     // 1. Worker already Done? (scan all layers — the worker may be in a
@@ -141,12 +141,12 @@ pub async fn handle_wait_for_any(
     // wait_for_actor_internal (commit 70e2bd8). Without this, a worker
     // that terminated between our existence check and our subscribe is
     // lost and we block until timeout.
-    let mut rx = state.root.done_tx.subscribe();
+    let mut rx = state.root.workers.done_tx.subscribe();
     let wait_duration = Duration::from_secs(timeout_secs.unwrap_or(3600));
 
     // Fast path: any already Done? Scan ALL layers — sub-lead-spawned
     // workers are registered in the sub-lead layer's workers map, not
-    // root's. Pre-fix, this only checked `state.root.workers.read()` (= root
+    // root's. Pre-fix, this only checked `state.root.workers.states.read()` (= root
     // via Deref) and so stayed blocked indefinitely on sub-lead-owned
     // workers. Same bug class as commit d134289 (which fixed wait_actor
     // + list_workers + worker_status) but this handler had its own

--- a/crates/pitboss-cli/tests/cancel_cascade_flows.rs
+++ b/crates/pitboss-cli/tests/cancel_cascade_flows.rs
@@ -27,7 +27,7 @@
 //! the eager-cascade block. The `is_terminated()` branch at
 //! `tools.rs:514-516` is genuine defensive coverage for an intra-handler
 //! race (terminate fires after target-layer resolution succeeds but
-//! before worker_cancels is read), which is not observable through the
+//! before workers.cancels is read), which is not observable through the
 //! external MCP API. Pinning that race would require an in-process hook
 //! that 100.2's refactor will provide naturally; revisit then.
 //!
@@ -164,7 +164,7 @@ async fn sublead_spawned_after_root_terminate_inherits_terminate() {
 /// Worker registered in a **drained sub-tree** (root still healthy) must
 /// inherit drain via the eager cascade at `tools.rs:506-521`. The
 /// per-sublead fire-once watcher already woke when the sub-tree's
-/// `cancel` was tripped and snapshotted an empty `worker_cancels` —
+/// `cancel` was tripped and snapshotted an empty `workers.cancels` —
 /// only the eager check can reach this late-registered worker.
 #[tokio::test]
 async fn worker_spawned_in_subtree_after_subtree_drain_inherits_drain() {
@@ -204,8 +204,8 @@ async fn worker_spawned_in_subtree_after_subtree_drain_inherits_drain() {
 
     let subleads = state.subleads.read().await;
     let sub_layer = subleads.get(&sublead_id).unwrap();
-    let worker_cancels = sub_layer.worker_cancels.read().await;
-    let tok = worker_cancels
+    let cancels = sub_layer.workers.cancels.read().await;
+    let tok = cancels
         .get(&task_id)
         .expect("worker cancel token must be registered on the sub-tree layer");
     assert!(

--- a/crates/pitboss-cli/tests/control_flows.rs
+++ b/crates/pitboss-cli/tests/control_flows.rs
@@ -87,11 +87,12 @@ async fn pause_op_writes_events_jsonl() {
     let worker_token = CancelToken::new();
     state
         .root
-        .worker_cancels
+        .workers
+        .cancels
         .write()
         .await
         .insert("w-1".into(), worker_token);
-    state.root.workers.write().await.insert(
+    state.root.workers.states.write().await.insert(
         "w-1".into(),
         WorkerState::Running {
             started_at: chrono::Utc::now(),
@@ -308,7 +309,7 @@ async fn server_emits_monotonic_seqs_on_wire() {
         None,
         std::sync::Arc::new(pitboss_cli::shared_store::SharedStore::new()),
     ));
-    state.root.workers.write().await.insert(
+    state.root.workers.states.write().await.insert(
         "w-seq".into(),
         WorkerState::Running {
             started_at: chrono::Utc::now(),
@@ -446,7 +447,7 @@ async fn emit_event_stream_writes_envelopes_to_events_jsonl() {
         None,
         std::sync::Arc::new(pitboss_cli::shared_store::SharedStore::new()),
     ));
-    state.root.workers.write().await.insert(
+    state.root.workers.states.write().await.insert(
         "w-1".into(),
         WorkerState::Running {
             started_at: chrono::Utc::now(),
@@ -1459,17 +1460,18 @@ async fn subscriber_writer_op_returns_op_failed() {
     let (state, run_id, _run_subdir) = make_subscriber_test_state(&dir).await;
 
     // Install a worker so a misrouted CancelWorker has something to find.
-    // The cancel must NOT fire — we rely on the worker_cancels token
+    // The cancel must NOT fire — we rely on the workers.cancels token
     // staying un-cancelled to prove the op was rejected before
     // dispatch_op ran.
     let worker_token = CancelToken::new();
     state
         .root
-        .worker_cancels
+        .workers
+        .cancels
         .write()
         .await
         .insert("w-1".into(), worker_token.clone());
-    state.root.workers.write().await.insert(
+    state.root.workers.states.write().await.insert(
         "w-1".into(),
         WorkerState::Running {
             started_at: chrono::Utc::now(),
@@ -1675,7 +1677,7 @@ async fn op_replies_broadcast_to_subscribers() {
     let (state, run_id, _run_subdir) = make_subscriber_test_state(&dir).await;
 
     // Install a worker so ListWorkers has a non-empty snapshot to return.
-    state.root.workers.write().await.insert(
+    state.root.workers.states.write().await.insert(
         "w-1".into(),
         WorkerState::Running {
             started_at: chrono::Utc::now(),
@@ -1684,7 +1686,8 @@ async fn op_replies_broadcast_to_subscribers() {
     );
     state
         .root
-        .worker_prompts
+        .workers
+        .prompts
         .write()
         .await
         .insert("w-1".into(), "investigate failure".into());

--- a/crates/pitboss-cli/tests/dogfood_fake_flows.rs
+++ b/crates/pitboss-cli/tests/dogfood_fake_flows.rs
@@ -448,7 +448,7 @@ async fn dogfood_isolation_strict_tree() {
 ///
 /// Same as spotlight #02: DispatchState + McpServer constructed in-process,
 /// driven via FakeMcpClient. Worker cancel tokens are injected directly into
-/// each sub-tree's `worker_cancels` map to simulate the state the cascade must
+/// each sub-tree's `workers.cancels` map to simulate the state the cascade must
 /// handle (Phase 4+ will wire real sub-tree workers).
 #[tokio::test]
 async fn dogfood_kill_cascade_drain() {
@@ -511,8 +511,8 @@ async fn dogfood_kill_cascade_drain() {
     for sublead_id in [&s1_id, &s2_id] {
         let subleads = state.subleads.read().await;
         let sub = subleads.get(sublead_id.as_str()).unwrap();
-        let mut workers = sub.workers.write().await;
-        let mut cancels = sub.worker_cancels.write().await;
+        let mut workers = sub.workers.states.write().await;
+        let mut cancels = sub.workers.cancels.write().await;
         for worker_n in 0..2 {
             let worker_id = format!("{sublead_id}-w{worker_n}");
             workers.insert(
@@ -528,13 +528,13 @@ async fn dogfood_kill_cascade_drain() {
         let subleads = state.subleads.read().await;
         assert_eq!(subleads.len(), 2, "both sub-leads should be registered");
         for (sublead_id, sub) in subleads.iter() {
-            let worker_cancels = sub.worker_cancels.read().await;
+            let cancels = sub.workers.cancels.read().await;
             assert_eq!(
-                worker_cancels.len(),
+                cancels.len(),
                 2,
                 "sub-lead {sublead_id} should have 2 worker cancel tokens pre-cancel"
             );
-            for (wid, tok) in worker_cancels.iter() {
+            for (wid, tok) in cancels.iter() {
                 assert!(
                     !tok.is_draining(),
                     "pre-cancel: worker token {wid} under {sublead_id} should not be draining"
@@ -573,7 +573,7 @@ async fn dogfood_kill_cascade_drain() {
                 sub.cancel.is_draining(),
                 "cascade should have drained sub-tree {sublead_id}"
             );
-            for (wid, tok) in sub.worker_cancels.read().await.iter() {
+            for (wid, tok) in sub.workers.cancels.read().await.iter() {
                 assert!(
                     tok.is_draining(),
                     "cascade should have drained sub-tree worker {wid} under {sublead_id}"

--- a/crates/pitboss-cli/tests/e2e_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_flows.rs
@@ -209,7 +209,7 @@ async fn e2e_lead_spawns_worker_via_real_subprocess() {
     ));
 
     // Worker state should be Done with a captured session_id.
-    let workers = state.root.workers.read().await;
+    let workers = state.root.workers.states.read().await;
     assert_eq!(
         workers.len(),
         1,
@@ -268,7 +268,7 @@ async fn e2e_lead_spawns_three_workers_and_waits_for_any() {
 
     // All 3 workers should be registered (at least 1 Done; the rest can be
     // Done or Running depending on timing).
-    let workers = state.root.workers.read().await;
+    let workers = state.root.workers.states.read().await;
     assert_eq!(
         workers.len(),
         3,
@@ -406,7 +406,7 @@ async fn e2e_lead_cancels_worker_mid_flight() {
     tokio::time::sleep(Duration::from_millis(1000)).await;
 
     // Worker should now be Cancelled.
-    let workers = state.root.workers.read().await;
+    let workers = state.root.workers.states.read().await;
     let (_, w) = workers.iter().next().expect("at least one worker");
     match w {
         pitboss_cli::dispatch::state::WorkerState::Done(rec) => {
@@ -548,7 +548,8 @@ async fn e2e_lead_request_approval_round_trip() {
     // Counters should record one request + one approval.
     let counters = state
         .root
-        .worker_counters
+        .workers
+        .counters
         .read()
         .await
         .get("lead")
@@ -683,7 +684,7 @@ async fn e2e_lead_reprompts_running_worker() {
 
     // Extract the worker's task_id for subsequent assertions.
     let task_id = {
-        let workers = state.root.workers.read().await;
+        let workers = state.root.workers.states.read().await;
         workers.keys().next().cloned().expect("at least one worker")
     };
 
@@ -698,7 +699,8 @@ async fn e2e_lead_reprompts_running_worker() {
     // Counter bumped.
     let counters = state
         .root
-        .worker_counters
+        .workers
+        .counters
         .read()
         .await
         .get(&task_id)
@@ -950,7 +952,7 @@ async fn e2e_lead_propose_plan_gate_unblocks_spawn() {
         .root
         .plan_approved
         .load(std::sync::atomic::Ordering::Acquire));
-    let workers = state.root.workers.read().await;
+    let workers = state.root.workers.states.read().await;
     assert_eq!(
         workers.len(),
         1,
@@ -1065,7 +1067,7 @@ impl ProcessSpawner for FakeClaudeWorkerSpawner {
 }
 
 /// Real-subprocess freeze-pause e2e. Workers are spawned as actual
-/// fake-claude processes (via FakeClaudeWorkerSpawner) so `worker_pids`
+/// fake-claude processes (via FakeClaudeWorkerSpawner) so `workers.pids`
 /// gets populated and `pause_worker(Freeze)` can send SIGSTOP.
 #[tokio::test]
 async fn e2e_freeze_pause_and_continue_real_subprocess_worker() {
@@ -1218,7 +1220,7 @@ async fn e2e_freeze_pause_and_continue_real_subprocess_worker() {
     // as exit code 5. The pause_worker call in particular requires a
     // live worker pid, which requires a real TokioSpawner subprocess
     // — so this test also proves the FakeClaudeWorkerSpawner wiring
-    // populates `worker_pids` correctly. No further assertions needed.
+    // populates `workers.pids` correctly. No further assertions needed.
     //
     // We do wait a tick for the worker background task to settle so
     // the test's Drop teardown doesn't race a live subprocess.

--- a/crates/pitboss-cli/tests/e2e_sublead_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_sublead_flows.rs
@@ -236,11 +236,12 @@ async fn root_kill_cascades_to_sublead_workers() {
         let subleads = state.subleads.read().await;
         let sub = subleads.get(&sublead_id).unwrap();
         for worker_id in ["worker-X", "worker-Y"] {
-            sub.workers.write().await.insert(
+            sub.workers.states.write().await.insert(
                 worker_id.into(),
                 pitboss_cli::dispatch::state::WorkerState::Pending,
             );
-            sub.worker_cancels
+            sub.workers
+                .cancels
                 .write()
                 .await
                 .insert(worker_id.into(), CancelToken::new());
@@ -251,7 +252,7 @@ async fn root_kill_cascades_to_sublead_workers() {
     {
         let subleads = state.subleads.read().await;
         let sub = subleads.get(&sublead_id).unwrap();
-        let cancels = sub.worker_cancels.read().await;
+        let cancels = sub.workers.cancels.read().await;
         for worker_id in ["worker-X", "worker-Y"] {
             let tok = cancels.get(worker_id).unwrap();
             assert!(
@@ -277,7 +278,7 @@ async fn root_kill_cascades_to_sublead_workers() {
         );
 
         // Sub-lead workers' cancel tokens should also be draining.
-        let cancels = sub.worker_cancels.read().await;
+        let cancels = sub.workers.cancels.read().await;
         for worker_id in ["worker-X", "worker-Y"] {
             let tok = cancels.get(worker_id).unwrap();
             assert!(
@@ -515,7 +516,7 @@ async fn reject_with_reason_reaches_sublead_session() {
     fcc_task.await.expect("FCC task panicked");
 
     // Give the control server's read loop time to process the Approve op and
-    // update the worker_counters map before we assert on it.
+    // update the workers.counters map before we assert on it.
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     // The sub-lead's MCP response should carry approved=false and the reason.
@@ -534,7 +535,8 @@ async fn reject_with_reason_reaches_sublead_session() {
     // ApprovalBridge credits the counter to the actor that submitted the request.
     let counters = state
         .root
-        .worker_counters
+        .workers
+        .counters
         .read()
         .await
         .get(&s1_id)

--- a/crates/pitboss-cli/tests/hierarchical_flows.rs
+++ b/crates/pitboss-cli/tests/hierarchical_flows.rs
@@ -240,9 +240,9 @@ async fn wait_actor_alias_resolves_worker_id() {
             actor_type: None,
             terminate_reason: None,
         };
-        let mut w = state_clone.root.workers.write().await;
+        let mut w = state_clone.root.workers.states.write().await;
         w.insert(worker_id_clone.clone(), WorkerState::Done(rec));
-        let _ = state_clone.root.done_tx.send(worker_id_clone);
+        let _ = state_clone.root.workers.done_tx.send(worker_id_clone);
     });
 
     // wait_actor should accept a worker id (back-compat path) and

--- a/crates/pitboss-cli/tests/live_stream_flows.rs
+++ b/crates/pitboss-cli/tests/live_stream_flows.rs
@@ -202,7 +202,7 @@ async fn live_only_receives_server_hello_envelope() {
         std::sync::Arc::new(pitboss_cli::shared_store::SharedStore::new()),
     ));
     // Seed a worker so the server's WorkersSnapshot has content.
-    state.root.workers.write().await.insert(
+    state.root.workers.states.write().await.insert(
         "w-live".into(),
         WorkerState::Running {
             started_at: chrono::Utc::now(),

--- a/crates/pitboss-cli/tests/sublead_flows.rs
+++ b/crates/pitboss-cli/tests/sublead_flows.rs
@@ -362,11 +362,12 @@ async fn root_cancel_cascades_to_sublead_workers() {
     {
         let subleads = state.subleads.read().await;
         let sub = subleads.get(sublead_id.as_str()).unwrap();
-        sub.workers.write().await.insert(
+        sub.workers.states.write().await.insert(
             "worker-A".into(),
             pitboss_cli::dispatch::state::WorkerState::Pending,
         );
-        sub.worker_cancels
+        sub.workers
+            .cancels
             .write()
             .await
             .insert("worker-A".into(), CancelToken::new());
@@ -381,7 +382,7 @@ async fn root_cancel_cascades_to_sublead_workers() {
     // Sub-tree's worker cancel token should be tripped
     let subleads = state.subleads.read().await;
     let sub = subleads.get(sublead_id.as_str()).unwrap();
-    let toks = sub.worker_cancels.read().await;
+    let toks = sub.workers.cancels.read().await;
     let tok = toks.get("worker-A").unwrap();
     assert!(
         tok.is_draining(),
@@ -891,11 +892,12 @@ async fn kill_worker_with_reason_reprompts_parent_sublead() {
     {
         let subleads = state.subleads.read().await;
         let sub = subleads.get(s1.as_str()).unwrap();
-        sub.workers.write().await.insert(
+        sub.workers.states.write().await.insert(
             "worker-A".into(),
             pitboss_cli::dispatch::state::WorkerState::Pending,
         );
-        sub.worker_cancels
+        sub.workers
+            .cancels
             .write()
             .await
             .insert("worker-A".into(), CancelToken::new());
@@ -1169,7 +1171,7 @@ async fn wait_actor_still_handles_worker_back_compat() {
     // Register a worker in Pending state.
     let worker_id = "worker-bc-test".to_string();
     {
-        let mut w = state.root.workers.write().await;
+        let mut w = state.root.workers.states.write().await;
         w.insert(worker_id.clone(), WorkerState::Pending);
     }
 
@@ -1203,9 +1205,9 @@ async fn wait_actor_still_handles_worker_back_compat() {
             actor_type: None,
             terminate_reason: None,
         };
-        let mut w = state_clone.root.workers.write().await;
+        let mut w = state_clone.root.workers.states.write().await;
         w.insert(worker_id_clone.clone(), WorkerState::Done(rec));
-        let _ = state_clone.root.done_tx.send(worker_id_clone);
+        let _ = state_clone.root.workers.done_tx.send(worker_id_clone);
     });
 
     // wait_actor should return the Worker variant for a regular worker.
@@ -1265,7 +1267,7 @@ async fn sublead_spawn_worker_registers_in_sub_tree_layer() {
 
     // Worker must be registered in the sub-lead's LayerState, NOT root.
     {
-        let root_workers = state.root.workers.read().await;
+        let root_workers = state.root.workers.states.read().await;
         assert!(
             !root_workers.contains_key(&task_id),
             "worker must NOT appear in root layer; got: {task_id}"
@@ -1276,7 +1278,7 @@ async fn sublead_spawn_worker_registers_in_sub_tree_layer() {
         let sub_layer = subleads
             .get(sublead_id.as_str())
             .expect("sub-tree layer should exist");
-        let sub_workers = sub_layer.workers.read().await;
+        let sub_workers = sub_layer.workers.states.read().await;
         assert!(
             sub_workers.contains_key(&task_id),
             "worker must appear in sub-lead's layer workers map; task_id={task_id}"
@@ -1348,7 +1350,7 @@ async fn v0_5_back_compat_no_meta_routes_to_root() {
     let task_id = result.task_id;
 
     // Worker must be in root layer.
-    let root_workers = state.root.workers.read().await;
+    let root_workers = state.root.workers.states.read().await;
     assert!(
         root_workers.contains_key(&task_id),
         "no-meta spawn must register worker in root layer; task_id={task_id}"
@@ -1404,11 +1406,12 @@ async fn kill_with_reason_delivers_synthetic_reprompt_to_running_lead() {
     {
         let subleads = state.subleads.read().await;
         let sub = subleads.get(s1.as_str()).unwrap();
-        sub.workers.write().await.insert(
+        sub.workers.states.write().await.insert(
             "worker-B".into(),
             pitboss_cli::dispatch::state::WorkerState::Pending,
         );
-        sub.worker_cancels
+        sub.workers
+            .cancels
             .write()
             .await
             .insert("worker-B".into(), CancelToken::new());
@@ -1498,11 +1501,12 @@ async fn kill_with_reason_skips_delivery_when_lead_already_terminated() {
     {
         let subleads = state.subleads.read().await;
         let sub = subleads.get(s1.as_str()).unwrap();
-        sub.workers.write().await.insert(
+        sub.workers.states.write().await.insert(
             "worker-C".into(),
             pitboss_cli::dispatch::state::WorkerState::Pending,
         );
-        sub.worker_cancels
+        sub.workers
+            .cancels
             .write()
             .await
             .insert("worker-C".into(), CancelToken::new());
@@ -1545,7 +1549,7 @@ async fn kill_with_reason_skips_delivery_when_lead_already_terminated() {
             actor_type: None,
             terminate_reason: None,
         };
-        sub.workers.write().await.insert(
+        sub.workers.states.write().await.insert(
             s1.clone(),
             pitboss_cli::dispatch::state::WorkerState::Done(done_rec),
         );
@@ -1567,7 +1571,7 @@ async fn kill_with_reason_skips_delivery_when_lead_already_terminated() {
         .await;
 
     // The cancel_worker call itself may fail (worker-C has no real cancel token
-    // running a subprocess, but it was inserted into worker_cancels above so
+    // running a subprocess, but it was inserted into workers.cancels above so
     // cancel_actor_in_tree should find it).
     // What matters is that there's no panic and the process doesn't hang.
     // Allow the async machinery to settle.
@@ -1679,13 +1683,14 @@ async fn kill_with_reason_delivers_to_root_lead() {
 
     // Inject a worker into the ROOT layer (not inside a sub-lead).
     {
-        state.root.workers.write().await.insert(
+        state.root.workers.states.write().await.insert(
             "worker-root-1".into(),
             pitboss_cli::dispatch::state::WorkerState::Pending,
         );
         state
             .root
-            .worker_cancels
+            .workers
+            .cancels
             .write()
             .await
             .insert("worker-root-1".into(), CancelToken::new());
@@ -1854,7 +1859,7 @@ async fn reconcile_terminated_sublead_marks_self_row_done() {
     // row — this is the state the bug observed (Running with a
     // session_id, never cleared).
     let started = chrono::Utc::now();
-    sub_layer.workers.write().await.insert(
+    sub_layer.workers.states.write().await.insert(
         sub_id.clone(),
         WorkerState::Running {
             started_at: started,
@@ -1881,7 +1886,7 @@ async fn reconcile_terminated_sublead_marks_self_row_done() {
         .iter()
         .find(|l| l.lead_id == sub_id)
         .expect("layer must be in terminated_sublead_layers after reconcile");
-    let workers = layer.workers.read().await;
+    let workers = layer.workers.states.read().await;
     let row = workers
         .get(&sub_id)
         .expect("sublead's own row must still be present after reconcile");
@@ -1998,7 +2003,7 @@ async fn reconcile_terminated_sublead_outcome_to_status_mapping() {
     for (id, outcome, expected) in cases {
         let (_dir, state) = mk_state_with_subleads();
         let sub_layer = build_sub_layer(&state, id);
-        sub_layer.workers.write().await.insert(
+        sub_layer.workers.states.write().await.insert(
             id.into(),
             WorkerState::Running {
                 started_at: chrono::Utc::now(),
@@ -2017,7 +2022,7 @@ async fn reconcile_terminated_sublead_outcome_to_status_mapping() {
 
         let term = state.terminated_sublead_layers.read().await;
         let layer = term.iter().find(|l| l.lead_id == id).unwrap();
-        let workers = layer.workers.read().await;
+        let workers = layer.workers.states.read().await;
         let row = workers.get(id).expect("row present");
         match row {
             WorkerState::Done(rec) => assert_eq!(

--- a/crates/pitboss-web/tests/control_bridge_integration.rs
+++ b/crates/pitboss-web/tests/control_bridge_integration.rs
@@ -287,7 +287,7 @@ async fn bridge_send_op_round_trips_through_dispatcher() {
 
     // Install a worker so ListWorkers returns a non-empty snapshot —
     // makes the assertion specific.
-    state.root.workers.write().await.insert(
+    state.root.workers.states.write().await.insert(
         "w-1".into(),
         WorkerState::Running {
             started_at: chrono::Utc::now(),
@@ -296,7 +296,8 @@ async fn bridge_send_op_round_trips_through_dispatcher() {
     );
     state
         .root
-        .worker_prompts
+        .workers
+        .prompts
         .write()
         .await
         .insert("w-1".into(), "look into the bug".into());

--- a/examples/dogfood/fake/03-kill-cascade-drain/expected-observables.md
+++ b/examples/dogfood/fake/03-kill-cascade-drain/expected-observables.md
@@ -10,7 +10,7 @@ A root lead spawns two sub-leads in parallel:
 - **S2** — "phase 2"
 
 Each sub-lead has two active workers simulated by injecting cancel tokens
-directly into the sub-tree's `worker_cancels` map:
+directly into the sub-tree's `workers.cancels` map:
 - **S1-w0**, **S1-w1** — workers under S1's sub-tree
 - **S2-w0**, **S2-w1** — workers under S2's sub-tree
 
@@ -44,7 +44,7 @@ waiting on `root_cancel.await_drain()`. It wakes immediately and:
 
 1. Iterates every sub-lead registered in `state.subleads`.
 2. Calls `sub_layer.cancel.drain()` on each sub-lead's own cancel token.
-3. Iterates every worker cancel token in `sub_layer.worker_cancels` and calls
+3. Iterates every worker cancel token in `sub_layer.workers.cancels` and calls
    `tok.drain()` on each.
 
 This happens entirely inside the tokio runtime, so in an in-process test a


### PR DESCRIPTION
## Summary

Step 1 of 3 for #487 (F-ARCH-8, severity: high — `LayerState` 31-field god-object split).

Pulls the nine per-task_id fields plus the worker-done broadcast off `LayerState` into a new `WorkerRegistry`:
- `states` (was `workers`), `cancels` (was `worker_cancels`), `prompts` (was `worker_prompts`), `models` (was `worker_models`), `actor_types` (was `worker_actor_types`), `counters` (was `worker_counters`), `pids` (was `worker_pids`), `reservations` (was `worker_reservations`), `done_tx`.

`LayerState` now exposes `pub workers: WorkerRegistry`, so handlers that only need worker bookkeeping can take `&WorkerRegistry` and physically can't touch budget or approval state — the audit's stated goal. Mechanical access-site rename across ~185 callers in `pitboss-cli` (src + tests) and one `pitboss-web` integration test.

## Why this works as a clean staged refactor

PR #560 unified all test factories through `TestStateBuilder`, so this PR's invariant changes (LayerState shape, constructor) touch one builder source instead of 14 hand-rolled factory bodies. Each subsequent step of #487 inherits that property.

## What ships in the followups

- **PR 2** — `BudgetState`: `spent_usd`, `reserved_usd`, `lead_spent_usd`, `abort_reason` (was `budget_abort_reason`). ~52 access sites. `original_reservation_usd` stays on `LayerState` (init-time constant, never participates in live counters).
- **PR 3** — `ApprovalState`: `bridge`, `queue`, `policy`, `plan_approved`, `policy_matcher`. ~34 access sites.

## Design notes

- **No `Arc<WorkerRegistry>`.** Every call site goes through `&LayerState`, so `Arc<>` would add an indirection without enabling a use case today. Trivial to introduce later if a handler needs to hold a registry independently.
- **`done_tx` is part of `WorkerRegistry`, not control plane.** Its purpose is to fire when a worker transitions to `Done`, and it's consumed exclusively by `wait_for_worker` handlers. Belongs with the worker bookkeeping.

## Test plan

- [x] `cargo test -p pitboss-cli` — 876 lib + ~140 integration tests pass
- [x] `cargo lint` — clean
- [x] `cargo tidy` — clean
- [x] `cargo check --workspace --all-targets` — pitboss-tui / pitboss-web cross-crate compile clean
- [ ] CI green

The pre-existing flake `e2e_lead_request_approval_round_trip` (2-second approval-queue poll race under heavy parallel load) intermittently fails under workspace-wide `cargo test`; passes in isolation. Unchanged by this PR.

Tracking: refs #487 — issue stays open until PRs 2 and 3 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)