### PR TITLE
Add container-dispatch background mode with source manifest preservation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -863,7 +863,8 @@ Files in the run dir:
 
 | File | Purpose |
 |---|---|
-| `manifest.snapshot.toml` | Exact manifest bytes used for this run. |
+| `manifest.snapshot.toml` | Exact manifest bytes used for this run. For container-dispatched runs this copy has the `[container]` section stripped (back-compat with older images that hit `deny_unknown_fields` on the key); see `manifest.source.toml` for the operator-typed original. |
+| `manifest.source.toml` | **Container-dispatch only.** Written host-side by `pitboss container-dispatch` before `exec()`. Preserves the operator's original manifest including the `[container]` block + `[[container.mount]]` entries. `pitboss-web`'s Fork-manifest button prefers this over the snapshot so forked container runs carry their full host-side config back into the workspace. |
 | `resolved.json` | Fully resolved manifest (defaults applied). |
 | `meta.json` | `run_id`, `started_at`, `claude_version`, `pitboss_version`. |
 | `summary.json` | Written on clean finalize. Full structured summary of the run. |

--- a/crates/pitboss-cli/src/cli.rs
+++ b/crates/pitboss-cli/src/cli.rs
@@ -185,11 +185,25 @@ pub enum Command {
         #[arg(long)]
         run_dir: Option<PathBuf>,
         /// Print the container run command and exit without executing.
-        #[arg(long)]
+        #[arg(long, conflicts_with_all = ["background", "internal_run_id"])]
         dry_run: bool,
         /// Override container runtime detection ("docker" or "podman").
         #[arg(long)]
         runtime: Option<String>,
+        /// Detach the dispatcher to run in the background. Mints a `run_id`
+        /// on the host, writes `manifest.source.toml` into the per-run dir,
+        /// spawns `pitboss container-dispatch --internal-run-id <id>` as a
+        /// session-leader child with stdio nulled, prints
+        /// `{run_id, manifest_path, started_at, child_pid, container: true}`
+        /// JSON to stdout, and exits 0. Same shape as `dispatch --background`.
+        #[arg(long, conflicts_with = "internal_run_id")]
+        background: bool,
+        /// Internal: re-use this UUID as the run id. Set automatically when
+        /// `--background` re-spawns the dispatcher as a detached child so
+        /// the parent's announced `run_id` matches what the child threads
+        /// through to the inner `pitboss dispatch`. Not for direct human use.
+        #[arg(long, hide = true, value_name = "UUID")]
+        internal_run_id: Option<String>,
     },
     /// Build a derived container image from the manifest's `[container]`
     /// section. Synthesizes a thin Dockerfile (`extra_apt` + `[[container.copy]]`),

--- a/crates/pitboss-cli/src/dispatch/background.rs
+++ b/crates/pitboss-cli/src/dispatch/background.rs
@@ -227,6 +227,132 @@ fn stderr_log_path_for(run_dir_override: Option<&Path>, run_id: &str) -> PathBuf
     base.join(format!("{run_id}.bg-stderr.log"))
 }
 
+/// Detached spawn for `pitboss container-dispatch --background`. Mirrors
+/// [`run_background`] but re-spawns `container-dispatch --internal-run-id`
+/// instead of `dispatch --internal-run-id`. The detached child's
+/// `run_container_dispatch` honors the pre-minted id and exec()s
+/// docker/podman with the id threaded into the in-container
+/// `pitboss dispatch` argv via `--internal-run-id`.
+///
+/// The JSON announcement carries an extra `"container": true` field so
+/// orchestrators (notably `pitboss-web`'s `/api/runs`) can distinguish
+/// container-dispatched runs from flat-mode ones without re-parsing the
+/// manifest. Other fields match `run_background` exactly.
+pub fn run_container_background(
+    manifest_path: &Path,
+    run_dir_override: Option<PathBuf>,
+) -> Result<i32> {
+    let run_id = Uuid::now_v7();
+    let run_id_str = run_id.to_string();
+    let started_at = Utc::now();
+
+    // Pre-flight: validate the manifest (and require `[container]`)
+    // BEFORE forking so TOML errors and missing-section errors surface
+    // on the parent's stderr where the operator/web client can see
+    // them. Mirrors `run_background`'s fail-fast preflight (#150 M8).
+    let resolved = crate::manifest::load::load_manifest_skip_dir_check(manifest_path, None)
+        .with_context(|| {
+            format!(
+                "validate manifest before background container-dispatch: {}",
+                manifest_path.display()
+            )
+        })?;
+    if resolved.container.is_none() {
+        anyhow::bail!(
+            "pitboss container-dispatch: manifest has no [container] section.\n\
+             Add a [container] block with at least [[container.mount]] entries \
+             to use container-dispatch."
+        );
+    }
+
+    let manifest_path_canonical = std::fs::canonicalize(manifest_path)
+        .with_context(|| format!("canonicalize manifest path: {}", manifest_path.display()))?;
+    let run_dir_canonical = run_dir_override
+        .as_ref()
+        .map(|d| std::fs::canonicalize(d).unwrap_or_else(|_| d.clone()));
+
+    // Write `manifest.source.toml` from the parent — before announcing
+    // and before the child even spawns. This way the artifact is on
+    // disk by the time `pitboss-web` follows the announcement to load
+    // the new run (even if the detached child later fails in
+    // `detect_runtime` or during the docker/podman exec). Without this,
+    // a podman-less CI run would announce a `run_id` but never write
+    // the artifact the Fork-manifest endpoint depends on.
+    let runs_base = run_dir_canonical
+        .clone()
+        .unwrap_or_else(crate::runs::runs_base_dir);
+    if let Err(e) = crate::dispatch::container::write_source_manifest_artifact(
+        &runs_base,
+        run_id,
+        &manifest_path_canonical,
+    ) {
+        eprintln!("pitboss container-dispatch: warning: could not write manifest.source.toml: {e}");
+    }
+
+    let exe = std::env::current_exe().context("locate current pitboss binary")?;
+
+    let mut cmd = std::process::Command::new(&exe);
+    cmd.arg("container-dispatch")
+        .arg(&manifest_path_canonical)
+        .args(["--internal-run-id", &run_id_str]);
+    if let Some(ref dir) = run_dir_canonical {
+        cmd.arg("--run-dir").arg(dir);
+    }
+
+    let stderr_log_path = stderr_log_path_for(run_dir_canonical.as_deref(), &run_id_str);
+    let stderr_target = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&stderr_log_path)
+        .map(Stdio::from)
+        .unwrap_or_else(|_| Stdio::null());
+
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(stderr_target);
+
+    // SAFETY: `pre_exec` runs in the forked child between fork() and
+    // exec(). `setsid()` is async-signal-safe per POSIX. Same shape as
+    // `run_background`.
+    unsafe {
+        cmd.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+
+    let child = cmd.spawn().with_context(|| {
+        format!(
+            "spawn detached container-dispatch (binary: {})",
+            exe.display()
+        )
+    })?;
+    let child_pid = child.id();
+    drop(child);
+
+    let payload = json!({
+        "run_id": run_id_str,
+        "manifest_path": manifest_path_canonical.to_string_lossy(),
+        "started_at": started_at.to_rfc3339(),
+        "child_pid": child_pid,
+        "bg_stderr_log": stderr_log_path.to_string_lossy(),
+        "container": true,
+    });
+    use std::io::Write as _;
+    let mut out = std::io::stdout().lock();
+    if let Err(e) = writeln!(out, "{payload}") {
+        if e.kind() != std::io::ErrorKind::BrokenPipe {
+            return Err(e).context("write background container-dispatch announcement");
+        }
+        tracing::debug!(error = %e, "background announcement: stdout EPIPE; child still running");
+    }
+    let _ = out.flush();
+
+    Ok(0)
+}
+
 /// Parse a `--internal-run-id` argument into a `Uuid`. Used by `main.rs`
 /// when forwarding the value into [`crate::dispatch::run_dispatch_inner`]
 /// or [`crate::dispatch::hierarchical::run_hierarchical`].

