### PR TITLE
refactor: protocol cleanup bundle (typed SubleadTerminated.outcome + TaskRecord Option consistency)

### DIFF
--- a/crates/pitboss-cli/src/control/protocol.rs
+++ b/crates/pitboss-cli/src/control/protocol.rs
@@ -162,6 +162,35 @@ fn is_default_client_mode(m: &ClientMode) -> bool {
     matches!(m, ClientMode::Writer)
 }
 
+/// Terminal classification for a sub-lead exit. Emitted on
+/// [`ControlEvent::SubleadTerminated`]`.outcome` and persisted on
+/// `dispatch::state::SubleadTerminalRecord.outcome`. Closed set; converted
+/// from the producer-side `dispatch::sublead::SubleadOutcome` (which
+/// additionally carries a free-text error message that the wire elides).
+///
+/// Wire shape matches the pre-typed string form 1:1
+/// (`Success` ↔ `"success"`, `ApprovalRejected` ↔ `"approval_rejected"`,
+/// …) so existing on-disk `events.jsonl` artifacts continue to parse.
+/// `rename_all = "snake_case"` (not `"lowercase"`) is load-bearing —
+/// the multi-word variants would collide with the wire format under
+/// `lowercase`.
+///
+/// `Default = Error`: a future dispatcher that omits the field on the
+/// wire (forward-compat per #515) deserializes to the safest possible
+/// terminal state rather than silently classifying a real outcome as
+/// something else.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TerminationOutcome {
+    Success,
+    Cancel,
+    Timeout,
+    #[default]
+    Error,
+    ApprovalRejected,
+    ApprovalTimedOut,
+}
+
 /// An operation sent from the TUI (client) to the dispatcher (server).
 ///
 /// Note: `Eq` is NOT derived — `UpdatePolicy` carries `Vec<ApprovalRule>`,
@@ -421,13 +450,17 @@ pub enum ControlEvent {
         /// meaningful (full reservation spent).
         #[serde(default)]
         unspent_usd: f64,
-        /// Terminal outcome: `"success"` | `"cancel"` | `"timeout"` | `"error"`.
-        /// Carries `#[serde(default)]` for forward-compat consistency
-        /// (closes F-PROTO-2 / #515). NOT skip-serialized: an empty
-        /// string is not a valid outcome value, so eliding it would
-        /// produce silently misclassified terminations on the wire.
+        /// Terminal outcome. Typed [`TerminationOutcome`] (closes #568);
+        /// the wire format is unchanged (`"success"`, `"cancel"`,
+        /// `"timeout"`, `"error"`, `"approval_rejected"`,
+        /// `"approval_timed_out"`). Carries `#[serde(default)]` for
+        /// forward-compat consistency (closes F-PROTO-2 / #515); the
+        /// default is `Error` — the safest sentinel for an omitted
+        /// terminal state. NOT skip-serialized: the operator-facing TUI
+        /// branches on the value, so eliding it would render an unknown
+        /// terminal state.
         #[serde(default)]
-        outcome: String,
+        outcome: TerminationOutcome,
     },
 }
 
@@ -1149,7 +1182,11 @@ mod tests {
                 assert_eq!(sublead_id, "sub-A");
                 assert_eq!(spent_usd, 0.0, "missing spent_usd must default to 0.0");
                 assert_eq!(unspent_usd, 0.0, "missing unspent_usd must default to 0.0");
-                assert_eq!(outcome, "", "missing outcome must default to empty string");
+                assert_eq!(
+                    outcome,
+                    TerminationOutcome::Error,
+                    "missing outcome must default to TerminationOutcome::Error (#568)"
+                );
             }
             other => panic!("expected SubleadTerminated, got {other:?}"),
         }
