### PR TITLE
refactor(core): unify ActorPath into pitboss-core, re-export from cli

### DIFF
--- a/crates/pitboss-cli/src/dispatch/actor.rs
+++ b/crates/pitboss-cli/src/dispatch/actor.rs
@@ -4,11 +4,17 @@
 //! and TUI display.
 
 use serde::{Deserialize, Serialize};
-use std::fmt;
 
 /// Unique actor identifier.
 /// String is fine for depth ≤ 3; revisit if ActorPath clones show up in profiles.
 pub type ActorId = String;
+
+/// Tree-path from root to the actor that produced an event (#481).
+/// Single source of truth lives in `pitboss-core` so this crate, the
+/// unified consumer stream, and the read-side consumers share one
+/// definition. Re-exported here so existing
+/// `pitboss_cli::dispatch::actor::ActorPath` imports keep working.
+pub use pitboss_core::control_protocol::ActorPath;
 
 /// Actor role for authz in depth-2 dispatch model.
 ///
@@ -30,73 +36,9 @@ pub enum ActorRole {
     Worker,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
-#[serde(transparent)]
-pub struct ActorPath(pub(crate) Vec<ActorId>);
-
-impl fmt::Display for ActorPath {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0.join("→"))
-    }
-}
-
-impl ActorPath {
-    /// Construct from a slice of actor ids.
-    pub fn new<I, S>(ids: I) -> Self
-    where
-        I: IntoIterator<Item = S>,
-        S: Into<ActorId>,
-    {
-        ActorPath(ids.into_iter().map(Into::into).collect())
-    }
-
-    /// Append an actor id to produce a deeper path.
-    pub fn child(&self, id: impl Into<ActorId>) -> Self {
-        let mut next = self.0.clone();
-        next.push(id.into());
-        ActorPath(next)
-    }
-
-    /// Last segment (the actor id this path identifies).
-    pub fn leaf(&self) -> Option<&ActorId> {
-        self.0.last()
-    }
-
-    /// Depth in the tree (root = 1, sub-lead = 2, worker = 3).
-    pub fn depth(&self) -> usize {
-        self.0.len()
-    }
-
-    /// Returns `true` if the path contains no segments.
-    /// Used as a `skip_serializing_if` predicate on `EventEnvelope.actor_path`
-    /// to keep the wire format backward-compatible: an empty path is simply
-    /// absent from the serialized JSON.
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn actor_path_renders_with_arrow_separator() {
-        let path = ActorPath(vec!["root".into(), "S1".into(), "W3".into()]);
-        assert_eq!(path.to_string(), "root→S1→W3");
-    }
-
-    #[test]
-    fn actor_path_renders_root_only() {
-        let path = ActorPath(vec!["root".into()]);
-        assert_eq!(path.to_string(), "root");
-    }
-
-    #[test]
-    fn actor_path_renders_empty_as_empty_string() {
-        let path = ActorPath::default();
-        assert_eq!(path.to_string(), "");
-    }
 
     #[test]
     fn actor_role_round_trips_through_serde() {

--- a/crates/pitboss-cli/src/stream.rs
+++ b/crates/pitboss-cli/src/stream.rs
@@ -12,13 +12,15 @@
 //! ## Where this lives
 //!
 //! The RFC put the unified API in `pitboss-core::stream`. We can't quite
-//! deliver that today because [`EventEnvelope`] depends on
-//! `dispatch::actor::ActorPath` and `mcp::policy::ApprovalRule`, both
-//! `pitboss-cli`-only types. Moving them down to `pitboss-core` is its
-//! own refactor; for now the live consumer lives **here** in
-//! `pitboss-cli::stream` and `pitboss-core::stream` exposes only the
-//! disk side. The two compose via [`From<RunStreamItem>`] for
-//! [`LiveStreamItem`].
+//! deliver that today because the typed [`EventEnvelope`] depends on
+//! `mcp::policy::ApprovalRule` and the rest of the `ControlEvent`
+//! payload types, which carry MCP/approval concerns that don't belong in
+//! `pitboss-core` (#481 unified `ActorPath` — the other half of the
+//! dependency — but stopped short of dragging `ApprovalRule` down as
+//! well; see `pitboss-core::control_protocol`'s preamble). For now the
+//! live consumer lives **here** in `pitboss-cli::stream` and
+//! `pitboss-core::stream` exposes only the disk side. The two compose
+//! via [`From<RunStreamItem>`] for [`LiveStreamItem`].
 //!
 //! ## What about `Subscribe { since_seq }`?
 //!

--- a/crates/pitboss-core/src/control_protocol.rs
+++ b/crates/pitboss-core/src/control_protocol.rs
@@ -30,18 +30,53 @@
 //! `ControlOp::Subscribe` — same tag (`"op":"subscribe"`), same payload
 //! shape. See [`crate::stream`] for the consumer-side handshake.
 
+use std::fmt;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
 /// Tree-path from root to the actor that produced an event. Serialized
 /// as a JSON array of actor-id strings; an empty path is omitted from
-/// the wire (matching `pitboss-cli`'s typed mirror).
+/// the wire (the `EventEnvelope` field carries
+/// `skip_serializing_if = "ActorPath::is_empty"`).
+///
+/// Lives in `pitboss-core` so the dispatcher (`pitboss-cli`), the unified
+/// consumer stream ([`crate::stream`]), and read-side consumers
+/// (`pitboss-tui`, `pitboss-web`) share one definition. The dispatcher
+/// re-exports it as `pitboss_cli::dispatch::actor::ActorPath` for source
+/// compatibility — pre-unification both crates carried their own copy
+/// (#481). The `EventEnvelope` itself stays split (typed `ControlEvent`
+/// in `pitboss-cli`, `serde_json::Value` here) by design — the typed
+/// enum carries MCP policy and approval-handling types that don't belong
+/// in `pitboss-core` (see this module's preamble).
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct ActorPath(pub Vec<String>);
 
 impl ActorPath {
+    /// Construct from any iterable of stringy ids.
+    pub fn new<I, S>(ids: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        ActorPath(ids.into_iter().map(Into::into).collect())
+    }
+
+    /// Append an actor id to produce a deeper path.
+    #[must_use]
+    pub fn child(&self, id: impl Into<String>) -> Self {
+        let mut next = self.0.clone();
+        next.push(id.into());
+        ActorPath(next)
+    }
+
+    /// Last segment (the actor id this path identifies).
+    #[must_use]
+    pub fn leaf(&self) -> Option<&String> {
+        self.0.last()
+    }
+
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
@@ -51,6 +86,12 @@ impl ActorPath {
     #[must_use]
     pub fn depth(&self) -> usize {
         self.0.len()
+    }
+}
+
+impl fmt::Display for ActorPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.join("→"))
     }
 }
 