--- a/crates/pitboss-cli/src/dispatch/container.rs
+++ b/crates/pitboss-cli/src/dispatch/container.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{bail, Context, Result};
+use uuid::Uuid;
 
 use crate::manifest::schema::ContainerConfig;
 
@@ -71,17 +72,27 @@ pub(crate) fn claude_setting_sources_args(
 ///
 /// Validates that the manifest has a `[container]` section, then builds and
 /// execs the container run command.
+///
+/// `pre_minted_run_id` is `Some(_)` when the host has minted the id
+/// before exec (the `--background` re-spawn flow). When set, the id is
+/// piped into the in-container `pitboss dispatch` via `--internal-run-id`
+/// so the id the parent announced matches what lands on disk. Foreground
+/// callers pass `None`; we mint locally so the host can still write
+/// `manifest.source.toml` into a deterministic per-run directory before
+/// exec.
 pub fn run_container_dispatch(
     manifest_path: &Path,
     container: &ContainerConfig,
     run_dir_override: Option<PathBuf>,
     dry_run: bool,
     runtime_override: Option<&str>,
+    pre_minted_run_id: Option<Uuid>,
 ) -> Result<()> {
     let runtime = detect_runtime(runtime_override, container.runtime.as_deref())?;
     let manifest_abs = manifest_path
         .canonicalize()
         .with_context(|| format!("canonicalizing manifest path {}", manifest_path.display()))?;
+    let run_id = pre_minted_run_id.unwrap_or_else(Uuid::now_v7);
 
     // Phase 2: when the manifest declares derived-image inputs, prefer
     // the locally-built derived tag if it exists. `[[container.copy]]`
@@ -127,6 +138,7 @@ pub fn run_container_dispatch(
         &manifest_abs,
         run_dir_override,
         derived_image_override,
+        Some(run_id),
     )?;
 
     if dry_run {
@@ -148,9 +160,21 @@ pub fn run_container_dispatch(
     // logged but does not abort dispatch (the operator's run shouldn't
     // hinge on the audit log being writable). (#476 / F-SEC-9)
     if let Err(e) =
-        append_container_dispatch_audit(&audit_runs_base, &runtime, &args, &manifest_abs)
+        append_container_dispatch_audit(&audit_runs_base, &runtime, &args, &manifest_abs, run_id)
     {
         eprintln!("pitboss container-dispatch: warning: could not write argv audit log: {e}");
+    }
+
+    // Preserve the operator-typed manifest into the per-run dir before
+    // exec replaces the process. The in-container dispatcher writes
+    // `manifest.snapshot.toml` from the [container]-stripped copy at
+    // `/run/pitboss.toml`, so without this the original `[container]`
+    // block (and the host-side mounts it declares) would never land on
+    // disk — and `pitboss-web`'s Fork-manifest would lose them.
+    // Fail-soft for the same reason the audit log is fail-soft: a fork
+    // disconnect is bad, but it is not worse than a failed dispatch.
+    if let Err(e) = write_source_manifest_artifact(&audit_runs_base, run_id, &manifest_abs) {
+        eprintln!("pitboss container-dispatch: warning: could not write manifest.source.toml: {e}");
     }
 
     let err = Command::new(&runtime).args(&args).exec();
@@ -164,12 +188,19 @@ pub fn run_container_dispatch(
 /// resolved a built derived image (apt + COPY already baked in). When
 /// set, the Phase-1 apt-at-spin-up wrap is skipped — the work is
 /// already in the image.
+///
+/// `pre_minted_run_id` is `Some(_)` when the host has minted the run id
+/// before exec; it is appended as `--internal-run-id <uuid>` to the
+/// in-container `pitboss dispatch` argv so the id is honored end-to-end.
+/// `None` lets the in-container dispatcher mint its own (legacy
+/// behavior, used only by callers that bypass the new pre-mint path).
 fn build_run_args(
     runtime: &str,
     container: &ContainerConfig,
     manifest_abs: &Path,
     run_dir_override: Option<PathBuf>,
     derived_image_override: Option<&str>,
+    pre_minted_run_id: Option<Uuid>,
 ) -> Result<Vec<String>> {
     let mut args: Vec<String> = vec!["run".into(), "--rm".into()];
 
@@ -385,12 +416,30 @@ fn build_run_args(
         .unwrap_or_else(|| DEFAULT_IMAGE.to_string());
     args.push(image);
 
+    // When the host pre-minted a run_id (e.g. via `--background` so the
+    // parent can announce the id before exec), append `--internal-run-id`
+    // to the inner dispatch argv so the in-container `pitboss dispatch`
+    // honors it instead of minting its own. Without this, the host-side
+    // `manifest.source.toml` (keyed by the pre-minted id) would land in
+    // a different per-run dir than the in-container snapshot.
+    let internal_run_id_args: Vec<String> = match pre_minted_run_id {
+        Some(id) => vec!["--internal-run-id".to_string(), id.to_string()],
+        None => Vec::new(),
+    };
+
     if bootstrap_apt {
         let pkg_list = container.extra_apt.join(" ");
+        let internal_tail = if internal_run_id_args.is_empty() {
+            String::new()
+        } else {
+            // Shell-safe: the id is a UUID v7 string, so plain interpolation
+            // is fine here.
+            format!(" {} {}", internal_run_id_args[0], internal_run_id_args[1])
+        };
         let cmd = format!(
             "apt-get update && \
              apt-get install -y --no-install-recommends {pkg_list} && \
-             exec runuser -u pitboss -- pitboss dispatch /run/pitboss.toml"
+             exec runuser -u pitboss -- pitboss dispatch /run/pitboss.toml{internal_tail}"
         );
         args.push("sh".into());
         args.push("-c".into());
@@ -399,6 +448,7 @@ fn build_run_args(
         args.push("pitboss".into());
         args.push("dispatch".into());
         args.push("/run/pitboss.toml".into());
+        args.extend(internal_run_id_args);
     }
 
     Ok(args)
@@ -726,7 +776,7 @@ fn default_run_dir() -> PathBuf {
 ///
 /// Format:
 /// ```jsonc
-/// {"at":"2026-05-14T12:34:56Z","manifest":"/abs/path/pitboss.toml",
+/// {"at":"2026-05-14T12:34:56Z","run_id":"019e4…","manifest":"/abs/…",
 ///  "runtime":"podman","argv":["run","--rm",…]}
 /// ```
 fn append_container_dispatch_audit(
@@ -734,6 +784,7 @@ fn append_container_dispatch_audit(
     runtime: &str,
     args: &[String],
     manifest_abs: &Path,
+    run_id: Uuid,
 ) -> Result<()> {
     use std::io::Write;
 
@@ -747,6 +798,7 @@ fn append_container_dispatch_audit(
 
     let record = serde_json::json!({
         "at": chrono::Utc::now().to_rfc3339(),
+        "run_id": run_id.to_string(),
         "manifest": manifest_abs.display().to_string(),
         "runtime": runtime,
         "argv": args,
@@ -759,6 +811,45 @@ fn append_container_dispatch_audit(
         .with_context(|| format!("opening audit log {}", log_path.display()))?;
     writeln!(f, "{record}")
         .with_context(|| format!("appending to audit log {}", log_path.display()))?;
+    Ok(())
+}
+
+/// Copy the operator's unmodified manifest into the per-run dir as
+/// `manifest.source.toml` before exec replaces the host process.
+///
+/// The inner `pitboss dispatch` writes `manifest.snapshot.toml` from the
+/// `[container]`-stripped copy at `/run/pitboss.toml`, so without this
+/// the source `[container]` block (and the host-side mounts it declares)
+/// would never land on disk — and `pitboss-web`'s Fork-manifest button
+/// would lose them, leaving forked container-dispatched runs unable to
+/// re-launch cleanly from the web UI.
+///
+/// The run_id is pre-minted on the host so the per-run directory is
+/// deterministic before exec. The in-container dispatcher honors the
+/// same id via `--internal-run-id` and writes the snapshot into the
+/// same directory.
+pub(crate) fn write_source_manifest_artifact(
+    runs_base: &Path,
+    run_id: Uuid,
+    manifest_abs: &Path,
+) -> Result<()> {
+    let run_subdir = runs_base.join(run_id.to_string());
+    std::fs::create_dir_all(&run_subdir).with_context(|| {
+        format!(
+            "creating per-run dir for source manifest: {}",
+            run_subdir.display()
+        )
+    })?;
+    let dest = run_subdir.join("manifest.source.toml");
+    // Read+write rather than fs::copy so the destination is created with
+    // the host-process umask (the in-container dispatcher will write its
+    // own snapshot alongside this file under the container's `-u` UID;
+    // either ownership shape is fine — both processes act as the same
+    // effective UID via the runtime's UID-alignment logic).
+    let bytes = std::fs::read(manifest_abs)
+        .with_context(|| format!("reading source manifest {}", manifest_abs.display()))?;
+    std::fs::write(&dest, bytes)
+        .with_context(|| format!("writing source manifest to {}", dest.display()))?;
     Ok(())
 }
 
@@ -885,7 +976,7 @@ prompt = "hi"
         let cfg = make_config(vec![]);
         let manifest = temp_manifest();
         // Build args without calling exec.
-        let args = build_run_args("podman", &cfg, &manifest, None, None).unwrap();
+        let args = build_run_args("podman", &cfg, &manifest, None, None, None).unwrap();
         let joined = args.join(" ");
         assert!(joined.contains("pitboss"), "should call pitboss: {joined}");
         assert!(
@@ -901,7 +992,7 @@ prompt = "hi"
     #[test]
     fn default_image_used_when_none_specified() {
         let cfg = make_config(vec![]);
-        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None, None).unwrap();
         let joined = args.join(" ");
         assert!(
             joined.contains(DEFAULT_IMAGE),
@@ -915,7 +1006,7 @@ prompt = "hi"
             image: Some("my-org/pitboss:latest".into()),
             ..ContainerConfig::default()
         };
-        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None, None).unwrap();
         let joined = args.join(" ");
         assert!(
             joined.contains("my-org/pitboss:latest"),
@@ -937,7 +1028,7 @@ prompt = "hi"
             }],
             ..ContainerConfig::default()
         };
-        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None, None).unwrap();
         let joined = args.join(" ");
         assert!(
             joined.contains("/home/alice/project:/project:rw,z"),
@@ -955,7 +1046,7 @@ prompt = "hi"
             }],
             ..ContainerConfig::default()
         };
-        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None).unwrap();
+        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None, None).unwrap();
         let joined = args.join(" ");
         assert!(joined.contains("/ref:/ref:ro,z"), "readonly flag: {joined}");
     }
@@ -963,7 +1054,7 @@ prompt = "hi"
     #[test]
     fn auto_inject_claude_when_not_in_mounts() {
         let cfg = make_config(vec![]);
-        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None, None).unwrap();
         let joined = args.join(" ");
         assert!(
             joined.contains("/home/pitboss/.claude"),
@@ -977,7 +1068,7 @@ prompt = "hi"
         // by default. A compromised worker cannot rewrite host
         // credentials or inject malicious hooks via the rw mount.
         let cfg = make_config(vec![]);
-        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None, None).unwrap();
         let claude_mount = args
             .windows(2)
             .find(|w| w[0] == "-v" && w[1].contains(":/home/pitboss/.claude:"))
@@ -998,7 +1089,7 @@ prompt = "hi"
             claude_mount_rw: true,
             ..ContainerConfig::default()
         };
-        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None, None).unwrap();
         let claude_mount = args
             .windows(2)
             .find(|w| w[0] == "-v" && w[1].contains(":/home/pitboss/.claude:"))
@@ -1020,7 +1111,7 @@ prompt = "hi"
             }],
             ..ContainerConfig::default()
         };
-        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None, None).unwrap();
         // Count -v args that mount to /home/pitboss/.claude — should be exactly 1
         // (the declared mount). The -w workdir may also reference the path but is
         // not a duplicate mount injection.