@@ -1165,7 +1202,7 @@ mod tests {
             sublead_id: "sub-A".into(),
             spent_usd: 0.0,
             unspent_usd: 0.0,
-            outcome: "cancel".into(),
+            outcome: TerminationOutcome::Cancel,
         };
         let s = serde_json::to_string(&ev).unwrap();
         assert!(
@@ -1187,7 +1224,7 @@ mod tests {
             sublead_id: "sub-B".into(),
             spent_usd: 1.25,
             unspent_usd: 0.75,
-            outcome: "success".into(),
+            outcome: TerminationOutcome::Success,
         };
         assert_eq!(roundtrip_event(&ev), ev);
     }

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -36,8 +36,10 @@ use uuid::Uuid;
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SubleadTerminalRecord {
     pub sublead_id: String,
-    /// "success" | "cancel" | "timeout" | "error"
-    pub outcome: String,
+    /// Typed terminal classification (#568). Wire/JSON shape is unchanged
+    /// — see [`crate::control::protocol::TerminationOutcome`] for the
+    /// closed value set and its on-the-wire string mapping.
+    pub outcome: crate::control::protocol::TerminationOutcome,
     pub spent_usd: f64,
     pub unspent_usd: f64,
     pub terminated_at: chrono::DateTime<chrono::Utc>,

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -77,6 +77,21 @@ impl SubleadOutcome {
         }
     }
 
+    /// Project to the wire/persistence-typed [`TerminationOutcome`] (#568).
+    /// The free-text error message on `Error(_)` is intentionally dropped —
+    /// it stays in dispatcher logs but is not part of the wire contract.
+    pub fn to_termination(&self) -> crate::control::protocol::TerminationOutcome {
+        use crate::control::protocol::TerminationOutcome;
+        match self {
+            SubleadOutcome::Success => TerminationOutcome::Success,
+            SubleadOutcome::Cancel => TerminationOutcome::Cancel,
+            SubleadOutcome::Timeout => TerminationOutcome::Timeout,
+            SubleadOutcome::Error(_) => TerminationOutcome::Error,
+            SubleadOutcome::ApprovalRejected => TerminationOutcome::ApprovalRejected,
+            SubleadOutcome::ApprovalTimedOut => TerminationOutcome::ApprovalTimedOut,
+        }
+    }
+
     /// Map to the `TaskStatus` used in `TaskRecord` and the
     /// `WorkerSnapshotEntry.state` wire string. Mirrors the on-exit
     /// classification done by `spawn_sublead_session` so the sub-lead's
@@ -1208,7 +1223,7 @@ pub async fn reconcile_terminated_sublead(
                 sublead_id: sublead_id.to_string(),
                 spent_usd: actual_spend,
                 unspent_usd: unspent,
-                outcome: outcome.as_str().to_string(),
+                outcome: outcome.to_termination(),
             },
         };
         state.root.broadcast_control_event(ev).await;
