### PR TITLE
docs(manifest): fill reference-table gaps for 5 manifest fields

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,7 @@ caps (which used to live here in v0.8) moved to `[lead]` in v0.9.
 
 | Key | Type | Required? | Default | Notes |
 |---|---|---|---|---|
+| `name` | string | no | unset | Human-readable label used to group related runs in the operational console (e.g. `"build-db"`, `"nightly-sync"`). When unset, the console falls back to the manifest filename. The canonical reference to a run remains its UUIDv7 `run_id`; this name is purely for cross-run grouping. |
 | `max_parallel_tasks` | int | no | 4 | Concurrency cap for flat-mode `[[task]]` runs. Overridden by `ANTHROPIC_MAX_CONCURRENT` env. Renamed from `max_parallel` in v0.9. |
 | `halt_on_failure` | bool | no | false | Flat mode. If a task fails, skip remaining tasks. |
 | `run_dir` | string path | no | `~/.local/share/pitboss/runs` | Where per-run artifacts land. |
@@ -140,6 +141,8 @@ caps (which used to live here in v0.8) moved to `[lead]` in v0.9.
 | `denial_termination_policy` | `"adapt"` \| `"reclassify"` | no | `"adapt"` | Path B only: how a denied `permission_prompt` affects the actor's terminal status. `"adapt"` (default, post-#377) trusts the actor's exit code; per-actor `events.jsonl::tool_denied` rows and the `approvals_rejected` counter remain authoritative for what was blocked. `"reclassify"` re-labels clean exits within 30s of a denial as `ApprovalRejected` (legacy heuristic, kept for operators who want fast-give-up distinguished in the status table — accepts that successful adaptation within the window will misclassify as failure). |
 | `require_plan_approval` | bool | no | false | Hierarchical: when true, `spawn_worker` refuses until a plan submitted via `propose_plan` has been operator-approved. |
 | `dump_shared_store` | bool | no | false | Hierarchical: at run finalize, write `shared-store.json` into the run dir for post-mortem inspection. |
+| `require_actor_type` | bool | no | false | When true, every `spawn_worker` and `spawn_sublead` call MUST name a declared `[[worker_type]]` / `[[sublead_type]]`; type-less spawns are rejected at the dispatcher. Default `false` for back-compat with manifests that pre-date typed profiles (#252). |
+| `untyped_actor_policy` | `"bridge"` \| `"block"` | no | `"bridge"` | Path-B-only behavior for un-typed callers reaching `permission_prompt`. `"bridge"` (default) routes to the operator approval queue, preserving pre-#252 semantics. `"block"` synthesizes an empty profile so anything outside `--allowedTools` auto-denies via `denied_by_profile` — the strict counterpart for headless production runs once every actor's profile has been declared. |
 
 ### `[[notification]]` sinks (v0.4.1+)
 
@@ -220,7 +223,8 @@ lead, not the run):
 | Key | Type | Default | Notes |
 |---|---|---|---|
 | `max_workers` | int | unset | Hard cap on the lead's concurrent + queued worker pool (1–16). Required when the lead spawns workers. |
-| `budget_usd` | float | unset | Soft cap with reservation accounting. `spawn_worker` fails with `budget exceeded` once `spent + reserved + next_estimate > budget`. |
+| `budget_usd` | float | unset | Soft cap with reservation accounting on the **run-wide total** (workers + lead + sub-leads). `spawn_worker` fails with `budget exceeded` once `spent + reserved + next_estimate > budget`; the lead is aborted if a reconciled turn drives total spend past the cap. |
+| `lead_budget_usd` | float | unset | Optional separate cap on **lead + sub-lead orchestration cost** (the lead session's own token spend plus every sub-lead session's own token spend — **worker spend does NOT count against this cap**). Independent of `budget_usd`. When set, the lead is aborted once accumulated lead/sub-lead spend exceeds this cap, even if `budget_usd` still has headroom. Use this to bound orchestration spend without constraining worker spend. (#253) |
 | `lead_timeout_secs` | int | 3600 fallback | Wall-clock cap on the lead session. No upper bound — set generously for multi-hour orchestration plans. |
 
 Depth-2 controls (sub-leads):
@@ -250,6 +254,7 @@ read_down = false
 | Key | Type | Notes |
 |---|---|---|
 | `budget_usd` | float | Per-sub-lead envelope when `read_down = false`. |
+| `lead_budget_usd` | float | Per-sub-lead cap on the sub-lead's own token spend (orchestration cost only — **does not count its workers' spend**). Analogous to `[lead].lead_budget_usd` but scoped to one sub-lead. Independent of `budget_usd`. Honored when `read_down = false`. |
 | `max_workers` | int | Per-sub-lead worker pool when `read_down = false`. |
 | `lead_timeout_secs` | int | Wall-clock cap for the sub-lead session. |
 | `read_down` | bool | When true, the sub-lead shares the root's budget and worker pool instead of carving its own envelope. |

