### PR TITLE
refactor(dispatch): extract BudgetState from LayerState

### DIFF
--- a/crates/pitboss-cli/src/dispatch/budget_watch.rs
+++ b/crates/pitboss-cli/src/dispatch/budget_watch.rs
@@ -15,13 +15,13 @@
 //!
 //! 1. Converts cumulative `TokenUsage` for the current subprocess to
 //!    USD via [`pitboss_core::prices::cost_usd`].
-//! 2. Atomically writes `layer.lead_spent_usd = baseline + cost`, where
+//! 2. Atomically writes `layer.budget.lead_spent_usd = baseline + cost`, where
 //!    `baseline` is the running total committed across prior kill+resume
 //!    iterations.
 //! 3. Computes the run-wide total (workers + lead + sub-leads across
 //!    every layer) and checks both `budget_usd` and the optional
 //!    `lead_budget_usd` cap. On breach, it stamps
-//!    `layer.budget_abort_reason` so `failure_detection` can name the
+//!    `layer.budget.abort_reason` so `failure_detection` can name the
 //!    overspend and then fires `layer.cancel.terminate()` to kill the
 //!    in-flight subprocess.
 //!
@@ -44,7 +44,7 @@ use crate::dispatch::state::DispatchState;
 #[derive(Default)]
 pub struct LeadSpendBaseline {
     /// Accumulated cost across prior kill+resume iterations. The
-    /// observer writes `layer.lead_spent_usd = baseline + this_iter_cost`
+    /// observer writes `layer.budget.lead_spent_usd = baseline + this_iter_cost`
     /// on every assistant-turn usage update.
     pub baseline_usd: Mutex<f64>,
 }
