### PR TITLE
refactor(runs): collapse six default_runs_dir copies onto runs_base_dir

### DIFF
--- a/crates/pitboss-cli/src/attach.rs
+++ b/crates/pitboss-cli/src/attach.rs
@@ -71,7 +71,7 @@ async fn run_async(
     runs_dir_override: Option<PathBuf>,
 ) -> Result<i32> {
     validate_task_id(task_id)?;
-    let base = runs_dir_override.unwrap_or_else(default_runs_dir);
+    let base = runs_dir_override.unwrap_or_else(crate::runs::runs_base_dir);
     let run_dir = resolve_run_dir(&base, run_id_prefix)?;
     let tasks_root = run_dir.join("tasks");
     let task_dir = tasks_root.join(task_id);
@@ -135,15 +135,6 @@ fn validate_task_id(task_id: &str) -> Result<()> {
         bail!("task id must not contain path separators or NUL: '{task_id}'");
     }
     Ok(())
-}
-
-/// Returns `~/.local/share/pitboss/runs/` — matches the default used by
-/// `pitboss resume` / `pitboss diff` and the TUI's run discovery.
-fn default_runs_dir() -> PathBuf {
-    std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("/"))
-        .join(".local/share/pitboss/runs")
 }
 
 /// Resolve a run id (full UUID or unique prefix) to an absolute run

--- a/crates/pitboss-cli/src/audit.rs
+++ b/crates/pitboss-cli/src/audit.rs
@@ -79,7 +79,7 @@ pub fn run(
     json: bool,
     run_dir_override: Option<PathBuf>,
 ) -> Result<i32> {
-    let base = run_dir_override.unwrap_or_else(default_runs_dir);
+    let base = run_dir_override.unwrap_or_else(crate::runs::runs_base_dir);
     let run_dir = crate::runs::resolve_run_dir_by_prefix(&base, run_id_prefix)?;
     let audit_path = run_dir.join("audit.jsonl");
 
@@ -269,13 +269,6 @@ fn event_detail(event: &TaskEvent) -> String {
             ..
         } => format!("tool={tool_name} actor_type={actor_type}"),
     }
-}
-
-fn default_runs_dir() -> PathBuf {
-    std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("/"))
-        .join(".local/share/pitboss/runs")
 }
 
 /// Test helper exposed so integration tests can drive `render` against

--- a/crates/pitboss-cli/src/dispatch/container.rs
+++ b/crates/pitboss-cli/src/dispatch/container.rs
@@ -131,7 +131,9 @@ pub fn run_container_dispatch(
         None
     };
 
-    let audit_runs_base = run_dir_override.clone().unwrap_or_else(default_run_dir);
+    let audit_runs_base = run_dir_override
+        .clone()
+        .unwrap_or_else(crate::runs::runs_base_dir);
     let args = build_run_args(
         &runtime,
         container,
@@ -285,7 +287,7 @@ fn build_run_args(
     // Artifacts produced inside the container should persist on the host.
     // We mount the effective run_dir (override > default) to the same
     // absolute path inside the container.
-    let effective_run_dir = run_dir_override.unwrap_or_else(default_run_dir);
+    let effective_run_dir = run_dir_override.unwrap_or_else(crate::runs::runs_base_dir);
     // Ensure the directory exists on the host so Docker doesn't create it
     // as root-owned when the mount target is absent.
     std::fs::create_dir_all(&effective_run_dir).ok();
@@ -762,12 +764,6 @@ fn expand_tilde(path: &Path) -> PathBuf {
 
 fn home_dir() -> Option<PathBuf> {
     std::env::var_os("HOME").map(PathBuf::from)
-}
-
-fn default_run_dir() -> PathBuf {
-    home_dir()
-        .unwrap_or_else(|| PathBuf::from("/tmp"))
-        .join(".local/share/pitboss/runs")
 }
 
 /// Append a single NDJSON record to `<runs_base>/container-dispatch.log`

--- a/crates/pitboss-cli/src/events.rs
+++ b/crates/pitboss-cli/src/events.rs
@@ -20,7 +20,7 @@ use crate::control::protocol::{ControlEvent, EventEnvelope};
 
 /// Entry point for the `events` subcommand.
 pub fn run(run_id_prefix: &str, json: bool, run_dir_override: Option<PathBuf>) -> Result<i32> {
-    let base = run_dir_override.unwrap_or_else(default_runs_dir);
+    let base = run_dir_override.unwrap_or_else(crate::runs::runs_base_dir);
     let run_dir = crate::runs::resolve_run_dir_by_prefix(&base, run_id_prefix)?;
     let events_path = run_dir.join("events.jsonl");
 
@@ -228,13 +228,6 @@ fn describe_event(event: &ControlEvent) -> (&'static str, String) {
             ),
         ),
     }
-}
-
-fn default_runs_dir() -> PathBuf {
-    std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("/"))
-        .join(".local/share/pitboss/runs")
 }
 
 /// Test helper exposed so `events::run`-equivalent integration tests

