### PR TITLE
fix(manifest): add #[serde(default)] to ResolvedManifest optional fields

### DIFF
--- a/crates/pitboss-cli/src/manifest/resolve.rs
+++ b/crates/pitboss-cli/src/manifest/resolve.rs
@@ -81,10 +81,13 @@ pub struct ResolvedLead {
 /// Resolved defaults for sub-lead spawn requests.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResolvedSubleadDefaults {
+    #[serde(default)]
     pub budget_usd: Option<f64>,
     #[serde(default)]
     pub lead_budget_usd: Option<f64>,
+    #[serde(default)]
     pub max_workers: Option<u32>,
+    #[serde(default)]
     pub lead_timeout_secs: Option<u64>,
     pub read_down: bool,
 }
@@ -134,7 +137,11 @@ pub struct ResolvedManifest {
     /// #320: pre-fix this was always `Some(DEFAULT_MAX_PARALLEL_TASKS)`
     /// even for hierarchical manifests, which made `resolved.json` lie
     /// about the run's actual concurrency model.
-    #[serde(alias = "max_parallel", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        alias = "max_parallel",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub max_parallel_tasks: Option<u32>,
     pub halt_on_failure: bool,
     pub run_dir: PathBuf,
@@ -148,11 +155,14 @@ pub struct ResolvedManifest {
     #[serde(default)]
     pub claude_setting_sources: Option<String>,
     pub tasks: Vec<ResolvedTask>,
+    #[serde(default)]
     pub lead: Option<ResolvedLead>,
     /// Surfaced from `[lead].max_workers` for consumer convenience.
     /// `None` in flat mode.
+    #[serde(default)]
     pub max_workers: Option<u32>,
     /// Surfaced from `[lead].budget_usd`. `None` in flat mode.
+    #[serde(default)]
     pub budget_usd: Option<f64>,
     /// Surfaced from `[lead].lead_budget_usd` — optional separate cap on
     /// lead + sub-lead token spend, independent of `budget_usd`. `None` when
@@ -160,11 +170,12 @@ pub struct ResolvedManifest {
     #[serde(default)]
     pub lead_budget_usd: Option<f64>,
     /// Surfaced from `[lead].lead_timeout_secs`. `None` in flat mode.
+    #[serde(default)]
     pub lead_timeout_secs: Option<u64>,
     /// Renamed from `approval_policy` in v0.9 to match the TOML field name
     /// and disambiguate from `approval_rules`.
     /// `alias` keeps pre-v0.9 `resolved.json` snapshots resumable.
-    #[serde(alias = "approval_policy")]
+    #[serde(default, alias = "approval_policy")]
     pub default_approval_policy: Option<crate::dispatch::state::ApprovalPolicy>,
     /// What happens to an actor's terminal status after a denied
     /// `permission_prompt`. `None` resolves to `Adapt` at read time.
@@ -1197,5 +1208,85 @@ category = "tool_use"
             Some(12),
             "alias `max_workers_across_tree` must populate max_total_workers"
         );
+    }
+
+    /// Regression test for `#[serde(default)]` coverage on the
+    /// `Option<T>` fields flagged by F-PROTO-8 (#521). Today serde
+    /// already deserializes a missing `Option<T>` as `None` regardless
+    /// of `#[serde(default)]`, so this test passes on the pre-fix code
+    /// too. The attribute matters as defense-in-depth against a future
+    /// `Option<T>` → `T` type change: without `default`, the same
+    /// missing-field snapshot would start failing with a typed serde
+    /// error rather than silently resuming. If you change any of these
+    /// fields off `Option`, this test must keep passing — restore the
+    /// default (`#[serde(default = "fn")]` with an explicit fallback)
+    /// or bump `CURRENT_MANIFEST_SCHEMA_VERSION` so resume rejects the
+    /// snapshot rather than mis-defaulting.
+    #[test]
+    fn resolved_manifest_accepts_missing_optional_top_level_fields() {
+        // Sparse snapshot: only fields that are genuinely required
+        // (no `Default` impl, no `#[serde(default)]`) are present.
+        // Everything else — including `manifest_schema_version`, which
+        // has its own `default_legacy_manifest_schema_version` — is
+        // omitted to verify defaulting end-to-end.
+        let sparse = serde_json::json!({
+            "halt_on_failure": false,
+            "run_dir": "/tmp/runs",
+            "worktree_cleanup": "on_success",
+            "emit_event_stream": false,
+            "tasks": [],
+        });
+
+        let r: ResolvedManifest = serde_json::from_value(sparse)
+            .expect("snapshot missing optional fields must deserialize");
+
+        // Originally-named fields (F-PROTO-8 / #521).
+        assert!(
+            r.max_parallel_tasks.is_none(),
+            "missing `max_parallel_tasks` must default to None"
+        );
+        assert!(
+            r.default_approval_policy.is_none(),
+            "missing `default_approval_policy` must default to None"
+        );
+        // Sibling Option<T> fields hardened in the same PR.
+        assert!(r.lead.is_none(), "missing `lead` must default to None");
+        assert!(
+            r.max_workers.is_none(),
+            "missing `max_workers` must default to None"
+        );
+        assert!(
+            r.budget_usd.is_none(),
+            "missing `budget_usd` must default to None"
+        );
+        assert!(
+            r.lead_timeout_secs.is_none(),
+            "missing `lead_timeout_secs` must default to None"
+        );
+        // `manifest_schema_version` carries its own `default = "fn"`;
+        // confirm it falls back to the legacy-era sentinel rather than
+        // failing deserialization.
+        assert_eq!(
+            r.manifest_schema_version, 0,
+            "missing `manifest_schema_version` must default to 0 (legacy era)"
+        );
+    }
+
+    /// Regression test for `#[serde(default)]` coverage on
+    /// `ResolvedSubleadDefaults` (the nested type embedded inside
+    /// `ResolvedLead.sublead_defaults`). Same forward-compat hazard as
+    /// the parent struct: `lead_budget_usd` already had `default`, the
+    /// other three `Option<T>` fields did not. Same fix logic applies.
+    #[test]
+    fn resolved_sublead_defaults_accepts_missing_optional_fields() {
+        let sparse = serde_json::json!({
+            "read_down": false,
+        });
+        let d: ResolvedSubleadDefaults =
+            serde_json::from_value(sparse).expect("sparse sublead_defaults must deserialize");
+        assert!(d.budget_usd.is_none());
+        assert!(d.lead_budget_usd.is_none());
+        assert!(d.max_workers.is_none());
+        assert!(d.lead_timeout_secs.is_none());
     }
 }


