### PR TITLE
fix(manifest): add remediation hints to five validation errors

### DIFF
--- a/crates/pitboss-cli/src/manifest/resolve.rs
+++ b/crates/pitboss-cli/src/manifest/resolve.rs
@@ -522,7 +522,10 @@ fn resolve_task(
                 .with_context(|| format!("rendering template '{}' for task '{}'", tid, task.id))?
         }
         (Some(_), Some(_)) => bail!("task '{}' sets both prompt and template", task.id),
-        (None, None) => bail!("task '{}' has no prompt and no template", task.id),
+        (None, None) => bail!(
+            "task '{}': prompt is required (set `prompt = \"...\"` or reference a [[template]] via `template = \"id\"`)",
+            task.id
+        ),
     };
     let prompt = compose_prompt(profile, &raw_prompt);
 

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -916,7 +916,12 @@ fn validate_branch_conflicts(r: &ResolvedManifest) -> Result<()> {
         if let Some(b) = &t.branch {
             let canon = std::fs::canonicalize(&t.directory).unwrap_or_else(|_| t.directory.clone());
             if !seen.insert((canon, b.clone())) {
-                bail!("two tasks target the same directory + branch '{}'", b);
+                bail!(
+                    "two [[task]] entries target the same git directory + branch '{}'; \
+                     give each task a unique branch (via `branch = \"...\"`) or point them \
+                     at separate directories",
+                    b
+                );
             }
         }
     }

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -731,7 +731,10 @@ fn validate_lead(r: &ResolvedManifest, skip_dir_check: bool) -> Result<()> {
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
     {
-        bail!("lead id '{}' contains invalid characters", lead.id);
+        bail!(
+            "lead id '{}' contains invalid characters (allowed: a-zA-Z0-9_-)",
+            lead.id
+        );
     }
     if !skip_dir_check && !lead.directory.is_dir() {
         bail!(
@@ -752,7 +755,7 @@ fn validate_lead(r: &ResolvedManifest, skip_dir_check: bool) -> Result<()> {
         );
     }
     if lead.timeout_secs == 0 {
-        bail!("lead timeout_secs must be > 0");
+        bail!("[lead].timeout_secs must be > 0 (per-actor wall-clock cap)");
     }
     Ok(())
 }
@@ -862,7 +865,10 @@ fn validate_ids(r: &ResolvedManifest) -> Result<()> {
     let mut seen = HashSet::new();
     for t in &r.tasks {
         if !seen.insert(&t.id) {
-            bail!("duplicate task id: {}", t.id);
+            bail!(
+                "duplicate task id: '{}'; each [[task]].id must be unique within the manifest",
+                t.id
+            );
         }
         if t.id.is_empty() {
             bail!("empty task id");


### PR DESCRIPTION
## Summary

Five operator-facing validation errors in `pitboss-cli::manifest` were missing the remediation hints that their sibling errors already provide. This PR brings them up to the same standard. Four close audit issues (#510 #511 #503 #502); the fifth is a preventative bundle of the same audit pattern in the same file caught during code review (validate.rs:919) — fixing now avoids an inevitable follow-up audit ticket.

| Location | Before | After | Audit issue |
|----------|--------|-------|-------------|
| `validate.rs:734` | `lead id '{}' contains invalid characters` | `lead id '{}' contains invalid characters (allowed: a-zA-Z0-9_-)` | #510 |
| `validate.rs:755` | `lead timeout_secs must be > 0` | `[lead].timeout_secs must be > 0 (per-actor wall-clock cap)` | #511 |
| `validate.rs:865` | `duplicate task id: {}` | `duplicate task id: '{}'; each [[task]].id must be unique within the manifest` | #503 |
| `resolve.rs:525` | `task '{}' has no prompt and no template` | `task '{}': prompt is required (set `prompt = "..."` or reference a [[template]] via `template = "id"`)` | #502 |
| `validate.rs:919` | `two tasks target the same directory + branch '{}'` | `two [[task]] entries target the same git directory + branch '{}'; give each task a unique branch (via `branch = "..."`) or point them at separate directories` | — |

## Why these together

All five are in the same module (`pitboss-cli::manifest`), all are validate-time error strings missing remediation hints, and the audit recommendations were not novel phrasing but **consistency with existing siblings:**
- `validate.rs:876` (`task id '{}' contains invalid characters (allowed: a-zA-Z0-9_-)`) is the template the lead-id fix mirrors.
- `validate.rs:817` (`[lead].lead_timeout_secs must be > 0`) is the field-path prefixing pattern the lead-timeout fix mirrors.

## Risk

- No callers depend on the exact error prose. `grep -rn` across all `*.rs` finds these strings only at their definition sites (verified for all five).
- All `cargo test -p pitboss-cli --lib` (891 tests) pass. `cargo lint` and `cargo tidy` clean.

## Why `fix(` not `docs(`

`cliff.toml:124` has `{ message = "^docs", skip = true }` — a `docs(`-prefixed commit would silently omit these from the v0.16.0 CHANGELOG. These are operator-visible runtime error strings, not docs-only files, so `fix(manifest):` routes them to the `### Fixed` section where operators will actually see them.

Closes #510
Closes #511
Closes #503
Closes #502