### PR TITLE
fix: batch three medium-severity concurrency findings (F-CONC-2/6/9)

### DIFF
--- a/crates/pitboss-cli/src/control/protocol.rs
+++ b/crates/pitboss-cli/src/control/protocol.rs
@@ -474,6 +474,19 @@ pub enum ControlEvent {
         #[serde(default)]
         outcome: TerminationOutcome,
     },
+    /// Gap sentinel emitted by the `events.jsonl` persistence subscriber
+    /// when the broadcast channel reports `Lagged(n)`. Without this, the
+    /// on-disk log silently skips `n` envelopes and downstream replay
+    /// (`pitboss events`, SPA Replay tab) sees a discontinuity it can't
+    /// detect. The sentinel is the dispatcher-side analogue of the SSE
+    /// `lagged` event (#445): consumers should treat it as "an unknown
+    /// number of envelopes were dropped here" and refetch live state if
+    /// reconciliation matters.
+    PersistenceGap {
+        /// Count reported by `broadcast::error::RecvError::Lagged(n)`.
+        #[serde(default)]
+        dropped: u64,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -926,6 +939,16 @@ mod tests {
             }
             other => panic!("expected WorkersSnapshot, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn persistence_gap_roundtrip() {
+        let gap = ControlEvent::PersistenceGap { dropped: 42 };
+        assert_eq!(
+            serde_json::to_string(&gap).unwrap(),
+            r#"{"event":"persistence_gap","dropped":42}"#
+        );
+        assert_eq!(roundtrip_event(&gap), gap);
     }
 
     #[test]

--- a/crates/pitboss-cli/src/dispatch/hierarchical.rs
+++ b/crates/pitboss-cli/src/dispatch/hierarchical.rs
@@ -751,8 +751,14 @@ pub async fn run_hierarchical(
         }
     }
     {
-        let subleads = state.subleads.read().await;
-        for (sublead_id, sub) in subleads.iter() {
+        // Snapshot (id, Arc) pairs and drop the outer `subleads` guard before
+        // awaiting any inner lock — otherwise `subleads.write()` (register /
+        // reconcile) starves until the cancel-synthesis walk completes.
+        let sub_layers: Vec<(String, std::sync::Arc<crate::dispatch::layer::LayerState>)> = {
+            let guard = state.subleads.read().await;
+            guard.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
+        };
+        for (sublead_id, sub) in &sub_layers {
             let workers = sub.workers.states.read().await;
             let models = sub.workers.models.read().await;
             let actor_types = sub.workers.actor_types.read().await;

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -516,6 +516,17 @@ impl DispatchState {
                                 "events.jsonl persistence subscriber lagged; \
                                  some envelopes will be missing from the log",
                             );
+                            // Persist a sentinel so downstream replay can
+                            // detect the discontinuity instead of silently
+                            // reading a file with missing records.
+                            let sentinel = crate::control::protocol::EventEnvelope {
+                                actor_path: crate::dispatch::actor::ActorPath::default(),
+                                seq: log.next_seq(),
+                                event: crate::control::protocol::ControlEvent::PersistenceGap {
+                                    dropped: n,
+                                },
+                            };
+                            log.persist(&sentinel).await;
                         }
                         Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
                     }

--- a/crates/pitboss-cli/src/events.rs
+++ b/crates/pitboss-cli/src/events.rs
@@ -227,6 +227,9 @@ fn describe_event(event: &ControlEvent) -> (&'static str, String) {
                 "level={level:?} total_rss_bytes={total_rss_bytes} available_bytes={available_bytes}"
             ),
         ),
+        ControlEvent::PersistenceGap { dropped } => {
+            ("persistence_gap", format!("dropped={dropped}"))
+        }
     }
 }
 

