### PR TITLE
refactor(dispatch): extract ApprovalState from LayerState

### DIFF
--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -320,7 +320,7 @@ async fn serve_connection(
 
     // Snapshot current policy rules (if any) to send in Hello.
     let policy_rules = {
-        let guard = state.root.policy_matcher.lock().await;
+        let guard = state.root.approvals.matcher.lock().await;
         guard
             .as_ref()
             .map(|m| m.rules().to_vec())
@@ -401,13 +401,13 @@ async fn serve_connection(
 
         // Drain any queued approvals now that a TUI is connected.
         {
-            let mut queue = state.root.approval_queue.lock().await;
+            let mut queue = state.root.approvals.queue.lock().await;
             while let Some(q) = queue.pop_front() {
                 // Transfer responder into the bridge map, preserving TTL metadata
                 // and display fields so expire_layer_approvals can still expire
                 // the entry and — per #102 — a subsequent TUI reconnect can
                 // replay pending approvals held by the bridge.
-                state.root.approval_bridge.lock().await.insert(
+                state.root.approvals.bridge.lock().await.insert(
                     q.request_id.clone(),
                     crate::dispatch::state::BridgeEntry {
                         responder: q.responder,
@@ -450,7 +450,7 @@ async fn serve_connection(
         // lock waiter (expire_layer_approvals, the Approve op handler, concurrent
         // Hello drain) for the full duration of the backpressure stall (#105).
         let pending: Vec<ControlEvent> = {
-            let bridge = state.root.approval_bridge.lock().await;
+            let bridge = state.root.approvals.bridge.lock().await;
             bridge
                 .iter()
                 .filter(|(_, entry)| !entry.responder.is_closed())
@@ -1528,7 +1528,7 @@ async fn dispatch_op(
             edited_summary,
             reason,
         } => {
-            let bridge_entry = state.root.approval_bridge.lock().await.remove(&request_id);
+            let bridge_entry = state.root.approvals.bridge.lock().await.remove(&request_id);
             if let Some(bridge_entry) = bridge_entry {
                 let caller_id = bridge_entry.task_id.clone();
                 let edited = edited_summary.is_some();
@@ -1923,7 +1923,7 @@ mod tests {
 
         // Pre-seed the bridge map with a request_id + BridgeEntry.
         let (tx, rx) = tokio::sync::oneshot::channel();
-        state.root.approval_bridge.lock().await.insert(
+        state.root.approvals.bridge.lock().await.insert(
             "req-1".into(),
             crate::dispatch::state::BridgeEntry {
                 responder: tx,
@@ -2013,7 +2013,7 @@ mod tests {
         // Simulate the "first TUI got the event then died" state: entry
         // lives in the bridge with a still-live responder oneshot.
         let (tx, rx) = tokio::sync::oneshot::channel();
-        state.root.approval_bridge.lock().await.insert(
+        state.root.approvals.bridge.lock().await.insert(
             "req-ghost".into(),
             crate::dispatch::state::BridgeEntry {
                 responder: tx,

--- a/crates/pitboss-cli/src/dispatch/layer.rs
+++ b/crates/pitboss-cli/src/dispatch/layer.rs
@@ -179,6 +179,59 @@ impl Default for BudgetState {
     }
 }
 
+/// Approval bookkeeping: live-TUI bridge, queued requests, the legacy
+/// fall-through policy, the declarative `PolicyMatcher`, and the
+/// plan-approval gate.
+///
+/// Split out of `LayerState` (#487 step 3) so handlers that only need
+/// approval state can take `&ApprovalState` instead of `&LayerState`
+/// and physically can't touch worker or budget bookkeeping.
+///
+/// The `plan_approved` gate stays as `AtomicBool` so reads on the
+/// hot-path (`spawn_worker`) are lock-free; the bridge and queue
+/// retain `Mutex` because the operations that mutate them
+/// (insert/remove/take) span more than a single atomic op.
+pub struct ApprovalState {
+    /// Live-TUI approval requests keyed by request_id.
+    ///
+    /// Values are `BridgeEntry` (not bare senders) so the TTL watcher can
+    /// expire bridge entries that the operator never acted on. Without TTL
+    /// metadata here, an approval that moves from `queue` to the bridge
+    /// on TUI connect loses its auto-resolve guarantee.
+    pub bridge: Mutex<HashMap<String, BridgeEntry>>,
+    /// Queued approval requests waiting for a TUI to attach.
+    pub queue: Mutex<VecDeque<QueuedApproval>>,
+    /// Legacy fall-through approval policy from `[run].default_approval_policy`.
+    /// Applies when no `[[approval_policy]]` rule matches.
+    pub policy: ApprovalPolicy,
+    /// Plan-approval gate. Atomic so the hot-path `spawn_worker` check
+    /// is lock-free.
+    pub plan_approved: std::sync::atomic::AtomicBool,
+    /// Operator-declared approval policy matcher. Loaded from manifest
+    /// `[[approval_policy]]` blocks at run startup. `None` means no
+    /// declarative rules; every approval falls through to the legacy
+    /// `policy` / operator queue path.
+    ///
+    /// NOTE: This is a run-level (root-layer) policy for v0.6. Per-sub-lead
+    /// policy is deferred to Phase 4.x.
+    pub matcher: Mutex<Option<PolicyMatcher>>,
+}
+
+impl ApprovalState {
+    /// Construct an approval state with the legacy fall-through policy
+    /// taken from the manifest. Bridge/queue start empty, plan gate
+    /// closed, no declarative matcher installed yet.
+    pub fn new(policy: ApprovalPolicy) -> Self {
+        Self {
+            bridge: Mutex::new(HashMap::new()),
+            queue: Mutex::new(VecDeque::new()),
+            policy,
+            plan_approved: std::sync::atomic::AtomicBool::new(false),
+            matcher: Mutex::new(None),
+        }
+    }
+}
+
 /// All state owned by a single coordination layer (root layer or a
 /// sub-tree layer).
 pub struct LayerState {
@@ -200,19 +253,10 @@ pub struct LayerState {
     pub cleanup_policy: CleanupPolicy,
     /// The per-run subdirectory where worker logs/artifacts land.
     pub run_subdir: PathBuf,
-    /// Approval bridge: maps request_id → sender that completes when the
-    /// TUI responds to an approval request.
-    /// Live-TUI approval requests keyed by request_id.
-    ///
-    /// Values are `BridgeEntry` (not bare senders) so the TTL watcher can
-    /// expire bridge entries that the operator never acted on. Without TTL
-    /// metadata here, an approval that moves from `approval_queue` to the
-    /// bridge on TUI connect loses its auto-resolve guarantee.
-    pub approval_bridge: Mutex<HashMap<String, BridgeEntry>>,
-    /// Queued approval requests waiting for a TUI to attach.
-    pub approval_queue: Mutex<VecDeque<QueuedApproval>>,
-    /// Approval policy from the manifest.
-    pub approval_policy: ApprovalPolicy,
+    /// Approval bookkeeping: live-TUI bridge, queue, legacy fall-through
+    /// policy, declarative matcher, and the plan-approval gate.
+    /// Split out of this struct in #487 step 3.
+    pub approvals: ApprovalState,
     /// Outbound control-socket event channel.
     ///
     /// `ControlWriterSlot` carries a per-connection `id` so disconnect
@@ -258,19 +302,9 @@ pub struct LayerState {
     pub notification_router: Option<std::sync::Arc<crate::notify::NotificationRouter>>,
     /// In-memory shared store for hub-mediated lead ↔ worker coordination.
     pub shared_store: std::sync::Arc<crate::shared_store::SharedStore>,
-    /// Plan-approval gate.
-    pub plan_approved: std::sync::atomic::AtomicBool,
     /// Original reservation amount (USD) at sub-lead spawn time.
     /// Only set for sub-leads; None for root layer.
     pub original_reservation_usd: Option<f64>,
-    /// Operator-declared approval policy matcher. Loaded from manifest
-    /// `[[approval_policy]]` blocks at run startup. `None` means no
-    /// declarative rules; every approval falls through to the legacy
-    /// ApprovalPolicy / operator queue path.
-    ///
-    /// NOTE: This is a run-level (root-layer) policy for v0.6. Per-sub-lead
-    /// policy is deferred to Phase 4.x.
-    pub policy_matcher: Mutex<Option<PolicyMatcher>>,
     /// Test-only hook: intercepts synthetic reprompts that would otherwise be
     /// delivered to this layer's Claude session. `None` in production (reprompt
     /// goes through the real MCP/subprocess path). Set via
@@ -363,17 +397,13 @@ impl LayerState {
             wt_mgr,
             cleanup_policy,
             run_subdir,
-            approval_bridge: Mutex::new(HashMap::new()),
-            approval_queue: Mutex::new(VecDeque::new()),
-            approval_policy,
+            approvals: ApprovalState::new(approval_policy),
             control_writer: Mutex::new(None),
             event_log,
             events_tx,
             notification_router,
             shared_store,
-            plan_approved: std::sync::atomic::AtomicBool::new(false),
             original_reservation_usd,
-            policy_matcher: Mutex::new(None),
             reprompt_hook: Mutex::new(None),
             reprompt_tx: Mutex::new(None),
         }
@@ -411,7 +441,7 @@ impl LayerState {
     /// resolving `[[approval_policy]]` blocks from the manifest. Can also be
     /// called in tests to inject policy without manifests.
     pub async fn set_policy_matcher(&self, matcher: PolicyMatcher) {
-        *self.policy_matcher.lock().await = Some(matcher);
+        *self.approvals.matcher.lock().await = Some(matcher);
     }
 
     /// Populate the reprompt delivery channel for this layer's lead subprocess.

--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -1263,7 +1263,7 @@ async fn expire_approvals(state: &Arc<crate::dispatch::state::DispatchState>) {
     expire_layer_approvals(state, &state.root).await;
 
     // Then every sub-lead layer. Acquiring the outer `subleads` read lock
-    // first and each inner `approval_queue` lock in a fresh per-iteration
+    // first and each inner `approvals.queue` lock in a fresh per-iteration
     // scope matches the project-wide lock ordering rule (see DispatchState
     // docs) and avoids holding both kinds of locks across await points.
     let subleads = state.subleads.read().await;
@@ -1297,9 +1297,9 @@ async fn expire_layer_approvals(
 
     let now = chrono::Utc::now();
 
-    // ── Scan approval_queue ───────────────────────────────────────────────────
+    // ── Scan approvals.queue ───────────────────────────────────────────────────
     // Entries here have not yet been seen by any TUI.
-    let mut queue = layer.approval_queue.lock().await;
+    let mut queue = layer.approvals.queue.lock().await;
     let mut i = 0;
     let mut expired_queue = Vec::new();
     while i < queue.len() {
@@ -1343,11 +1343,11 @@ async fn expire_layer_approvals(
         let _ = entry.responder.send(response);
     }
 
-    // ── Scan approval_bridge ──────────────────────────────────────────────────
+    // ── Scan approvals.bridge ──────────────────────────────────────────────────
     // Entries here were drained to a TUI that may have disconnected before
     // responding. Without this scan they would silently miss their TTL.
     let expired_bridge_ids: Vec<String> = {
-        let bridge = layer.approval_bridge.lock().await;
+        let bridge = layer.approvals.bridge.lock().await;
         bridge
             .iter()
             .filter_map(|(id, entry)| {
@@ -1367,7 +1367,7 @@ async fn expire_layer_approvals(
     };
 
     for request_id in expired_bridge_ids {
-        let entry = layer.approval_bridge.lock().await.remove(&request_id);
+        let entry = layer.approvals.bridge.lock().await.remove(&request_id);
         if let Some(entry) = entry {
             let fallback = entry.fallback.unwrap_or(ApprovalFallback::Block);
             let approved = matches!(fallback, ApprovalFallback::AutoApprove);

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -285,7 +285,7 @@ pub struct QueuedApproval {
 ///
 /// Carries TTL metadata so `expire_layer_approvals` can expire bridge entries
 /// that the operator never acted on — the same guarantee it provides for
-/// `approval_queue` entries. Without this, an approval that moves from queue
+/// `approvals.queue` entries. Without this, an approval that moves from queue
 /// to bridge (when a TUI connects) loses TTL coverage: the queue is empty so
 /// the watcher does nothing, while the bridge has no metadata to check against.
 ///
@@ -745,10 +745,10 @@ mod tests {
     #[tokio::test]
     async fn state_initializes_new_v04_fields() {
         let st = mk_state(None, None);
-        assert!(st.root.approval_bridge.lock().await.is_empty());
-        assert!(st.root.approval_queue.lock().await.is_empty());
+        assert!(st.root.approvals.bridge.lock().await.is_empty());
+        assert!(st.root.approvals.queue.lock().await.is_empty());
         assert!(matches!(
-            st.root.approval_policy,
+            st.root.approvals.policy,
             crate::dispatch::state::ApprovalPolicy::Block
         ));
         assert!(st.root.control_writer.lock().await.is_none());

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -368,7 +368,7 @@ pub async fn spawn_sublead(
                 CleanupPolicy::Never, // sub-tree shares run cleanup behaviour; finalized by root
                 state.root.run_subdir.clone(),
                 // Inherit root approval policy; sub-leads can escalate via request_approval.
-                state.root.approval_policy,
+                state.root.approvals.policy,
                 // No notification router for sub-trees — root router handles run events.
                 None,
                 sub_store,

--- a/crates/pitboss-cli/src/mcp/approval.rs
+++ b/crates/pitboss-cli/src/mcp/approval.rs
@@ -202,7 +202,7 @@ impl ApprovalBridge {
         // path. Operators who want manual review with a fallback should use
         // `[[approval_policy]]` rules (which already short-circuit) and
         // leave `default_approval_policy` at its default of `block`.
-        match self.state.root.approval_policy {
+        match self.state.root.approvals.policy {
             ApprovalPolicy::AutoApprove => {
                 let _ = tx.send(ApprovalResponse {
                     approved: true,
@@ -240,11 +240,11 @@ impl ApprovalBridge {
         // `w.send(ev)`. A previous version released the writer lock between
         // the "is it present?" check and the insert, so a TUI that
         // disconnected in that window would leave the responder orphaned
-        // in `approval_bridge` — stuck until the bridge timeout.
+        // in `approvals.bridge` — stuck until the bridge timeout.
         let writer_guard = self.state.root.control_writer.lock().await;
 
         if let Some(w) = writer_guard.as_ref() {
-            self.state.root.approval_bridge.lock().await.insert(
+            self.state.root.approvals.bridge.lock().await.insert(
                 request_id.clone(),
                 crate::dispatch::state::BridgeEntry {
                     responder: tx,
@@ -295,7 +295,8 @@ impl ApprovalBridge {
                 // responder isn't orphaned.
                 self.state
                     .root
-                    .approval_bridge
+                    .approvals
+                    .bridge
                     .lock()
                     .await
                     .remove(&request_id);
@@ -349,7 +350,8 @@ impl ApprovalBridge {
             self.state.root.event_log.persist(&queue_envelope).await;
             self.state
                 .root
-                .approval_queue
+                .approvals
+                .queue
                 .lock()
                 .await
                 .push_back(QueuedApproval {
@@ -402,7 +404,8 @@ impl ApprovalBridge {
                 // Timeout: remove the pending entry so a late respond doesn't panic.
                 self.state
                     .root
-                    .approval_bridge
+                    .approvals
+                    .bridge
                     .lock()
                     .await
                     .remove(&request_id); // removes BridgeEntry; responder dropped
@@ -411,7 +414,8 @@ impl ApprovalBridge {
                                           // approval modal for a request that has already resolved.
                 self.state
                     .root
-                    .approval_queue
+                    .approvals
+                    .queue
                     .lock()
                     .await
                     .retain(|q| q.request_id != request_id);
@@ -429,7 +433,8 @@ impl ApprovalBridge {
         let bridge_entry = self
             .state
             .root
-            .approval_bridge
+            .approvals
+            .bridge
             .lock()
             .await
             .remove(request_id)

--- a/crates/pitboss-cli/src/mcp/tools/approval.rs
+++ b/crates/pitboss-cli/src/mcp/tools/approval.rs
@@ -111,7 +111,7 @@ pub async fn handle_request_approval(
 
     // Evaluate operator-declared policy before falling through to the legacy queue.
     {
-        let matcher_guard = state.root.policy_matcher.lock().await;
+        let matcher_guard = state.root.approvals.matcher.lock().await;
         if let Some(matcher) = matcher_guard.as_ref() {
             match matcher.evaluate(&pending, args.tool_name.as_deref(), args.cost_estimate) {
                 Some(ApprovalAction::AutoApprove) => {
@@ -216,7 +216,7 @@ pub async fn handle_request_approval(
 /// Plan approval is per-layer: the root lead's approval gates root-layer
 /// worker spawns; each sub-lead's approval gates its own sub-tree's
 /// worker spawns. Previously, every `propose_plan` acceptance flipped
-/// `state.root.plan_approved`, so a sub-lead's approval silently
+/// `state.root.approvals.plan_approved`, so a sub-lead's approval silently
 /// unblocked worker spawns for the root lead and every sibling sub-lead
 /// — bypassing the root's own plan gate. `spawn_worker` now reads from
 /// the target layer, and this handler writes to the caller's layer.
@@ -281,7 +281,7 @@ pub async fn handle_propose_plan(
 
     // Evaluate operator-declared policy before falling through to the legacy queue.
     {
-        let matcher_guard = state.root.policy_matcher.lock().await;
+        let matcher_guard = state.root.approvals.matcher.lock().await;
         if let Some(matcher) = matcher_guard.as_ref() {
             // #151 M5: forward the caller-supplied cost estimate (if any)
             // so cost_over rules can fire on plan-level approvals. Pre-fix
@@ -294,6 +294,7 @@ pub async fn handle_propose_plan(
                         "plan auto-approved by policy"
                     );
                     caller_layer
+                        .approvals
                         .plan_approved
                         .store(true, std::sync::atomic::Ordering::Release);
                     state
@@ -376,6 +377,7 @@ pub async fn handle_propose_plan(
         Ok(resp) => {
             if resp.approved {
                 caller_layer
+                    .approvals
                     .plan_approved
                     .store(true, std::sync::atomic::Ordering::Release);
             }
@@ -547,7 +549,7 @@ pub async fn handle_permission_prompt(
 
     // Evaluate operator-declared policy first.
     {
-        let matcher_guard = state.root.policy_matcher.lock().await;
+        let matcher_guard = state.root.approvals.matcher.lock().await;
         if let Some(matcher) = matcher_guard.as_ref() {
             // #151 M5: forward the caller-supplied cost estimate (if any)
             // so cost_over rules can fire on permission_prompt. Pre-fix

--- a/crates/pitboss-cli/src/mcp/tools/spawn.rs
+++ b/crates/pitboss-cli/src/mcp/tools/spawn.rs
@@ -98,6 +98,7 @@ pub async fn handle_spawn_worker(
     // layer worker spawns succeed.
     if state.root.manifest.require_plan_approval
         && !target_layer
+            .approvals
             .plan_approved
             .load(std::sync::atomic::Ordering::Acquire)
     {

--- a/crates/pitboss-cli/src/mcp/tools/tests.rs
+++ b/crates/pitboss-cli/src/mcp/tools/tests.rs
@@ -1423,7 +1423,7 @@ async fn register_test_sublead(
         state.root.wt_mgr.clone(),
         CleanupPolicy::Never,
         state.root.run_subdir.clone(),
-        state.root.approval_policy,
+        state.root.approvals.policy,
         None,
         std::sync::Arc::new(crate::shared_store::SharedStore::new()),
         None,
@@ -2278,6 +2278,7 @@ async fn propose_plan_auto_approve_flips_flag() {
     let state = mk_plan_state(crate::dispatch::state::ApprovalPolicy::AutoApprove, true).await;
     assert!(!state
         .root
+        .approvals
         .plan_approved
         .load(std::sync::atomic::Ordering::Acquire));
 
@@ -2300,6 +2301,7 @@ async fn propose_plan_auto_approve_flips_flag() {
     assert!(resp.approved);
     assert!(state
         .root
+        .approvals
         .plan_approved
         .load(std::sync::atomic::Ordering::Acquire));
 }
@@ -2348,6 +2350,7 @@ async fn propose_plan_cost_over_rule_auto_rejects_when_estimate_exceeds() {
     assert!(
         !state
             .root
+            .approvals
             .plan_approved
             .load(std::sync::atomic::Ordering::Acquire),
         "rejected plan must not flip plan_approved"
@@ -3089,6 +3092,7 @@ async fn propose_plan_auto_reject_leaves_flag_false() {
     assert!(
         !state
             .root
+            .approvals
             .plan_approved
             .load(std::sync::atomic::Ordering::Acquire),
         "rejected plan must not flip plan_approved — lead should be able to retry"

--- a/crates/pitboss-cli/tests/control_flows.rs
+++ b/crates/pitboss-cli/tests/control_flows.rs
@@ -785,7 +785,7 @@ async fn block_policy_queue_drains_on_tui_connect() {
 
     // Give the request a moment to queue.
     tokio::time::sleep(Duration::from_millis(50)).await;
-    assert_eq!(state.root.approval_queue.lock().await.len(), 1);
+    assert_eq!(state.root.approvals.queue.lock().await.len(), 1);
 
     // Connect a TUI. The server drains the queue on connect.
     let sock = dir.path().join("block-drain.sock");
@@ -1146,6 +1146,7 @@ async fn propose_plan_end_to_end_unblocks_spawn_gate() {
     assert!(resp.approved);
     assert!(state
         .root
+        .approvals
         .plan_approved
         .load(std::sync::atomic::Ordering::Acquire));
 

--- a/crates/pitboss-cli/tests/dogfood_fake_flows.rs
+++ b/crates/pitboss-cli/tests/dogfood_fake_flows.rs
@@ -824,7 +824,7 @@ async fn dogfood_policy_auto_filter() {
 
     // Verify no approval was queued for S1's tool-use.
     {
-        let q = state.root.approval_queue.lock().await;
+        let q = state.root.approvals.queue.lock().await;
         assert_eq!(
             q.len(),
             0,
@@ -858,7 +858,7 @@ async fn dogfood_policy_auto_filter() {
 
     // Verify S2's approval was queued (didn't match any auto-action rule).
     {
-        let q = state.root.approval_queue.lock().await;
+        let q = state.root.approvals.queue.lock().await;
         assert_eq!(
             q.len(),
             1,
@@ -899,7 +899,7 @@ async fn dogfood_policy_auto_filter() {
 
     // Verify S1's plan approval was queued (Rule 2 forces operator review).
     {
-        let q = state.root.approval_queue.lock().await;
+        let q = state.root.approvals.queue.lock().await;
         assert_eq!(
             q.len(),
             2,

--- a/crates/pitboss-cli/tests/e2e_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_flows.rs
@@ -460,10 +460,10 @@ async fn e2e_lead_request_approval_round_trip() {
     let ctrl_sock_bg = ctrl_sock.clone();
     let state_for_fcc = state.clone();
     let fcc_task = tokio::spawn(async move {
-        // Poll up to 2s for the approval_queue to fill.
+        // Poll up to 2s for the approvals.queue to fill.
         let poll_deadline = tokio::time::Instant::now() + Duration::from_secs(2);
         loop {
-            if !state_for_fcc.root.approval_queue.lock().await.is_empty() {
+            if !state_for_fcc.root.approvals.queue.lock().await.is_empty() {
                 break;
             }
             if tokio::time::Instant::now() >= poll_deadline {
@@ -881,7 +881,7 @@ async fn e2e_lead_propose_plan_gate_unblocks_spawn() {
     let fcc_task = tokio::spawn(async move {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
         loop {
-            if !state_for_fcc.root.approval_queue.lock().await.is_empty() {
+            if !state_for_fcc.root.approvals.queue.lock().await.is_empty() {
                 break;
             }
             if tokio::time::Instant::now() >= deadline {
@@ -950,6 +950,7 @@ async fn e2e_lead_propose_plan_gate_unblocks_spawn() {
     // plan_approved latched true, one worker spawned successfully.
     assert!(state
         .root
+        .approvals
         .plan_approved
         .load(std::sync::atomic::Ordering::Acquire));
     let workers = state.root.workers.states.read().await;

--- a/crates/pitboss-cli/tests/e2e_sublead_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_sublead_flows.rs
@@ -465,10 +465,10 @@ async fn reject_with_reason_reaches_sublead_session() {
     let reason_text = "output format must be JSON, not CSV".to_string();
     let reason_clone = reason_text.clone();
     let fcc_task = tokio::spawn(async move {
-        // Poll until the approval_queue is non-empty (sub-lead's request landed).
+        // Poll until the approvals.queue is non-empty (sub-lead's request landed).
         let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
         loop {
-            if !state_for_bg.root.approval_queue.lock().await.is_empty() {
+            if !state_for_bg.root.approvals.queue.lock().await.is_empty() {
                 break;
             }
             if tokio::time::Instant::now() >= deadline {

--- a/crates/pitboss-cli/tests/sublead_flows.rs
+++ b/crates/pitboss-cli/tests/sublead_flows.rs
@@ -653,7 +653,7 @@ async fn policy_auto_approves_matching_actor() {
     );
 
     // Verify no approval was queued (the legacy block-mode path was bypassed).
-    let queue = state.root.approval_queue.lock().await;
+    let queue = state.root.approvals.queue.lock().await;
     assert!(
         queue.is_empty(),
         "policy short-circuit should not enqueue approval; queue has {} items",
@@ -738,7 +738,7 @@ async fn policy_auto_approves_sublead_actor() {
     );
 
     // Verify nothing was queued in the operator approval queue.
-    let queue = state.root.approval_queue.lock().await;
+    let queue = state.root.approvals.queue.lock().await;
     assert!(
         queue.is_empty(),
         "policy short-circuit must not enqueue approval; queue has {} items",
@@ -823,14 +823,14 @@ async fn approval_ttl_triggers_auto_reject_fallback() {
         created_at: chrono::Utc::now(),
     };
 
-    state.root.approval_queue.lock().await.push_back(approval);
+    state.root.approvals.queue.lock().await.push_back(approval);
 
     // Spawn the TTL watcher
     pitboss_cli::dispatch::runner::install_approval_ttl_watcher(state.clone());
 
     // Verify it's in the queue before TTL expires
     {
-        let queue = state.root.approval_queue.lock().await;
+        let queue = state.root.approvals.queue.lock().await;
         assert!(
             queue.iter().any(|a| a.request_id == request_id),
             "approval should be in queue initially"
@@ -842,7 +842,7 @@ async fn approval_ttl_triggers_auto_reject_fallback() {
     let mut found_removed = false;
     for _ in 0..10 {
         tokio::time::sleep(std::time::Duration::from_millis(250)).await;
-        let queue = state.root.approval_queue.lock().await;
+        let queue = state.root.approvals.queue.lock().await;
         if queue.iter().all(|a| a.request_id != request_id) {
             found_removed = true;
             break;


### PR DESCRIPTION
## Summary

Final step of #487 — collapse five approval-related fields on `LayerState` into a single `ApprovalState` sub-struct accessible as `layer.approvals`. Builds on #561 (WorkerRegistry) and #562 (BudgetState).

Fields moved (with within-substruct renames where the `approval_` / `policy_` prefix becomes redundant inside the new sub-struct):

| Before                       | After                          |
|---                           |---                             |
| `layer.approval_bridge`      | `layer.approvals.bridge`       |
| `layer.approval_queue`       | `layer.approvals.queue`        |
| `layer.approval_policy`      | `layer.approvals.policy`       |
| `layer.plan_approved`        | `layer.approvals.plan_approved`|
| `layer.policy_matcher`       | `layer.approvals.matcher`      |

`plan_approved` keeps its name within `ApprovalState` since it's already unambiguous without an `approval_` prefix.

The `set_policy_matcher` helper on `LayerState` stays in place; its body now delegates to `self.approvals.matcher`. The 9 call sites are untouched — this is a no-op nicety to keep the diff small. A follow-up could move it to `ApprovalState::set_matcher` if desired.

## What's deliberately NOT touched

- **Manifest TOML field names** — `[run].approval_policy`, `[[approval_policy]]` rule blocks, `default_approval_policy`. These are operator-facing and live in the manifest schema. The sed used `(?!\()` to avoid renaming `.approval_policy(...)` builder calls on `TestStateBuilder`, and I reverted six docstring/warning-message instances that still refer to the legacy TOML field.
- **`TestStateBuilder.approval_policy`** — that's a private field on the test builder struct, not on `LayerState`. Skipped from the sed pass entirely.
- **`ApprovalPolicy` type, `ApprovalRule`, `PolicyMatcher`** — type names, not field names; different case in the regex.

## After the 3-PR series

`LayerState` now has 22 fields (down from the 31 the F-ARCH-8 audit flagged) with bookkeeping grouped into three handle structs that physically narrow handler access:

```
LayerState
├── workers: WorkerRegistry      (PR #561) — per-task_id maps + Done broadcast
├── budget:  BudgetState         (PR #562) — layer-aggregate USD + abort reason
├── approvals: ApprovalState     (this PR) — bridge, queue, policy, plan gate, matcher
└── … (run-level state, deps, lifecycle channels)
```

Closes #487.

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo lint` — clean
- [x] `cargo tidy` — clean
- [x] `cargo test -p pitboss-cli --lib` — 876 passed, 0 failed (one TOML-field warning-message test caught a misapplied rewrite; reverted)
- [x] `cargo test -p pitboss-cli --test sublead_flows --test hierarchical_flows --test control_flows --test dogfood_fake_flows` — all green
- [ ] CI on Linux (the ground truth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)