### PR DESCRIPTION
## Summary
- Add `#[serde(default)]` to **nine** `Option<T>` fields total across `ResolvedManifest` + `ResolvedSubleadDefaults` that were missing it.
- Add two regression tests pinning the missing-field behavior on each struct.

This supersedes #570 (closed) — that PR was based pre-#569 and the GitHub diff view included the absorbed F-SEC-8 commits. Same intent, cleanly rebased on main, with three reviewer-converged scope expansions.

## Why scope expanded beyond the two fields the audit named

Issue #521 named `max_parallel_tasks` and `default_approval_policy`. A three-reviewer panel on the original PR all converged on the same finding: every sibling `Option<T>` on the same struct (and on the nested `ResolvedSubleadDefaults`) carries the **identical** forward-compat hazard, and `lead_budget_usd` already had `#[serde(default)]` while the adjacent `budget_usd` did not — the inconsistency was concrete, not hypothetical. Convergence between all three reviewers is the bar I use to expand scope past a narrow audit framing.

## Fields touched
- `ResolvedManifest::max_parallel_tasks` — added `default` to existing `alias + skip_serializing_if`
- `ResolvedManifest::default_approval_policy` — added `default` to existing `alias`
- `ResolvedManifest::lead` — new `default`
- `ResolvedManifest::max_workers` — new `default`
- `ResolvedManifest::budget_usd` — new `default`
- `ResolvedManifest::lead_timeout_secs` — new `default`
- `ResolvedSubleadDefaults::budget_usd` — new `default`
- `ResolvedSubleadDefaults::max_workers` — new `default`
- `ResolvedSubleadDefaults::lead_timeout_secs` — new `default`

## Why this is style / not a functional fix
Per the audit validation: serde already deserializes a missing `Option<T>` as `None` regardless of `#[serde(default)]`. The annotation matters as a forward-compat guard: if any field's type ever changes off `Option`, the missing-field path silently breaks resume without the explicit `default`. The new tests document the contract; they pass on the pre-fix code too because today serde handles `Option<T>` defaults implicitly.

## Out of scope (follow-up)
`ResolvedLead::branch` and `ResolvedTask::branch` (both `Option<String>`) also lack `#[serde(default)]`. These represent a different semantic surface (auto-generate vs explicit worktree branch name) — splitting them into a follow-up PR keeps the diff coherent.

## Test plan
- [x] `TMPDIR=/private/tmp/pb cargo test -p pitboss-cli --lib manifest::resolve` — 27 tests pass including the two new regressions
- [x] `TMPDIR=/private/tmp/pb cargo test -p pitboss-cli --lib` — 891 pass
- [x] `cargo lint` — clean
- [x] `cargo tidy` — clean

Closes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)