@@ -1044,7 +1135,7 @@ prompt = "hi"
             }],
             ..ContainerConfig::default()
         };
-        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None, None).unwrap();
         // -w should be followed by /project
         let w_pos = args.iter().position(|a| a == "-w").expect("-w flag");
         assert_eq!(args[w_pos + 1], "/project", "workdir: {args:?}");
@@ -1053,7 +1144,7 @@ prompt = "hi"
     #[test]
     fn workdir_falls_back_to_home_pitboss_when_no_mounts() {
         let cfg = make_config(vec![]);
-        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None, None).unwrap();
         let w_pos = args.iter().position(|a| a == "-w").expect("-w flag");
         assert_eq!(
             args[w_pos + 1],
@@ -1073,7 +1164,7 @@ prompt = "hi"
             workdir: Some(PathBuf::from("/project/sub")),
             ..ContainerConfig::default()
         };
-        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None, None).unwrap();
         let w_pos = args.iter().position(|a| a == "-w").expect("-w flag");
         assert_eq!(
             args[w_pos + 1],
@@ -1088,7 +1179,7 @@ prompt = "hi"
             extra_args: vec!["--network=host".into(), "--cap-drop=ALL".into()],
             ..ContainerConfig::default()
         };
-        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None).unwrap();
+        let args = build_run_args("docker", &cfg, &temp_manifest(), None, None, None).unwrap();
         let net_pos = args
             .iter()
             .position(|a| a == "--network=host")
@@ -1119,8 +1210,15 @@ prompt = "hi"
     fn run_dir_mount_uses_override() {
         let custom = PathBuf::from("/tmp/my-runs");
         let cfg = make_config(vec![]);
-        let args =
-            build_run_args("docker", &cfg, &temp_manifest(), Some(custom.clone()), None).unwrap();
+        let args = build_run_args(
+            "docker",
+            &cfg,
+            &temp_manifest(),
+            Some(custom.clone()),
+            None,
+            None,
+        )
+        .unwrap();
         let joined = args.join(" ");
         assert!(
             joined.contains("/tmp/my-runs"),
@@ -1133,7 +1231,7 @@ prompt = "hi"
         // Sanity: with no extra_apt the entrypoint args are still the bare
         // `pitboss dispatch /run/pitboss.toml` triplet — no shell wrap.
         let cfg = make_config(vec![]);
-        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None).unwrap();
+        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None, None).unwrap();
         assert!(
             !args.iter().any(|a| a == "sh"),
             "no sh wrapper expected: {args:?}"
@@ -1154,13 +1252,71 @@ prompt = "hi"
         );
     }
 
