### PR TITLE
MCP server hardening (F-SEC-3/4/5/6)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1419,7 +1419,7 @@ Match fields (all optional; unset fields match any value):
 |---|---|---|
 | `actor` | string | `ActorPath` rendered as `"root"` or `"root→S1"` or `"root→S1→W3"` |
 | `category` | string | snake_case enum: `"tool_use"`, `"plan"`, `"cost"`, `"other"` |
-| `tool_name` | string | Exact tool name; only meaningful when `category = "tool_use"` |
+| `tool_name` | string | Tool-name matcher, only meaningful when `category = "tool_use"`. Supports glob patterns (`mcp__myserver__*` matches every tool from one MCP server, `*` matches any). A bare name like `"Bash"` matches exactly. (#530) |
 | `cost_over` | float | Matches when the `cost_estimate` hint on the approval exceeds this USD value. **Advisory only** — `cost_estimate` is caller-supplied; an actor that passes `cost_estimate=0.0` bypasses any threshold. For hard cost gates use `auto_reject` on `tool_name`/`actor`, or the server-side `[run].budget_usd` cap. (F-SEC-8 / #531) |
 
 Action values (snake_case):

--- a/book/src/operator-guide/approval-policy-reference.md
+++ b/book/src/operator-guide/approval-policy-reference.md
@@ -34,7 +34,7 @@ action = "block"
 |-------|------|--------------|-------|
 | `actor` | string (optional) | The approval's `actor_path` rendered as a string (e.g., `"root"` or `"root→S1"`) equals the value | Use `"root"` for root-level requests. Use `"root→<sublead_id>"` for a specific sub-lead; sub-lead IDs are UUIDv7 and runtime-generated, so this field is most useful when you know the sub-lead's identity in advance — e.g., from a prior `spawn_sublead` response. Exact string match only; no wildcard patterns. |
 | `category` | enum (optional) | The approval's category field equals the value exactly | Allowed values: `"tool_use"`, `"plan"`, `"cost"`, `"other"`. Most `request_approval` calls land in `tool_use`; `propose_plan` lands in `plan`. Cost-category approvals are not emitted by default (see deferment notes). |
-| `tool_name` | string (optional) | The lead's optional `tool_name` hint on `request_approval` equals the value | Only fires if the lead populates the optional `tool_name` arg. Without it, this field never matches. Exact string match only. |
+| `tool_name` | string (optional) | The lead's optional `tool_name` hint on `request_approval` matches the value as a glob pattern (`mcp__myserver__*`, `*`, or a bare name like `"Bash"` for exact match) | Only fires if the lead populates the optional `tool_name` arg. Without it, this field never matches. Glob patterns from the `glob` crate (since #530); invalid patterns silently fall back to exact-string comparison. |
 | `cost_over` | float (optional) | The lead's optional `cost_estimate` hint exceeds this threshold (strict `>` comparison) | Only fires if the lead passes a `cost_estimate` arg to `request_approval`. Without it, this field never matches. Numeric greater-than comparison. **Advisory only** — see [Cost gates: advisory vs hard](#cost-gates-advisory-vs-hard) below. |
 
 ---
@@ -146,9 +146,9 @@ The following features are not in v0.6 but are requested or planned:
 
 TUI commands to add/remove rules mid-run are deferred to v0.7+. v0.6 reads the policy once at manifest load. You cannot change rules while a run is in flight.
 
-### No regex or glob patterns in match values
+### `tool_name` supports glob patterns; `actor` is exact-match only
 
-Match fields support exact string comparison only. Wildcard patterns like `tool_name = "Read*"` or `actor = "root→sublead-*"` are not supported. Matching is literal. If you have a use case that needs wildcard matching (e.g., "auto-approve all Read variants"), please file an issue.
+`tool_name` accepts glob patterns from the `glob` crate (since #530) — e.g. `mcp__myserver__*` matches every tool a single MCP server exposes, and `*` matches any tool name. A bare name like `"Bash"` continues to match exactly. `actor` and `category` are still exact-string comparisons; matching e.g. `actor = "root→sublead-*"` is not yet supported. File an issue if the actor-side wildcard would help.
 
 ### Cost-category approvals are not emitted by default
 

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -32,6 +32,7 @@ fn validate_inner(resolved: &ResolvedManifest, skip_dir_check: bool) -> Result<(
     validate_mcp_server_scopes(resolved)?;
     validate_mcp_server_tools(resolved)?;
     validate_mcp_tool_consistency(resolved)?;
+    warn_unknown_actor_type_tools(resolved);
     validate_agent_profiles(resolved)?;
     validate_claude_setting_sources(resolved)?;
     if resolved.lead.is_some() {
@@ -381,6 +382,119 @@ fn validate_mcp_tool_consistency(r: &ResolvedManifest) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Warn on `[[worker_type]].tools` / `[[sublead_type]].tools` entries
+/// that don't match any known claude-code built-in, pitboss MCP tool, or
+/// declared `[[mcp_server]]` namespace (F-SEC-5 / #529).
+///
+/// The typed-profile gate fails CLOSED — an unrecognized entry results
+/// in `DeniedByProfile` auto-deny at runtime, not auto-approve — so this
+/// is a typo-drift safety net, not a security gate. We warn rather than
+/// bail because:
+/// - Operators legitimately reference `mcp__<server>__<tool>` for
+///   third-party MCP servers we don't ship; raising those to errors
+///   would require enumerating every conceivable tool.
+/// - claude-code adds tools across releases; a bailing check goes stale
+///   the next time a new built-in lands. The warn-only stance ages
+///   gracefully.
+///
+/// `mcp__<declared-server>__<tool>` entries are already checked for
+/// allowlist consistency by [`validate_mcp_tool_consistency`]; this
+/// function complements that by catching typos in the bare-name and
+/// `mcp__pitboss__*` cases.
+fn warn_unknown_actor_type_tools(r: &ResolvedManifest) {
+    use crate::dispatch::runner::{COMMUNICATION_MCP_TOOLS, PITBOSS_MCP_TOOLS_BASE};
+
+    // Snapshot of claude-code's documented built-in tool names as of
+    // 2026-05. Lower-case `mcp__*` and operator-namespaced tools are
+    // handled separately below. Sourced from
+    // <https://docs.claude.com/en/docs/build-with-claude/tool-use> and
+    // the claude-code release notes; update when claude-code introduces
+    // a new built-in. Out-of-list entries do not bail — they emit a
+    // `tracing::warn` so the operator notices a likely typo without
+    // blocking the run.
+    const KNOWN_CLAUDE_TOOLS: &[&str] = &[
+        "Bash",
+        "BashOutput",
+        "Edit",
+        "ExitPlanMode",
+        "Glob",
+        "Grep",
+        "KillShell",
+        "MultiEdit",
+        "NotebookEdit",
+        "Read",
+        "SlashCommand",
+        "Task",
+        "TodoWrite",
+        "WebFetch",
+        "WebSearch",
+        "Write",
+    ];
+
+    fn check_entry(surface: &str, entry: &str, declared_servers: &[String]) {
+        // mcp__pitboss__* — match against the static pitboss tool set.
+        if let Some(rest) = entry.strip_prefix("mcp__pitboss__") {
+            let known = PITBOSS_MCP_TOOLS_BASE
+                .iter()
+                .chain(COMMUNICATION_MCP_TOOLS.iter())
+                .any(|t| t.strip_prefix("mcp__pitboss__") == Some(rest));
+            if !known {
+                tracing::warn!(
+                    "{surface}: tool {entry:?} does not match any known \
+                     pitboss MCP tool. Likely a typo — at runtime the \
+                     typed-profile gate will auto-deny this entry. \
+                     Check `pitboss agents-md` for the canonical list."
+                );
+            }
+            return;
+        }
+        // mcp__<server>__* — `validate_mcp_tool_consistency` already
+        // checks per-server allowlists. We only warn when the prefix
+        // matches a server id that ISN'T declared (operator referenced a
+        // server they forgot to declare). The longest-prefix-match logic
+        // mirrors `parse_mcp_tool_name`.
+        if let Some(rest) = entry.strip_prefix("mcp__") {
+            let resolves = declared_servers.iter().any(|id| {
+                rest.len() > id.len() + 2
+                    && rest.starts_with(id)
+                    && rest[id.len()..].starts_with("__")
+            });
+            if !resolves {
+                tracing::warn!(
+                    "{surface}: tool {entry:?} references an MCP server \
+                     that is not declared via `[[mcp_server]]`. Either \
+                     declare the server or remove the entry — at runtime \
+                     the typed-profile gate will auto-deny this entry."
+                );
+            }
+            return;
+        }
+        // Bare name — must match a known claude built-in.
+        if !KNOWN_CLAUDE_TOOLS.contains(&entry) {
+            tracing::warn!(
+                "{surface}: tool {entry:?} is not a known claude-code \
+                 built-in. Likely a typo — at runtime the typed-profile \
+                 gate will auto-deny this entry. Known built-ins: {known:?}",
+                known = KNOWN_CLAUDE_TOOLS,
+            );
+        }
+    }
+
+    let declared_servers: Vec<String> = r.mcp_servers.iter().map(|s| s.id.clone()).collect();
+    for wt in &r.worker_types {
+        let surface = format!("[[worker_type]] {:?}.tools", wt.id);
+        for entry in &wt.tools {
+            check_entry(&surface, entry, &declared_servers);
+        }
+    }
+    for st in &r.sublead_types {
+        let surface = format!("[[sublead_type]] {:?}.tools", st.id);
+        for entry in &st.tools {
+            check_entry(&surface, entry, &declared_servers);
+        }
+    }
 }
 
 /// Reject zero ceilings on `[communication]`. Zero would silently disable

--- a/crates/pitboss-cli/src/mcp/policy.rs
+++ b/crates/pitboss-cli/src/mcp/policy.rs
@@ -26,7 +26,10 @@ pub struct ApprovalMatch {
     /// Match category exactly
     #[serde(default)]
     pub category: Option<ApprovalCategory>,
-    /// Match exact tool name (relevant for ToolUse category)
+    /// Match tool name (relevant for ToolUse category). Supports glob
+    /// patterns from the `glob` crate: `mcp__myserver__*` matches every
+    /// tool exposed by an MCP server, `*` matches any tool, and a bare
+    /// name like `"Bash"` continues to match exactly. (F-SEC-6 / #530)
     #[serde(default)]
     pub tool_name: Option<String>,
     /// Match if approval's cost > this value (relevant for Cost category).
@@ -98,9 +101,24 @@ fn rule_matches(
         }
     }
     if let Some(want) = &m.tool_name {
-        match tool_name {
-            Some(actual) if actual == want => {}
-            _ => return false,
+        let Some(actual) = tool_name else {
+            return false;
+        };
+        // F-SEC-6 (#530): treat the rule's tool_name as a glob so
+        // operators can match `mcp__myserver__*` against every tool a
+        // single MCP server exposes without enumerating each one. An
+        // invalid pattern silently falls back to exact match — the
+        // matcher is the wrong place to surface manifest errors, and
+        // failing closed (no match) would change semantics for any
+        // existing rule that happens to contain glob metacharacters.
+        match glob::Pattern::new(want) {
+            Ok(pat) if pat.matches(actual) => {}
+            Ok(_) => return false,
+            Err(_) => {
+                if actual != want {
+                    return false;
+                }
+            }
         }
     }
     // `cost_over` rules fire whenever the caller provides an explicit
@@ -210,7 +228,7 @@ mod tests {
     }
 
     #[test]
-    fn tool_name_match_requires_exact_string() {
+    fn tool_name_match_exact_string() {
         let m = PolicyMatcher::new(vec![ApprovalRule {
             r#match: ApprovalMatch {
                 tool_name: Some("Bash".into()),
@@ -224,6 +242,49 @@ mod tests {
             Some(ApprovalAction::AutoReject)
         );
         assert_eq!(m.evaluate(&a, Some("Edit"), None), None);
+        assert_eq!(m.evaluate(&a, None, None), None);
+    }
+
+    #[test]
+    fn tool_name_match_glob_mcp_server_prefix() {
+        let m = PolicyMatcher::new(vec![ApprovalRule {
+            r#match: ApprovalMatch {
+                tool_name: Some("mcp__myserver__*".into()),
+                ..Default::default()
+            },
+            action: ApprovalAction::AutoApprove,
+        }]);
+        let a = mk_approval(ActorPath::new(["root"]), ApprovalCategory::ToolUse);
+        assert_eq!(
+            m.evaluate(&a, Some("mcp__myserver__read"), None),
+            Some(ApprovalAction::AutoApprove)
+        );
+        assert_eq!(
+            m.evaluate(&a, Some("mcp__myserver__write_file"), None),
+            Some(ApprovalAction::AutoApprove)
+        );
+        assert_eq!(m.evaluate(&a, Some("mcp__otherserver__read"), None), None);
+        assert_eq!(m.evaluate(&a, Some("Bash"), None), None);
+    }
+
+    #[test]
+    fn tool_name_match_glob_wildcard() {
+        let m = PolicyMatcher::new(vec![ApprovalRule {
+            r#match: ApprovalMatch {
+                tool_name: Some("*".into()),
+                ..Default::default()
+            },
+            action: ApprovalAction::Block,
+        }]);
+        let a = mk_approval(ActorPath::new(["root"]), ApprovalCategory::ToolUse);
+        assert_eq!(
+            m.evaluate(&a, Some("Bash"), None),
+            Some(ApprovalAction::Block)
+        );
+        assert_eq!(
+            m.evaluate(&a, Some("mcp__pitboss__spawn_worker"), None),
+            Some(ApprovalAction::Block)
+        );
         assert_eq!(m.evaluate(&a, None, None), None);
     }
 }

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -346,33 +346,40 @@ impl PitbossHandler {
     /// core of issue #145.
     ///
     /// Errors:
-    /// - `_meta` missing entirely: returns `Ok(())` (per-tool MetaField
-    ///   handlers will reject if they require it; read-only tools that
-    ///   accept `Option<MetaField>` continue to work without identity).
+    /// - `_meta` missing entirely (no `arguments` map, or no `_meta`
+    ///   key): rejected with `invalid-request` (F-SEC-4 / #528). Pre-
+    ///   #528 this returned `Ok(())` and deferred identity checks to
+    ///   per-tool handlers, which left a defense-in-depth gap: a tool
+    ///   declared with `Option<MetaField>` was silently anonymous-
+    ///   callable. The bridge injects `_meta` on every `tools/call`, so
+    ///   this strict check is invisible to production callers.
     /// - `_meta.token` present but unknown / unbindable: returns an
     ///   invalid-request error (the connection has presented a token
     ///   we did not mint).
     /// - `_meta.token` missing AND no identity already bound: returns
     ///   an invalid-request error if the wire claims an actor_id (a
     ///   weak forgery — likely a direct socket connection that bypasses
-    ///   the bridge). Calls without any `_meta` at all are still
-    ///   rejected by per-tool handlers that require it.
+    ///   the bridge).
     async fn authenticate_and_rebind(
         &self,
         request: &mut rmcp::model::CallToolRequestParams,
     ) -> Result<(), ErrorData> {
-        // Reach into params.arguments._meta. If the caller didn't supply
-        // arguments at all, there's nothing to authenticate — let the
-        // per-tool handler decide how to react.
-        let Some(args) = request.arguments.as_mut() else {
-            return Ok(());
-        };
-        // Pull out _meta as a mutable JSON object slot.
-        let Some(meta_val) = args.get_mut("_meta") else {
-            // No _meta on the wire. Per-tool handlers that require
-            // identity will reject; bail-out tools (read-only KV) accept.
-            return Ok(());
-        };
+        // F-SEC-4 (#528): require `_meta` on every tool call. The bridge
+        // injects it for production callers; tests connect via
+        // `FakeMcpClient::connect_as` / `connect_with_token` which also
+        // inject. Rejecting at the auth layer means a new tool with
+        // `Option<MetaField>` cannot accidentally create an anonymous
+        // surface — handlers no longer carry the "what if _meta is
+        // absent" branch as a defense-in-depth concern.
+        const MISSING_META_MSG: &str = "missing _meta on tool call: every tools/call must carry \
+             _meta.actor_id + _meta.actor_role (connect via pitboss mcp-bridge)";
+        let args = request
+            .arguments
+            .as_mut()
+            .ok_or_else(|| ErrorData::invalid_request(MISSING_META_MSG.to_string(), None))?;
+        let meta_val = args
+            .get_mut("_meta")
+            .ok_or_else(|| ErrorData::invalid_request(MISSING_META_MSG.to_string(), None))?;
         let Some(meta_obj) = meta_val.as_object_mut() else {
             return Err(ErrorData::invalid_request(
                 "_meta must be an object".to_string(),

--- a/crates/pitboss-cli/src/mcp/server.rs
+++ b/crates/pitboss-cli/src/mcp/server.rs
@@ -1472,7 +1472,22 @@ impl McpServer {
         if socket_path.exists() {
             let _ = std::fs::remove_file(&socket_path);
         }
-        let listener = tokio::net::UnixListener::bind(&socket_path).with_context(|| {
+        // F-SEC-3 (#527): clamp the process umask to 0o077 across `bind()`
+        // so the socket file is created with 0o600 atomically rather than
+        // inheriting an inherited 0o022 umask and being world-readable for
+        // the window between `bind()` and the post-hoc `set_permissions`.
+        // Restored immediately after — `start()` is called once per run
+        // from a single call site (`hierarchical::run`/`runner::run`), so
+        // the window where this thread's umask is restrictive cannot race
+        // with another file creation in the same process.
+        #[cfg(unix)]
+        let _prev_umask = unsafe { libc::umask(0o077) };
+        let bind_result = tokio::net::UnixListener::bind(&socket_path);
+        #[cfg(unix)]
+        unsafe {
+            libc::umask(_prev_umask);
+        }
+        let listener = bind_result.with_context(|| {
             format!(
                 "bind MCP socket at {} (#550: on macOS+Podman the runs dir is virtiofs-backed, \
                  which rejects AF_UNIX bind() with EINVAL — set [container].extra_args = [\"-e\", \
@@ -1480,10 +1495,9 @@ impl McpServer {
                 socket_path.display()
             )
         })?;
-        // Explicit hardening — inherited umask (e.g. 0022) would leave the
-        // socket world-readable, letting any local user connect and inject
-        // `actor_role: root_lead` in _meta to call spawn_worker / kv_set.
-        // 0o600 restricts to the running user.
+        // Belt-and-braces: re-assert 0o600 after the bind in case the
+        // umask clamp above was a no-op (e.g. a future non-Unix port, or
+        // a platform where umask doesn't apply to AF_UNIX sockets).
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;

--- a/crates/pitboss-cli/tests/e2e_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_flows.rs
@@ -61,6 +61,12 @@ fn mk_state(
 
 /// Build + spawn fake-claude as the lead subprocess, connecting to `mcp_sock`.
 /// Returns the SessionOutcome.
+///
+/// Retained for completeness even though every current caller routes via
+/// the bridge — F-SEC-4 (#528) requires `_meta` on every tools/call, so
+/// direct-socket usage will hit `invalid_request` at the auth layer. New
+/// tests should prefer [`run_fake_claude_lead_via_bridge`].
+#[allow(dead_code)]
 async fn run_fake_claude_lead(
     cwd: &std::path::Path,
     script_path: &std::path::Path,
@@ -188,10 +194,17 @@ async fn e2e_lead_spawns_worker_via_real_subprocess() {
 
     // Run fake-claude as the lead. A real TokioSpawner subprocess, not the
     // FakeSpawner in state.root.spawner (which backs the workers it spawns).
-    let outcome = run_fake_claude_lead(
+    // Route through the bridge with a minted token — F-SEC-4 (#528) now
+    // rejects tools/call without _meta at the auth layer, so the direct-
+    // socket path is no longer a viable test shortcut.
+    let token = state.mint_token("lead", "lead").await;
+    let outcome = run_fake_claude_lead_via_bridge(
         dir.path(),
         &script,
         &sock,
+        "lead",
+        "lead",
+        &token,
         CancelToken::new(),
         Duration::from_secs(30),
     )
@@ -251,10 +264,14 @@ async fn e2e_lead_spawns_three_workers_and_waits_for_any() {
 "#;
     tokio::fs::write(&script, script_body).await.unwrap();
 
-    let outcome = run_fake_claude_lead(
+    let token = state.mint_token("lead", "lead").await;
+    let outcome = run_fake_claude_lead_via_bridge(
         dir.path(),
         &script,
         &sock,
+        "lead",
+        "lead",
+        &token,
         CancelToken::new(),
         Duration::from_secs(30),
     )
@@ -507,10 +524,14 @@ async fn e2e_lead_request_approval_round_trip() {
 "#;
     tokio::fs::write(&script, script_body).await.unwrap();
 
-    let outcome = run_fake_claude_lead(
+    let token = state.mint_token("lead", "lead").await;
+    let outcome = run_fake_claude_lead_via_bridge(
         dir.path(),
         &script,
         &mcp_sock,
+        "lead",
+        "lead",
+        &token,
         CancelToken::new(),
         Duration::from_secs(30),
     )
@@ -933,10 +954,14 @@ async fn e2e_lead_propose_plan_gate_unblocks_spawn() {
 "#;
     tokio::fs::write(&script, script_body).await.unwrap();
 
-    let outcome = run_fake_claude_lead(
+    let token = state.mint_token("lead", "lead").await;
+    let outcome = run_fake_claude_lead_via_bridge(
         dir.path(),
         &script,
         &mcp_sock,
+        "lead",
+        "lead",
+        &token,
         CancelToken::new(),
         Duration::from_secs(30),
     )


### PR DESCRIPTION
## Summary

Closes the four MCP-server audit findings from the 2026-05-14 codebase review (Group B in the punch list). Each finding lands as its own commit so `git-cliff` routes them into the right CHANGELOG section under rebase-merge.

| Commit | Issue | Type | Change |
|---|---|---|---|
| `fix(mcp): close TOCTOU window between socket bind and chmod` | #527 (F-SEC-3) | Fixed | Clamp umask to `0o077` across `bind()` so the socket is created `0o600` atomically; keep post-hoc `set_permissions` as belt-and-braces. |
| `fix(mcp): require _meta on every tools/call` | #528 (F-SEC-4) | Fixed | `authenticate_and_rebind` rejects `_meta`-absent calls at the auth layer instead of deferring to per-tool handlers. Closes the defense-in-depth gap where any tool declaring `meta: Option<MetaField>` was silently anonymous-callable. |
| `feat(manifest): warn on unknown tools in [[worker_type]] / [[sublead_type]]` | #529 (F-SEC-5) | Added | New `warn_unknown_actor_type_tools` validator surfaces typo-drift (e.g. `"Bahs"` vs `"Bash"`) that would otherwise auto-deny silently via the typed-profile gate. Warn-only — operator manifests legitimately reference third-party MCP tools. |
| `feat(approval): glob matching on [[approval_policy]] tool_name` | #530 (F-SEC-6) | Added | `ApprovalMatch.tool_name` now accepts glob patterns (`mcp__myserver__*`, `*`, bare names for exact match). Reduces policy-drift burden when an MCP server adds new tools. |

### Test fallout

Four `e2e_flows` tests that wired `fake-claude` through the direct-socket path are converted to route via `pitboss mcp-bridge` with a minted token. The bridge has been production reality since v0.5; tests now mirror it. `run_fake_claude_lead` is retained (`#[allow(dead_code)]`) with a doc note pointing future tests at the bridge variant.

### Test plan

- [x] `cargo lint` clean
- [x] `cargo tidy` clean
- [x] `cargo test --workspace --features pitboss-core/test-support` — full sweep green (one flake on `e2e_lead_request_approval_round_trip` under parallel load; passes consistently in isolation, pre-existing timing issue unrelated to this branch)
- [x] `cargo test -p pitboss-cli --lib mcp::policy` — 7 tests including new glob coverage
- [x] `cargo test -p pitboss-cli --test e2e_flows` — 10 tests, all green
- [x] AGENTS.md + book reference updated for the new `tool_name` glob semantics

Closes #527
Closes #528
Closes #529
Closes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)