--- a/crates/pitboss-core/src/session/cancel.rs
+++ b/crates/pitboss-core/src/session/cancel.rs
@@ -45,7 +45,13 @@ impl CancelToken {
     /// trail reaches `TaskRecord::terminate_reason`. Retained for the
     /// shutdown-cascade path where the reason is already set on the
     /// parent token and `cascade_to` will propagate it. (#475)
+    ///
+    /// Also flips the drain signal so `await_drain` observers wake on
+    /// terminate too — terminate is strictly stronger than drain, and
+    /// any actor with a drain-only listener would otherwise hang when
+    /// cancellation skipped straight to terminate (budget-abort path).
     pub fn terminate(&self) {
+        let _ = self.drain_tx.send(true);
         let _ = self.terminate_tx.send(true);
     }
 
@@ -56,8 +62,12 @@ impl CancelToken {
     /// facing audit trail names the kill site. Setting the reason BEFORE
     /// the boolean signal prevents an observer racing on terminate from
     /// reading `None`. (#475)
+    ///
+    /// Send order is `reason → drain → terminate`: drain wakes ahead of
+    /// terminate so a drain-only awaiter sees the reason already in place.
     pub fn terminate_with_reason(&self, reason: TerminateReason) {
         let _ = self.reason_tx.send(Some(reason));
+        let _ = self.drain_tx.send(true);
         let _ = self.terminate_tx.send(true);
     }
 
@@ -152,11 +162,39 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn terminate_is_independent_of_drain() {
+    async fn terminate_implies_drain() {
+        // terminate is strictly stronger than drain: any actor with a
+        // drain-only listener would otherwise hang on the budget-abort
+        // path that goes straight to terminate.
         let t = CancelToken::new();
         t.terminate();
         assert!(t.is_terminated());
-        assert!(!t.is_draining());
+        assert!(t.is_draining());
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn terminate_unblocks_await_drain() {
+        let t = CancelToken::new();
+        let handle = {
+            let t = t.clone();
+            tokio::spawn(async move { t.await_drain().await })
+        };
+        tokio::time::advance(Duration::from_millis(10)).await;
+        t.terminate();
+        handle.await.unwrap();
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn terminate_with_reason_unblocks_await_drain() {
+        let t = CancelToken::new();
+        let handle = {
+            let t = t.clone();
+            tokio::spawn(async move { t.await_drain().await })
+        };
+        tokio::time::advance(Duration::from_millis(10)).await;
+        t.terminate_with_reason(TerminateReason::OperatorCtrlC);
+        handle.await.unwrap();
+        assert_eq!(t.terminate_reason(), Some(TerminateReason::OperatorCtrlC));
     }
 
     #[test]
@@ -185,9 +223,9 @@ mod tests {
         parent.terminate();
         parent.cascade_to(&child);
         assert!(child.is_terminated());
-        // Whether `is_draining` is also true depends on whether
-        // terminate implicitly sets drain; we deliberately only assert
-        // terminate here because that's the dominant signal.
+        // terminate implies drain on the child too — drain-only awaiters
+        // shouldn't hang when cancellation skips the graceful step.
+        assert!(child.is_draining());
     }
 
     #[test]
@@ -197,12 +235,11 @@ mod tests {
         parent.drain();
         parent.terminate();
         parent.cascade_to(&child);
+        // The stricter signal still wins for the cascade choice
+        // (child.terminate(), not child.drain()), but child.terminate()
+        // now also raises drain so an `await_drain` observer wakes.
         assert!(child.is_terminated());
-        // Crucially, drain is NOT applied to the child when terminate
-        // is also set on the parent — the stricter signal wins, so we
-        // never tell the child "you may finish current work" while the
-        // parent has already said "stop now".
-        assert!(!child.is_draining());
+        assert!(child.is_draining());
     }
 
     // ── #475: terminate_reason audit trail ──────────────────────────────

--- a/crates/pitboss-web/spa/src/lib/api.ts
+++ b/crates/pitboss-web/spa/src/lib/api.ts
@@ -409,6 +409,16 @@ export interface ResourcePressureEvent {
   message?: string;
 }
 
+/** Mirror of the `persistence_gap` `ControlEvent` variant. Written to
+ *  `events.jsonl` by the persistence subscriber when the broadcast
+ *  channel reports `Lagged(n)` — N envelopes were dropped before this
+ *  sentinel. Replay consumers should treat this as a discontinuity
+ *  marker and refetch live state if reconciliation matters. */
+export interface PersistenceGapEvent {
+  event: 'persistence_gap';
+  dropped?: number;
+}
+
 /** Mirror of `pitboss_core::store::record::ResourceHighWater` (finalize-
  *  time roll-up persisted to `summary.json`). */
 export interface ResourceHighWater {


### PR DESCRIPTION
## Summary

Three medium-severity concurrency issues from the 2026-05-14 audit, bundled in one PR per request. Each is a distinct commit with its own conventional prefix so git-cliff routes all three into the CHANGELOG.

| Commit | Issue | Crate | Shape |
|---|---|---|---|
| \`fix(dispatch): release subleads guard before walking sub-tree workers in cancel-synthesis\` | #492 | pitboss-cli | snapshot-Arcs pattern, mirrors #595 |
| \`fix(core): terminate() now implies drain() to unblock drain-only awaiters\` | #496 | pitboss-core | invariant change |
| \`fix(dispatch): write gap sentinel to events.jsonl when persistence subscriber lags\` | #499 | pitboss-cli (+ SPA mirror) | new \`PersistenceGap\` variant |

### Design notes for #496 (the substantive one)

This changes a previously-documented invariant: \`CancelToken::terminate()\` no longer leaves \`drain_tx\` untouched. Three tests asserted the prior independence; they're rewritten to assert the new \"terminate is strictly stronger than drain\" semantics:

- \`terminate_is_independent_of_drain\` → \`terminate_implies_drain\` (flipped assertion)
- \`cascade_to_terminate_dominates_drain\` — \`cascade_to\` still picks terminate as the dominant signal for the child, but \`child.terminate()\` now also raises \`child.drain_tx\`, so \`child.is_draining()\` is true.
- \`cascade_to_terminates_child_when_parent_terminated\` — \`is_draining\` is now asserted true and the wishy-washy comment is replaced with the firm semantic.

Two new tests prove the bug fix directly: \`terminate_unblocks_await_drain\` and \`terminate_with_reason_unblocks_await_drain\`.

Send order is preserved per the documented design rule (#4 in \`pitboss-core/CLAUDE.md\`): \`reason → drain → terminate\` keeps the reason set before any awaiter wakes.

### Design notes for #499

\`PersistenceGap { dropped: u64 }\` is the dispatcher-side analogue of the SSE \`lagged\` event (#445). The SSE path already surfaces broadcast lag as a typed event; this closes the on-disk asymmetry where the persistence subscriber dropped envelopes with only a \`tracing::warn!\`. Mirrored in \`spa/src/lib/api.ts\` per the workspace CLAUDE.md rule.

The audit's recommendation also suggested a \`seq_range\` field. I went with just \`dropped\` — the persistence subscriber doesn't have visibility into the seqs of the dropped envelopes (broadcast just gives a count). Consumers wanting to reconcile can call \`/api/runs/:id/events\` (live) and reconcile from there.

## Test plan

- [x] \`TMPDIR=/private/tmp/pb cargo test -p pitboss-core --features test-support session::cancel\` — 16 passed (including 2 new + 3 rewritten)
- [x] \`TMPDIR=/private/tmp/pb cargo test -p pitboss-cli\` — 900 passed (one parallel-flake on \`continue_worker_from_paused_transitions_running\` cleared on re-run; unrelated to this PR)
- [x] \`TMPDIR=/private/tmp/pb cargo test -p pitboss-cli --test wire_compat_guard\` — 4 passed, the new variant is wire-safe
- [x] \`cargo lint\` — clean
- [x] \`cargo tidy\` — clean
- [x] \`(cd crates/pitboss-web/spa && npm run check)\` — 0 errors / 0 warnings
- [ ] CI \`test + lint + fmt\` green
- [x] macOS-only \`process::tokio_impl::tests::terminate_after_exit_is_ok\` flake observed (\`BinaryNotFound /bin/true\`) — documented; Linux CI is the ground truth

Closes #492
Closes #496
Closes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)