+    /// When the host pre-mints a run_id (e.g. via `--background` so the
+    /// parent can announce the id before exec), `build_run_args` must
+    /// append `--internal-run-id <uuid>` to the in-container
+    /// `pitboss dispatch` argv. Without this, the host-side
+    /// `manifest.source.toml` (keyed by the pre-minted id) lands in a
+    /// different per-run dir than the in-container snapshot — the bug
+    /// `Fork manifest` was supposed to fix.
+    #[test]
+    fn pre_minted_run_id_appended_to_bare_entrypoint() {
+        let id = Uuid::now_v7();
+        let cfg = make_config(vec![]);
+        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None, Some(id)).unwrap();
+        let dispatch_pos = args.iter().position(|a| a == "dispatch").expect("dispatch");
+        assert_eq!(args[dispatch_pos + 1], "/run/pitboss.toml");
+        assert_eq!(args[dispatch_pos + 2], "--internal-run-id");
+        assert_eq!(args[dispatch_pos + 3], id.to_string());
+    }
+
+    /// The apt-bootstrap shell wrap (`sh -c "apt-get install … && exec
+    /// runuser -u pitboss -- pitboss dispatch /run/pitboss.toml"`) must
+    /// also carry the pre-minted id when one is supplied. The wrap is
+    /// a single string passed to `sh -c`, so the assertion looks for the
+    /// `--internal-run-id <uuid>` tail inside it rather than as separate
+    /// argv entries.
+    #[test]
+    fn pre_minted_run_id_appended_to_apt_bootstrap_entrypoint() {
+        let id = Uuid::now_v7();
+        let cfg = ContainerConfig {
+            extra_apt: vec!["mdbook".into()],
+            ..ContainerConfig::default()
+        };
+        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None, Some(id)).unwrap();
+        let img_pos = args.iter().position(|a| a == DEFAULT_IMAGE).expect("image");
+        assert_eq!(args[img_pos + 1], "sh", "wrapped entrypoint: {args:?}");
+        assert_eq!(args[img_pos + 2], "-c", "wrapped entrypoint: {args:?}");
+        let cmd = &args[img_pos + 3];
+        let expected = format!(
+            "exec runuser -u pitboss -- pitboss dispatch /run/pitboss.toml --internal-run-id {id}"
+        );
+        assert!(
+            cmd.contains(&expected),
+            "shell entrypoint must carry --internal-run-id {id}: {cmd}"
+        );
+    }
+
+    /// When `pre_minted_run_id` is `None`, the legacy argv is unchanged —
+    /// no `--internal-run-id` appears. Catches accidental always-on
+    /// regressions of the pre-mint logic.
+    #[test]
+    fn bare_entrypoint_omits_internal_run_id_when_not_pre_minted() {
+        let cfg = make_config(vec![]);
+        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None, None).unwrap();
+        assert!(
+            !args.iter().any(|a| a == "--internal-run-id"),
+            "no --internal-run-id expected when not pre-minted: {args:?}"
+        );
+    }
+
     #[test]
     fn extra_apt_wraps_entrypoint_with_apt_install_and_runuser() {
         let cfg = ContainerConfig {
             extra_apt: vec!["mdbook".into(), "jq".into()],
             ..ContainerConfig::default()
         };
-        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None).unwrap();
+        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None, None).unwrap();
 
         // -u 0:0 must appear (so apt-get can run as root).
         let u_pos = args
@@ -1214,7 +1370,7 @@ prompt = "hi"
                 extra_apt: vec![bad.into()],
                 ..ContainerConfig::default()
             };
-            let result = build_run_args("podman", &cfg, &temp_manifest(), None, None);
+            let result = build_run_args("podman", &cfg, &temp_manifest(), None, None, None);
             assert!(
                 result.is_err(),
                 "expected rejection for {bad:?}, got: {result:?}"
@@ -1243,6 +1399,7 @@ prompt = "hi"
             &temp_manifest(),
             None,
             Some("pitboss-derived-abc123:local"),
+            None,
         )
         .unwrap();
         assert!(
@@ -1270,6 +1427,7 @@ prompt = "hi"
             &temp_manifest(),
             None,
             Some("pitboss-derived-deadbeef:local"),
+            None,
         )
         .unwrap();
         assert!(
@@ -1296,7 +1454,7 @@ prompt = "hi"
             extra_args: vec!["--privileged".into()],
             ..ContainerConfig::default()
         };
-        let err = build_run_args("podman", &cfg, &temp_manifest(), None, None)
+        let err = build_run_args("podman", &cfg, &temp_manifest(), None, None, None)
             .expect_err("--privileged must be rejected");
         let msg = err.to_string();
         assert!(
@@ -1319,7 +1477,7 @@ prompt = "hi"
                 extra_args: vec![bad.into()],
                 ..ContainerConfig::default()
             };
-            let err = build_run_args("podman", &cfg, &temp_manifest(), None, None)
+            let err = build_run_args("podman", &cfg, &temp_manifest(), None, None, None)
                 .expect_err(&format!("{bad} must be rejected"));
             assert!(
                 err.to_string().contains(bad),
@@ -1337,7 +1495,7 @@ prompt = "hi"
                 extra_args: vec![bad.into(), "/etc:/etc:rw".into()],
                 ..ContainerConfig::default()
             };
-            let err = build_run_args("podman", &cfg, &temp_manifest(), None, None)
+            let err = build_run_args("podman", &cfg, &temp_manifest(), None, None, None)
                 .expect_err(&format!("{bad} must be rejected"));
             assert!(
                 err.to_string().contains("container.mount"),
@@ -1354,7 +1512,7 @@ prompt = "hi"
             extra_args: vec!["--volume=/etc:/etc:rw".into()],
             ..ContainerConfig::default()
         };
-        let err = build_run_args("podman", &cfg, &temp_manifest(), None, None)
+        let err = build_run_args("podman", &cfg, &temp_manifest(), None, None, None)
             .expect_err("--volume=src:dst must be rejected");
         assert!(
             err.to_string().contains("--volume=/etc:/etc:rw"),
@@ -1377,7 +1535,7 @@ prompt = "hi"
                 extra_args: vec![bad.into()],
                 ..ContainerConfig::default()
             };
-            let err = build_run_args("podman", &cfg, &temp_manifest(), None, None)
+            let err = build_run_args("podman", &cfg, &temp_manifest(), None, None, None)
                 .expect_err(&format!("{bad} must be rejected"));
             assert!(
                 err.to_string().contains("cap-add"),
@@ -1396,7 +1554,7 @@ prompt = "hi"
                 ..ContainerConfig::default()
             };
             assert!(
-                build_run_args("podman", &cfg, &temp_manifest(), None, None).is_err(),
+                build_run_args("podman", &cfg, &temp_manifest(), None, None, None).is_err(),
                 "{bad} must be rejected"
             );
         }
@@ -1405,7 +1563,7 @@ prompt = "hi"
             ..ContainerConfig::default()
         };
         assert!(
-            build_run_args("podman", &cfg, &temp_manifest(), None, None).is_err(),
+            build_run_args("podman", &cfg, &temp_manifest(), None, None, None).is_err(),
             "--user=0:0 must be rejected"
         );
     }
@@ -1418,7 +1576,7 @@ prompt = "hi"
                 ..ContainerConfig::default()
             };
             assert!(
-                build_run_args("podman", &cfg, &temp_manifest(), None, None).is_err(),
+                build_run_args("podman", &cfg, &temp_manifest(), None, None, None).is_err(),
                 "{bad} must be rejected"
             );
         }
