### PR TITLE
fix(dispatch): release subleads read guard before walking sub-tree workers

### DIFF
--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -240,14 +240,17 @@ pub async fn resolve_envelope(
     // ── Cap: max_total_workers ─────────────────────────────────────────
     if let Some(cap) = lead.and_then(|l| l.max_total_workers) {
         let root_workers = state.root.workers.states.read().await.len() as u32;
-        let subleads_guard = state.subleads.read().await;
-        let sub_workers: u32 = {
-            let mut total = 0u32;
-            for sub in subleads_guard.values() {
-                total += sub.workers.states.read().await.len() as u32;
-            }
-            total
+        // Snapshot sub-layer Arcs and drop the outer guard before awaiting
+        // inner locks — otherwise `subleads.write()` (register/reconcile)
+        // starves until this walk completes.
+        let sub_layers: Vec<Arc<LayerState>> = {
+            let guard = state.subleads.read().await;
+            guard.values().cloned().collect()
         };
+        let mut sub_workers = 0u32;
+        for sub in &sub_layers {
+            sub_workers += sub.workers.states.read().await.len() as u32;
+        }
         let projected = root_workers + sub_workers + max_workers;
         if projected > cap {
             return Err(anyhow!(

--- a/crates/pitboss-cli/tests/sublead_flows.rs
+++ b/crates/pitboss-cli/tests/sublead_flows.rs
@@ -1029,6 +1029,56 @@ async fn spawn_sublead_rejected_when_over_max_sublead_budget() {
     );
 }
 
+/// `resolve_envelope` enforces the `max_total_workers` cap by summing root
+/// workers + sub-tree workers + the requested `max_workers`. Walks at least
+/// one registered sub-layer to exercise the per-sub worker read.
+#[tokio::test]
+async fn resolve_envelope_rejects_when_max_total_workers_exceeded() {
+    use pitboss_cli::dispatch::sublead::{resolve_envelope, SubleadSpawnRequest};
+
+    let (_dir, state) = TestStateBuilder::new()
+        .with_lead()
+        .lead_id("root")
+        .allow_subleads()
+        .max_total_workers(2)
+        .max_workers(20)
+        .budget(20.0)
+        .build();
+
+    // Register a sub-tree entry so the cap check walks at least one sub-layer.
+    state
+        .register_sublead("sub-1".to_string(), state.root.clone())
+        .await;
+
+    let over = SubleadSpawnRequest {
+        prompt: "p".into(),
+        model: "m".into(),
+        budget_usd: Some(5.0),
+        max_workers: Some(3),
+        lead_timeout_secs: Some(1800),
+        ..Default::default()
+    };
+    let err = resolve_envelope(&state, &over)
+        .await
+        .expect_err("requesting 3 workers under a cap of 2 should be rejected");
+    assert!(
+        err.to_string().contains("max_total_workers cap"),
+        "error should mention the cap; got: {err}"
+    );
+
+    let at_cap = SubleadSpawnRequest {
+        prompt: "p".into(),
+        model: "m".into(),
+        budget_usd: Some(5.0),
+        max_workers: Some(2),
+        lead_timeout_secs: Some(1800),
+        ..Default::default()
+    };
+    resolve_envelope(&state, &at_cap)
+        .await
+        .expect("at-cap request should resolve");
+}
+
 // ── Task 1.3 fix: wait_actor works on sub-lead ids ────────────────────────────
 
 /// After `reconcile_terminated_sublead` runs, `wait_actor(sublead_id)` should

--- a/crates/pitboss-cli/tests/support/state_builder.rs
+++ b/crates/pitboss-cli/tests/support/state_builder.rs
@@ -219,6 +219,13 @@ impl TestStateBuilder {
         self
     }
 
+    pub fn max_total_workers(mut self, n: u32) -> Self {
+        let mut lead = self.lead.unwrap_or_else(default_lead);
+        lead.max_total_workers = Some(n);
+        self.lead = Some(lead);
+        self
+    }
+
     // ── runtime knobs ───────────────────────────────────────────────────────
 
     pub fn spawner(mut self, s: Arc<dyn ProcessSpawner>) -> Self {


### PR DESCRIPTION
## Summary

- `resolve_envelope`'s `max_total_workers` cap held `state.subleads.read()` across every sub-layer's `workers.states.read().await`. Concurrent `subleads.write()` (`register_sublead` / `reconcile_terminated_sublead`) starved until the walk completed — worst-case latency was `N_subleads × await-scheduler-jitter`.
- Snapshot sub-layer `Arc`s under a short-lived guard, drop it, then iterate. `Arc::clone` is just a refcount bump.
- Adds the first unit test for the `max_total_workers` cap path; prior coverage only exercised `max_sublead_budget_usd`.

Closes #489

Note: the audit framed this as "three concurrently-held read locks." It's actually two — the `state.root.workers.states.read()` on line 242 is a chained-temporary dropped after `.len()`. The contention story (writer starvation) is unchanged.

Out of scope: the sibling F-CONC-2 cluster in `dispatch/hierarchical.rs` (#492) follows the same pattern but is tracked separately.

## Test plan

- [x] `TMPDIR=/private/tmp/pb cargo test -p pitboss-cli --test sublead_flows` — 34 passed, including the new `resolve_envelope_rejects_when_max_total_workers_exceeded`
- [x] `cargo lint` — clean
- [x] `cargo tidy` — clean
- [x] CI `test + lint + fmt` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)