--- a/book/src/operator-guide/depth-2-subleads.md
+++ b/book/src/operator-guide/depth-2-subleads.md
@@ -50,6 +50,7 @@ read_down = false
 | `allow_subleads` | false | Required to expose `spawn_sublead` to the root lead. |
 | `max_subleads` | none | Optional cap on total sub-leads spawned across the run. |
 | `max_sublead_budget_usd` | none | Cap on the per-sub-lead `budget_usd` envelope. Spawn attempts exceeding this fail fast before any state is mutated. |
+| `lead_budget_usd` | none | Cap on **lead + sub-lead orchestration cost** only — independent of `budget_usd` and does not count worker spend. See [Manifest schema](./manifest-schema.md#lead--hierarchical-mode-single-table-exactly-one). |
 | `max_workers_across_tree` | none | Cap on total live workers (root + all sub-trees). |
 
 ### `[lead.sublead_defaults]`

--- a/book/src/operator-guide/depth-2-subleads.md
+++ b/book/src/operator-guide/depth-2-subleads.md
@@ -15,20 +15,11 @@ Do not use sub-leads for every multi-worker job. Plain workers are cheaper and s
 
 ## Manifest
 
-Enable sub-leads by setting `allow_subleads = true` on the `[[lead]]` block:
+Enable sub-leads by setting `allow_subleads = true` on the `[lead]` block:
 
 ```toml
-[run]
-max_workers = 20
-budget_usd = 20.00
-lead_timeout_secs = 7200
-
-[[lead]]
+[lead]
 id = "root"
-allow_subleads = true
-max_subleads = 4
-max_sublead_budget_usd = 5.00
-max_workers_across_tree = 16
 directory = "/path/to/repo"
 prompt = """
 Decompose this project into phases. For each phase, spawn a sub-lead with
@@ -36,14 +27,25 @@ its own budget and a focused prompt via spawn_sublead. Wait for all sub-leads
 via wait_actor. Synthesize the results.
 """
 
-[lead.sublead_defaults]
+# Lead-level caps (moved from [run] in v0.9).
+max_workers = 20
+budget_usd = 20.00
+lead_timeout_secs = 7200
+
+# Depth-2 controls.
+allow_subleads = true
+max_subleads = 4
+max_sublead_budget_usd = 5.00
+max_total_workers = 16
+
+[sublead_defaults]
 budget_usd = 2.00
 max_workers = 4
 lead_timeout_secs = 1800
 read_down = false
 ```
 
-### `[[lead]]` fields for sub-leads
+### `[lead]` fields for sub-leads
 
 | Field | Default | Notes |
 |-------|---------|-------|
@@ -51,11 +53,11 @@ read_down = false
 | `max_subleads` | none | Optional cap on total sub-leads spawned across the run. |
 | `max_sublead_budget_usd` | none | Cap on the per-sub-lead `budget_usd` envelope. Spawn attempts exceeding this fail fast before any state is mutated. |
 | `lead_budget_usd` | none | Cap on **lead + sub-lead orchestration cost** only — independent of `budget_usd` and does not count worker spend. See [Manifest schema](./manifest-schema.md#lead--hierarchical-mode-single-table-exactly-one). |
-| `max_workers_across_tree` | none | Cap on total live workers (root + all sub-trees). |
+| `max_total_workers` | none | Cap on total live workers (root + all sub-trees). Renamed from `max_workers_across_tree` in v0.9. |
 
-### `[lead.sublead_defaults]`
+### `[sublead_defaults]`
 
-Optional defaults inherited by `spawn_sublead` calls that omit those parameters.
+Optional defaults inherited by `spawn_sublead` calls that omit those parameters. Top-level in v0.9 (promoted from the v0.8 nested `[lead.sublead_defaults]` form).
 
 ## `spawn_sublead` MCP tool
 

--- a/book/src/operator-guide/manifest-schema.md
+++ b/book/src/operator-guide/manifest-schema.md
@@ -20,6 +20,7 @@ pitboss validate pitboss.toml
 
 | Key | Type | Required? | Default | Notes |
 |-----|------|-----------|---------|-------|
+| `name` | string | no | unset | Human-readable label used to group related runs in the operational console (e.g. `"build-db"`, `"nightly-sync"`). When unset, the console falls back to the manifest filename. The canonical run identifier remains the UUIDv7 `run_id`. |
 | `max_parallel_tasks` | int | no | 4 | Flat mode: concurrency cap for `[[task]]` runs. Overridden by `ANTHROPIC_MAX_CONCURRENT` env. Renamed from `max_parallel` in v0.9. |
 | `halt_on_failure` | bool | no | false | Flat mode: stop remaining tasks on first failure. |
 | `run_dir` | string path | no | `~/.local/share/pitboss/runs` | Where per-run artifacts land. |
@@ -28,6 +29,8 @@ pitboss validate pitboss.toml
 | `default_approval_policy` | `"block"` \| `"auto_approve"` \| `"auto_reject"` | no | `"block"` | Hierarchical: default action for `request_approval` / `propose_plan` when no TUI is attached and no `[[approval_policy]]` rule matches. Renamed from `approval_policy` in v0.9. |
 | `require_plan_approval` | bool | no | false | Hierarchical: when true, `spawn_worker` refuses until a `propose_plan` call has been approved. |
 | `dump_shared_store` | bool | no | false | Hierarchical: write `shared-store.json` into the run directory on finalize. |
+| `require_actor_type` | bool | no | false | Hierarchical: when true, every `spawn_worker` and `spawn_sublead` call MUST name a declared `[[worker_type]]` / `[[sublead_type]]`; type-less spawns are rejected at the dispatcher. Default `false` for back-compat with pre-typed-profile manifests (#252). |
+| `untyped_actor_policy` | `"bridge"` \| `"block"` | no | `"bridge"` | Hierarchical, Path-B only: behavior for un-typed callers reaching `permission_prompt`. `"bridge"` routes to the operator queue (pre-#252 default). `"block"` synthesizes an empty profile so anything outside `--allowedTools` auto-denies — strict counterpart for headless production once every actor has a profile. |
 
 ---
 
@@ -79,7 +82,8 @@ Lead-level caps (moved from `[run]` in v0.9):
 | Key | Type | Default | Notes |
 |-----|------|---------|-------|
 | `max_workers` | int | unset | Hard cap on the lead's concurrent + queued worker pool (1–16). Required when the lead spawns workers. |
-| `budget_usd` | float | unset | Soft cap with reservation accounting. `spawn_worker` fails with `budget exceeded` once `spent + reserved + next_estimate > budget`. |
+| `budget_usd` | float | unset | Soft cap with reservation accounting on the **run-wide total** (workers + lead + sub-leads). `spawn_worker` fails with `budget exceeded` once `spent + reserved + next_estimate > budget`; the lead is aborted if a reconciled turn drives total spend past the cap. |
+| `lead_budget_usd` | float | unset | Optional separate cap on **lead + sub-lead orchestration cost** (the lead session's own token spend plus every sub-lead session's own token spend — **worker spend does NOT count against this cap**). Independent of `budget_usd`. Lead is aborted once accumulated lead/sub-lead spend exceeds this cap, even if `budget_usd` still has headroom. (#253) |
 | `lead_timeout_secs` | int | 3600 | Wall-clock cap on the lead session. No upper bound — set generously for multi-hour plans. |
 
 Depth-2 controls (sub-leads):
@@ -90,7 +94,7 @@ Depth-2 controls (sub-leads):
 | `max_subleads` | int | unset | Cap on total sub-leads spawned. |
 | `max_sublead_budget_usd` | float | unset | Cap on the per-sub-lead `budget_usd` envelope. |
 | `max_total_workers` | int | unset | Cap on total live workers across the entire tree (root + sub-trees). Renamed from `max_workers_across_tree` in v0.9. |
-| `permission_routing` | `"path_a"` \| `"path_b"` | `"path_a"` | `"path_a"` (default) sets `CLAUDE_CODE_ENTRYPOINT=sdk-ts` — pitboss is the sole permission authority. `"path_b"` routes claude's permission gate through the `permission_prompt` MCP tool — rejected at validation time until stabilization (issues #92–#94). |
+| `permission_routing` | `"path_a"` \| `"path_b"` | `"path_b"` (since v0.12) | `"path_b"` (default) leaves claude's per-tool gate active and wires `--permission-prompt-tool mcp__pitboss__permission_prompt`; per-tool checks the model wants outside its `--allowedTools` route through pitboss with layered enforcement (per-server allowlist → operator `[[approval_policy]]` → typed profile cap → bridge fallback). Denials are non-terminating — claude receives a structured response and adapts. `"path_a"` is the opt-out: sets `CLAUDE_CODE_ENTRYPOINT=sdk-ts` plus `--dangerously-skip-permissions`, bypassing claude's gate entirely so pitboss's `[[approval_policy]]` rules + bridge are the sole authority. See [AGENTS.md](https://github.com/SDS-Mode/pitboss/blob/main/AGENTS.md) `[lead]` table for full enforcement-order details. |
 
 ---
 
@@ -109,6 +113,7 @@ read_down = false
 | Key | Type | Notes |
 |-----|------|-------|
 | `budget_usd` | float | Per-sub-lead envelope when `read_down = false`. |
+| `lead_budget_usd` | float | Per-sub-lead cap on the sub-lead's own token spend (orchestration cost only — **does not count its workers' spend**). Analogous to `[lead].lead_budget_usd` but scoped to one sub-lead. Independent of `budget_usd`. Honored when `read_down = false`. |
 | `max_workers` | int | Per-sub-lead worker pool when `read_down = false`. |
 | `lead_timeout_secs` | int | Wall-clock cap for the sub-lead session. |
 | `read_down` | bool | When true, the sub-lead shares the root's budget and worker pool instead of carving its own envelope. |

--- a/pitboss.example.toml
+++ b/pitboss.example.toml
@@ -24,6 +24,13 @@
 
 [run]
 
+# Human-readable label used to group related runs in the operational
+# console (e.g. "build-db", "nightly-sync"). When unset, the console
+# falls back to the manifest filename. The canonical run identifier
+# remains the UUIDv7 run_id; this name is purely for cross-run
+# grouping.
+# name = "example-shared-store"
+
 # Flat-mode concurrency cap. Only meaningful when [[task]] is used (not
 # when [lead] is set). Default 4. Overridden by ANTHROPIC_MAX_CONCURRENT.
 # Renamed from `max_parallel` in v0.9.
@@ -194,7 +201,8 @@ Then exit.
 
 # Lead-level caps (moved from [run] in v0.9).
 max_workers = 3                     # 1–16; required when the lead spawns workers
-budget_usd = 1.50                   # soft cap; reservation accounting at spawn time
+budget_usd = 1.50                   # soft cap on run-wide total (workers + lead + sub-leads); reservation accounting at spawn time
+# lead_budget_usd = 0.50            # optional separate cap on lead + sub-lead orchestration cost only (worker spend NOT counted); independent of budget_usd (#253)
 lead_timeout_secs = 900             # wall-clock cap on the lead session
 
 # Permission routing (v0.8+, default flipped to path_b in v0.12).
@@ -227,6 +235,7 @@ lead_timeout_secs = 900             # wall-clock cap on the lead session
 #
 # [sublead_defaults]
 # budget_usd = 2.00         # per-sub-lead envelope when read_down = false
+# lead_budget_usd = 0.50    # per-sub-lead cap on the sub-lead's own token spend (orchestration cost only — its workers' spend NOT counted); analogous to [lead].lead_budget_usd
 # max_workers = 4           # per-sub-lead worker pool when read_down = false
 # lead_timeout_secs = 1800  # wall-clock cap for the sub-lead session
 # read_down = false         # when true, sub-lead shares root's budget + pool
@@ -317,3 +326,12 @@ lead_timeout_secs = 900             # wall-clock cap on the lead session
 # spawn_sublead call to name a declared profile. Type-less spawns are
 # rejected. Default false for back-compat with pre-#252 manifests.
 # require_actor_type = true
+
+# Path-B-only behavior for un-typed callers reaching permission_prompt
+# (only meaningful when require_actor_type = false, i.e. some actors
+# are still type-less). "bridge" (default) routes those callers to the
+# operator approval queue, preserving pre-#252 semantics. "block"
+# synthesizes an empty profile so anything outside --allowedTools
+# auto-denies via denied_by_profile — the strict counterpart for
+# headless production runs once every actor's profile is declared.
+# untyped_actor_policy = "bridge"


### PR DESCRIPTION
## Summary
Five fields exist in the schema and ship in real manifests but were absent from the hand-maintained reference tables. This adds rows on every operator-facing surface that has a `[run]` / `[lead]` / `[sublead_defaults]` table, plus annotated examples in the operator template.

Supersedes #572 (closed) — that branch was based on a stale local main and GitHub's 3-dot PR diff showed an absorbed PROTO-8 commit. This PR is on a clean base off `origin/main` and folds in convergent reviewer findings before opening.

## Surfaces touched

| Surface | Change |
|---|---|
| `AGENTS.md` (bundled spec) | 5 new rows; `[lead].budget_usd` note clarified as run-wide total |
| `book/src/operator-guide/manifest-schema.md` | Same 5 rows; same clarification; pre-existing `permission_routing` default fix (`"path_a"` → `"path_b"`, since v0.12) |
| `book/src/operator-guide/depth-2-subleads.md` | `lead_budget_usd` row added; entire example code block + adjacent prose migrated from pre-v0.9 to v0.9 schema (commit 7244129; R1+R2 convergent finding on the re-PR review round) |
| `pitboss.example.toml` | Commented examples for `name`, `untyped_actor_policy`, `[lead].lead_budget_usd`, `[sublead_defaults].lead_budget_usd`; `budget_usd` comment tightened to "run-wide total" |

## Issue → field mapping

| Field | AGENTS.md issue | Book mirror issue |
|---|---|---|
| `[run].name` | #517 (F-PROTO-4) | #500 (F-DOCS-1) |
| `[run].require_actor_type` | #518 (F-PROTO-5) | #500 (F-DOCS-1) |
| `[run].untyped_actor_policy` | #518 (F-PROTO-5) | #500 (F-DOCS-1) |
| `[lead].lead_budget_usd` | #519 (F-PROTO-6) | #504 (F-DOCS-2) |
| `[sublead_defaults].lead_budget_usd` | #520 (F-PROTO-7) | #505 (F-DOCS-3) |

## Notes for reviewers

- **Semantic precision on `lead_budget_usd`**: per `dispatch/budget_watch.rs`, this cap compares against `breakdown.lead_usd + breakdown.subleads_usd` — **worker spend is NOT counted**. Both new rows and the example.toml comment make this explicit.
- **`[lead].budget_usd` clarification**: the existing row said "Soft cap with reservation accounting" — accurate but ambiguous next to the new `lead_budget_usd` row. Tightened to "Soft cap … on the **run-wide total** (workers + lead + sub-leads)" — matches `dispatch/budget_watch.rs` which checks `breakdown.total_usd()` against this cap.
- **Pre-existing `permission_routing` default fix**: the book mirror still said the default was `"path_a"`, but it's `"path_b"` since v0.12 (AGENTS.md was already correct). Since the PR touches the adjacent depth-2 caps table, this is the natural moment to fix the bug.
- **v0.9 schema migration in `depth-2-subleads.md`**: the file's illustrative code block (and one row in its narrative table) used pre-v0.9 schema that `pitboss validate` now rejects. Touched-this-file scope.
- **`docs/manifest-map.md` and `docs/manifest-reference.toml`** are auto-generated from the schema's `FieldMetadata` macro and already had these fields. The gap was only in the hand-maintained surfaces.

## Out of scope (follow-up)
- `book/src/operator-guide/cost-and-model-selection.md` "See also" omits `lead_budget_usd`. Narrative-page gap, not a reference-table miss.
- Same pre-v0.9 schema staleness exists in `book/src/operator-guide/cost-and-model-selection.md:99-115` and `book/src/security/defense-in-depth.md:144-165` — neither file is touched by this PR; worth a separate v0.9-migration audit issue.
- `manifest-schema.md` book table missing `claude_setting_sources` and `denial_termination_policy` rows that AGENTS.md has — pre-existing drift, separate issue.
- There is no content-guard test for AGENTS.md tables — only frontmatter / version / length assertions exist in `crates/pitboss-cli/src/agents_md.rs`. Pre-existing test-coverage gap.

## Test plan
- [x] `cargo build -p pitboss-cli` clean (AGENTS.md is `include_str!`'d)
- [x] Existing AGENTS.md content tests pass (frontmatter + version + length checks unaffected)
- [x] `cd book && mdbook build` clean (4 pre-existing changelog HTML-tag warnings unrelated to this PR)

Closes #517
Closes #518
Closes #519
Closes #520
Closes #500
Closes #504
Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)