### PR TITLE
fix(control): add wire-compat defaults to RunFinishedSummary + WorkerSnapshotEntry

### DIFF
--- a/crates/pitboss-cli/src/control/protocol.rs
+++ b/crates/pitboss-cli/src/control/protocol.rs
@@ -400,9 +400,19 @@ pub struct WorkerSnapshotEntry {
     pub session_id: Option<String>,
 }
 
+/// Payload embedded inside the `RunFinished` `ControlEvent` variant.
+///
+/// Every field carries `#[serde(default)]` so this nested struct follows
+/// the same wire-compat contract as the surrounding `ControlEvent` variants
+/// (see the top-of-file convention). Without per-field defaults, adding a
+/// new field like `total_spend_usd` would silently break every older TUI
+/// client that parses `RunFinished` — a regression class that the variant-
+/// level contract alone does not cover for nested payload structs.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RunFinishedSummary {
+    #[serde(default)]
     pub tasks_total: usize,
+    #[serde(default)]
     pub tasks_failed: usize,
 }
 
@@ -729,6 +739,28 @@ mod tests {
             },
         };
         assert_eq!(roundtrip_event(&rf), rf);
+    }
+
+    #[test]
+    fn run_finished_summary_accepts_missing_fields() {
+        // Simulates an older dispatcher emitting `RunFinished` before
+        // either field existed (or, equivalently, a newer dispatcher
+        // emitting fields the local serde shape doesn't know about): the
+        // struct must deserialize with field-level defaults rather than
+        // failing the whole event. F-PROTO-3 / #516.
+        let s: RunFinishedSummary = serde_json::from_str("{}").unwrap();
+        assert_eq!(s.tasks_total, 0);
+        assert_eq!(s.tasks_failed, 0);
+
+        let ev: ControlEvent =
+            serde_json::from_str(r#"{"event":"run_finished","summary":{}}"#).unwrap();
+        match ev {
+            ControlEvent::RunFinished { summary } => {
+                assert_eq!(summary.tasks_total, 0);
+                assert_eq!(summary.tasks_failed, 0);
+            }
+            other => panic!("expected RunFinished, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/pitboss-cli/src/control/protocol.rs
+++ b/crates/pitboss-cli/src/control/protocol.rs
@@ -387,10 +387,21 @@ pub struct ActorActivityEntry {
     pub artifact_ops: u64,
 }
 
+/// Payload embedded inside the `WorkersSnapshot` `ControlEvent` variant.
+///
+/// `WorkersSnapshot` is emitted on every TUI connect/reconnect, making this
+/// a high-traffic nested payload — the version-skew window for adding a
+/// new field is much wider than for a once-per-run event. Every field
+/// carries `#[serde(default)]` so older TUI clients tolerate fields they
+/// don't yet know about, following the same wire-compat contract as the
+/// surrounding `ControlEvent` variants (see the top-of-file convention).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WorkerSnapshotEntry {
+    #[serde(default)]
     pub task_id: String,
+    #[serde(default)]
     pub state: String,
+    #[serde(default)]
     pub prompt_preview: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub started_at: Option<String>,
@@ -721,6 +732,33 @@ mod tests {
             }],
         };
         assert_eq!(roundtrip_event(&ev), ev);
+    }
+
+    #[test]
+    fn worker_snapshot_entry_accepts_missing_fields() {
+        // Same back-compat rationale as `RunFinishedSummary` but for the
+        // higher-traffic `WorkersSnapshot` event (emitted on every TUI
+        // connect/reconnect). Required String fields must deserialize to
+        // empty defaults rather than failing the whole snapshot when an
+        // older dispatcher omits a field, or a newer dispatcher adds one
+        // that this client doesn't know about. F-PROTO-3 bundling.
+        let e: WorkerSnapshotEntry = serde_json::from_str("{}").unwrap();
+        assert_eq!(e.task_id, "");
+        assert_eq!(e.state, "");
+        assert_eq!(e.prompt_preview, "");
+        assert!(e.started_at.is_none());
+        assert!(e.parent_task_id.is_none());
+        assert!(e.session_id.is_none());
+
+        let ev: ControlEvent =
+            serde_json::from_str(r#"{"event":"workers_snapshot","workers":[{}]}"#).unwrap();
+        match ev {
+            ControlEvent::WorkersSnapshot { workers } => {
+                assert_eq!(workers.len(), 1);
+                assert_eq!(workers[0].task_id, "");
+            }
+            other => panic!("expected WorkersSnapshot, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`RunFinishedSummary` and `WorkerSnapshotEntry` are both nested payload structs embedded inside `ControlEvent` variants. The wire-compat contract documented at the top of `control/protocol.rs` covers `ControlEvent` variant fields — but nested payload structs are not automatically included. A future field addition to either struct without `#[serde(default)]` on the existing fields would silently break every older TUI client.

This PR:
- Adds `#[serde(default)]` to both fields of `RunFinishedSummary` (the audit-tracked F-PROTO-3 fix).
- Adds `#[serde(default)]` to the three required `String` fields of `WorkerSnapshotEntry` (`task_id`, `state`, `prompt_preview`) — bundled because it's the same class of bug in the same file with a **larger blast radius** (`WorkersSnapshot` is emitted on every TUI connect/reconnect, vs. `RunFinished` firing once per run). Preempts an immediate follow-up audit ticket.
- Adds struct-level doc comments to both, locking the contract in for future field additions.
- Adds regression tests for both, pinning the standalone-struct and embedded-event forms. The tests are the heart of the closure — without them the `#[serde(default)]` attributes are easily reverted by a "cleanup" refactor.

**No behavior change** for current emitters or consumers — all fields are still always serialized, only the read side gains tolerance for missing fields.

## Out of scope (follow-up)

- **`ApprovalPlanWire.summary`** (line 80) has the same gap but is mitigated by the enclosing `Option<ApprovalPlanWire>` wrapper on `ApprovalRequest.plan` — a missing struct-entirely is already handled by the outer `Option`. Worth a separate audit issue when convenient.
- **`ActorActivityEntry.actor_id`** intentionally lacks a default — identity-bearing fields should fail loudly rather than default to `""` (analogous design call to `SubleadTerminated.sublead_id`).
- **Content-guard test** to mechanize the wire-compat contract — after four PRs (#566, #567, #571, #575) closing identical-pattern audit findings, a `syn`-based test in `tests/wire_compat_guard.rs` that asserts every `pub` field inside a struct embedded in a `ControlEvent`/`ControlOp` variant carries `#[serde(default)]` or `skip_serializing_if` would make the contract enforceable rather than purely social. Out of scope for this PR.

## Pattern

Mirrors PR #571, #567, #566 — all closing F-PROTO audit findings in the wire-compat category.

## Risk

- 34 `cargo test -p pitboss-cli --lib control::protocol` pass (+2 new regression tests). `cargo lint` clean. `cargo tidy` clean.
- Existing `superseded_and_run_finished_roundtrip` and `workers_snapshot_roundtrips` tests unchanged and still passing on populated shapes.

Closes #516