@@ -59,7 +59,7 @@ impl LeadSpendBaseline {
     // from the prior run's `summary.jsonl` so a resumed lead doesn't
     // restart with a $0 budget envelope against the original cap. The
     // current implementation mirrors the existing gap for
-    // `layer.spent_usd` (workers) — neither is restored on resume — so
+    // `layer.budget.spent_usd` (workers) — neither is restored on resume — so
     // this parallel gap is "fix both together" rather than "regressed
     // by this PR." Tracked as part of #259 (persistent control event
     // stream replay).
@@ -92,9 +92,10 @@ impl SpendBreakdown {
 /// Walk every layer in the run (root + live sub-leads + terminated
 /// sub-leads) and assemble the current spend totals.
 pub async fn compute_total_spend(state: &DispatchState) -> SpendBreakdown {
-    let workers_root = *state.root.spent_usd.lock().await;
+    let workers_root = *state.root.budget.spent_usd.lock().await;
     let lead_usd = *state
         .root
+        .budget
         .lead_spent_usd
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -104,8 +105,9 @@ pub async fn compute_total_spend(state: &DispatchState) -> SpendBreakdown {
     {
         let live = state.subleads.read().await;
         for layer in live.values() {
-            workers_subs += *layer.spent_usd.lock().await;
+            workers_subs += *layer.budget.spent_usd.lock().await;
             subleads_usd += *layer
+                .budget
                 .lead_spent_usd
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -114,8 +116,9 @@ pub async fn compute_total_spend(state: &DispatchState) -> SpendBreakdown {
     {
         let terminated = state.terminated_sublead_layers.read().await;
         for layer in terminated.iter() {
-            workers_subs += *layer.spent_usd.lock().await;
+            workers_subs += *layer.budget.spent_usd.lock().await;
             subleads_usd += *layer
+                .budget
                 .lead_spent_usd
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -136,9 +139,16 @@ pub async fn compute_total_spend(state: &DispatchState) -> SpendBreakdown {
 /// same instant the contention is benign and the next observer fire
 /// gets a fresh reading.
 fn compute_total_spend_blocking(state: &DispatchState) -> SpendBreakdown {
-    let workers_root = state.root.spent_usd.try_lock().map(|g| *g).unwrap_or(0.0);
+    let workers_root = state
+        .root
+        .budget
+        .spent_usd
+        .try_lock()
+        .map(|g| *g)
+        .unwrap_or(0.0);
     let lead_usd = *state
         .root
+        .budget
         .lead_spent_usd
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -147,8 +157,9 @@ fn compute_total_spend_blocking(state: &DispatchState) -> SpendBreakdown {
     let mut subleads_usd = 0.0_f64;
     if let Ok(live) = state.subleads.try_read() {
         for layer in live.values() {
-            workers_subs += layer.spent_usd.try_lock().map(|g| *g).unwrap_or(0.0);
+            workers_subs += layer.budget.spent_usd.try_lock().map(|g| *g).unwrap_or(0.0);
             subleads_usd += *layer
+                .budget
                 .lead_spent_usd
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -156,8 +167,9 @@ fn compute_total_spend_blocking(state: &DispatchState) -> SpendBreakdown {
     }
     if let Ok(terminated) = state.terminated_sublead_layers.try_read() {
         for layer in terminated.iter() {
-            workers_subs += layer.spent_usd.try_lock().map(|g| *g).unwrap_or(0.0);
+            workers_subs += layer.budget.spent_usd.try_lock().map(|g| *g).unwrap_or(0.0);
             subleads_usd += *layer
+                .budget
                 .lead_spent_usd
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -197,6 +209,7 @@ pub fn build_lead_usage_observer(
 
         {
             let mut g = layer
+                .budget
                 .lead_spent_usd
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -207,7 +220,8 @@ pub fn build_lead_usage_observer(
         // many times in quick succession; cancel() is idempotent but the
         // reason stamp would race).
         if layer
-            .budget_abort_reason
+            .budget
+            .abort_reason
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .is_some()
@@ -251,7 +265,8 @@ pub fn build_lead_usage_observer(
 fn trip_budget_abort(layer: &LayerState, reason: String) {
     {
         let mut g = layer
-            .budget_abort_reason
+            .budget
+            .abort_reason
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         *g = Some(reason.clone());
@@ -338,7 +353,7 @@ mod tests {
         let (_dir, state) = mk_state_with_caps(Some(1.00), None);
         let layer = state.root.clone();
         assert!(!layer.cancel.is_terminated());
-        assert!(layer.budget_abort_reason.lock().unwrap().is_none());
+        assert!(layer.budget.abort_reason.lock().unwrap().is_none());
 
         let baseline = LeadSpendBaseline::new();
         let obs = build_lead_usage_observer(
@@ -354,7 +369,7 @@ mod tests {
         // Fire the observer with usage that exceeds the cap.
         obs(usage(100_000, 100_000));
 
-        let reason = layer.budget_abort_reason.lock().unwrap().clone();
+        let reason = layer.budget.abort_reason.lock().unwrap().clone();
         assert!(
             reason.is_some(),
             "expected budget_abort_reason set after overspend"
@@ -406,7 +421,7 @@ mod tests {
             state.root.manifest.lead_budget_usd,
         );
         obs(usage(100_000, 100_000));
-        let reason = layer.budget_abort_reason.lock().unwrap().clone();
+        let reason = layer.budget.abort_reason.lock().unwrap().clone();
         let msg = reason.expect("expected reason set");
         assert!(
             msg.contains("lead_budget_usd"),
@@ -433,10 +448,10 @@ mod tests {
         // 1k+1k tokens at Opus = 1k * $15/M + 1k * $75/M ≈ $0.09 — far
         // below either cap.
         obs(usage(1_000, 1_000));
-        assert!(layer.budget_abort_reason.lock().unwrap().is_none());
+        assert!(layer.budget.abort_reason.lock().unwrap().is_none());
         assert!(!layer.cancel.is_terminated());
         // lead_spent_usd should reflect the priced cost.
-        let live = *layer.lead_spent_usd.lock().unwrap();
+        let live = *layer.budget.lead_spent_usd.lock().unwrap();
         assert!(live > 0.0 && live < 1.0, "live spend out of range: {live}");
     }
 

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -340,7 +340,7 @@ pub async fn run_hierarchical(
     };
 
     // 3d. Budget watcher — installs a per-message usage observer that
-    //     updates `state.root.lead_spent_usd` live and aborts the lead
+    //     updates `state.root.budget.lead_spent_usd` live and aborts the lead
     //     when `budget_usd` (run-wide total) or `lead_budget_usd`
     //     (orchestration-only) caps are exceeded. (#253)
     let baseline = crate::dispatch::budget_watch::LeadSpendBaseline::new();
@@ -476,7 +476,8 @@ pub async fn run_hierarchical(
             // budget_usd" not "Cancelled".
             let budget_reason = state
                 .root
-                .budget_abort_reason
+                .budget
+                .abort_reason
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .clone();

--- a/crates/pitboss-cli/src/dispatch/layer.rs
+++ b/crates/pitboss-cli/src/dispatch/layer.rs
@@ -126,21 +126,20 @@ impl Default for WorkerRegistry {
     }
 }
 
-/// All state owned by a single coordination layer (root layer or a
-/// sub-tree layer).
-pub struct LayerState {
-    pub run_id: Uuid,
-    pub manifest: ResolvedManifest,
-    pub store: Arc<dyn SessionStore>,
-    pub cancel: CancelToken,
-    pub lead_id: String,
-    /// Worker bookkeeping: per-task_id maps + the `Done` broadcast.
-    /// Split out of this struct in #487.
-    pub workers: WorkerRegistry,
-    /// Total USD cost spent so far on completed workers in this layer.
-    /// Lead and sub-lead token spend live in their own counters
-    /// (`lead_spent_usd`); helpers that compute the total run spend sum
-    /// across layers.
+/// Layer-aggregate USD spend counters + the budget-abort reason.
+///
+/// Split out of `LayerState` (#487 step 2) so handlers that only need
+/// budget bookkeeping can take `&BudgetState` instead of `&LayerState`
+/// and physically can't touch worker or approval state.
+///
+/// Per-worker USD reservations are NOT here — they're keyed by
+/// `task_id` and live on `WorkerRegistry.reservations` alongside the
+/// rest of the per-task_id maps. This struct only owns the
+/// layer-aggregate counters and the abort signal.
+pub struct BudgetState {
+    /// Total USD spent so far on completed workers in this layer.
+    /// Lead and sub-lead token spend are accounted in `lead_spent_usd`;
+    /// helpers that compute the total run spend sum across layers.
     pub spent_usd: Mutex<f64>,
     /// USD reserved for in-flight workers at spawn time.
     pub reserved_usd: Mutex<f64>,
@@ -158,7 +157,42 @@ pub struct LayerState {
     /// startup and read by `failure_detection` so the lead's
     /// `TaskRecord.failure_reason` names the overspend rather than
     /// looking like a generic cancellation. (#253)
-    pub budget_abort_reason: std::sync::Mutex<Option<String>>,
+    pub abort_reason: std::sync::Mutex<Option<String>>,
+}
+
+impl BudgetState {
+    /// Construct a zeroed budget state. All counters start at 0.0
+    /// and `abort_reason` is `None`.
+    pub fn new() -> Self {
+        Self {
+            spent_usd: Mutex::new(0.0),
+            reserved_usd: Mutex::new(0.0),
+            lead_spent_usd: std::sync::Mutex::new(0.0),
+            abort_reason: std::sync::Mutex::new(None),
+        }
+    }
+}
+
+impl Default for BudgetState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// All state owned by a single coordination layer (root layer or a
+/// sub-tree layer).
+pub struct LayerState {
+    pub run_id: Uuid,
+    pub manifest: ResolvedManifest,
+    pub store: Arc<dyn SessionStore>,
+    pub cancel: CancelToken,
+    pub lead_id: String,
+    /// Worker bookkeeping: per-task_id maps + the `Done` broadcast.
+    /// Split out of this struct in #487 step 1.
+    pub workers: WorkerRegistry,
+    /// Layer-aggregate USD counters + budget-abort signal.
+    /// Split out of this struct in #487 step 2.
+    pub budget: BudgetState,
     /// Dependencies needed to actually launch worker subprocesses.
     pub spawner: Arc<dyn ProcessSpawner>,
     pub claude_binary: PathBuf,
@@ -323,10 +357,7 @@ impl LayerState {
             cancel,
             lead_id,
             workers: WorkerRegistry::new(),
-            spent_usd: Mutex::new(0.0),
-            reserved_usd: Mutex::new(0.0),
-            lead_spent_usd: std::sync::Mutex::new(0.0),
-            budget_abort_reason: std::sync::Mutex::new(None),
+            budget: BudgetState::new(),
             spawner,
             claude_binary,
             wt_mgr,
@@ -536,7 +567,7 @@ impl LayerState {
 
     pub async fn budget_remaining(&self) -> Option<f64> {
         let budget = self.manifest.budget_usd?;
-        let spent = *self.spent_usd.lock().await;
+        let spent = *self.budget.spent_usd.lock().await;
         Some((budget - spent).max(0.0))
     }
 
@@ -590,8 +621,8 @@ mod tests {
         let (_dir, layer) = mk_layer();
         assert!(layer.workers.states.read().await.is_empty());
         assert!(layer.workers.cancels.read().await.is_empty());
-        assert_eq!(*layer.spent_usd.lock().await, 0.0);
-        assert_eq!(*layer.reserved_usd.lock().await, 0.0);
+        assert_eq!(*layer.budget.spent_usd.lock().await, 0.0);
+        assert_eq!(*layer.budget.reserved_usd.lock().await, 0.0);
     }
 
     #[tokio::test]

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -713,7 +713,7 @@ mod tests {
     async fn budget_remaining_reflects_spent() {
         let st = mk_state(Some(10.0), None);
         assert_eq!(st.root.budget_remaining().await, Some(10.0));
-        *st.root.spent_usd.lock().await = 3.5;
+        *st.root.budget.spent_usd.lock().await = 3.5;
         assert_eq!(st.root.budget_remaining().await, Some(6.5));
     }
 

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -308,8 +308,8 @@ pub async fn spawn_sublead(
             // Fixes the TOCTOU described in #106: two independent lock
             // snapshots + an unlocked check allowed both callers to pass
             // the guard before either wrote, enabling budget over-commit.
-            let spent = *state.root.spent_usd.lock().await;
-            let mut reserved = state.root.reserved_usd.lock().await;
+            let spent = *state.root.budget.spent_usd.lock().await;
+            let mut reserved = state.root.budget.reserved_usd.lock().await;
             if spent + *reserved + amount > cap {
                 bail!(
                     "spawn_sublead: budget exceeded: ${:.2} spent + ${:.2} reserved + ${:.2} estimated > ${:.2} budget",
@@ -321,7 +321,7 @@ pub async fn spawn_sublead(
             }
             *reserved += amount;
         } else {
-            *state.root.reserved_usd.lock().await += amount;
+            *state.root.budget.reserved_usd.lock().await += amount;
         }
         Some(amount)
     } else {
@@ -449,7 +449,7 @@ pub async fn spawn_sublead(
     // I-2: On failure, release the reservation to avoid leaking reserved budget.
     if result.is_err() {
         if let Some(amount) = reserved_amount {
-            let mut reserved = state.root.reserved_usd.lock().await;
+            let mut reserved = state.root.budget.reserved_usd.lock().await;
             *reserved = (*reserved - amount).max(0.0);
         }
     }
@@ -721,7 +721,7 @@ async fn spawn_sublead_session(
     let sublead_type_bg = sublead_type.clone();
 
     // Sub-lead budget watcher — mirrors the root lead's observer:
-    // updates `sub_layer.lead_spent_usd` live per assistant turn and
+    // updates `sub_layer.budget.lead_spent_usd` live per assistant turn and
     // aborts the sub-lead when its own `lead_budget_usd` cap (if any)
     // or the run-wide `budget_usd` cap is exceeded. (#253)
     let sublead_lead_budget_usd = match &envelope {
@@ -863,7 +863,7 @@ async fn spawn_sublead_session(
         // sub-tree can occur between iterations because the sub-lead's
         // MCP session is closed while its subprocess is dead).
         if let Some(cost) = pitboss_core::prices::cost_usd(&model_bg, &total_token_usage) {
-            *sub_layer_bg.spent_usd.lock().await += cost;
+            *sub_layer_bg.budget.spent_usd.lock().await += cost;
         }
 
         // Close the reprompt channel so further sends return errors.
@@ -1066,7 +1066,7 @@ pub async fn reconcile_terminated_sublead(
         .await
         .push(sub_layer.clone());
 
-    let actual_spend = *sub_layer.spent_usd.lock().await;
+    let actual_spend = *sub_layer.budget.spent_usd.lock().await;
     let original_reservation_usd = sub_layer.original_reservation_usd.unwrap_or(0.0);
     let unspent = (original_reservation_usd - actual_spend).max(0.0);
 
@@ -1155,12 +1155,12 @@ pub async fn reconcile_terminated_sublead(
 
     // Release the original reservation in full
     {
-        let mut reserved = state.root.reserved_usd.lock().await;
+        let mut reserved = state.root.budget.reserved_usd.lock().await;
         *reserved = (*reserved - original_reservation_usd).max(0.0);
     }
     // Then record the actual spend
     {
-        let mut spent = state.root.spent_usd.lock().await;
+        let mut spent = state.root.budget.spent_usd.lock().await;
         *spent += actual_spend;
     }
 

--- a/crates/pitboss-cli/src/mcp/tools/spawn.rs
+++ b/crates/pitboss-cli/src/mcp/tools/spawn.rs
@@ -212,13 +212,14 @@ pub async fn handle_spawn_worker(
         // before either increments the reservation. Spent_usd is captured
         // inside the same critical section to keep the arithmetic on a
         // single consistent snapshot.
-        let mut reserved_guard = target_layer.reserved_usd.lock().await;
-        let spent = *target_layer.spent_usd.lock().await;
+        let mut reserved_guard = target_layer.budget.reserved_usd.lock().await;
+        let spent = *target_layer.budget.spent_usd.lock().await;
         let reserved = *reserved_guard;
         // (#253) Include the lead/sub-lead's own token spend in the
         // budget check — `budget_usd` is now the run-wide cap across
         // workers + lead orchestration cost for this layer.
         let lead_spent = *target_layer
+            .budget
             .lead_spent_usd
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -827,7 +828,7 @@ async fn run_worker(
 
     // Accumulate cost into the layer's spent_usd.
     if let Some(cost) = pitboss_core::prices::cost_usd(&model, &rec.token_usage) {
-        *layer.spent_usd.lock().await += cost;
+        *layer.budget.spent_usd.lock().await += cost;
     }
 
     // Transition to Done + broadcast on the layer's done channel.
@@ -870,7 +871,7 @@ async fn release_reservation_for_layer(layer: &Arc<LayerState>, task_id: &str) {
         .remove(task_id)
         .unwrap_or(0.0);
     if reserved_amount > 0.0 {
-        let mut r = layer.reserved_usd.lock().await;
+        let mut r = layer.budget.reserved_usd.lock().await;
         *r = (*r - reserved_amount).max(0.0);
     }
 }

--- a/crates/pitboss-cli/src/mcp/tools/tests.rs
+++ b/crates/pitboss-cli/src/mcp/tools/tests.rs
@@ -458,7 +458,7 @@ async fn spawn_worker_refuses_when_max_workers_reached() {
 #[tokio::test]
 async fn spawn_worker_refuses_when_budget_exceeded() {
     let state = test_state().await; // budget_usd = 5.0
-    *state.root.spent_usd.lock().await = 5.0; // at cap
+    *state.root.budget.spent_usd.lock().await = 5.0; // at cap
     let args = SpawnWorkerArgs {
         prompt: "p".into(),
         directory: None,
@@ -877,7 +877,7 @@ async fn spawn_worker_completes_and_updates_spent_usd_and_parent_task_id() {
 
     // Verify cost accumulation. claude-haiku-4-5: input $0.80/1M, output $4.00/1M.
     // 1000 input = $0.0008; 2000 output = $0.008; total = $0.0088.
-    let spent = *state.root.spent_usd.lock().await;
+    let spent = *state.root.budget.spent_usd.lock().await;
     assert!(
         (spent - 0.0088).abs() < 1e-6,
         "expected spent_usd ≈ 0.0088, got {spent}"
@@ -933,7 +933,7 @@ async fn burst_spawn_is_budget_capped_via_reservation() {
     );
 
     // Sanity: the reservation should now reflect the two passing spawns.
-    let reserved_now = *state.root.reserved_usd.lock().await;
+    let reserved_now = *state.root.budget.reserved_usd.lock().await;
     assert!(
         (reserved_now - 0.20).abs() < 1e-9,
         "expected reserved ≈ 0.20, got {reserved_now}"
@@ -980,7 +980,7 @@ async fn reservation_released_on_worker_completion() {
         .expect("broadcast channel open");
     assert_eq!(completed_id, spawn.task_id);
 
-    let reserved_after = *state.root.reserved_usd.lock().await;
+    let reserved_after = *state.root.budget.reserved_usd.lock().await;
     assert!(
         reserved_after.abs() < 1e-9,
         "reservation should be released after completion, got {reserved_after}"

--- a/crates/pitboss-cli/tests/dogfood_fake_flows.rs
+++ b/crates/pitboss-cli/tests/dogfood_fake_flows.rs
@@ -1055,7 +1055,7 @@ async fn dogfood_envelope_cap_rejection() {
 
     // Verify no budget reservation was made
     {
-        let reserved = *state.root.reserved_usd.lock().await;
+        let reserved = *state.root.budget.reserved_usd.lock().await;
         assert_eq!(
             reserved, 0.0,
             "after rejected spawn, reserved_usd should be 0.0; got: {reserved}"
@@ -1099,7 +1099,7 @@ async fn dogfood_envelope_cap_rejection() {
 
     // Verify budget IS reserved
     {
-        let reserved = *state.root.reserved_usd.lock().await;
+        let reserved = *state.root.budget.reserved_usd.lock().await;
         assert!(
             (reserved - 2.0).abs() < 1e-9,
             "after successful spawn with budget_usd=2.0, reserved_usd should be 2.0; got: {reserved}"

--- a/crates/pitboss-cli/tests/e2e_sublead_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_sublead_flows.rs
@@ -100,8 +100,8 @@ fn mk_state_hold_workers(dir: &std::path::Path) -> (Uuid, Arc<DispatchState>) {
 /// completion (simulated by directly setting up and reconciling the sub-tree).
 /// Asserts:
 /// - `subleads` map has 1 entry after spawn
-/// - root.reserved_usd == sub-lead budget after spawn
-/// - after reconcile: root.spent_usd == sub-lead actual spend
+/// - root.budget.reserved_usd == sub-lead budget after spawn
+/// - after reconcile: root.budget.spent_usd == sub-lead actual spend
 /// - unspent portion ($budget - $actual) is freed from reserved pool
 /// - sub-lead entry removed from `subleads` map after reconcile
 #[tokio::test]
@@ -149,7 +149,7 @@ async fn root_spawns_sublead_which_completes() {
         );
     }
     assert_eq!(
-        *state.root.reserved_usd.lock().await,
+        *state.root.budget.reserved_usd.lock().await,
         envelope_budget,
         "root should have reserved the full envelope"
     );
@@ -158,7 +158,7 @@ async fn root_spawns_sublead_which_completes() {
     {
         let subleads = state.subleads.read().await;
         let sub_layer = subleads.get(&sublead_id).expect("sub-layer should exist");
-        *sub_layer.spent_usd.lock().await = actual_spend;
+        *sub_layer.budget.spent_usd.lock().await = actual_spend;
     }
 
     // Trigger reconciliation (mimics Event::Result terminal event).
@@ -172,14 +172,14 @@ async fn root_spawns_sublead_which_completes() {
 
     // After reconcile: reservation released, actual spend recorded, sub-lead removed.
     assert_eq!(
-        *state.root.reserved_usd.lock().await,
+        *state.root.budget.reserved_usd.lock().await,
         0.0,
-        "root.reserved_usd should be 0 after reconcile"
+        "root.budget.reserved_usd should be 0 after reconcile"
     );
     assert_eq!(
-        *state.root.spent_usd.lock().await,
+        *state.root.budget.spent_usd.lock().await,
         actual_spend,
-        "root.spent_usd should equal sub-lead actual spend"
+        "root.budget.spent_usd should equal sub-lead actual spend"
     );
     assert!(
         expected_unspent > 0.0,
@@ -554,8 +554,8 @@ async fn reject_with_reason_reaches_sublead_session() {
 
 /// Sub-lead spawns with $5 envelope, spends $2, then terminates.
 /// Asserts:
-/// - root.spent_usd increases by $2 (actual sub-lead spend)
-/// - root.reserved_usd returns to pre-spawn value (full $5 reservation released)
+/// - root.budget.spent_usd increases by $2 (actual sub-lead spend)
+/// - root.budget.reserved_usd returns to pre-spawn value (full $5 reservation released)
 /// - net effect: $3 unspent returned to reservable pool
 #[tokio::test]
 async fn budget_envelope_returns_to_root_pool() {
@@ -568,8 +568,8 @@ async fn budget_envelope_returns_to_root_pool() {
     let actual_spend = 2.0_f64;
 
     // Record root's pre-spawn baseline.
-    let pre_spawn_reserved = *state.root.reserved_usd.lock().await;
-    let pre_spawn_spent = *state.root.spent_usd.lock().await;
+    let pre_spawn_reserved = *state.root.budget.reserved_usd.lock().await;
+    let pre_spawn_spent = *state.root.budget.spent_usd.lock().await;
 
     // Root lead spawns sub-lead with $5 envelope.
     let req = SubleadSpawnRequest {
@@ -592,7 +592,7 @@ async fn budget_envelope_returns_to_root_pool() {
 
     // Verify reservation was made.
     assert_eq!(
-        *state.root.reserved_usd.lock().await,
+        *state.root.budget.reserved_usd.lock().await,
         pre_spawn_reserved + envelope_budget,
         "root should have reserved the sub-lead's full envelope"
     );
@@ -601,7 +601,7 @@ async fn budget_envelope_returns_to_root_pool() {
     {
         let subleads = state.subleads.read().await;
         let sub_layer = subleads.get(&sublead_id).expect("sub-layer must exist");
-        *sub_layer.spent_usd.lock().await = actual_spend;
+        *sub_layer.budget.spent_usd.lock().await = actual_spend;
     }
 
     // Reconcile (terminate the sub-lead).
@@ -618,14 +618,14 @@ async fn budget_envelope_returns_to_root_pool() {
     // - spent_usd rose by $2 (the actual spend)
     // - the $3 unspent is now available in the reservable pool (not reserved)
     assert_eq!(
-        *state.root.reserved_usd.lock().await,
+        *state.root.budget.reserved_usd.lock().await,
         pre_spawn_reserved,
-        "root.reserved_usd should return to pre-spawn value after reconcile"
+        "root.budget.reserved_usd should return to pre-spawn value after reconcile"
     );
     assert_eq!(
-        *state.root.spent_usd.lock().await,
+        *state.root.budget.spent_usd.lock().await,
         pre_spawn_spent + actual_spend,
-        "root.spent_usd should increase by the sub-lead's actual spend"
+        "root.budget.spent_usd should increase by the sub-lead's actual spend"
     );
     // Verify the sub-lead entry is cleaned up.
     assert!(
@@ -808,7 +808,7 @@ async fn sublead_session_spawns_runs_and_reconciles() {
         "sub-lead should be registered after spawn"
     );
     assert!(
-        (*state.root.reserved_usd.lock().await - 2.0).abs() < 1e-9,
+        (*state.root.budget.reserved_usd.lock().await - 2.0).abs() < 1e-9,
         "root should reserve $2.0 for the sub-lead"
     );
 
@@ -861,9 +861,9 @@ async fn sublead_session_spawns_runs_and_reconciles() {
 
     // 7. Root's reservation is released and spend is recorded.
     assert_eq!(
-        *state.root.reserved_usd.lock().await,
+        *state.root.budget.reserved_usd.lock().await,
         0.0,
-        "root.reserved_usd should be 0 after reconcile"
+        "root.budget.reserved_usd should be 0 after reconcile"
     );
 
     state.root.cancel.terminate();

--- a/crates/pitboss-cli/tests/hierarchical_flows.rs
+++ b/crates/pitboss-cli/tests/hierarchical_flows.rs
@@ -108,7 +108,7 @@ async fn mcp_spawn_over_max_workers_returns_error() {
 #[tokio::test]
 async fn mcp_spawn_over_budget_returns_error() {
     let (_dir, state) = mk_state(); // budget_usd = 5.0
-    *state.root.spent_usd.lock().await = 5.0;
+    *state.root.budget.spent_usd.lock().await = 5.0;
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await

--- a/crates/pitboss-cli/tests/sublead_flows.rs
+++ b/crates/pitboss-cli/tests/sublead_flows.rs
@@ -326,7 +326,7 @@ async fn spawn_sublead_creates_isolated_layer() {
     assert_eq!(plan_value, json!("do thing"));
 
     // Root's reservation should reflect the sub-lead's envelope.
-    assert_eq!(*state.root.reserved_usd.lock().await, 5.0);
+    assert_eq!(*state.root.budget.reserved_usd.lock().await, 5.0);
 }
 
 #[tokio::test]
@@ -447,17 +447,17 @@ async fn unspent_sublead_envelope_returns_to_root_pool() {
         .expect("spawn_sublead should succeed");
 
     // Verify the reservation was made
-    assert_eq!(*state.root.reserved_usd.lock().await, 5.0);
+    assert_eq!(*state.root.budget.reserved_usd.lock().await, 5.0);
 
     // Simulate sub-lead spending only $2 then terminating.
     // (In production this happens automatically as the sub-lead's
     // workers complete and accumulate spend in the sub-tree's
-    // LayerState.spent_usd; the reconciliation is triggered by the
+    // LayerState.budget.spent_usd; the reconciliation is triggered by the
     // sub-lead's terminal Event::Result.)
     {
         let subleads = state.subleads.read().await;
         let sub_layer = subleads.get(&sublead_id).expect("sub-layer should exist");
-        *sub_layer.spent_usd.lock().await = 2.0;
+        *sub_layer.budget.spent_usd.lock().await = 2.0;
     }
 
     // Trigger reconciliation
@@ -471,8 +471,8 @@ async fn unspent_sublead_envelope_returns_to_root_pool() {
 
     // After: root's reserved_usd dropped by $5, spent_usd rose by $2,
     // releasing $3 to reservable pool.
-    assert_eq!(*state.root.reserved_usd.lock().await, 0.0);
-    assert_eq!(*state.root.spent_usd.lock().await, 2.0);
+    assert_eq!(*state.root.budget.reserved_usd.lock().await, 0.0);
+    assert_eq!(*state.root.budget.spent_usd.lock().await, 2.0);
     // Verify sub-layer was removed during reconciliation
     assert!(
         state.subleads.read().await.get(&sublead_id).is_none(),
@@ -1066,7 +1066,7 @@ async fn wait_actor_returns_for_terminated_sublead() {
     {
         let subleads = state.subleads.read().await;
         let sub_layer = subleads.get(&sublead_id).expect("sub-layer should exist");
-        *sub_layer.spent_usd.lock().await = 1.0;
+        *sub_layer.budget.spent_usd.lock().await = 1.0;
     }
 
     // Reconcile (terminate the sub-lead).
@@ -1613,7 +1613,7 @@ async fn sublead_worker_budget_reserved_against_sublead_envelope() {
 
     // Snapshot root's reservation before the sub-lead spawns a worker.
     // (Root has $5 reserved for the sub-lead envelope at this point.)
-    let root_reserved_before = *state.root.reserved_usd.lock().await;
+    let root_reserved_before = *state.root.budget.reserved_usd.lock().await;
 
     // Sub-lead calls spawn_worker with its identity in _meta.
     let args = SpawnWorkerArgs {
@@ -1635,7 +1635,7 @@ async fn sublead_worker_budget_reserved_against_sublead_envelope() {
 
     // Root's reserved_usd must NOT have changed (the new reservation went to
     // the sub-lead's layer, not root's).
-    let root_reserved_after = *state.root.reserved_usd.lock().await;
+    let root_reserved_after = *state.root.budget.reserved_usd.lock().await;
     assert!(
         (root_reserved_after - root_reserved_before).abs() < 1e-9,
         "root reserved_usd should be unchanged after sub-lead spawn_worker; \
@@ -1647,7 +1647,7 @@ async fn sublead_worker_budget_reserved_against_sublead_envelope() {
     let sub_layer = subleads
         .get(sublead_id.as_str())
         .expect("sub-tree layer must exist");
-    let sub_reserved = *sub_layer.reserved_usd.lock().await;
+    let sub_reserved = *sub_layer.budget.reserved_usd.lock().await;
     assert!(
         sub_reserved > 0.0,
         "sub-lead's reserved_usd must be > 0 after spawning a worker; got={sub_reserved}"

--- a/examples/dogfood/fake/06-envelope-cap-rejection/README.md
+++ b/examples/dogfood/fake/06-envelope-cap-rejection/README.md
@@ -19,7 +19,7 @@ The spotlight proves:
 
 3. **Clean state after rejection**: After a rejected spawn attempt:
    - `state.subleads.read().await.is_empty()` (no partial registration)
-   - `*state.root.reserved_usd.lock().await == 0.0` (no phantom reservation)
+   - `*state.root.budget.reserved_usd.lock().await == 0.0` (no phantom reservation)
 
 4. **Successful retry with compliant budget**: When the same root lead retries with `budget_usd = 2.0` (within the 3.0 cap):
    - The spawn succeeds

--- a/examples/dogfood/fake/06-envelope-cap-rejection/expected-observables.md
+++ b/examples/dogfood/fake/06-envelope-cap-rejection/expected-observables.md
@@ -23,13 +23,13 @@ varying budgets.
 ### Result: Clean rejection
 - **MCP error returned** with message containing "exceeds per-sublead cap"
 - **No LayerState registered** — `state.subleads` remains empty
-- **No budget reservation made** — `state.root.reserved_usd` stays at 0.0
+- **No budget reservation made** — `state.root.budget.reserved_usd` stays at 0.0
 - **No partial state left behind** — dispatch remains clean for retry
 
 ### Observable in state
 ```
 state.subleads.read().await.is_empty() == true   // no partial registration
-*state.root.reserved_usd.lock().await == 0.0      // no phantom reservation
+*state.root.budget.reserved_usd.lock().await == 0.0      // no phantom reservation
 ```
 
 ---
@@ -44,13 +44,13 @@ state.subleads.read().await.is_empty() == true   // no partial registration
 ### Result: Clean success
 - **MCP returns sublead_id** (e.g., `sublead-xxx`)
 - **LayerState IS registered** — sub-lead appears in `state.subleads`
-- **Budget IS reserved** — `state.root.reserved_usd` increases to 2.0
+- **Budget IS reserved** — `state.root.budget.reserved_usd` increases to 2.0
 - **Sub-lead is ready** — root can interact with it via MCP
 
 ### Observable in state
 ```
 state.subleads.read().await.contains_key(sublead_id) == true  // registered
-*state.root.reserved_usd.lock().await == 2.0                  // envelope reserved
+*state.root.budget.reserved_usd.lock().await == 2.0                  // envelope reserved
 ```
 
 ---


### PR DESCRIPTION
## Summary

Step 2 of 3 for #487 (`LayerState` god-object split). Builds on #561's `WorkerRegistry` extraction.

Pulls the four layer-aggregate USD-spend fields off `LayerState` into a new `BudgetState`:
- `spent_usd` — total USD spent on completed workers in this layer
- `reserved_usd` — USD reserved for in-flight workers at spawn time
- `lead_spent_usd` — token spend (USD) attributed to this layer's lead
- `abort_reason` (renamed from `budget_abort_reason`) — set when the dispatcher decides to abort because of a budget cap breach

`LayerState` now exposes `pub budget: BudgetState` alongside `pub workers: WorkerRegistry`. Handlers that only need USD accounting can take `&BudgetState` and physically can't touch worker or approval state.

Mechanical access-site rename across ~52 callers in `pitboss-cli`, plus three dogfood scenario doc references in `examples/dogfood/fake/06-envelope-cap-rejection/`.

## Why this PR is small

- `worker_reservations` (per-task_id USD reserved) already moved to `WorkerRegistry` in #561 — it's keyed by task_id, structurally a worker map, even though the audit grouped it as budget. `BudgetState` only owns the four layer-aggregate counters.
- `original_reservation_usd` (init-time constant set once at sub-lead spawn) stays on `LayerState`. It never participates in live spend tracking and isn't mutated post-construction.

## Critical invariant preserved

`lead_spent_usd` keeps `std::sync::Mutex` (not `tokio::sync::Mutex`). It's written from the synchronous stream-json event observer where no `.await` may cross the lock guard (#253). The doc comment on `BudgetState` documents this explicitly so a future refactor doesn't silently swap the lock type.

## Field rename

`budget_abort_reason` → `abort_reason` since `LayerState.budget` is now the container — keeping the `budget_` prefix on the inner field would be redundant (`layer.budget.budget_abort_reason` reads worse than `layer.budget.abort_reason`).

## Test plan

- [x] `cargo test -p pitboss-cli` — 876 lib + ~140 integration tests pass
- [x] `cargo lint` — clean
- [x] `cargo tidy` — clean
- [x] `cargo check --workspace --all-targets` — pitboss-tui / pitboss-web clean
- [ ] CI green

Pre-existing `e2e_flows` flake class (`e2e_lead_request_approval_round_trip`, `e2e_lead_through_mcp_bridge_injects_meta` — `TokioSpawner + /bin/true` vs background task race) intermittently fails under heavy parallel load; both pass in isolation. Unchanged by this PR.

## Coming next

**PR 3** extracts `ApprovalState`: `bridge`, `queue`, `policy`, `plan_approved`, `policy_matcher`. ~34 access sites. After that, `LayerState` narrows to identity + deps + control plane + 3 sub-struct handles.

Tracking: refs #487 — issue stays open until PR 3 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)