### PR TITLE
fix(changelog): rescue PR #574 audit closures from docs-skip in cliff.toml

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -91,6 +91,13 @@ commit_preprocessors = [
     { pattern = '(?m) \(#\d+\)( \(#\d+\))*$', replace = "" },
     # Fix Dependabot's double-scope (`chore(deps)(deps): bump …`).
     { pattern = '^chore\(deps\)\(deps\)', replace = "chore(deps)" },
+    # One-shot: PR #574 was retitled `docs(manifest):` → `fix(manifest):`
+    # before merge so the PR title would route to `### Fixed`, but the
+    # repo's rebase-and-merge landed the original `docs(` commit on main
+    # untouched. Rewrite that exact subject so its four audit-issue
+    # closures (#510, #511, #503, #502) appear in the v0.16.0 CHANGELOG.
+    # **Remove this rule once v0.16.0 has been tagged and released.**
+    { pattern = '^docs\(manifest\): add remediation hints to four validation errors', replace = 'fix(manifest): add remediation hints to four validation errors' },
 ]
 # Map commit type → CHANGELOG section. Order matters — first match wins.
 # The wider community uses "Added/Fixed/Changed" from Keep-a-Changelog;


### PR DESCRIPTION
## Summary

PR #574 was retitled from `docs(manifest):` to `fix(manifest):` before merge to route its audit-closure commit through `cliff.toml`'s `^fix` group instead of being skipped by the `^docs` rule (`cliff.toml:124`). The retitle assumed squash-merge — which had been the consistent style for the 5 prior PRs — would make the PR title the single squash commit subject visible to git-cliff.

PR #574 was actually **rebase-and-merged**, so its two branch commits landed on main untouched: `8fab0e8 docs(manifest): add remediation hints to four validation errors` (the audit-closure commit) and `20eea23 fix(manifest): add field-path prefix to branch-conflict error` (the `:919` bundle).

Result: the `docs(` commit will be silently skipped from v0.16.0's CHANGELOG, dropping the closures for issues **#510, #511, #503, #502** from the `### Fixed` section. Only the `:919` bundle survives.

## What this PR does

Adds a single targeted `commit_preprocessors` rule in `cliff.toml` that rewrites the exact lost commit subject from `docs(manifest):` to `fix(manifest):`. The pattern is keyed on the literal subject text — verified by `grep` over the full history — so there is no over-match risk.

```toml
{ pattern = '^docs\(manifest\): add remediation hints to four validation errors',
  replace = 'fix(manifest): add remediation hints to four validation errors' },
```

The rule is **one-shot**. After v0.16.0 is tagged and released, the rescued line will be in the committed CHANGELOG file and the preprocessor can be removed. The inline comment in cliff.toml documents this lifecycle.

## Verification

`git-cliff --unreleased`:

**Before this PR (current main):**
```
### Fixed
- Bundle WorkerSnapshotEntry into same wire-compat fix ([#575](...))
- Add #[serde(default)] to RunFinishedSummary fields
- Add field-path prefix to branch-conflict error ([#574](...))         ← only this from PR #574
- Add #[serde(default)] to ResolvedManifest optional fields ([#571](...))
...
```

**After this PR:**
```
### Fixed
- Bundle WorkerSnapshotEntry into same wire-compat fix ([#575](...))
- Add #[serde(default)] to RunFinishedSummary fields
- Add field-path prefix to branch-conflict error ([#574](...))
- Add remediation hints to four validation errors                       ← rescued
- Add #[serde(default)] to ResolvedManifest optional fields ([#571](...))
...
```

## Known limitation: no `(#574)` link on the rescued entry

cliff only attaches `commit.remote.pr_number` to the merge-commit of a PR. Under rebase-and-merge that's the LAST commit, not the first. Both PR #574 and PR #575 already exhibit this artifact for their respective first commits — it is not introduced by this preprocessor. To fix it would require deeper cliff configuration (or a one-off `--include-path` style override) that's not worth the complexity here.

## Out of scope (follow-up)

- **`cliff.toml:85-86` comment is slightly misleading** — says preprocessors apply "to the FIRST line of the commit (the subject)" but the regex engine sees the whole multi-line message, with `^` and `$` anchored to start/end of string by default. My first attempt at the rescue rule used `$` and silently failed because the body comes after the subject. Worth a one-line clarification PR.
- **Memory-saved guidance for future PRs**: under rebase-merge, every branch commit's prefix must independently route correctly; PR title alone is insufficient. Saved in session memory.

## Risk

- Pure config change — no Rust code touched, no behavior change at runtime.
- `git-cliff --tag v0.15.0` against this branch produces a CHANGELOG-shape diff identical to current main except for the one rescued line under v0.16.0's Unreleased.
- Preprocessor pattern is unique-literal-text matching; verified no over-match via `grep`.