@@ -1436,7 +1594,7 @@ prompt = "hi"
                 ..ContainerConfig::default()
             };
             assert!(
-                build_run_args("podman", &cfg, &temp_manifest(), None, None).is_err(),
+                build_run_args("podman", &cfg, &temp_manifest(), None, None, None).is_err(),
                 "{bad} must be rejected"
             );
         }
@@ -1450,7 +1608,7 @@ prompt = "hi"
                 ..ContainerConfig::default()
             };
             assert!(
-                build_run_args("podman", &cfg, &temp_manifest(), None, None).is_err(),
+                build_run_args("podman", &cfg, &temp_manifest(), None, None, None).is_err(),
                 "{bad} must be rejected"
             );
         }
@@ -1473,7 +1631,7 @@ prompt = "hi"
             ],
             ..ContainerConfig::default()
         };
-        build_run_args("podman", &cfg, &temp_manifest(), None, None)
+        build_run_args("podman", &cfg, &temp_manifest(), None, None, None)
             .expect("realistic safe extra_args must pass validation");
     }
 
@@ -1490,7 +1648,7 @@ prompt = "hi"
             ],
             ..ContainerConfig::default()
         };
-        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None)
+        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None, None)
             .expect("realistic package names should validate");
         let img_pos = args.iter().position(|a| a == DEFAULT_IMAGE).expect("image");
         let cmd = &args[img_pos + 3];
@@ -1544,7 +1702,7 @@ prompt = "hi"
     #[test]
     fn macos_auto_injects_xdg_runtime_dir() {
         let cfg = ContainerConfig::default();
-        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None).unwrap();
+        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None, None).unwrap();
         assert_eq!(
             count_env_inject(&args, "XDG_RUNTIME_DIR"),
             1,
@@ -1568,7 +1726,7 @@ prompt = "hi"
     #[test]
     fn linux_does_not_auto_inject_xdg_runtime_dir() {
         let cfg = ContainerConfig::default();
-        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None).unwrap();
+        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None, None).unwrap();
         assert_eq!(
             count_env_inject(&args, "XDG_RUNTIME_DIR"),
             0,
@@ -1588,7 +1746,7 @@ prompt = "hi"
             extra_args: vec!["-e".into(), "XDG_RUNTIME_DIR=/run/custom".into()],
             ..ContainerConfig::default()
         };
-        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None).unwrap();
+        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None, None).unwrap();
         assert_eq!(
             count_env_inject(&args, "XDG_RUNTIME_DIR"),
             1,
@@ -1616,7 +1774,7 @@ prompt = "hi"
             extra_args: vec!["--env".into(), "XDG_RUNTIME_DIR=/x".into()],
             ..ContainerConfig::default()
         };
-        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None).unwrap();
+        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None, None).unwrap();
         assert_eq!(count_env_inject(&args, "XDG_RUNTIME_DIR"), 1);
         assert!(args.iter().any(|a| a == "XDG_RUNTIME_DIR=/x"));
     }
@@ -1631,7 +1789,7 @@ prompt = "hi"
             extra_args: vec!["-e=XDG_RUNTIME_DIR=/joined".into()],
             ..ContainerConfig::default()
         };