@@ -168,6 +209,42 @@ mod tests {
             back.event.get("event").and_then(|v| v.as_str()),
             Some("op_acked")
         );
+    }
+
+    #[test]
+    fn actor_path_renders_with_arrow_separator() {
+        let path = ActorPath(vec!["root".into(), "S1".into(), "W3".into()]);
+        assert_eq!(path.to_string(), "root→S1→W3");
+    }
+
+    #[test]
+    fn actor_path_renders_root_only() {
+        let path = ActorPath(vec!["root".into()]);
+        assert_eq!(path.to_string(), "root");
+    }
+
+    #[test]
+    fn actor_path_renders_empty_as_empty_string() {
+        let path = ActorPath::default();
+        assert_eq!(path.to_string(), "");
+    }
+
+    #[test]
+    fn actor_path_child_appends_segment() {
+        let path = ActorPath::new(["root"]);
+        let child = path.child("S1");
+        assert_eq!(child.0, vec!["root", "S1"]);
+        // Parent unchanged.
+        assert_eq!(path.0, vec!["root"]);
+    }
+
+    #[test]
+    fn actor_path_leaf_returns_last_segment() {
+        assert_eq!(
+            ActorPath::new(["root", "S1"]).leaf(),
+            Some(&"S1".to_string())
+        );
+        assert_eq!(ActorPath::default().leaf(), None);
     }
 
     /// Pre-PR-B dispatchers wrote bare `ControlEvent` without the


### PR DESCRIPTION
## Summary

Pre-fix: two `ActorPath` types with identical wire shape but divergent API surfaces.

| Surface | Type | API |
|---|---|---|
| `pitboss_core::control_protocol::ActorPath` | `pub struct ActorPath(pub Vec<String>)` | `is_empty`, `depth` |
| `pitboss_cli::dispatch::actor::ActorPath` | `pub struct ActorPath(pub(crate) Vec<ActorId>)` | `new`, `child`, `leaf`, `is_empty`, `depth`, `Display` |

Adding a method to one meant remembering to mirror it in the other. The audit on this issue (validator note: "ActorPath has been partially moved") flagged the burden — this completes the unification.

### What this PR does

- Move the richer API down to `pitboss-core`: add `new` / `child` / `leaf` / `Display` to the canonical type.
- Port the three `Display` tests inline; add two new tests for `child`/`leaf`.
- Replace `pitboss-cli`'s struct with `pub use pitboss_core::control_protocol::ActorPath`. Existing `crate::dispatch::actor::ActorPath` imports keep working byte-for-byte across `pitboss-cli`, `pitboss-web`, `pitboss-tui`, and the integration tests that reach into `pitboss_cli::dispatch::actor::ActorPath`.

### What this PR does **not** do

The typed `EventEnvelope` stays split (typed `ControlEvent` in `pitboss-cli`, `serde_json::Value` in `pitboss-core`) per the explicit rule in `pitboss-core/CLAUDE.md`:

> The temptation to make `EventEnvelope`'s inner `event` typed (instead of `serde_json::Value`) shows up regularly; resist it — the typed `ControlEvent` enum carries the MCP policy module and approval-handling types, none of which belong here.

Unifying `ActorPath` alone — without dragging `ApprovalRule` and the MCP policy surface down with it — is the scope the architecture allows. `stream.rs`'s preamble comment updated to reflect the partial unification (the cross-crate seam now narrows to "`ControlEvent` payload types" rather than "`ActorPath` + `ApprovalRule`").

Wire shape is unchanged — both pre-unification types already serialized transparently as a JSON array of strings.

Closes #481

## Test plan

- [x] `cargo build --workspace --tests` — clean
- [x] `cargo lint` — clean
- [x] `cargo tidy` — clean
- [x] `cargo test -p pitboss-core --features test-support control_protocol::tests` — 11 passed (includes the 3 ported + 2 new ActorPath tests)
- [x] `cargo test -p pitboss-cli --features pitboss-core/test-support --lib dispatch::actor` — 2 passed (`ActorRole` tests stay here)
- [x] Full workspace: `cargo test --workspace --features pitboss-core/test-support` — green modulo the pre-existing macOS test-interference flakes (`process::tokio_impl::tests::terminate_after_exit_is_ok` + the occasional cli e2e flake under parallel load); both reproduce identically on `main` in isolation
- [ ] CI green on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)