### PR TITLE
feat(dispatch): stamp wire-time on ResourceSample envelopes

### DIFF
--- a/crates/pitboss-cli/src/control/protocol.rs
+++ b/crates/pitboss-cli/src/control/protocol.rs
@@ -342,6 +342,18 @@ pub enum ControlEvent {
     /// out to in-flight viewers. (#553)
     ResourceSample {
         samples: Vec<ResourceSampleEntry>,
+        /// Unix milliseconds at the moment the watcher took the sample
+        /// (parent-side `SystemTime::now`). Stamped so `events.jsonl`
+        /// replay tooling can plot the time-series at the original
+        /// cadence — without this, replaying N hours of samples
+        /// collapses to a single instant (the replay clock) and live
+        /// X-axes match receive order instead of sample order under
+        /// tokio scheduler backlog. `#[serde(default)]` (= `0`) so
+        /// pre-v0.17 envelopes decode cleanly; SPA consumers prefer
+        /// this when present (`> 0`) and fall back to `Date.now()`
+        /// otherwise. (#580 FU-4)
+        #[serde(default)]
+        sampled_at_unix_ms: u64,
         /// `cgroup memory.current` at sample time, in bytes.
         /// `None` in flat host dispatch (no cgroup in scope).
         #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/pitboss-cli/src/dispatch/resource_watch.rs
+++ b/crates/pitboss-cli/src/dispatch/resource_watch.rs
@@ -38,7 +38,7 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use pitboss_core::store::record::ResourceHighWater;
 
@@ -192,6 +192,7 @@ async fn run_sampler(
         // the order on the wire is "facts, then judgement."
         let sample_event = ControlEvent::ResourceSample {
             samples: samples.clone(),
+            sampled_at_unix_ms: now_unix_ms(),
             cgroup_memory_current_bytes: cgroup.as_ref().map(|c| c.current_bytes),
             cgroup_memory_max_bytes: cgroup.as_ref().map(|c| c.max_bytes),
             host_mem_total_bytes: host_total,
@@ -471,6 +472,21 @@ async fn read_meminfo_total() -> Option<u64> {
 
 fn proc_filesystem_available() -> bool {
     Path::new("/proc/self/stat").exists()
+}
+
+/// Unix-epoch milliseconds at the moment of the call. Used to stamp
+/// `ResourceSample.sampled_at_unix_ms` so `events.jsonl` replay can
+/// plot at the original cadence rather than collapsing every sample
+/// onto the replay clock. (#580 FU-4)
+///
+/// Saturates to `0` on the impossible-in-practice case where
+/// `SystemTime::now()` predates `UNIX_EPOCH`; consumers treat `0` as
+/// the "no wire-time stamp" sentinel and fall back to receive-time.
+fn now_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+        .unwrap_or(0)
 }
 
 // ---- pressure tracker --------------------------------------------------
@@ -813,6 +829,16 @@ mod tests {
             }
             other => panic!("expected ResourcePressure variant, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn now_unix_ms_is_post_2024() {
+        // Sanity-check the wall-clock helper: must be well above the
+        // 2024-01-01 floor (1_704_067_200_000 ms) and below i64::MAX.
+        // The exact value drifts every call; just bracket the magnitude.
+        let now = now_unix_ms();
+        assert!(now > 1_704_067_200_000, "{now} should be > 2024-01-01 ms");
+        assert!(now < (i64::MAX as u64), "{now} should fit in i64");
     }
 
     #[test]

--- a/crates/pitboss-web/spa/src/lib/api.ts
+++ b/crates/pitboss-web/spa/src/lib/api.ts
@@ -387,6 +387,14 @@ export type PressureLevel = 'clear' | 'warn' | 'error';
 export interface ResourceSampleEvent {
   event: 'resource_sample';
   samples: ResourceSampleEntry[];
+  /**
+   * Unix ms when the dispatcher took the sample. Absent / `0` for
+   * pre-v0.17 envelopes — consumers should fall back to `Date.now()`
+   * at receive time when this is missing. Stamped server-side so
+   * `events.jsonl` replay plots at the original cadence instead of
+   * collapsing onto the replay clock. (#580 FU-4)
+   */
+  sampled_at_unix_ms?: number;
   cgroup_memory_current_bytes?: number;
   cgroup_memory_max_bytes?: number;
   host_mem_total_bytes?: number;

--- a/crates/pitboss-web/spa/src/routes/runs/[id]/+page.svelte
+++ b/crates/pitboss-web/spa/src/routes/runs/[id]/+page.svelte
@@ -541,7 +541,16 @@
         const ev = e as ControlEnvelope & ResourceSampleEvent;
         latestResourceSample = ev;
         if (resourceSamples.length >= 240) resourceSamples.shift();
-        resourceSamples.push({ envelope: ev, at: Date.now() });
+        // Prefer the server-side wire timestamp (#580 FU-4) so the
+        // chart's X-axis matches sample order, not receive order, and
+        // events.jsonl replay plots at the original cadence. Fall
+        // back to receive time for pre-v0.17 envelopes where the
+        // field is absent or zero.
+        const at =
+          ev.sampled_at_unix_ms && ev.sampled_at_unix_ms > 0
+            ? ev.sampled_at_unix_ms
+            : Date.now();
+        resourceSamples.push({ envelope: ev, at });
         resourceSamples = resourceSamples; // trigger reactivity
         break;
       }


### PR DESCRIPTION
## Summary

Second slice of the [#580](https://github.com/SDS-Mode/pitboss/issues/580) audit follow-ups — adds the missing wire-time stamp to `ResourceSample` envelopes so replay tooling and live charts plot at sample-order rather than receive-order.

### Rust side

- New variant field: `ControlEvent::ResourceSample.sampled_at_unix_ms: u64` with `#[serde(default)]` (`0` sentinel for pre-v0.17 envelopes).
- New helper `now_unix_ms()` in `dispatch::resource_watch` — saturates to `u64::MAX` on absurd futures, `0` on the impossible `now() < UNIX_EPOCH` case.
- Stamp wired in at the single `ControlEvent::ResourceSample` construction site (`run_sampler`).

### SPA side (intentional Rust↔TS duplication per `pitboss-web/CLAUDE.md`)

- `lib/api.ts` ResourceSampleEvent type gains `sampled_at_unix_ms?: number` with a doc-comment explaining the fallback contract.
- `routes/runs/[id]/+page.svelte` push site now prefers `ev.sampled_at_unix_ms` (when `> 0`) over `Date.now()` for the rolling buffer entry's `at`. Falls back to `Date.now()` for absent/zero values so pre-v0.17 dispatchers keep working.

### Why this matters

From the audit body:
1. Future `events.jsonl` replay (planned per the watcher's module doc) would collapse N hours of samples onto one instant — the replay clock — without a wire-time stamp. The chart X-axis and CPU% delta math both read `s.at`.
2. Under tokio scheduler backlog — the OOM-near-edge moment when sample-emit lag is largest — the X-axis monotonicity would match receive order, not sample order. The wire stamp is the only signal that's robust to backlog.

## Wire-compat

- Field is additive on an existing variant; back-compat via `#[serde(default)]` per the contract in `control/protocol.rs`'s top-of-file doc.
- The wire-compat guard test (`wire_compat_guard.rs::every_nested_struct_field_in_wire_variants_has_back_compat_attr`) continues to pass — the new field is in an inline variant scope, which the guard intentionally exempts (see FU-5 for the corresponding scope-doc work).
- TS interface change is also additive (`?:` optional field) so older SPA bundles served by newer dispatchers ignore the field harmlessly.

## Test plan

- [x] `cargo test -p pitboss-cli --lib dispatch::resource_watch::tests` — 17/17 ✅ (1 new: `now_unix_ms_is_post_2024`)
- [x] `cargo test -p pitboss-cli --test wire_compat_guard` — 2/2 ✅
- [x] `cargo test -p pitboss-cli --lib` — 896/896 ✅
- [x] `cargo lint` — clean
- [x] `cargo tidy` — clean
- [x] `(cd crates/pitboss-web/spa && npm run check)` — 0 errors, 0 warnings
- [ ] CI (Linux) — workspace suite

Refs #580.

🤖 Generated with [Claude Code](https://claude.com/claude-code)