-        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None).unwrap();
+        let args = build_run_args("podman", &cfg, &temp_manifest(), None, None, None).unwrap();
         assert!(
             !args.iter().any(|a| a == "XDG_RUNTIME_DIR=/tmp"),
             "default must be suppressed by `-e=` joined override: {args:?}"

--- a/crates/pitboss-cli/src/main.rs
+++ b/crates/pitboss-cli/src/main.rs
@@ -162,8 +162,35 @@ fn main() -> Result<()> {
             run_dir,
             dry_run,
             runtime,
+            background,
+            internal_run_id,
         } => {
-            run_container_dispatch(&manifest, run_dir, dry_run, runtime.as_deref());
+            // Mirror the `Dispatch` arm at line 31-68: `--background`
+            // short-circuits to a detached re-spawn that announces
+            // `run_id` on stdout. The foreground branch parses
+            // `--internal-run-id` (when present) so the host-side
+            // pre-minted run_id flows into the inner `pitboss dispatch`
+            // via `--internal-run-id` argv appending.
+            if background {
+                match dispatch::background::run_container_background(&manifest, run_dir) {
+                    Ok(code) => std::process::exit(code),
+                    Err(e) => {
+                        eprintln!("background container-dispatch: {e:#}");
+                        std::process::exit(1);
+                    }
+                }
+            }
+            let pre_minted = match internal_run_id.as_deref() {
+                None => None,
+                Some(s) => match dispatch::background::parse_internal_run_id(s) {
+                    Ok(u) => Some(u),
+                    Err(e) => {
+                        eprintln!("{e:#}");
+                        std::process::exit(2);
+                    }
+                },
+            };
+            run_container_dispatch(&manifest, run_dir, dry_run, runtime.as_deref(), pre_minted);
         }
         Command::ContainerBuild {
             manifest,
@@ -663,6 +690,7 @@ fn run_container_dispatch(
     run_dir: Option<std::path::PathBuf>,
     dry_run: bool,
     runtime: Option<&str>,
+    pre_minted_run_id: Option<uuid::Uuid>,
 ) -> ! {
     let env_mp = parse_env_max_parallel();
     let resolved = match manifest::load_manifest_skip_dir_check(manifest, env_mp) {
@@ -684,7 +712,12 @@ fn run_container_dispatch(
         }
     };
     match dispatch::container::run_container_dispatch(
-        manifest, container, run_dir, dry_run, runtime,
+        manifest,
+        container,
+        run_dir,
+        dry_run,
+        runtime,
+        pre_minted_run_id,
     ) {
         Ok(()) => std::process::exit(0),
         Err(e) => {

--- a/crates/pitboss-cli/tests/container_dispatch_background_flows.rs
+++ b/crates/pitboss-cli/tests/container_dispatch_background_flows.rs
@@ -1,0 +1,180 @@
+//! Integration tests for `pitboss container-dispatch --background`.
+//!
+//! These exercise the parent's contract (validate, pre-mint a UUID v7,
+//! write `manifest.source.toml`, print a JSON announcement carrying
+//! `container: true`, exit 0) without requiring docker or podman to be
+//! present on the test host. The detached child will fail in
+//! `detect_runtime` when no runtime is installed — that's fine, because
+//! `manifest.source.toml` is written by the parent before the child is
+//! spawned. The Fork-manifest contract depends only on the parent's
+//! artifact write, not on the child reaching exec().
+
+mod support;
+
+use std::process::{Command, Stdio};
+use support::*;
+use tempfile::TempDir;
+
+#[test]
+fn background_writes_source_manifest_and_announces_run_id() {
+    ensure_built();
+    let repo = TempDir::new().unwrap();
+    init_git_repo(repo.path());
+    let run_dir = TempDir::new().unwrap();
+
+    let manifest_text = format!(
+        r#"
+[run]
+max_parallel_tasks = 1
+run_dir = "{run_dir}"
+worktree_cleanup = "always"
+
+[defaults]
+use_worktree = false
+
+[container]
+image = "ghcr.io/example/pitboss:latest"
+
+[[container.mount]]
+host = "{repo}"
+container = "/project"
+
+[[task]]
+id = "t1"
+directory = "/project"
+prompt = "p"
+"#,
+        run_dir = run_dir.path().display(),
+        repo = repo.path().display()
+    );
+    let manifest_path = repo.path().join("pitboss.toml");
+    std::fs::write(&manifest_path, &manifest_text).unwrap();
+
+    let mut cmd = Command::new(pitboss_binary());
+    cmd.arg("container-dispatch")
+        .arg(&manifest_path)
+        .arg("--background")
+        .arg("--run-dir")
+        .arg(run_dir.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let out = cmd
+        .output()
+        .expect("spawn pitboss container-dispatch --background");
+
+    assert!(
+        out.status.success(),
+        "parent should exit 0; stdout={:?} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let announce: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("stdout is not single JSON line: {stdout:?} ({e})"));
+    let announced_run_id = announce["run_id"]
+        .as_str()
+        .expect("run_id present")
+        .to_string();
+    let parsed = uuid::Uuid::parse_str(&announced_run_id).expect("valid UUID");
+    assert_eq!(parsed.get_version_num(), 7, "run_id must be UUID v7");
+    assert_eq!(
+        announce["container"].as_bool(),
+        Some(true),
+        "announcement must carry container: true so /api/runs callers can disambiguate"
+    );
+    assert!(announce["manifest_path"].as_str().is_some());
+    assert!(announce["started_at"].as_str().is_some());
+    assert!(announce["child_pid"].as_u64().is_some());
+
+    // manifest.source.toml must be on disk by the time the parent exits.
+    // This is the central correctness claim: the Fork-manifest endpoint
+    // can rely on the source artifact even if the detached child later
+    // fails to find docker/podman.
+    let source = run_dir
+        .path()
+        .join(&announced_run_id)
+        .join("manifest.source.toml");
+    assert!(
+        source.is_file(),
+        "manifest.source.toml must land at {} (run_dir contents: {:?})",
+        source.display(),
+        std::fs::read_dir(run_dir.path())
+            .ok()
+            .map(|d| d.flatten().map(|e| e.file_name()).collect::<Vec<_>>())
+    );
+    let on_disk = std::fs::read_to_string(&source).unwrap();
+    assert_eq!(
+        on_disk, manifest_text,
+        "source manifest bytes must match the operator-typed input verbatim"
+    );
+}
+
+#[test]
+fn background_rejects_manifest_without_container_section() {
+    // The pre-flight inside `run_container_background` mirrors
+    // `pitboss container-dispatch` foreground: a manifest with no
+    // `[container]` section is rejected before any spawn or announce.
+    ensure_built();
+    let repo = TempDir::new().unwrap();
+    init_git_repo(repo.path());
+
+    let manifest_path = repo.path().join("pitboss.toml");
+    std::fs::write(
+        &manifest_path,
+        format!(
+            r#"
+[defaults]
+use_worktree = false
+
+[[task]]
+id = "t1"
+directory = "{repo}"
+prompt = "p"
+"#,
+            repo = repo.path().display()
+        ),
+    )
+    .unwrap();
+
+    let out = Command::new(pitboss_binary())
+        .arg("container-dispatch")
+        .arg(&manifest_path)
+        .arg("--background")
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "should fail without [container]");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("[container]"),
+        "stderr must mention the missing section: {stderr}"
+    );
+}
+
+#[test]
+fn background_rejects_dry_run_combination() {
+    // --background and --dry-run are clap-mutually-exclusive at the
+    // ContainerDispatch arg level. Combining them must fail before the
+    // dispatcher body runs.
+    ensure_built();
+    let repo = TempDir::new().unwrap();
+    init_git_repo(repo.path());
+
+    let manifest_path = repo.path().join("pitboss.toml");
+    std::fs::write(&manifest_path, "[container]\n").unwrap();
+
+    let out = Command::new(pitboss_binary())
+        .arg("container-dispatch")
+        .arg(&manifest_path)
+        .arg("--background")
+        .arg("--dry-run")
+        .output()
+        .unwrap();
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--background") || stderr.contains("--dry-run"),
+        "clap should surface the conflict: {stderr}"
+    );
+}

--- a/crates/pitboss-web/spa/src/routes/manifests/[name]/+page.svelte
+++ b/crates/pitboss-web/spa/src/routes/manifests/[name]/+page.svelte
@@ -46,6 +46,15 @@
 
   const dirty = $derived(contents !== original);
 
+  // Detect a `[container]` section in the editor buffer so the operator
+  // can tell at a glance that clicking Dispatch will route to
+  // container-dispatch (via `/api/runs`'s auto-routing). The regex
+  // tolerates leading whitespace and matches only the top-level table
+  // header — `[container.mount]` and `[[container.copy]]` lines also
+  // match, which is fine since their presence implies a `[container]`
+  // root table.
+  const isContainerMode = $derived(/^\s*\[\[?container/m.test(contents));
+
   async function load() {
     loading = true;
     loadError = null;
@@ -166,6 +175,14 @@
     <CardContent class="text-muted-foreground py-12 text-center text-sm">Loading…</CardContent>
   </Card>
 {:else}
+  {#if isContainerMode}
+    <div
+      class="mb-3 rounded-md border border-sky-500/40 bg-sky-500/5 px-3 py-2 text-xs text-sky-700 dark:text-sky-300"
+    >
+      Container mode detected — dispatching this manifest will launch via
+      <code class="bg-sky-500/10 rounded px-1 py-0.5">pitboss container-dispatch</code>.
+    </div>
+  {/if}
   <div class="grid gap-4 lg:grid-cols-[1fr_22rem]">
     <Card>
       <CardHeader class="pb-3">

--- a/crates/pitboss-web/src/api/manifests.rs
+++ b/crates/pitboss-web/src/api/manifests.rs
@@ -258,6 +258,29 @@ pub async fn dispatch(
         return Err(ApiError::NotFound);
     }
 
+    // Auto-route: when the manifest declares a `[container]` section,
+    // shell to `pitboss container-dispatch --background` so the run
+    // launches in container mode. Otherwise stay on flat-mode
+    // `pitboss dispatch --background`. This is what makes the SPA's
+    // Dispatch button do the right thing for forks of
+    // container-dispatched runs (where the source manifest carries
+    // the `[container]` block back into the workspace).
+    let bytes = tokio::fs::read(&manifest_path).await?;
+    let subcommand = match toml::from_slice::<toml::Value>(&bytes) {
+        Ok(v) => {
+            if v.get("container").and_then(|c| c.as_table()).is_some() {
+                "container-dispatch"
+            } else {
+                "dispatch"
+            }
+        }
+        Err(e) => {
+            return Err(ApiError::BadRequest(format!(
+                "manifest is not valid TOML: {e}"
+            )));
+        }
+    };
+
     let bin = std::env::var("PITBOSS_BIN").unwrap_or_else(|_| "pitboss".to_string());
     // Forward state.runs_dir() to the dispatcher so the new run lands
     // where THIS console will read it from. Without this, the dispatcher
@@ -265,7 +288,7 @@ pub async fn dispatch(
     // the console's --runs-dir override, leaving the SPA staring at a
     // 404 while the run is happily running somewhere else.
     let output = tokio::process::Command::new(&bin)
-        .arg("dispatch")
+        .arg(subcommand)
         .arg(&manifest_path)
         .arg("--background")
         .arg("--run-dir")
@@ -319,13 +342,21 @@ pub async fn fork_run(
     Json(body): Json<ForkBody>,
 ) -> ApiResult<Json<ForkResult>> {
     let run_seg = sanitize_run_id(&run_id)?;
-    let snapshot = state
-        .runs_dir()
-        .join(run_seg)
-        .join("manifest.snapshot.toml");
-    if !snapshot.is_file() {
+    let run_subdir = state.runs_dir().join(run_seg);
+    // Prefer `manifest.source.toml` (written host-side by
+    // `pitboss container-dispatch` before exec) so a forked container
+    // run carries its full `[container]` block back into the workspace.
+    // Fall back to `manifest.snapshot.toml` for flat-mode runs and for
+    // container runs predating the host-side source-manifest write.
+    let source_path = run_subdir.join("manifest.source.toml");
+    let snapshot_path = run_subdir.join("manifest.snapshot.toml");
+    let pick = if source_path.is_file() {
+        source_path
+    } else if snapshot_path.is_file() {
+        snapshot_path
+    } else {
         return Err(ApiError::NotFound);
-    }
+    };
     let dest = manifest_path(state.manifests_dir(), &body.new_name)?;
     if let Some(parent) = dest.parent() {
         tokio::fs::create_dir_all(parent).await?;
@@ -335,7 +366,7 @@ pub async fn fork_run(
             "destination manifest already exists".into(),
         ));
     }
-    tokio::fs::copy(&snapshot, &dest).await?;
+    tokio::fs::copy(&pick, &dest).await?;
     Ok(Json(ForkResult {
         name: sanitize_manifest_name(&body.new_name)?.to_string(),
     }))

--- a/crates/pitboss-web/tests/dispatch_routing_integration.rs
+++ b/crates/pitboss-web/tests/dispatch_routing_integration.rs
@@ -1,0 +1,160 @@
+//! Verifies `/api/runs` auto-routes to `pitboss container-dispatch`
+//! when the saved manifest declares a `[container]` section, and to
+//! `pitboss dispatch` otherwise.
+//!
+//! We point `PITBOSS_BIN` at a fake-pitboss shell script that dumps its
+//! argv into a per-call log file and exits non-zero, so the endpoint
+//! surfaces the script's argv through `ApiError::BadRequest` (we don't
+//! depend on stderr parsing — we read the log directly).
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Mutex;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    routing::post,
+    Router,
+};
+use serde_json::json;
+use tower::ServiceExt;
+
+// `PITBOSS_BIN` is process-global; cargo's default test threading would
+// race two tests on the same env var. Serialize through a mutex held
+// for the full test body (env set → handler spawn → log read → env
+// unset). One mutex per file is plenty.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+#[allow(dead_code, unused_imports)]
+#[path = "../src/control_bridge.rs"]
+mod control_bridge;
+#[allow(dead_code, unused_imports)]
+#[path = "../src/error.rs"]
+mod error;
+#[allow(dead_code, unused_imports)]
+#[path = "../src/insights/mod.rs"]
+mod insights;
+#[allow(dead_code, unused_imports)]
+#[path = "../src/api/manifests.rs"]
+mod manifests;
+#[allow(dead_code, unused_imports)]
+#[path = "../src/state.rs"]
+mod state;
+
+use state::AppState;
+
+static FAKE_BIN_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+/// Lay down a one-shot shell script that records its argv to a log file
+/// and exits 1. Returns `(bin_path, log_path)`.
+fn lay_fake_pitboss() -> (PathBuf, PathBuf) {
+    let n = FAKE_BIN_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("pitboss-routing-test-{}-{n}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let log = dir.join("argv.log");
+    let bin = dir.join("fake-pitboss");
+    // Record every argv entry on its own line; exit 1 so the handler
+    // returns BadRequest (whose body we don't actually need).
+    let script = format!(
+        "#!/bin/sh\nfor a in \"$@\"; do printf '%s\\n' \"$a\" >> {log:?}; done\nexit 1\n",
+        log = log.display()
+    );
+    std::fs::write(&bin, script).unwrap();
+    let mut perms = std::fs::metadata(&bin).unwrap().permissions();
+    use std::os::unix::fs::PermissionsExt;
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&bin, perms).unwrap();
+    (bin, log)
+}
+
+fn fixture_router(manifests_dir: PathBuf, runs_dir: PathBuf) -> Router {
+    let st = AppState::new(runs_dir, manifests_dir, None);
+    Router::new()
+        .route("/api/runs", post(manifests::dispatch))
+        .with_state(st)
+}
+
+async fn post_dispatch(app: Router, manifest_name: &str) -> StatusCode {
+    let body = serde_json::to_vec(&json!({ "manifest_name": manifest_name })).unwrap();
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/runs")
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    res.status()
+}
+
+// `await_holding_lock`: deliberate. The env mutation (`PITBOSS_BIN`)
+// must remain in place across the spawn-and-await, and the
+// current_thread runtime means there's no second task that could
+// contend for the std::sync::Mutex.
+#[allow(clippy::await_holding_lock)]
+#[tokio::test(flavor = "current_thread")]
+async fn dispatch_routes_container_manifest_to_container_dispatch() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let manifests = tempfile::tempdir().unwrap();
+    let runs = tempfile::tempdir().unwrap();
+    let (bin, log) = lay_fake_pitboss();
+
+    std::fs::write(
+        manifests.path().join("with-container.toml"),
+        b"[container]\nimage = \"x\"\n\n[[container.mount]]\nhost = \"/h\"\ncontainer = \"/c\"\n\n[[task]]\nid = \"t\"\ndirectory = \"/c\"\nprompt = \"p\"\n",
+    )
+    .unwrap();
+
+    // SAFETY: ENV_LOCK serializes env mutation across tests in this file.
+    unsafe { std::env::set_var("PITBOSS_BIN", &bin) };
+
+    let app = fixture_router(manifests.path().to_path_buf(), runs.path().to_path_buf());
+    let status = post_dispatch(app, "with-container").await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "fake-pitboss exits 1 so the handler surfaces BadRequest"
+    );
+    let argv = std::fs::read_to_string(&log).expect("fake-pitboss must have run and logged argv");
+    let first_arg = argv.lines().next().unwrap_or("");
+    assert_eq!(
+        first_arg, "container-dispatch",
+        "container manifest must route to container-dispatch (full argv: {argv})"
+    );
+
+    unsafe { std::env::remove_var("PITBOSS_BIN") };
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test(flavor = "current_thread")]
+async fn dispatch_routes_flat_manifest_to_plain_dispatch() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let manifests = tempfile::tempdir().unwrap();
+    let runs = tempfile::tempdir().unwrap();
+    let (bin, log) = lay_fake_pitboss();
+
+    std::fs::write(
+        manifests.path().join("flat.toml"),
+        b"[[task]]\nid = \"t\"\ndirectory = \"/tmp\"\nprompt = \"p\"\n",
+    )
+    .unwrap();
+
+    // SAFETY: ENV_LOCK serializes env mutation across tests in this file.
+    unsafe { std::env::set_var("PITBOSS_BIN", &bin) };
+
+    let app = fixture_router(manifests.path().to_path_buf(), runs.path().to_path_buf());
+    let status = post_dispatch(app, "flat").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let argv = std::fs::read_to_string(&log).expect("fake-pitboss must have run and logged argv");
+    let first_arg = argv.lines().next().unwrap_or("");
+    assert_eq!(
+        first_arg, "dispatch",
+        "manifest without [container] must route to flat dispatch (full argv: {argv})"
+    );
+
+    unsafe { std::env::remove_var("PITBOSS_BIN") };
+}

--- a/crates/pitboss-web/tests/fork_prefers_source_integration.rs
+++ b/crates/pitboss-web/tests/fork_prefers_source_integration.rs
@@ -1,0 +1,118 @@
+//! Verifies that `POST /api/runs/:id/fork` prefers `manifest.source.toml`
+//! over `manifest.snapshot.toml` when both are present (the
+//! container-dispatch case), and falls back to `manifest.snapshot.toml`
+//! when only the snapshot exists (pre-fix runs and flat-mode runs).
+
+use std::path::PathBuf;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    routing::post,
+    Router,
+};
+use serde_json::json;
+use tower::ServiceExt;
+
+#[allow(dead_code, unused_imports)]
+#[path = "../src/control_bridge.rs"]
+mod control_bridge;
+#[allow(dead_code, unused_imports)]
+#[path = "../src/error.rs"]
+mod error;
+#[allow(dead_code, unused_imports)]
+#[path = "../src/insights/mod.rs"]
+mod insights;
+#[allow(dead_code, unused_imports)]
+#[path = "../src/api/manifests.rs"]
+mod manifests;
+#[allow(dead_code, unused_imports)]
+#[path = "../src/state.rs"]
+mod state;
+
+use state::AppState;
+
+const SOURCE_BYTES: &[u8] = b"[container]\nimage = \"src\"\n";
+const SNAPSHOT_BYTES: &[u8] = b"# stripped snapshot\n";
+
+fn fixture_router(manifests_dir: PathBuf, runs_dir: PathBuf) -> Router {
+    let st = AppState::new(runs_dir, manifests_dir, None);
+    Router::new()
+        .route("/api/runs/{run_id}/fork", post(manifests::fork_run))
+        .with_state(st)
+}
+
+async fn post_fork(app: Router, run_id: &str, new_name: &str) -> (StatusCode, Vec<u8>) {
+    let body = serde_json::to_vec(&json!({ "new_name": new_name })).unwrap();
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/runs/{run_id}/fork"))
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = res.status();
+    let bytes = axum::body::to_bytes(res.into_body(), 64 * 1024)
+        .await
+        .unwrap()
+        .to_vec();
+    (status, bytes)
+}
+
+#[tokio::test]
+async fn fork_prefers_source_manifest_when_both_present() {
+    let manifests = tempfile::tempdir().unwrap();
+    let runs = tempfile::tempdir().unwrap();
+    let run_id = uuid::Uuid::now_v7().to_string();
+    let run_subdir = runs.path().join(&run_id);
+    std::fs::create_dir_all(&run_subdir).unwrap();
+    std::fs::write(run_subdir.join("manifest.source.toml"), SOURCE_BYTES).unwrap();
+    std::fs::write(run_subdir.join("manifest.snapshot.toml"), SNAPSHOT_BYTES).unwrap();
+
+    let app = fixture_router(manifests.path().to_path_buf(), runs.path().to_path_buf());
+    let (status, _body) = post_fork(app, &run_id, "forked").await;
+    assert_eq!(status, StatusCode::OK, "fork should succeed");
+    let workspace = manifests.path().join("forked.toml");
+    let bytes = std::fs::read(&workspace).expect("fork must write workspace file");
+    assert_eq!(
+        bytes, SOURCE_BYTES,
+        "fork must prefer manifest.source.toml when both exist (got snapshot bytes back)"
+    );
+}
+
+#[tokio::test]
+async fn fork_falls_back_to_snapshot_when_no_source_present() {
+    // Pre-fix runs (and flat-mode runs) only have manifest.snapshot.toml.
+    // Fork must continue working against them — the artifact preference
+    // is opportunistic, not load-bearing.
+    let manifests = tempfile::tempdir().unwrap();
+    let runs = tempfile::tempdir().unwrap();
+    let run_id = uuid::Uuid::now_v7().to_string();
+    let run_subdir = runs.path().join(&run_id);
+    std::fs::create_dir_all(&run_subdir).unwrap();
+    std::fs::write(run_subdir.join("manifest.snapshot.toml"), SNAPSHOT_BYTES).unwrap();
+
+    let app = fixture_router(manifests.path().to_path_buf(), runs.path().to_path_buf());
+    let (status, _body) = post_fork(app, &run_id, "forked-flat").await;
+    assert_eq!(status, StatusCode::OK);
+    let workspace = manifests.path().join("forked-flat.toml");
+    let bytes = std::fs::read(&workspace).expect("fork must write workspace file");
+    assert_eq!(bytes, SNAPSHOT_BYTES);
+}
+
+#[tokio::test]
+async fn fork_returns_404_when_neither_artifact_present() {
+    let manifests = tempfile::tempdir().unwrap();
+    let runs = tempfile::tempdir().unwrap();
+    let run_id = uuid::Uuid::now_v7().to_string();
+    let run_subdir = runs.path().join(&run_id);
+    std::fs::create_dir_all(&run_subdir).unwrap();
+
+    let app = fixture_router(manifests.path().to_path_buf(), runs.path().to_path_buf());
+    let (status, _body) = post_fork(app, &run_id, "missing").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}


### PR DESCRIPTION
## Summary

This PR adds support for `pitboss container-dispatch --background`, enabling detached container-dispatched runs with proper manifest artifact preservation. It introduces a host-side pre-minting flow that writes `manifest.source.toml` before exec, ensuring the full `[container]` block is available for fork operations and web UI interactions.

## Key Changes

- **Background container-dispatch mode**: Added `run_container_background()` in `background.rs` that mirrors the flat-dispatch background flow but spawns `container-dispatch --internal-run-id` instead of `dispatch --internal-run-id`. Announces a JSON payload with `"container": true` to distinguish container runs from flat-mode ones.

- **Host-side manifest artifact writing**: Introduced `write_source_manifest_artifact()` that copies the operator's unmodified manifest to `manifest.source.toml` in the per-run directory before exec. This happens on the host (parent process) before the child is spawned, ensuring the artifact exists even if the detached child later fails to find docker/podman.

- **Pre-minted run ID threading**: Modified `run_container_dispatch()` to accept an optional `pre_minted_run_id` parameter. When provided (via `--internal-run-id`), this UUID is threaded into the in-container `pitboss dispatch` argv so the host-side and container-side run IDs match end-to-end.

- **Audit log enhancement**: Updated `append_container_dispatch_audit()` to include the `run_id` field in the JSON audit record for better traceability.

- **Web API auto-routing**: Modified `/api/runs` dispatch endpoint to detect `[container]` sections in saved manifests and automatically route to `container-dispatch --background` instead of flat `dispatch --background`. This ensures forked container runs preserve their `[container]` block.

- **Fork manifest preference**: Updated `/api/runs/:id/fork` to prefer `manifest.source.toml` over `manifest.snapshot.toml` when both exist, falling back to snapshot for pre-fix and flat-mode runs.

- **CLI argument updates**: Added `--background` and `--internal-run-id` flags to `ContainerDispatch` command, with `--dry-run` marked as conflicting with `--background`.

- **Web UI indicator**: Added container-mode detection in the manifest editor to visually indicate when a manifest will route to container-dispatch.

## Implementation Details

- The pre-minting flow ensures deterministic per-run directories before exec, allowing the host to write artifacts that the in-container dispatcher can locate using the same run ID.
- The `--internal-run-id` parameter is appended to both the shell-wrapped apt bootstrap command and the direct `pitboss dispatch` invocation, maintaining compatibility with both bootstrap and non-bootstrap paths.
- Manifest artifact writes are fail-soft (logged as warnings) to match the audit log behavior, ensuring a fork disconnect doesn't abort the dispatch.
- Integration tests verify the background flow writes artifacts correctly and that the web API routes manifests appropriately based on `[container]` presence.

https://claude.ai/code/session_01SvDhUxufrsF5kKdm9sgpLE