### PR TITLE
fix(dispatch): bound resource_sample_secs + emit shutdown Clear pressure

### DIFF
--- a/crates/pitboss-cli/src/dispatch/resource_watch.rs
+++ b/crates/pitboss-cli/src/dispatch/resource_watch.rs
@@ -142,11 +142,19 @@ async fn run_sampler(
     let mut interval = tokio::time::interval(cadence);
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let mut tracker = PressureTracker::default();
+    // FU-2 (#580): retain the most recent (total_rss, denominator) so
+    // the synthetic shutdown-Clear envelope carries non-zero context
+    // when a run finalizes mid-incident. Only updated when we had a
+    // usable denominator (otherwise the % is undefined anyway).
+    let mut last_observed: Option<(u64, u64)> = None;
 
     loop {
         tokio::select! {
             _ = state.root.cancel.await_terminate() => {
                 tracing::debug!("resource_watch: cancel fired, exiting sampler");
+                if let Some(event) = synthesize_shutdown_clear(tracker.state, last_observed) {
+                    broadcast(&state.root, event).await;
+                }
                 break;
             }
             _ = interval.tick() => {}
@@ -191,6 +199,7 @@ async fn run_sampler(
         broadcast(&state.root, sample_event).await;
 
         if denominator > 0 {
+            last_observed = Some((total_rss, denominator));
             if let Some(transition) = tracker.observe(total_rss, denominator) {
                 let message = pressure_message(transition.level, total_rss, denominator);
                 broadcast(
@@ -206,6 +215,34 @@ async fn run_sampler(
             }
         }
     }
+}
+
+/// Build a synthetic `ResourcePressure { level: Clear, .. }` envelope
+/// when the sampler shuts down while the tracker is still in Warn or
+/// Error. Without this, live banners stay stuck until SSE disconnects
+/// and `events.jsonl` replay tooling sees a stale warn/error as the
+/// final pressure event for the run. Returns `None` when the tracker
+/// is already in `Clear` — no transition to announce. (#580 FU-2)
+///
+/// `last_observed` carries the freshest `(total_rss, denominator)` the
+/// sampler ever saw with a valid denominator; falls back to `(0, 0)`
+/// when the sampler exited before its first successful read.
+fn synthesize_shutdown_clear(
+    current: PressureLevel,
+    last_observed: Option<(u64, u64)>,
+) -> Option<ControlEvent> {
+    if matches!(current, PressureLevel::Clear) {
+        return None;
+    }
+    let (total_rss, available) = last_observed.unwrap_or((0, 0));
+    Some(ControlEvent::ResourcePressure {
+        level: PressureLevel::Clear,
+        total_rss_bytes: total_rss,
+        available_bytes: available,
+        message:
+            "Memory pressure cleared (run finalized while a warn/error transition was active)."
+                .to_string(),
+    })
 }
 
 async fn broadcast(layer: &LayerState, event: ControlEvent) {
@@ -743,5 +780,61 @@ mod tests {
         let h = HighWaterAccum::with_cadence(0).into_summary();
         assert_eq!(h.sample_count, 0);
         assert_eq!(h.sample_cadence_secs, 0);
+    }
+
+    // -- shutdown-Clear synthesis (#580 FU-2) -------------------------
+
+    #[test]
+    fn shutdown_clear_skipped_when_tracker_already_clear() {
+        // Tracker never tripped (or already cleared) → no synthetic
+        // envelope. Avoids emitting redundant Clears on every run.
+        assert!(synthesize_shutdown_clear(PressureLevel::Clear, Some((100, 1000))).is_none());
+        assert!(synthesize_shutdown_clear(PressureLevel::Clear, None).is_none());
+    }
+
+    #[test]
+    fn shutdown_clear_emitted_when_tracker_is_warn() {
+        let ev = synthesize_shutdown_clear(PressureLevel::Warn, Some((700, 1000)))
+            .expect("warn → clear envelope");
+        match ev {
+            ControlEvent::ResourcePressure {
+                level,
+                total_rss_bytes,
+                available_bytes,
+                message,
+            } => {
+                assert_eq!(level, PressureLevel::Clear);
+                assert_eq!(total_rss_bytes, 700);
+                assert_eq!(available_bytes, 1000);
+                assert!(
+                    message.contains("cleared"),
+                    "shutdown message should signal clearance; got: {message}"
+                );
+            }
+            other => panic!("expected ResourcePressure variant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn shutdown_clear_emitted_when_tracker_is_error_with_no_observation() {
+        // Sampler exited before its first successful denominator read
+        // (e.g. /proc unavailable on darwin; or every read failed). We
+        // still emit Clear so consumers dismiss the banner — total_rss
+        // and available default to 0.
+        let ev =
+            synthesize_shutdown_clear(PressureLevel::Error, None).expect("error → clear envelope");
+        match ev {
+            ControlEvent::ResourcePressure {
+                level,
+                total_rss_bytes,
+                available_bytes,
+                ..
+            } => {
+                assert_eq!(level, PressureLevel::Clear);
+                assert_eq!(total_rss_bytes, 0);
+                assert_eq!(available_bytes, 0);
+            }
+            other => panic!("expected ResourcePressure variant, got {other:?}"),
+        }
     }
 }

--- a/crates/pitboss-cli/src/manifest/validate.rs
+++ b/crates/pitboss-cli/src/manifest/validate.rs
@@ -25,6 +25,7 @@ fn validate_inner(resolved: &ResolvedManifest, skip_dir_check: bool) -> Result<(
         crate::notify::config::validate(cfg)?;
     }
     validate_lifecycle(resolved)?;
+    validate_run_settings(resolved)?;
     validate_container(resolved)?;
     validate_communication(resolved)?;
     validate_actor_types(resolved)?;
@@ -745,6 +746,33 @@ fn validate_mode(r: &ResolvedManifest) -> Result<()> {
     }
     if r.tasks.is_empty() && r.lead.is_none() {
         bail!("empty manifest: define either [[task]] entries or exactly one [lead]");
+    }
+    Ok(())
+}
+
+/// Upper bound on `[run].resource_sample_secs` (#580 FU-1). 3600 s = 1 h.
+/// Beyond this the sampler effectively never fires, silently defeating the
+/// purpose — operators who set e.g. `86400` would see a never-tripped
+/// `resource_pressure` banner and an empty `resource_high_water` even on
+/// runs that came close to the cgroup ceiling.
+const RESOURCE_SAMPLE_SECS_MAX: u64 = 3600;
+
+/// Validate `[run]`-scoped settings that apply in both flat and
+/// hierarchical mode. Currently only enforces the
+/// `[run].resource_sample_secs` envelope. `0` remains the documented
+/// "disable sampling" sentinel — the upper bound exists because beyond
+/// ~1 hour the watcher is effectively dormant. (#580 FU-1)
+fn validate_run_settings(r: &ResolvedManifest) -> Result<()> {
+    if r.resource_sample_secs > RESOURCE_SAMPLE_SECS_MAX {
+        bail!(
+            "[run].resource_sample_secs = {} exceeds the supported envelope \
+             (0 disables sampling; otherwise pick a value in [1, {}] seconds). \
+             Cadences beyond ~1 h are effectively dormant — the watcher would \
+             never trip the 70% / 90% memory-pressure thresholds before a \
+             typical run finalizes.",
+            r.resource_sample_secs,
+            RESOURCE_SAMPLE_SECS_MAX,
+        );
     }
     Ok(())
 }
@@ -3306,5 +3334,48 @@ mod tests {
                 "{bad:?} error should name the canonical form; got: {err}"
             );
         }
+    }
+
+    // -- [run].resource_sample_secs envelope (#580 FU-1) ---------------
+
+    /// `0` stays valid — it is the documented "disable sampling"
+    /// sentinel that `ResourceWatcher::spawn` keys off (returns an
+    /// empty accumulator instead of spawning the periodic task).
+    /// Rejecting it would silently break manifests that intentionally
+    /// turn the watcher off.
+    #[test]
+    fn resource_sample_secs_zero_sentinel_is_accepted() {
+        let r = rm_with(|m| m.resource_sample_secs = 0);
+        assert!(validate_skip_dir_check(&r).is_ok());
+    }
+
+    #[test]
+    fn resource_sample_secs_at_upper_bound_is_accepted() {
+        let r = rm_with(|m| m.resource_sample_secs = RESOURCE_SAMPLE_SECS_MAX);
+        assert!(validate_skip_dir_check(&r).is_ok());
+    }
+
+    #[test]
+    fn resource_sample_secs_above_upper_bound_is_rejected() {
+        let r = rm_with(|m| m.resource_sample_secs = RESOURCE_SAMPLE_SECS_MAX + 1);
+        let err = validate_skip_dir_check(&r).unwrap_err().to_string();
+        assert!(
+            err.contains("resource_sample_secs"),
+            "error should name the offending field; got: {err}"
+        );
+        assert!(
+            err.contains("3600"),
+            "error should name the upper bound so an operator can fix it; got: {err}"
+        );
+    }
+
+    /// `86400` (one sample per day) was the motivating case in the
+    /// audit ticket — silently dormant on real-world run lengths.
+    /// Pin a value far above the envelope so a future bump still
+    /// rejects this without test churn.
+    #[test]
+    fn resource_sample_secs_one_per_day_is_rejected() {
+        let r = rm_with(|m| m.resource_sample_secs = 86_400);
+        assert!(validate_skip_dir_check(&r).is_err());
     }
 }


### PR DESCRIPTION
## Summary

First slice of the [#580](https://github.com/SDS-Mode/pitboss/issues/580) audit follow-ups carved out of the PR #579 review — the two smallest, schema-stable items, paired as the issue's own sequencing suggested.

- **FU-1 — `[run].resource_sample_secs` envelope validation** *(commit 1, +71 LoC)*
  - New `validate_run_settings()` rejects `resource_sample_secs > 3600` (1 hour) at validate-time.
  - `0` stays accepted: it remains the documented "disable sampling" sentinel that `ResourceWatcher::spawn` keys off.
  - Motivating case from the audit: `resource_sample_secs = 86400` is currently accepted but silently defeats the watcher — it never trips the 70%/90% memory-pressure thresholds before a typical run finalizes.
  - 4 new unit tests cover the boundary, the sentinel, and the audit's worked example.

- **FU-2 — synthetic Clear pressure on watcher shutdown** *(commit 2, +93 LoC)*
  - When the sampler's `select!` on `cancel.await_terminate()` fires while `PressureTracker.state` is `Warn`/`Error`, broadcast one synthetic `ResourcePressure { level: Clear, .. }` envelope before the `break`.
  - Without this, the SPA's live banner stays non-null until SSE disconnects, and future `events.jsonl` replay tooling sees a stale Warn/Error as the run's final pressure event.
  - Carries the last observed `(total_rss, denominator)` for internal consistency; falls back to `(0, 0)` when the sampler exited before any successful read.
  - Synthesis decision extracted into a pure helper (`synthesize_shutdown_clear`) so the three cases are unit-testable without spinning up the whole dispatcher. 3 new tests.

No wire-protocol or schema changes. No consumer-side mirror update needed — the `ResourcePressure` variant already exists, this just emits one more instance of it.

## Scope notes

This is **Refs #580, not Closes** — four follow-ups remain (FU-3 resume rehydration, FU-4 sample timestamps, FU-5 wire-guard enum coverage, FU-6 TUI surfaces). Each gets its own PR per the issue's own sequencing.

The known macOS `process::tokio_impl::tests::terminate_after_exit_is_ok` flake (`BinaryNotFound /bin/true`) appears under local workspace test runs on this branch — it also reproduces on `main` and is documented in the workspace CLAUDE.md as a known sandboxing artifact. CI on Linux is the ground truth.

## Test plan

- [x] `cargo test -p pitboss-cli --lib manifest::validate::tests::resource_sample_secs` — 4/4 ✅
- [x] `cargo test -p pitboss-cli --lib dispatch::resource_watch::tests` — 16/16 ✅ (3 new)
- [x] `cargo test -p pitboss-cli --lib` — 895/895 ✅
- [x] `cargo lint` — clean
- [x] `cargo tidy` — clean
- [ ] CI (Linux) — covers the full workspace suite that the macOS flake masks locally

Refs #580.

🤖 Generated with [Claude Code](https://claude.com/claude-code)