### PR TITLE
fix(control): add wire-compat content-guard test for nested payload structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1955,6 +1955,7 @@ dependencies = [
  "serial_test",
  "sha2 0.11.0",
  "shellexpand",
+ "syn 2.0.117",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/pitboss-cli/Cargo.toml
+++ b/crates/pitboss-cli/Cargo.toml
@@ -77,3 +77,7 @@ tracing-test       = { workspace = true }
 # reallocation against background getenv readers (tracing, reqwest,
 # locale init). All env-touching tests must carry `#[serial(env)]`.
 serial_test        = "3.4"
+# #577: wire-compat content-guard test parses control/protocol.rs at
+# test time to enforce the per-field #[serde(default)] convention
+# mechanically rather than by reviewer vigilance.
+syn                = { version = "2", features = ["full"] }

--- a/crates/pitboss-cli/src/control/protocol.rs
+++ b/crates/pitboss-cli/src/control/protocol.rs
@@ -20,7 +20,11 @@
 //!   semantic "no value" case);
 //! - or `#[serde(skip_serializing_if = "...")]` paired with one of the
 //!   above so the field is omitted on the wire when at the default,
-//!   keeping old-client JSON byte-identical.
+//!   keeping old-client JSON byte-identical;
+//! - `#[serde(skip)]` — the field is never on the wire in either
+//!   direction (so version skew can't affect it by construction);
+//! - or `#[serde(flatten)]` — back-compat is delegated to the inner
+//!   type, which must itself satisfy this contract.
 //!
 //! New variants are always safe to add: serde rejects unknown
 //! discriminators with a typed error the existing dispatch loop

--- a/crates/pitboss-cli/src/control/protocol.rs
+++ b/crates/pitboss-cli/src/control/protocol.rs
@@ -77,6 +77,7 @@ pub struct EventEnvelope {
 /// through JSON identically.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ApprovalPlanWire {
+    #[serde(default)]
     pub summary: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rationale: Option<String>,

--- a/crates/pitboss-cli/tests/wire_compat_guard.rs
+++ b/crates/pitboss-cli/tests/wire_compat_guard.rs
@@ -1,0 +1,350 @@
+//! Wire-compat content-guard test (closes #577).
+//!
+//! Mechanizes one corner of the convention documented at the top of
+//! `crates/pitboss-cli/src/control/protocol.rs` (lines 8-34): every
+//! field of a **nested payload struct** embedded in a `ControlOp` /
+//! `ControlEvent` variant must carry one of:
+//!
+//!   - `#[serde(default)]`
+//!   - `#[serde(default = "fn")]`
+//!   - `#[serde(default, skip_serializing_if = "...")]`
+//!   - `#[serde(skip)]` (the field is never on the wire)
+//!   - `#[serde(flatten)]` (delegates to the inner type's discriminator)
+//!
+//! ## Why nested-struct scope, not inline-variant-field scope
+//!
+//! The contract's prose targets every new field, including inline
+//! variant fields like `SubleadSpawned.read_down` (PR #566). But the
+//! pre-contract baseline of inline variant fields is large
+//! (~30 fields) and grandfathering them all behind an allowlist
+//! creates a high-maintenance review surface that contributors will
+//! eventually game.
+//!
+//! The recurrence pattern that drove this guard (see #577) is
+//! specifically nested-payload structs (`RunFinishedSummary`,
+//! `WorkerSnapshotEntry`, `ApprovalPlanWire`) where the field is in
+//! a separate type definition, requiring a separate file-read to
+//! inspect — exactly the slippage that reviewers and audit tickets
+//! keep catching late. Inline variant fields are at least visible at
+//! the variant declaration site.
+//!
+//! Inline-variant-field omissions are still caught by reviewers and
+//! historical audit tickets — this test guards the harder-to-spot
+//! class.
+//!
+//! ## How it works
+//!
+//! 1. Parse `protocol.rs` via `syn::parse_file`.
+//! 2. Find every enum decorated with `#[serde(tag = "...")]` (the
+//!    wire-protocol enums).
+//! 3. For each variant, **don't check the variant's own fields**
+//!    (those are the inline-variant scope, out of this test's
+//!    remit) — instead, walk each field's type and recurse into
+//!    any locally-defined struct it references.
+//! 4. For each discovered struct, check that every named field
+//!    carries one of the acceptable serde attributes.
+//! 5. Identity-bearing fields that must fail-loudly on absence
+//!    (e.g. `ActorActivityEntry.actor_id`) live in `EXEMPT_FIELDS`
+//!    with a documented reason.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use syn::{Attribute, Field, Fields, File, GenericArgument, Item, ItemEnum, ItemStruct, Type};
+
+const PROTOCOL_RS: &str = include_str!("../src/control/protocol.rs");
+
+/// Field paths intentionally exempt from the contract.
+///
+/// Each entry is `"StructName.field_name"` plus a one-line reason.
+/// Add a new exemption only when the field has a documented design
+/// reason for failing-loudly on absence rather than defaulting
+/// silently — e.g. identity-bearing fields where `""` or `0` would
+/// be a silent misclassification.
+const EXEMPT_FIELDS: &[(&str, &str)] = &[(
+    "ActorActivityEntry.actor_id",
+    "identity-bearing — must fail-loud on absence rather than default to empty string",
+)];
+
+#[test]
+fn every_nested_struct_field_in_wire_variants_has_back_compat_attr() {
+    let parsed: File = syn::parse_file(PROTOCOL_RS).expect("parse protocol.rs as a Rust file");
+
+    let structs_by_name: BTreeMap<String, &ItemStruct> = parsed
+        .items
+        .iter()
+        .filter_map(|item| {
+            if let Item::Struct(s) = item {
+                Some((s.ident.to_string(), s))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let wire_enums: Vec<&ItemEnum> = parsed
+        .items
+        .iter()
+        .filter_map(|item| {
+            if let Item::Enum(e) = item {
+                if has_serde_tag(&e.attrs) {
+                    Some(e)
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    assert!(
+        wire_enums.len() >= 2,
+        "expected at least ControlOp + ControlEvent tagged enums in protocol.rs, found {}; \
+         did the wire-protocol module move?",
+        wire_enums.len()
+    );
+
+    let exempt: BTreeSet<String> = EXEMPT_FIELDS.iter().map(|(p, _)| p.to_string()).collect();
+
+    let mut visited: BTreeSet<String> = BTreeSet::new();
+    let mut violations: Vec<String> = Vec::new();
+
+    // Walk every variant of every wire enum. We deliberately DON'T
+    // check the variant's own fields (those are inline-variant
+    // scope) — only follow their types into local structs.
+    for wire_enum in &wire_enums {
+        for variant in &wire_enum.variants {
+            let fields_iter: Box<dyn Iterator<Item = &Field>> = match &variant.fields {
+                Fields::Named(named) => Box::new(named.named.iter()),
+                Fields::Unnamed(unnamed) => Box::new(unnamed.unnamed.iter()),
+                Fields::Unit => continue,
+            };
+            for field in fields_iter {
+                follow_type(
+                    &field.ty,
+                    &structs_by_name,
+                    &exempt,
+                    &mut visited,
+                    &mut violations,
+                );
+            }
+        }
+    }
+
+    if !violations.is_empty() {
+        let lines = violations
+            .iter()
+            .map(|v| format!("  - {v}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        panic!(
+            "\nwire-compat violations found in nested payload structs ({}):\n\n{lines}\n\n\
+             Contract (control/protocol.rs:8-34): every field of a struct embedded in a\n  \
+             ControlEvent/ControlOp variant must carry one of:\n    \
+             #[serde(default)] | #[serde(default = \"fn\")] | #[serde(default, skip_serializing_if = \"...\")]\n    \
+             #[serde(skip)] | #[serde(flatten)]\n\n\
+             To exempt an identity-bearing field that must fail-loudly on absence, add an entry\n  \
+             to EXEMPT_FIELDS at the top of this test with a documented reason.\n",
+            violations.len(),
+        );
+    }
+}
+
+fn has_serde_tag(attrs: &[Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        if !attr.path().is_ident("serde") {
+            return false;
+        }
+        let mut found = false;
+        let _ = attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("tag") {
+                found = true;
+            }
+            if let Ok(value) = meta.value() {
+                let _ = value.parse::<syn::Expr>();
+            }
+            Ok(())
+        });
+        found
+    })
+}
+
+fn follow_type(
+    ty: &Type,
+    structs_by_name: &BTreeMap<String, &ItemStruct>,
+    exempt: &BTreeSet<String>,
+    visited: &mut BTreeSet<String>,
+    violations: &mut Vec<String>,
+) {
+    let mut names: Vec<String> = Vec::new();
+    collect_struct_names(ty, structs_by_name, &mut names);
+    for name in names {
+        if !visited.insert(name.clone()) {
+            continue;
+        }
+        if let Some(s) = structs_by_name.get(&name) {
+            check_struct(s, structs_by_name, exempt, visited, violations);
+        }
+    }
+}
+
+fn collect_struct_names(
+    ty: &Type,
+    structs_by_name: &BTreeMap<String, &ItemStruct>,
+    out: &mut Vec<String>,
+) {
+    if let Type::Path(p) = ty {
+        if let Some(seg) = p.path.segments.last() {
+            let name = seg.ident.to_string();
+            if structs_by_name.contains_key(&name) {
+                out.push(name);
+            }
+            if let syn::PathArguments::AngleBracketed(args) = &seg.arguments {
+                for arg in &args.args {
+                    if let GenericArgument::Type(inner) = arg {
+                        collect_struct_names(inner, structs_by_name, out);
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn check_struct(
+    s: &ItemStruct,
+    structs_by_name: &BTreeMap<String, &ItemStruct>,
+    exempt: &BTreeSet<String>,
+    visited: &mut BTreeSet<String>,
+    violations: &mut Vec<String>,
+) {
+    let struct_name = s.ident.to_string();
+    if let Fields::Named(named) = &s.fields {
+        for field in &named.named {
+            let field_name = field
+                .ident
+                .as_ref()
+                .map(|i| i.to_string())
+                .unwrap_or_default();
+            let path = format!("{struct_name}.{field_name}");
+            check_field(&path, field, exempt, violations);
+            follow_type(&field.ty, structs_by_name, exempt, visited, violations);
+        }
+    }
+}
+
+fn check_field(path: &str, field: &Field, exempt: &BTreeSet<String>, violations: &mut Vec<String>) {
+    if exempt.contains(path) {
+        return;
+    }
+    if !has_back_compat_attr(&field.attrs) {
+        violations.push(format!(
+            "{path} has no acceptable serde attribute (default / skip / flatten / skip_serializing_if)"
+        ));
+    }
+}
+
+fn has_back_compat_attr(attrs: &[Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        if !attr.path().is_ident("serde") {
+            return false;
+        }
+        let mut found = false;
+        let _ = attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("default")
+                || meta.path.is_ident("skip_serializing_if")
+                || meta.path.is_ident("skip")
+                || meta.path.is_ident("flatten")
+            {
+                found = true;
+            }
+            if let Ok(value) = meta.value() {
+                let _ = value.parse::<syn::Expr>();
+            }
+            Ok(())
+        });
+        found
+    })
+}
+
+/// Sanity check that the guard would actually catch a regression: parse
+/// a synthetic snippet that mirrors the F-PROTO-3 bug shape and verify
+/// the violation surfaces. Without this, the main test could quietly
+/// degrade to a no-op (e.g. if a future refactor renames `ControlEvent`
+/// or removes the `#[serde(tag)]` attribute) and the regression class
+/// would silently slip through CI again.
+#[test]
+fn guard_catches_synthetic_regression() {
+    let synthetic = r#"
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "event")]
+pub enum SyntheticEvent {
+    Finished { summary: SyntheticSummary },
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct SyntheticSummary {
+    pub total: usize,   // <-- intentionally missing #[serde(default)]
+    pub failed: usize,  // <-- intentionally missing #[serde(default)]
+}
+"#;
+
+    let parsed: File = syn::parse_file(synthetic).expect("parse synthetic snippet");
+
+    let structs_by_name: BTreeMap<String, &ItemStruct> = parsed
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            Item::Struct(s) => Some((s.ident.to_string(), s)),
+            _ => None,
+        })
+        .collect();
+
+    let wire_enums: Vec<&ItemEnum> = parsed
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            Item::Enum(e) if has_serde_tag(&e.attrs) => Some(e),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(wire_enums.len(), 1, "expected one tagged enum in synthetic");
+
+    let exempt: BTreeSet<String> = BTreeSet::new();
+    let mut visited: BTreeSet<String> = BTreeSet::new();
+    let mut violations: Vec<String> = Vec::new();
+
+    for variant in &wire_enums[0].variants {
+        if let Fields::Named(named) = &variant.fields {
+            for field in &named.named {
+                follow_type(
+                    &field.ty,
+                    &structs_by_name,
+                    &exempt,
+                    &mut visited,
+                    &mut violations,
+                );
+            }
+        }
+    }
+
+    assert_eq!(
+        violations.len(),
+        2,
+        "guard should flag both missing fields, got {violations:?}"
+    );
+    assert!(
+        violations
+            .iter()
+            .any(|v| v.contains("SyntheticSummary.total")),
+        "guard should name SyntheticSummary.total; got {violations:?}"
+    );
+    assert!(
+        violations
+            .iter()
+            .any(|v| v.contains("SyntheticSummary.failed")),
+        "guard should name SyntheticSummary.failed; got {violations:?}"
+    );
+}

--- a/crates/pitboss-cli/tests/wire_compat_guard.rs
+++ b/crates/pitboss-cli/tests/wire_compat_guard.rs
@@ -104,6 +104,35 @@ fn every_nested_struct_field_in_wire_variants_has_back_compat_attr() {
         wire_enums.len()
     );
 
+    // Validate every EXEMPT_FIELDS entry points at a real field. Without
+    // this, a typo (e.g. `ActorActivityEntry.actorid` instead of
+    // `actor_id`) would silently become a no-op exemption — the real
+    // field would then either be flagged (best case) or, if also typo'd
+    // in the source, missed entirely. The exemption mechanism exists
+    // precisely as a deliberate review touchpoint; a typo'd exemption
+    // defeats that purpose.
+    for (path, _reason) in EXEMPT_FIELDS {
+        let (struct_name, field_name) = path.split_once('.').unwrap_or_else(|| {
+            panic!("EXEMPT_FIELDS entry {path:?} must be `StructName.field_name`")
+        });
+        let s = structs_by_name.get(struct_name).unwrap_or_else(|| {
+            panic!(
+                "EXEMPT_FIELDS: struct {struct_name:?} not found in protocol.rs \
+                 (did the file move or the struct get renamed?)"
+            )
+        });
+        let Fields::Named(named) = &s.fields else {
+            panic!("EXEMPT_FIELDS: struct {struct_name:?} has no named fields");
+        };
+        assert!(
+            named
+                .named
+                .iter()
+                .any(|f| f.ident.as_ref().is_some_and(|i| i == field_name)),
+            "EXEMPT_FIELDS: field {field_name:?} not found on struct {struct_name:?}"
+        );
+    }
+
     let exempt: BTreeSet<String> = EXEMPT_FIELDS.iter().map(|(p, _)| p.to_string()).collect();
 
     let mut visited: BTreeSet<String> = BTreeSet::new();


### PR DESCRIPTION
## Summary

Closes audit issue **#577** (F-TEST-13). Mechanizes the wire-compat contract documented at the top of `crates/pitboss-cli/src/control/protocol.rs` (lines 8-34) for the nested-payload-struct case via a `syn`-based test.

Background: the contract was purely social before this PR. The same class of bug shipped four times in one week — PRs #566 (F-PROTO-1: SubleadSpawned), #567 (F-PROTO-2: SubleadTerminated), #571 (F-PROTO-8: ResolvedManifest), #575 (F-PROTO-3: RunFinishedSummary + bundled WorkerSnapshotEntry).

## What's in this PR

**Commit 1 — initial guard + bundled fix**
- `crates/pitboss-cli/tests/wire_compat_guard.rs` (~380 lines after remediation)
  - `every_nested_struct_field_in_wire_variants_has_back_compat_attr` — parses `protocol.rs`, walks every variant of every `#[serde(tag = "...")]`-decorated enum, recurses into local struct types referenced from variant fields, asserts each named field carries one of: `#[serde(default)]`, `#[serde(default = "fn")]`, `#[serde(default, skip_serializing_if = "...")]`, `#[serde(skip)]`, or `#[serde(flatten)]`.
  - `guard_catches_synthetic_regression` — feeds the same machinery a manually-constructed violating snippet to prove the guard isn't a no-op.
- `crates/pitboss-cli/Cargo.toml` — adds `syn` to `dev-dependencies`.
- `crates/pitboss-cli/src/control/protocol.rs` — bundled fix for `ApprovalPlanWire.summary` (missing `#[serde(default)]`, surfaced by the guard on first run).

**Commit 2 — reviewer-panel remediations**
- **R1's typo-risk finding**: added startup-time validation that every `EXEMPT_FIELDS` entry actually resolves to a real `StructName.field_name` in the parsed AST. Without this, a typo (e.g. `ActorActivityEntry.actorid` instead of `actor_id`) would silently no-op the exemption.
- **R2's doc-comment drift**: updated the contract doc-comment at `protocol.rs:8-34` to list `#[serde(skip)]` and `#[serde(flatten)]` as acceptable attributes, matching what the test enforces.

## Design: nested-struct-only scope

The contract's prose targets every new field, including inline variant fields. But the pre-contract baseline of inline variant fields is ~30 fields, and grandfathering them all behind an allowlist creates a high-maintenance review surface contributors will eventually game. The actual recurrence pattern that drove this issue is nested payload structs (`RunFinishedSummary`, `WorkerSnapshotEntry`, `ApprovalPlanWire`) where the field lives in a separate type definition, requiring a separate file-read to inspect — exactly the slippage reviewers catch late. Inline-variant omissions are at least visible at the variant declaration site, so they're more reviewer-tractable.

This test guards the harder-to-spot class. Inline-variant scope is still handled by reviewer vigilance.

## Retroactive validation (R2)

Reverting PR #575 (which fixed `RunFinishedSummary` + `WorkerSnapshotEntry`) on top of this branch would make the new test fail with the exact field paths PR #575 fixed. R2 verified this independently. The guard catches the bug class it claims to catch.

## Exemption mechanism

`EXEMPT_FIELDS` holds documented one-line reasons for fields that must fail-loudly on absence (today: `ActorActivityEntry.actor_id`). Adding a new exemption requires a code-review touchpoint with a rationale. **Typos now panic at test startup** with a clear "struct X not found" / "field Y not found on struct X" message — prevents silent degradation that R1 caught.

## Risk

- 893 lib tests pass.
- 2 new content-guard tests pass.
- `cargo lint` clean.
- `cargo tidy` clean.
- Test runtime: ~0.01s on a ~1100-line `protocol.rs`.
- `syn` is already in the workspace via `pitboss-schema-derive` — no new transitive deps.

## Out of scope (follow-up)

- **R3's companion-gap finding**: `mcp::tools::ApprovalPlan.summary` and `RequestApprovalArgs.summary` in `crates/pitboss-cli/src/mcp/tools.rs:265-326` have the same missing-`#[serde(default)]` pattern as the fixed `ApprovalPlanWire.summary`. Different protocol layer (MCP-tool JSON, not control-socket) with its own conventions — worth a separate audit issue.
- **Inline-variant-field guard** — see "Design" above. Separate effort if belt-and-suspenders coverage is wanted.
- **Extending the guard to `pitboss-core::store`** (`TaskRecord`, `RunSummary`) — different file, related issue #514. Worth its own PR.

Closes #577