### PR TITLE
docs(security): mark approval policy cost_over as advisory only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1376,7 +1376,7 @@ Match fields (all optional; unset fields match any value):
 | `actor` | string | `ActorPath` rendered as `"root"` or `"root→S1"` or `"root→S1→W3"` |
 | `category` | string | snake_case enum: `"tool_use"`, `"plan"`, `"cost"`, `"other"` |
 | `tool_name` | string | Exact tool name; only meaningful when `category = "tool_use"` |
-| `cost_over` | float | Matches when the `cost_estimate` hint on the approval exceeds this USD value |
+| `cost_over` | float | Matches when the `cost_estimate` hint on the approval exceeds this USD value. **Advisory only** — `cost_estimate` is caller-supplied; an actor that passes `cost_estimate=0.0` bypasses any threshold. For hard cost gates use `auto_reject` on `tool_name`/`actor`, or the server-side `[run].budget_usd` cap. (F-SEC-8 / #531) |
 
 Action values (snake_case):
 

--- a/book/src/mcp-reference/approvals.md
+++ b/book/src/mcp-reference/approvals.md
@@ -38,7 +38,7 @@ Gate a single in-flight action on operator approval. The lead blocks until the o
 
 **Notes:**
 - The `plan` field is optional for simple approvals but strongly recommended for non-trivial actions (deletions, multi-file edits, irreversible operations).
-- `tool_name` and `cost_estimate` are hints that allow `[[approval_policy]]` rules to match on `tool_name` / `cost_over` criteria.
+- `tool_name` and `cost_estimate` are hints that allow `[[approval_policy]]` rules to match on `tool_name` / `cost_over` criteria. **`cost_estimate` is advisory only** — caller-supplied; a buggy or adversarial caller can pass `0.0` to bypass any `cost_over` threshold. For hard cost gates use `[run].budget_usd` (server-side cap) or `auto_reject` on `tool_name`/`actor`. See [Approval policy reference → Cost gates: advisory vs hard](../operator-guide/approval-policy-reference.md#cost-gates-advisory-vs-hard).
 - Policy rules (if configured) are evaluated before the request reaches the operator queue. A matching `auto_approve` or `auto_reject` rule skips the operator entirely.
 
 ---

--- a/book/src/operator-guide/approval-policy-reference.md
+++ b/book/src/operator-guide/approval-policy-reference.md
@@ -35,7 +35,7 @@ action = "block"
 | `actor` | string (optional) | The approval's `actor_path` rendered as a string (e.g., `"root"` or `"root→S1"`) equals the value | Use `"root"` for root-level requests. Use `"root→<sublead_id>"` for a specific sub-lead; sub-lead IDs are UUIDv7 and runtime-generated, so this field is most useful when you know the sub-lead's identity in advance — e.g., from a prior `spawn_sublead` response. Exact string match only; no wildcard patterns. |
 | `category` | enum (optional) | The approval's category field equals the value exactly | Allowed values: `"tool_use"`, `"plan"`, `"cost"`, `"other"`. Most `request_approval` calls land in `tool_use`; `propose_plan` lands in `plan`. Cost-category approvals are not emitted by default (see deferment notes). |
 | `tool_name` | string (optional) | The lead's optional `tool_name` hint on `request_approval` equals the value | Only fires if the lead populates the optional `tool_name` arg. Without it, this field never matches. Exact string match only. |
-| `cost_over` | float (optional) | The lead's optional `cost_estimate` hint exceeds this threshold (strict `>` comparison) | Only fires if the lead passes a `cost_estimate` arg to `request_approval`. Without it, this field never matches. Numeric greater-than comparison. |
+| `cost_over` | float (optional) | The lead's optional `cost_estimate` hint exceeds this threshold (strict `>` comparison) | Only fires if the lead passes a `cost_estimate` arg to `request_approval`. Without it, this field never matches. Numeric greater-than comparison. **Advisory only** — see [Cost gates: advisory vs hard](#cost-gates-advisory-vs-hard) below. |
 
 ---
 
@@ -115,9 +115,26 @@ match = { category = "cost" }
 action = "auto_approve"
 ```
 
-**How it works:** Cost-category approvals over $1.00 always reach the operator. Smaller ones auto-approve. This is a firewall against unexpectedly expensive operations.
+**How it works:** Cost-category approvals over $1.00 always reach the operator. Smaller ones auto-approve. This is a firewall against unexpectedly expensive operations — but read the advisory-only caveat below before relying on it as a security control.
 
 **Note:** This pattern is forward-looking. As of v0.6, leads do not emit cost-category approvals by default. The lead must explicitly call `request_approval` with `category = "cost"` for these rules to fire. See deferment notes below.
+
+---
+
+## Cost gates: advisory vs hard
+
+The `cost_over` match field compares against the caller's optional `cost_estimate` argument on `request_approval` / `propose_plan` / `permission_prompt`. The caller — the lead, sub-lead, or claude's own permission gate — *supplies* the value pitboss compares against.
+
+**This means `cost_over` is advisory only, not a security control.** A buggy or adversarial caller can pass `cost_estimate = 0.0` and slip past any `cost_over = N` rule, no matter how high `N` is. Use `cost_over` for routine "escalate big plans to the operator" hygiene against well-behaved callers — not for blocking expensive operations that an untrusted actor might want to run.
+
+For **hard cost gates** that don't rely on caller honesty:
+
+- **`auto_reject` on `tool_name`** — deny the tools that can incur high cost outright. The match is on the tool the caller is *about* to invoke, not on a self-reported estimate.
+- **`auto_reject` on `actor`** — deny entire actor paths (e.g. a specific sub-lead's tree) from making expensive approvals at all.
+- **`[run].budget_usd`** — the run-wide USD cap. Enforced server-side from observed token usage via `dispatch::budget_watch`, not from caller hints. This is the only authoritative cost ceiling.
+- **`[lead].lead_budget_usd`** — orchestration-only sub-cap. Same enforcement mechanism, narrower scope.
+
+Tracked at [F-SEC-8 / #531](https://github.com/SDS-Mode/pitboss/issues/531). A future server-side cost estimator (cost-of-tool-call before it runs) would make `cost_over` authoritative; that work has not been scheduled.
 
 ---
 

--- a/book/src/operator-guide/approvals.md
+++ b/book/src/operator-guide/approvals.md
@@ -70,7 +70,9 @@ action = "auto_approve"
 match = { category = "plan" }
 action = "block"
 
-# Block any cost event over $0.50
+# Escalate any cost event over $0.50 to the operator
+# (advisory only — cost_estimate is caller-supplied; see "Cost gates: advisory vs hard"
+#  in the approval policy reference for hard alternatives)
 [[approval_policy]]
 match = { category = "cost", cost_over = 0.50 }
 action = "block"
@@ -85,7 +87,7 @@ Rules are evaluated first-match-wins in declaration order. A request that doesn'
 | `actor` | string | Actor path, e.g., `"root→S1"`. Unset matches all actors. |
 | `category` | string | `"tool_use"`, `"plan"`, `"cost"`. Unset matches all categories. |
 | `tool_name` | string | Specific MCP tool name. Unset matches all. |
-| `cost_over` | float | Fires when `cost_estimate > cost_over` (USD). |
+| `cost_over` | float | Fires when `cost_estimate > cost_over` (USD). **Advisory only** — `cost_estimate` is caller-supplied; see [Approval policy reference → Cost gates: advisory vs hard](./approval-policy-reference.md#cost-gates-advisory-vs-hard). |
 
 ### Actions
 

--- a/book/src/operator-guide/manifest-schema.md
+++ b/book/src/operator-guide/manifest-schema.md
@@ -136,7 +136,7 @@ action = "block"
 | `actor` | string | Actor path, e.g., `"root→S1"` or `"root→S1→W3"`. |
 | `category` | string | `"tool_use"`, `"plan"`, `"cost"`, etc. |
 | `tool_name` | string | Specific MCP tool name. |
-| `cost_over` | float | Fires when the request's `cost_estimate` exceeds this value (USD). |
+| `cost_over` | float | Fires when the request's `cost_estimate` exceeds this value (USD). **Advisory only** — `cost_estimate` is caller-supplied; see [Approval policy reference → Cost gates: advisory vs hard](./approval-policy-reference.md#cost-gates-advisory-vs-hard). |
 
 **Actions:** `"auto_approve"`, `"auto_reject"`, `"block"` (forces operator review).
 

--- a/book/src/security/defense-in-depth.md
+++ b/book/src/security/defense-in-depth.md
@@ -242,11 +242,22 @@ The lead's prompt instructs it to pass a TTL on sensitive requests:
 To set a run-level fallback on all approval requests, combine the TTL with `[[approval_policy]]`:
 
 ```toml
-# Block all approvals; set a cost-over firewall for large events
+# Escalate large cost-category events to the operator
+# (NOT a hard firewall — cost_estimate is caller-supplied and can be underreported.
+#  For an actually-enforced cost ceiling use [run].budget_usd; see below.)
 [[approval_policy]]
 match  = { category = "cost", cost_over = 1.00 }
 action = "block"
 ```
+
+⚠️ **`cost_over` is advisory, not a hard gate.** The value it compares against is the caller's self-reported `cost_estimate` argument — an actor that passes `cost_estimate = 0.0` slips past any `cost_over` threshold. For hard cost enforcement that doesn't trust the caller, use one of:
+
+- `[run].budget_usd` — run-wide USD cap, enforced server-side from observed token usage in `dispatch::budget_watch`
+- `[lead].lead_budget_usd` — same enforcement, orchestration-cost sub-cap
+- `auto_reject` on `tool_name` — deny the specific tools that can incur high cost
+- `auto_reject` on `actor` — deny entire actor paths (e.g. a sub-tree) from making expensive calls
+
+See [Approval policy reference → Cost gates: advisory vs hard](../operator-guide/approval-policy-reference.md#cost-gates-advisory-vs-hard) for the full explainer.
 
 Operator-side: if you expect off-hours runs where the TUI may be unattended, set `approval_policy = "auto_reject"` in `[run]` as the baseline. Approvals that aren't explicitly auto-approved by a policy rule will reject rather than queue indefinitely.
 

--- a/crates/pitboss-cli/src/manifest/schema.rs
+++ b/crates/pitboss-cli/src/manifest/schema.rs
@@ -512,7 +512,7 @@ pub struct ApprovalMatchSpec {
     pub tool_name: Option<String>,
     #[field(
         label = "Cost over (USD)",
-        help = "Fires when the request's cost_estimate exceeds this value."
+        help = "Fires when the request's caller-supplied cost_estimate exceeds this value. Advisory only — a buggy or malicious caller can pass cost_estimate=0.0 to bypass the threshold. For hard cost gates use auto_reject rules on tool_name/actor, or the server-side [run].budget_usd cap. See AGENTS.md and the approval policy reference."
     )]
     pub cost_over: Option<f64>,
 }

--- a/crates/pitboss-cli/src/mcp/policy.rs
+++ b/crates/pitboss-cli/src/mcp/policy.rs
@@ -29,7 +29,16 @@ pub struct ApprovalMatch {
     /// Match exact tool name (relevant for ToolUse category)
     #[serde(default)]
     pub tool_name: Option<String>,
-    /// Match if approval's cost > this value (relevant for Cost category)
+    /// Match if approval's cost > this value (relevant for Cost category).
+    ///
+    /// **Advisory only**: the `cost` value compared here is the
+    /// caller-supplied `cost_estimate` hint, which a buggy or
+    /// malicious actor can underreport (e.g. set to `0.0`) to bypass
+    /// the threshold. For hard cost gates, prefer `auto_reject` rules
+    /// matched on `tool_name` (deny the tools that can incur high
+    /// cost) or `actor` (deny entire actor paths). The run-wide
+    /// `[run].budget_usd` cap (enforced server-side from observed
+    /// usage) is the only authoritative cost guard. (F-SEC-8 / #531)
     #[serde(default)]
     pub cost_over: Option<f64>,
 }
@@ -95,13 +104,17 @@ fn rule_matches(
         }
     }
     // `cost_over` rules fire whenever the caller provides an explicit
-    // `cost_estimate` hint — which is now plumbed through all three
+    // `cost_estimate` hint — which is plumbed through all three
     // approval entry points: `RequestApprovalArgs`, `ProposePlanArgs`,
-    // and `PermissionPromptArgs`. Callers that omit it continue to fall
-    // through to `None` matching (rule does not match). Future work:
-    // automatic cost estimation that emits `ApprovalCategory::Cost`
-    // approvals server-side so rules can fire without caller hints.
-    // (#151 M5)
+    // and `PermissionPromptArgs`. Callers that omit it (or pass
+    // `0.0`) fall through to `None`/below-threshold matching, so this
+    // rule cannot serve as a hard cost gate against an actor that
+    // underreports — operators who need one should use `auto_reject`
+    // rules on `tool_name`/`actor`, or rely on the server-side
+    // `[run].budget_usd` cap. Future work: automatic cost estimation
+    // that emits `ApprovalCategory::Cost` approvals server-side so
+    // rules can fire on observed-cost rather than caller hints.
+    // (#151 M5 / F-SEC-8 / #531)
     if let Some(threshold) = m.cost_over {
         match cost {
             Some(actual) if actual > threshold => {}

--- a/crates/pitboss-cli/src/mcp/tools.rs
+++ b/crates/pitboss-cli/src/mcp/tools.rs
@@ -310,6 +310,12 @@ pub struct RequestApprovalArgs {
     /// Optional cost estimate (USD) hint for policy matching. When
     /// provided, the policy matcher can evaluate `match.cost_over` rules
     /// against this value. Falls through to `None` matching when omitted.
+    ///
+    /// **Advisory only — caller-supplied, not trustworthy.** A buggy
+    /// or malicious caller can pass `0.0` to bypass any `cost_over`
+    /// threshold. Operators who need hard cost gates should use
+    /// `auto_reject` rules on `tool_name`/`actor` or rely on the
+    /// server-side `[run].budget_usd` cap. (F-SEC-8 / #531)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cost_estimate: Option<f64>,
     /// Caller identity injected by mcp-bridge. Used to build the correct
@@ -352,6 +358,12 @@ pub struct ProposePlanArgs {
     /// `cost_over = 5.0 → block` to escalate any plan whose total
     /// estimated cost exceeds $5. Falls through to `None` matching
     /// when omitted, matching the pre-#151-M5 behavior. (#151 M5)
+    ///
+    /// **Advisory only — caller-supplied, not trustworthy.** A buggy
+    /// or malicious lead can pass `0.0` to bypass any `cost_over`
+    /// threshold. Operators who need hard cost gates should use
+    /// `auto_reject` rules on `tool_name`/`actor` or rely on the
+    /// server-side `[run].budget_usd` cap. (F-SEC-8 / #531)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cost_estimate: Option<f64>,
     /// Caller identity injected by mcp-bridge. Used to build the correct

--- a/crates/pitboss-cli/src/mcp/tools/approval.rs
+++ b/crates/pitboss-cli/src/mcp/tools/approval.rs
@@ -412,6 +412,13 @@ pub struct PermissionPromptArgs {
     /// operator-declared `cost_over` rule fires for expensive
     /// permission requests. Falls through to `None` matching when
     /// omitted, matching the pre-#151-M5 behavior. (#151 M5)
+    ///
+    /// **Advisory only — caller-supplied, not trustworthy.** A buggy
+    /// or malicious caller (Claude's gate code is also a caller here)
+    /// can pass `0.0` to bypass any `cost_over` threshold. Operators
+    /// who need hard cost gates should use `auto_reject` rules on
+    /// `tool_name`/`actor` or rely on the server-side
+    /// `[run].budget_usd` cap. (F-SEC-8 / #531)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cost_estimate: Option<f64>,
     /// Caller identity injected by mcp-bridge.

--- a/pitboss.example.toml
+++ b/pitboss.example.toml
@@ -241,7 +241,11 @@ lead_timeout_secs = 900             # wall-clock cap on the lead session
 # match = { actor = "root→S1", category = "tool_use", tool_name = "Read" }
 # action = "auto_approve"
 #
-# # Force explicit approval for any cost-category event over $0.50
+# # Escalate any cost-category event over $0.50 to the operator.
+# # ADVISORY ONLY: cost_estimate is caller-supplied; an actor can pass
+# # cost_estimate=0.0 to bypass this threshold. For hard cost gates use
+# # [run].budget_usd or auto_reject on tool_name/actor.
+# # See book/src/operator-guide/approval-policy-reference.md ("Cost gates: advisory vs hard").
 # [[approval_policy]]
 # match = { category = "cost", cost_over = 0.50 }
 # action = "block"


### PR DESCRIPTION
## Summary

- `[[approval_policy]].match.cost_over` compares against caller-supplied `cost_estimate` on `request_approval` / `propose_plan` / `permission_prompt`. A buggy or malicious actor can pass `cost_estimate = 0.0` and slip past any `cost_over = N` rule. This PR surfaces the limitation prominently and points operators at the alternatives that *do* enforce server-side: `auto_reject` on `tool_name`/`actor`, `[run].budget_usd`, and `[lead].lead_budget_usd`.
- Doc-only fix per the audit's recommendation. Behavior unchanged; existing `cost_over_threshold_matches` test still passes.

## Files touched

| File | What |
|---|---|
| `crates/pitboss-cli/src/mcp/policy.rs` | Advisory-only note on `ApprovalMatch.cost_over` field doc + tightened inline matcher comment |
| `crates/pitboss-cli/src/mcp/tools.rs` | Same note on `RequestApprovalArgs.cost_estimate` and `ProposePlanArgs.cost_estimate` |
| `crates/pitboss-cli/src/mcp/tools/approval.rs` | Same note on `PermissionPromptArgs.cost_estimate` |
| `crates/pitboss-cli/src/manifest/schema.rs` | Operator-facing `#[field(help = ...)]` on `cost_over` — propagates to `pitboss schema`, SPA manifest editor, auto-generated `docs/manifest-map.md` |
| `AGENTS.md` | Advisory note on the `[[approval_policy]]` table row for `cost_over` (bundled into binary via `pitboss agents-md`) |
| `book/src/operator-guide/approval-policy-reference.md` | New "Cost gates: advisory vs hard" H2 with full explainer + link from the `cost_over` table row |
| `book/src/operator-guide/manifest-schema.md` | Cross-link from manifest-schema reference so both entry points land on the same explainer |

## Why doc-only

The audit's recommendation (#531) is explicit: document `cost_over` as advisory and recommend `auto_reject` for hard gates. Implementing a server-side cost estimator (so `cost_over` becomes authoritative) is a substantial separate project — it has to model per-tool, per-model, per-input-size costs *before* the call runs, where today `[run].budget_usd` enforces post-hoc from observed usage. Pre-staging that work is out of scope for F-SEC-8.

## Test plan

- [x] `cargo build -p pitboss-cli` — clean
- [x] `cargo lint` — clean (doc comments don't trip `missing_docs_in_private_items` or any clippy lint)
- [x] `cargo tidy` — clean
- [x] `cargo test -p pitboss-cli --lib mcp::policy::` — 5/5 passing (no behavior change)
- [ ] CI on Linux
- [ ] mdBook renders new H2 anchor `#cost-gates-advisory-vs-hard` correctly (verified mentally — H2 "Cost gates: advisory vs hard" → standard mdBook slug)

Closes #531.

🤖 Generated with [Claude Code](https://claude.com/claude-code)