### PR TITLE
refactor(notify): extract pure env-value parsers (close #351 / F-TEST-11)

### DIFF
--- a/crates/pitboss-cli/src/notify/config.rs
+++ b/crates/pitboss-cli/src/notify/config.rs
@@ -79,7 +79,25 @@ fn default_severity_min() -> Severity {
 /// Walk a mutable string: replace `${IDENT}` tokens with the value of
 /// `std::env::var(IDENT)`. Errors if any `${IDENT}` has no matching env var
 /// or if the name does not start with `PITBOSS_` (see ENV_VAR_ALLOWED_PREFIX).
+///
+/// Thin wrapper over [`substitute_env_vars_with`]; tests should call the
+/// pure variant with a closure to avoid mutating `std::env`. (#351 /
+/// F-TEST-11)
 pub fn substitute_env_vars(s: &str) -> Result<String> {
+    substitute_env_vars_with(s, |name| std::env::var(name).ok())
+}
+
+/// Pure variant of [`substitute_env_vars`]. `lookup` receives each
+/// `${IDENT}` name and returns the value to substitute (or `None` to
+/// emit the same "env var is not set" error the env-reading variant
+/// would). Used by callers that need deterministic substitution
+/// independent of the process env (notably the test suite, which would
+/// otherwise need `#[serial(env)]` on every call site to keep the glibc
+/// `setenv`/`getenv` race contained).
+pub fn substitute_env_vars_with<F>(s: &str, lookup: F) -> Result<String>
+where
+    F: Fn(&str) -> Option<String>,
+{
     let mut out = String::with_capacity(s.len());
     let mut rest = s;
     while !rest.is_empty() {
@@ -98,7 +116,7 @@ pub fn substitute_env_vars(s: &str) -> Result<String> {
                      (rename the var to `{ENV_VAR_ALLOWED_PREFIX}{name}` or similar)"
                 );
             }
-            let val = std::env::var(name).map_err(|_| {
+            let val = lookup(name).ok_or_else(|| {
                 anyhow::anyhow!("notification uses ${{{name}}} but env var is not set")
             })?;
             out.push_str(&val);
@@ -114,8 +132,17 @@ pub fn substitute_env_vars(s: &str) -> Result<String> {
 /// Run env-var substitution over every string field of the config.
 /// Currently just `url`; keep extensible if we add more string fields.
 pub fn apply_env_substitution(cfg: &mut NotificationConfig) -> Result<()> {
+    apply_env_substitution_with(cfg, |name| std::env::var(name).ok())
+}
+
+/// Pure variant of [`apply_env_substitution`]. Used by the test suite
+/// to avoid `std::env` mutation; see [`substitute_env_vars_with`].
+pub fn apply_env_substitution_with<F>(cfg: &mut NotificationConfig, lookup: F) -> Result<()>
+where
+    F: Fn(&str) -> Option<String>,
+{
     if let Some(url) = cfg.url.as_mut() {
-        *url = substitute_env_vars(url)?;
+        *url = substitute_env_vars_with(url, lookup)?;
     }
     Ok(())
 }
@@ -404,21 +431,33 @@ fn is_disallowed_ip(ip: &IpAddr) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serial_test::serial;
+
+    // #351 / F-TEST-11: the four `substitute_env_vars` tests below used
+    // to mutate `std::env` and were gated on `#[serial(env)]`. The
+    // refactor extracted `substitute_env_vars_with(s, lookup)` which
+    // takes a closure for the env-var lookup; each test now passes its
+    // own deterministic closure instead of touching the process env,
+    // eliminating the glibc setenv/getenv race entirely.
+
+    fn lookup<'a>(pairs: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<String> + 'a {
+        move |name: &str| {
+            pairs
+                .iter()
+                .find_map(|(k, v)| (*k == name).then(|| (*v).to_string()))
+        }
+    }
 
     #[test]
-    #[serial(env)]
     fn env_var_substitution_replaces_tokens() {
-        std::env::set_var("PITBOSS_NOTIFY_TEST_URL", "https://example.com/hook");
-        let out = substitute_env_vars("${PITBOSS_NOTIFY_TEST_URL}/sub").unwrap();
+        let lk = lookup(&[("PITBOSS_NOTIFY_TEST_URL", "https://example.com/hook")]);
+        let out = substitute_env_vars_with("${PITBOSS_NOTIFY_TEST_URL}/sub", lk).unwrap();
         assert_eq!(out, "https://example.com/hook/sub");
     }
 
     #[test]
-    #[serial(env)]
     fn env_var_missing_fails_loud() {
-        std::env::remove_var("PITBOSS_NOTIFY_TEST_MISSING_XYZ");
-        let err = substitute_env_vars("${PITBOSS_NOTIFY_TEST_MISSING_XYZ}").unwrap_err();
+        let lk = lookup(&[]);
+        let err = substitute_env_vars_with("${PITBOSS_NOTIFY_TEST_MISSING_XYZ}", lk).unwrap_err();
         assert!(err.to_string().contains("env var is not set"));
     }
 
@@ -428,10 +467,12 @@ mod tests {
     /// URL — both are runtime values pitboss itself sets, and one of them
     /// (PITBOSS_PARENT_NOTIFY_URL) is itself a sensitive operator endpoint.
     #[test]
-    #[serial(env)]
     fn env_var_pitboss_run_id_not_substitutable() {
-        std::env::set_var("PITBOSS_RUN_ID", "019d0000-aaaa-bbbb-cccc-dddddddddddd");
-        let err = substitute_env_vars("${PITBOSS_RUN_ID}").unwrap_err();
+        // Even if PITBOSS_RUN_ID is "set" in our test lookup, the prefix
+        // check rejects it before lookup runs — proving the narrowed
+        // prefix is enforced at parse time, not just at env-read time.
+        let lk = lookup(&[("PITBOSS_RUN_ID", "019d0000-aaaa-bbbb-cccc-dddddddddddd")]);
+        let err = substitute_env_vars_with("${PITBOSS_RUN_ID}", lk).unwrap_err();
         let msg = err.to_string();
         assert!(
             msg.contains("PITBOSS_NOTIFY_"),
@@ -473,10 +514,9 @@ url = "https://example.com""#;
     }
 
     #[test]
-    #[serial(env)]
     fn env_var_without_pitboss_prefix_rejected() {
-        std::env::set_var("NOTIFY_TEST_FOREIGN", "leaked");
-        let err = substitute_env_vars("${NOTIFY_TEST_FOREIGN}").unwrap_err();
+        let lk = lookup(&[("NOTIFY_TEST_FOREIGN", "leaked")]);
+        let err = substitute_env_vars_with("${NOTIFY_TEST_FOREIGN}", lk).unwrap_err();
         let msg = err.to_string();
         assert!(
             msg.contains("PITBOSS_NOTIFY_"),

--- a/crates/pitboss-cli/src/notify/mod.rs
+++ b/crates/pitboss-cli/src/notify/mod.rs
@@ -193,6 +193,18 @@ pub const DEFAULT_DEDUP_CACHE_SIZE: usize = 64;
 /// the value is non-numeric or zero. Issue #156 (L1).
 pub const DEDUP_CACHE_SIZE_ENV: &str = "PITBOSS_NOTIFY_DEDUP_CACHE_SIZE";
 
+/// Pure parser for the dedup-cache-size env var. Returns the parsed
+/// capacity when the raw value trims to a positive integer; falls back
+/// to [`DEFAULT_DEDUP_CACHE_SIZE`] otherwise (non-numeric, zero, blank,
+/// or absent). Extracted from [`NotificationRouter::new`] so tests can
+/// verify the parsing logic without mutating `std::env`. (#351 /
+/// F-TEST-11)
+pub fn parse_dedup_cache_size(raw: Option<&str>) -> usize {
+    raw.and_then(|s| s.trim().parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(DEFAULT_DEDUP_CACHE_SIZE)
+}
+
 /// Router fans envelopes to multiple sinks with LRU dedup and retry.
 pub struct NotificationRouter {
     sinks: Vec<(Arc<dyn NotificationSink>, SinkFilter)>,
@@ -216,12 +228,8 @@ impl NotificationRouter {
     /// honors `PITBOSS_NOTIFY_DEDUP_CACHE_SIZE` when set to a positive
     /// integer, otherwise falls back to [`DEFAULT_DEDUP_CACHE_SIZE`].
     pub fn new(sinks: Vec<(Arc<dyn NotificationSink>, SinkFilter)>) -> Self {
-        let capacity = std::env::var(DEDUP_CACHE_SIZE_ENV)
-            .ok()
-            .and_then(|s| s.trim().parse::<usize>().ok())
-            .filter(|n| *n > 0)
-            .unwrap_or(DEFAULT_DEDUP_CACHE_SIZE);
-        Self::new_with_capacity(sinks, capacity)
+        let raw = std::env::var(DEDUP_CACHE_SIZE_ENV).ok();
+        Self::new_with_capacity(sinks, parse_dedup_cache_size(raw.as_deref()))
     }
 
     /// Like [`Self::new`] but with an explicit dedup-cache size — used by
@@ -423,7 +431,6 @@ fn is_fatal(err: &anyhow::Error) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serial_test::serial;
 
     #[test]
     fn severity_ord_is_info_warning_error_critical() {
@@ -648,20 +655,27 @@ mod tests {
         assert!(body.contains("synthetic emit failure"), "{body}");
     }
 
-    /// #156 (L1) regression: env-var override of dedup cache size is
-    /// honored by `NotificationRouter::new`. We can't observe the cache
-    /// size directly, so we verify the constructor doesn't panic for an
-    /// extreme value (which a misuse of NonZeroUsize might).
+    /// #156 (L1) regression: the dedup-cache-size env-var parse logic
+    /// extracted into [`parse_dedup_cache_size`] honors valid positive
+    /// integers and falls back to the default for blank / zero /
+    /// non-numeric input. Pre-#351 this test mutated `std::env` and was
+    /// gated on `#[serial(env)]`; the pure parser eliminates the
+    /// `setenv`/`getenv` race entirely.
     #[test]
-    #[serial(env)]
-    fn router_new_honors_dedup_cache_size_env() {
-        std::env::set_var(DEDUP_CACHE_SIZE_ENV, "1024");
-        let _ = NotificationRouter::new(vec![]);
-        std::env::set_var(DEDUP_CACHE_SIZE_ENV, "0"); // should fall back to default
-        let _ = NotificationRouter::new(vec![]);
-        std::env::set_var(DEDUP_CACHE_SIZE_ENV, "not a number");
-        let _ = NotificationRouter::new(vec![]);
-        std::env::remove_var(DEDUP_CACHE_SIZE_ENV);
+    fn parse_dedup_cache_size_honors_positive_integer() {
+        assert_eq!(parse_dedup_cache_size(Some("1024")), 1024);
+        assert_eq!(parse_dedup_cache_size(Some("  1024  ")), 1024);
+    }
+
+    #[test]
+    fn parse_dedup_cache_size_falls_back_on_invalid() {
+        assert_eq!(parse_dedup_cache_size(None), DEFAULT_DEDUP_CACHE_SIZE);
+        assert_eq!(parse_dedup_cache_size(Some("")), DEFAULT_DEDUP_CACHE_SIZE);
+        assert_eq!(parse_dedup_cache_size(Some("0")), DEFAULT_DEDUP_CACHE_SIZE);
+        assert_eq!(
+            parse_dedup_cache_size(Some("not a number")),
+            DEFAULT_DEDUP_CACHE_SIZE
+        );
     }
 
     /// #187 regression: a poisoned `dedup_cache` mutex must not panic the

--- a/crates/pitboss-cli/src/notify/parent.rs
+++ b/crates/pitboss-cli/src/notify/parent.rs
@@ -61,9 +61,23 @@ pub const RUN_ID_ENV: &str = "PITBOSS_RUN_ID";
 /// hours later on the first emit). The returned sink bypasses the
 /// per-request SSRF guard — see the module-level comment for why that's
 /// safe.
+///
+/// This is a thin wrapper over [`build_parent_sink_from`] that reads the
+/// env var exactly once. Tests should call the pure variant directly to
+/// avoid the `setenv`/`getenv` race documented in #351 / F-TEST-11.
 pub fn build_parent_sink(http: &Arc<reqwest::Client>) -> Option<Arc<dyn NotificationSink>> {
-    let url = std::env::var(PARENT_NOTIFY_URL_ENV).ok()?;
-    let trimmed = url.trim();
+    build_parent_sink_from(std::env::var(PARENT_NOTIFY_URL_ENV).ok().as_deref(), http)
+}
+
+/// Pure variant of [`build_parent_sink`]. Takes the raw env-var value
+/// (`None` for unset) as an argument so callers can construct it without
+/// process-wide env mutation. Production code routes through the
+/// `_from_env` wrapper above; tests pass the value directly.
+pub fn build_parent_sink_from(
+    raw_url: Option<&str>,
+    http: &Arc<reqwest::Client>,
+) -> Option<Arc<dyn NotificationSink>> {
+    let trimmed = raw_url?.trim();
     if trimmed.is_empty() {
         return None;
     }
@@ -85,11 +99,24 @@ pub fn build_parent_sink(http: &Arc<reqwest::Client>) -> Option<Arc<dyn Notifica
 /// Read `PITBOSS_RUN_ID` from the current process env. Used at dispatch
 /// start to populate `RunDispatched.parent_run_id`. `None` for top-level
 /// dispatches (env var unset or empty).
+///
+/// Thin wrapper over [`parse_parent_run_id`]; see that function's
+/// docstring for the trimming/empty rules.
 pub fn parent_run_id() -> Option<String> {
-    std::env::var(RUN_ID_ENV)
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
+    parse_parent_run_id(std::env::var(RUN_ID_ENV).ok().as_deref())
+}
+
+/// Pure variant of [`parent_run_id`]. Takes the raw env-var value
+/// (`None` for unset) and applies the same trim-and-discard-empty
+/// normalization. Tests target this function directly to avoid the
+/// `setenv`/`getenv` race documented in #351 / F-TEST-11.
+pub fn parse_parent_run_id(raw: Option<&str>) -> Option<String> {
+    let trimmed = raw?.trim().to_string();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
 }
 
 /// Build a [`NotificationRouter`] combining manifest `[[notification]]`
@@ -106,6 +133,23 @@ pub fn build_router(
     manifest_sinks: &[NotificationConfig],
     http: &Arc<reqwest::Client>,
 ) -> Result<Option<Arc<NotificationRouter>>> {
+    build_router_with(
+        manifest_sinks,
+        std::env::var(PARENT_NOTIFY_URL_ENV).ok().as_deref(),
+        http,
+    )
+}
+
+/// Pure variant of [`build_router`]. Takes the parent-notify URL as an
+/// argument (`None` when the env var is unset) so callers can construct
+/// it without process-wide env mutation. Tests target this function
+/// directly to avoid the `setenv`/`getenv` race documented in #351 /
+/// F-TEST-11.
+pub fn build_router_with(
+    manifest_sinks: &[NotificationConfig],
+    parent_url: Option<&str>,
+    http: &Arc<reqwest::Client>,
+) -> Result<Option<Arc<NotificationRouter>>> {
     let mut sinks: Vec<(Arc<dyn NotificationSink>, SinkFilter)> = manifest_sinks
         .iter()
         .enumerate()
@@ -116,7 +160,7 @@ pub fn build_router(
         })
         .collect::<Result<_>>()?;
 
-    if let Some(parent_sink) = build_parent_sink(http) {
+    if let Some(parent_sink) = build_parent_sink_from(parent_url, http) {
         // Open filter — operator orchestrators want every signal pitboss can give.
         sinks.push((
             parent_sink,
@@ -137,69 +181,63 @@ pub fn build_router(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serial_test::serial;
 
-    // #351: every test in this module mutates parent-notify env vars.
-    // `#[serial(env)]` serializes against every other env-touching
-    // test in the crate, replacing the previous module-local
-    // `ENV_GUARD` (which only protected this file).
+    // #351 / F-TEST-11: pre-refactor these tests mutated PITBOSS_RUN_ID
+    // / PITBOSS_PARENT_NOTIFY_URL via std::env and gated each one on
+    // `#[serial(env)]`. The refactor extracted pure variants
+    // (`parse_parent_run_id`, `build_parent_sink_from`,
+    // `build_router_with`) that take the raw env value as a parameter,
+    // so every test below can run in parallel without touching the
+    // process env — eliminating the glibc setenv/getenv race entirely.
 
     #[test]
-    #[serial(env)]
-    fn parent_run_id_returns_none_when_unset() {
-        std::env::remove_var(RUN_ID_ENV);
-        assert!(parent_run_id().is_none());
+    fn parse_parent_run_id_returns_none_when_unset() {
+        assert!(parse_parent_run_id(None).is_none());
     }
 
     #[test]
-    #[serial(env)]
-    fn parent_run_id_returns_some_when_set() {
-        std::env::set_var(RUN_ID_ENV, "  019d0000-aaaa-bbbb-cccc-dddddddddddd  ");
-        let v = parent_run_id();
-        std::env::remove_var(RUN_ID_ENV);
+    fn parse_parent_run_id_returns_some_when_set() {
+        let v = parse_parent_run_id(Some("  019d0000-aaaa-bbbb-cccc-dddddddddddd  "));
         assert_eq!(v.as_deref(), Some("019d0000-aaaa-bbbb-cccc-dddddddddddd"));
     }
 
     #[test]
-    #[serial(env)]
-    fn parent_run_id_returns_none_when_empty() {
-        std::env::set_var(RUN_ID_ENV, "   ");
-        let v = parent_run_id();
-        std::env::remove_var(RUN_ID_ENV);
-        assert!(v.is_none());
+    fn parse_parent_run_id_returns_none_when_empty() {
+        assert!(parse_parent_run_id(Some("   ")).is_none());
+        assert!(parse_parent_run_id(Some("")).is_none());
     }
 
     #[test]
-    #[serial(env)]
-    fn build_parent_sink_returns_none_when_env_unset() {
-        std::env::remove_var(PARENT_NOTIFY_URL_ENV);
+    fn build_parent_sink_from_returns_none_when_unset() {
         let http = Arc::new(reqwest::Client::new());
-        assert!(build_parent_sink(&http).is_none());
+        assert!(build_parent_sink_from(None, &http).is_none());
     }
 
     #[test]
-    #[serial(env)]
-    fn build_parent_sink_returns_none_when_env_unparseable() {
+    fn build_parent_sink_from_returns_none_when_unparseable() {
         // A typo'd scheme (`htttp://…`) used to silently construct a sink
         // that failed on first emit. Catch it at dispatch start instead.
         // No scheme delimiter at all → reqwest::Url::parse rejects.
         // (`htttp://…` parses fine: any token is a valid scheme.)
-        std::env::set_var(PARENT_NOTIFY_URL_ENV, "definitely not a url");
         let http = Arc::new(reqwest::Client::new());
-        let sink = build_parent_sink(&http);
-        std::env::remove_var(PARENT_NOTIFY_URL_ENV);
+        let sink = build_parent_sink_from(Some("definitely not a url"), &http);
         assert!(
             sink.is_none(),
-            "unparseable URL should be rejected at build_parent_sink"
+            "unparseable URL should be rejected at build_parent_sink_from"
         );
     }
 
+    #[test]
+    fn build_parent_sink_from_returns_none_when_empty() {
+        let http = Arc::new(reqwest::Client::new());
+        assert!(build_parent_sink_from(Some("   "), &http).is_none());
+    }
+
     #[tokio::test]
-    #[serial(env)]
     async fn parent_sink_posts_run_dispatched_to_localhost() {
-        // End-to-end: env var → trusted webhook sink → POST to a local mock.
-        // Verifies that the SSRF bypass actually lets a localhost target work
-        // (the manifest path would refuse it at parse time).
+        // End-to-end: parameter → trusted webhook sink → POST to a local
+        // mock. Verifies that the SSRF bypass actually lets a localhost
+        // target work (the manifest path would refuse it at parse time).
         use crate::notify::{NotificationEnvelope, PitbossEvent, Severity};
         use chrono::Utc;
         use wiremock::matchers::{method, path};
@@ -213,10 +251,8 @@ mod tests {
             .await;
 
         let url = format!("{}/notify", mock.uri());
-        std::env::set_var(PARENT_NOTIFY_URL_ENV, &url);
         let http = Arc::new(reqwest::Client::new());
-        let sink = build_parent_sink(&http).expect("env-derived sink");
-        std::env::remove_var(PARENT_NOTIFY_URL_ENV);
+        let sink = build_parent_sink_from(Some(&url), &http).expect("sink");
 
         let env = NotificationEnvelope::new(
             "child-run-1",
@@ -234,11 +270,10 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial(env)]
     async fn parent_sink_bypasses_https_only_check() {
-        // Manifest webhook validation rejects http:// + loopback. The env-var
-        // path must accept both, since the canonical orchestrator topology is
-        // `http://localhost:N` on the same host.
+        // Manifest webhook validation rejects http:// + loopback. The
+        // env-var path must accept both, since the canonical orchestrator
+        // topology is `http://localhost:N` on the same host.
         use crate::notify::{NotificationEnvelope, PitbossEvent, Severity};
         use chrono::Utc;
         use wiremock::matchers::method;
@@ -252,10 +287,9 @@ mod tests {
 
         // mock.uri() returns http://127.0.0.1:<port> — exactly the case the
         // SSRF guard refuses for manifest URLs.
-        std::env::set_var(PARENT_NOTIFY_URL_ENV, mock.uri());
+        let uri = mock.uri();
         let http = Arc::new(reqwest::Client::new());
-        let sink = build_parent_sink(&http).expect("env-derived sink");
-        std::env::remove_var(PARENT_NOTIFY_URL_ENV);
+        let sink = build_parent_sink_from(Some(&uri), &http).expect("sink");
 
         let env = NotificationEnvelope::new(
             "run-x",
@@ -274,21 +308,16 @@ mod tests {
     }
 
     #[test]
-    #[serial(env)]
-    fn build_router_returns_none_when_no_sources() {
-        std::env::remove_var(PARENT_NOTIFY_URL_ENV);
+    fn build_router_with_returns_none_when_no_sources() {
         let http = Arc::new(reqwest::Client::new());
-        let router = build_router(&[], &http).unwrap();
+        let router = build_router_with(&[], None, &http).unwrap();
         assert!(router.is_none());
     }
 
     #[test]
-    #[serial(env)]
-    fn build_router_includes_parent_sink_when_env_set() {
-        std::env::set_var(PARENT_NOTIFY_URL_ENV, "http://127.0.0.1:9/x");
+    fn build_router_with_includes_parent_sink_when_url_provided() {
         let http = Arc::new(reqwest::Client::new());
-        let router = build_router(&[], &http).unwrap();
-        std::env::remove_var(PARENT_NOTIFY_URL_ENV);
+        let router = build_router_with(&[], Some("http://127.0.0.1:9/x"), &http).unwrap();
         assert!(
             router.is_some(),
             "router should be built when only env-var sink contributes"


### PR DESCRIPTION
## Summary

Splits every env-reading helper in `notify/` into a thin wrapper (single `std::env` read) plus a pure variant that takes the raw value as an argument. Tests target the pure variants — no `std::env` mutation, no `#[serial(env)]` guards. Eliminates the glibc setenv/getenv race for all notify tests instead of just gating it.

This completes the follow-up flagged in commit `e1de793` when `serial_test` was first adopted.

## What's pure now

| Production helper (unchanged signature, now thin wrapper) | New pure variant |
|---|---|
| `notify::parent::parent_run_id()` | `parse_parent_run_id(raw: Option<&str>)` |
| `notify::parent::build_parent_sink(http)` | `build_parent_sink_from(raw_url: Option<&str>, http)` |
| `notify::parent::build_router(sinks, http)` | `build_router_with(sinks, parent_url: Option<&str>, http)` |
| `notify::NotificationRouter::new(...)` (dedup-cache size env-read) | `notify::parse_dedup_cache_size(raw: Option<&str>)` |
| `notify::config::substitute_env_vars(s)` | `substitute_env_vars_with(s, lookup: Fn(&str) -> Option<String>)` |
| `notify::config::apply_env_substitution(cfg)` | `apply_env_substitution_with(cfg, lookup)` |

Production callers in `dispatch/entrypoint.rs`, `dispatch/resume.rs`, and `manifest/resolve.rs` are untouched — the existing public names still resolve to a one-liner that reads `std::env` once and delegates.

## Test changes

- `notify/parent.rs` tests (10): all rewritten to call pure variants. `#[serial(env)]` removed.
- `notify/config.rs` tests (4 env-touching): rewritten to call `substitute_env_vars_with(s, closure)` with a deterministic lookup closure. `serial_test` import removed.
- `notify/mod.rs` (1 env-touching → 2 pure tests): `router_new_honors_dedup_cache_size_env` split into `parse_dedup_cache_size_honors_positive_integer` + `parse_dedup_cache_size_falls_back_on_invalid`. `serial_test` import removed.

## Test plan

- [x] `cargo lint` clean
- [x] `cargo tidy` clean
- [x] `cargo test -p pitboss-cli --lib notify::` — 80/80 green
- [x] `cargo test --workspace --features pitboss-core/test-support` — 912/913 (one unrelated control-plane flake on `continue_worker_from_paused_transitions_running`; passes consistently in isolation)
- [x] Production callers (`dispatch/entrypoint.rs:82, 147`, `dispatch/resume.rs:105`, `manifest/resolve.rs:384`) unchanged — they keep calling the same names; behavior preserved by the thin wrappers.

Closes #351
Closes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)