--- a/crates/pitboss-cli/src/manifest/resolve.rs
+++ b/crates/pitboss-cli/src/manifest/resolve.rs
@@ -376,7 +376,10 @@ pub fn resolve(
         )
     };
 
-    let run_dir = manifest.run.run_dir.unwrap_or_else(default_run_dir);
+    let run_dir = manifest
+        .run
+        .run_dir
+        .unwrap_or_else(crate::runs::runs_base_dir);
 
     // Apply env-var substitution to notification URLs at resolve time.
     let mut notifications = manifest.notification.clone();
@@ -623,18 +626,6 @@ fn substitute(template: &str, vars: &HashMap<String, String>) -> Result<String> 
         }
     }
     Ok(out)
-}
-
-fn default_run_dir() -> PathBuf {
-    if let Some(h) = dirs_home() {
-        h.join(".local/share/pitboss/runs")
-    } else {
-        PathBuf::from("./pitboss-runs")
-    }
-}
-
-fn dirs_home() -> Option<PathBuf> {
-    std::env::var_os("HOME").map(PathBuf::from)
 }
 
 /// Convert a TOML `ApprovalRuleSpec` into a typed `ApprovalRule`.

--- a/crates/pitboss-cli/src/status.rs
+++ b/crates/pitboss-cli/src/status.rs
@@ -16,7 +16,7 @@ pub fn run(
     run_dir_override: Option<PathBuf>,
     resources: bool,
 ) -> Result<i32> {
-    let base = run_dir_override.unwrap_or_else(default_runs_dir);
+    let base = run_dir_override.unwrap_or_else(crate::runs::runs_base_dir);
     let run_dir = resolve_run_dir(&base, run_id_prefix)?;
 
     let summary_json = run_dir.join("summary.json");
@@ -349,13 +349,6 @@ fn status_label(s: &TaskStatus) -> &'static str {
         TaskStatus::ApprovalRejected => "⊘ ApprovalRej",
         TaskStatus::ApprovalTimedOut => "⏱ ApprovalTO",
     }
-}
-
-fn default_runs_dir() -> PathBuf {
-    std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("/"))
-        .join(".local/share/pitboss/runs")
 }
 
 fn resolve_run_dir(base: &Path, prefix: &str) -> Result<PathBuf> {


### PR DESCRIPTION
## Summary

- Six call sites in `pitboss-cli` (`status`, `audit`, `events`, `attach`, `manifest/resolve`, `dispatch/container`) each carried a private `default_runs_dir`/`default_run_dir` that hardcoded `$HOME/.local/share/pitboss/runs` with three different missing-`HOME` fallbacks (`/`, `/tmp`, `./pitboss-runs`).
- The canonical `runs::runs_base_dir()` already handles XDG + legacy back-compat + missing-`HOME` gracefully — and crucially uses `dirs::data_dir()` which resolves to `~/Library/Application Support/pitboss/runs` on macOS instead of the Linux-style path.
- Pre-fix consequence on macOS: `pitboss dispatch` wrote runs via the canonical path (`background.rs` already used `runs_base_dir`), but `pitboss status`/`attach`/`events`/`audit` read from the Linux-style hardcode. On a fresh macOS install the CLI read side could miss freshly-written runs that the TUI and web console saw correctly. The `runs_base_dir` legacy fallback clause keeps existing macOS users with `~/.local/share/pitboss/runs` unaffected.

Pure delete-and-rewire: `+12 / −55` across six files, no behavior change on Linux (where `dirs::data_dir()` and the hardcoded fallback agree), behavioral fix on macOS.

Closes #477

## Test plan

- [x] `cargo build -p pitboss-cli` — clean
- [x] `cargo lint` — clean
- [x] `cargo tidy` — clean (fmt re-wrapped two lines after the swap)
- [x] `cargo test -p pitboss-cli --features pitboss-core/test-support` — `914 passed; 1 failed` matching `main` exactly (the failing `continue_worker_from_paused_transitions_running` is a pre-existing sibling-test race on macOS; passes in isolation; per workspace `CLAUDE.md`, Linux CI is the ground truth)
- [ ] CI green on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)