@@ -1230,7 +1245,7 @@ pub async fn reconcile_terminated_sublead(
     // Persist terminal record so wait_actor(sublead_id) can return it.
     let record = SubleadTerminalRecord {
         sublead_id: sublead_id.to_string(),
-        outcome: outcome.as_str().to_string(),
+        outcome: outcome.to_termination(),
         spent_usd: actual_spend,
         unspent_usd: unspent,
         terminated_at: chrono::Utc::now(),

--- a/crates/pitboss-cli/tests/control_flows.rs
+++ b/crates/pitboss-cli/tests/control_flows.rs
@@ -200,7 +200,7 @@ async fn sublead_terminated_event_roundtrips() {
         sublead_id: "S1".into(),
         spent_usd: 2.50,
         unspent_usd: 2.50,
-        outcome: "success".into(),
+        outcome: pitboss_cli::control::protocol::TerminationOutcome::Success,
     };
     let s = serde_json::to_string(&event).unwrap();
     assert!(
@@ -220,7 +220,10 @@ async fn sublead_terminated_event_roundtrips() {
             assert_eq!(sublead_id, "S1");
             assert!((spent_usd - 2.50).abs() < 1e-9);
             assert!((unspent_usd - 2.50).abs() < 1e-9);
-            assert_eq!(outcome, "success");
+            assert_eq!(
+                outcome,
+                pitboss_cli::control::protocol::TerminationOutcome::Success
+            );
         }
         other => panic!("expected SubleadTerminated, got {other:?}"),
     }

--- a/crates/pitboss-cli/tests/e2e_sublead_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_sublead_flows.rs
@@ -844,8 +844,9 @@ async fn sublead_session_spawns_runs_and_reconciles() {
                 "sublead_id in record should match"
             );
             assert_eq!(
-                rec.outcome, "success",
-                "sub-lead outcome should be 'success'; got: {}",
+                rec.outcome,
+                pitboss_cli::control::protocol::TerminationOutcome::Success,
+                "sub-lead outcome should be Success; got: {:?}",
                 rec.outcome
             );
         }

--- a/crates/pitboss-cli/tests/sublead_flows.rs
+++ b/crates/pitboss-cli/tests/sublead_flows.rs
@@ -1082,7 +1082,11 @@ async fn wait_actor_returns_for_terminated_sublead() {
     match result {
         ActorTerminalRecord::Sublead(rec) => {
             assert_eq!(rec.sublead_id, sublead_id, "sublead_id should match");
-            assert_eq!(rec.outcome, "success", "outcome should be 'success'");
+            assert_eq!(
+                rec.outcome,
+                pitboss_cli::control::protocol::TerminationOutcome::Success,
+                "outcome should be Success"
+            );
             assert!((rec.spent_usd - 1.0).abs() < 1e-9, "spent should be $1.0");
             assert!(
                 (rec.unspent_usd - 1.0).abs() < 1e-9,
@@ -1150,7 +1154,10 @@ async fn wait_actor_blocks_then_wakes_on_sublead_termination() {
     match result {
         ActorTerminalRecord::Sublead(rec) => {
             assert_eq!(rec.sublead_id, sublead_id, "sublead_id should match");
-            assert_eq!(rec.outcome, "success");
+            assert_eq!(
+                rec.outcome,
+                pitboss_cli::control::protocol::TerminationOutcome::Success
+            );
         }
         ActorTerminalRecord::Worker(_) => panic!("expected Sublead variant, got Worker"),
     }

--- a/crates/pitboss-core/src/store/record.rs
+++ b/crates/pitboss-core/src/store/record.rs
@@ -160,7 +160,11 @@ pub struct TaskRecord {
     /// spawn was untyped or the record is from a pre-v0.12 run. Lets the
     /// TUI / `pitboss status` / `pitboss-web` group workers by class
     /// without re-deriving from the manifest snapshot. Added with #252.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Aligned to the majority `serde(default)`-only pattern of the other
+    /// `Option<_>` fields on this struct (#514) — pre-fix this carried
+    /// `skip_serializing_if`, which was the only field forcing consumers
+    /// to handle both "absent" and `null` forms.
+    #[serde(default)]
     pub actor_type: Option<String>,
     /// Set by every dispatcher-initiated kill path (budget breach, parent
     /// cancel cascade, operator Ctrl-C, MCP `terminate_*`, runtime timeout,

--- a/crates/pitboss-web/spa/src/lib/api.ts
+++ b/crates/pitboss-web/spa/src/lib/api.ts
@@ -354,7 +354,10 @@ export interface SubleadInfo {
   budget_usd?: number | null;
   max_workers?: number | null;
   read_down: boolean;
-  /** Set once the sub-tree exits — `success` | `cancel` | `timeout` | `error`. */
+  /** Set once the sub-tree exits — one of `success` | `cancel` | `timeout`
+   *  | `error` | `approval_rejected` | `approval_timed_out`. Mirrors the
+   *  Rust `TerminationOutcome` enum in `crates/pitboss-cli/src/control/protocol.rs`
+   *  (#568). */
   outcome?: string;
   spent_usd?: number;
   unspent_usd?: number;

--- a/crates/pitboss-web/tests/control_bridge_integration.rs
+++ b/crates/pitboss-web/tests/control_bridge_integration.rs
@@ -246,7 +246,7 @@ async fn bridge_subscribe_shares_connection_for_multiple_subscribers() {
             sublead_id: "S1".into(),
             spent_usd: 0.5,
             unspent_usd: 0.5,
-            outcome: "success".into(),
+            outcome: pitboss_cli::control::protocol::TerminationOutcome::Success,
         },
     };
     state.root.broadcast_control_event(envelope).await;


### PR DESCRIPTION
## Summary

Two independent refactors bundled because both are wire-shape-stable protocol cleanups.

### Commit 1 — `refactor(control): type SubleadTerminated.outcome as TerminationOutcome enum`

`ControlEvent::SubleadTerminated.outcome` (and the internal `dispatch/state.rs::SubleadTerminalRecord.outcome` mirror) were typed `String` — the only `String`-typed closed-set discriminator in the control plane. Every other discriminator (`PauseMode`, `ApprovalKind`, `ClientMode`, `FailureReason`, `TaskStatus`) uses a typed Rust enum with `#[serde(rename_all)]`.

- New `TerminationOutcome` enum in `control/protocol.rs` with `#[serde(rename_all = "snake_case")]`. Covers all six values the producer actually emits today: `Success`, `Cancel`, `Timeout`, `Error`, `ApprovalRejected`, `ApprovalTimedOut`.
- Wire shape is byte-identical to the pre-typed string form — the six lowercase/snake_case strings match `SubleadOutcome::as_str()` output 1:1. On-disk `events.jsonl` artifacts continue to parse.
- `Default = Error`, the safest sentinel for an omitted terminal state per #515's forward-compat contract — a future dispatcher that elides the field deserializes as `Error` rather than silently misclassifying.
- The issue listed four values (`success`/`cancel`/`timeout`/`error`); the producer actually emits six (the two approval-related variants were missing from the issue body). The enum captures the real value set.
- `SubleadOutcome::to_termination()` helper added — drops the free-text error string when projecting onto the wire-typed variant.

**Why `snake_case` and not `lowercase`:** `ApprovalRejected` / `ApprovalTimedOut` would collide on the wire under `lowercase` (→ `approvalrejected`) but match the producer's existing strings (`approval_rejected`) under `snake_case`.

Closes #568

### Commit 2 — `refactor(core): drop skip_serializing_if from TaskRecord.actor_type`

`TaskRecord.actor_type` was the lone `Option<_>` field carrying `skip_serializing_if = "Option::is_none"` — every other optional field (`model`, `failure_reason`, `cost_usd`, `final_message`, `parent_task_id`) only had `serde(default)`. Consumers had to handle both "field absent" and "field present but null" forms for one specific field.

Aligned `actor_type` to the majority pattern by removing `skip_serializing_if`. The wire grows by ~17 bytes per record when `actor_type` is absent (`"actor_type":null,`) — negligible vs. the simpler reader contract.

Closes #514

## Test plan

- [x] `cargo build --workspace --tests` — clean
- [x] `cargo lint` — clean
- [x] `cargo tidy` — clean
- [x] `cargo test -p pitboss-cli --features pitboss-core/test-support --test sublead_flows --test e2e_sublead_flows --test control_flows` — all 59 tests passed
- [x] `cargo test -p pitboss-web --features pitboss-core/test-support --test control_bridge_integration` — all 5 passed
- [x] `cargo test -p pitboss-cli --features pitboss-core/test-support --lib control::protocol::tests` — 34 passed
- [x] `cargo test -p pitboss-core --features test-support` — `211 passed; 1 failed`, identical to `main` (the failing `process::tokio_impl::tests::terminate_after_exit_is_ok` is a pre-existing macOS flake; Linux CI is the ground truth)
- [ ] CI green on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)