### PR TITLE
fix(control): add #[serde(default)] to SubleadSpawned.read_down

### DIFF
--- a/crates/pitboss-cli/src/control/protocol.rs
+++ b/crates/pitboss-cli/src/control/protocol.rs
@@ -130,6 +130,10 @@ fn is_zero_u64(v: &u64) -> bool {
     *v == 0
 }
 
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
 /// Selects whether a control-socket client wants to write ops (default,
 /// pre-v0.14 behavior) or only read the broadcast envelope stream.
 ///
@@ -312,7 +316,12 @@ pub enum ControlEvent {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         max_workers: Option<u32>,
         /// Whether the sub-lead was spawned with read_down=true (can read
-        /// root-layer KV keys).
+        /// root-layer KV keys). Defaults to `false` for back-compat with
+        /// pre-v0.6 TUI clients that don't know about read-down mode
+        /// (closes F-PROTO-1 / #512). The field is omitted from the wire
+        /// when `false` so a pre-v0.6 dispatcher's JSON stays
+        /// byte-identical.
+        #[serde(default, skip_serializing_if = "is_false")]
         read_down: bool,
     },
     /// A worker, sub-lead, or lead claude subprocess exited non-zero and
@@ -848,6 +857,67 @@ mod tests {
             !s.contains("\"lease_ops\":0"),
             "zero kv/lease counters should be omitted"
         );
+        assert_eq!(roundtrip_event(&ev), ev);
+    }
+
+    /// F-PROTO-1 (#512): `SubleadSpawned` from a pre-v0.6 dispatcher
+    /// omits the `read_down` field. Verify a payload without it
+    /// deserializes successfully (default `false`).
+    #[test]
+    fn sublead_spawned_back_compat_no_read_down() {
+        let raw = r#"{"event":"sublead_spawned","sublead_id":"sub-A"}"#;
+        let ev: ControlEvent = serde_json::from_str(raw)
+            .expect("sublead_spawned without read_down must deserialize (back-compat)");
+        match ev {
+            ControlEvent::SubleadSpawned {
+                sublead_id,
+                budget_usd,
+                lead_budget_usd,
+                max_workers,
+                read_down,
+            } => {
+                assert_eq!(sublead_id, "sub-A");
+                assert_eq!(budget_usd, None);
+                assert_eq!(lead_budget_usd, None);
+                assert_eq!(max_workers, None);
+                assert!(!read_down, "missing read_down must default to false");
+            }
+            other => panic!("expected SubleadSpawned, got {other:?}"),
+        }
+    }
+
+    /// F-PROTO-1 (#512): a `SubleadSpawned` with `read_down: false` must
+    /// elide the field on the wire so a pre-v0.6 TUI parsing the JSON
+    /// sees byte-identical output.
+    #[test]
+    fn sublead_spawned_read_down_false_elided_on_wire() {
+        let ev = ControlEvent::SubleadSpawned {
+            sublead_id: "sub-A".into(),
+            budget_usd: None,
+            lead_budget_usd: None,
+            max_workers: None,
+            read_down: false,
+        };
+        let s = serde_json::to_string(&ev).unwrap();
+        assert!(
+            !s.contains("read_down"),
+            "read_down=false should be elided; got: {s}"
+        );
+        assert_eq!(roundtrip_event(&ev), ev);
+    }
+
+    /// F-PROTO-1 (#512): `read_down: true` is serialized and round-trips.
+    #[test]
+    fn sublead_spawned_read_down_true_round_trips() {
+        let ev = ControlEvent::SubleadSpawned {
+            sublead_id: "sub-B".into(),
+            budget_usd: Some(2.0),
+            lead_budget_usd: None,
+            max_workers: Some(4),
+            read_down: true,
+        };
+        let s = serde_json::to_string(&ev).unwrap();
+        assert!(s.contains("\"read_down\":true"), "{s}");
         assert_eq!(roundtrip_event(&ev), ev);
     }
 }


### PR DESCRIPTION
## Summary

Closes #512 (F-PROTO-1, medium severity from the 2026-05-14 audit).

**Resubmission of #565** (closed) — that branch was inadvertently based on the prior PR's branch, so its diff included a duplicate of #564's merged work. This PR is the clean version: one commit, +71/-1, the SubleadSpawned change only.

## What changes

The `read_down` field on `ControlEvent::SubleadSpawned` was a bare `bool` without `#[serde(default)]`. Per the wire-compat contract at the top of `control/protocol.rs`, every optional/added field must carry `#[serde(default)]` (paired with `skip_serializing_if` for elision) so deserialization stays back-compat across long-running-dispatcher / freshly-built-TUI splits.

## The bug direction

A v0.6+ TUI parsing a `SubleadSpawned` event from an older dispatcher that pre-dates `read_down` sees a missing required field and rejects it with a typed `serde_json::Error`. With `#[serde(default)]`, the field deserializes as `false` (matching the pre-v0.6 semantic of "no read-down mode").

`skip_serializing_if = "is_false"` elides the field from the wire when it's at the default, so a v0.6+ dispatcher emitting to a pre-v0.6 TUI produces byte-identical JSON for the common `read_down=false` case.

## Style note (addressed in code review)

The audit's suggested attribute (`skip_serializing_if = "std::ops::Not::not"`) works and is correct, but every other predicate in `control/protocol.rs` is a named free function (`is_zero_u64`, `is_default_approval_kind`, etc.). Added a local `is_false` helper to match the file's idiom.

## Tests (in `control::protocol::tests`)

- `sublead_spawned_back_compat_no_read_down` — pre-v0.6 payload parses with default `false`
- `sublead_spawned_read_down_false_elided_on_wire` — `false` is not serialized
- `sublead_spawned_read_down_true_round_trips` — `true` is serialized and round-trips

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo lint` — clean
- [x] `cargo tidy` — clean
- [x] `cargo test -p pitboss-cli --lib` — 886 passed (3 new + 883 prior)
- [x] CI on Linux

Closes #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)