### PR TITLE
fix(dispatch): close F-CONC-3 + F-CONC-5 (budget under-count, cancel-cascade doc)

### DIFF
--- a/crates/pitboss-cli/src/dispatch/budget_watch.rs
+++ b/crates/pitboss-cli/src/dispatch/budget_watch.rs
@@ -92,7 +92,12 @@ impl SpendBreakdown {
 /// Walk every layer in the run (root + live sub-leads + terminated
 /// sub-leads) and assemble the current spend totals.
 pub async fn compute_total_spend(state: &DispatchState) -> SpendBreakdown {
-    let workers_root = *state.root.budget.spent_usd.lock().await;
+    let workers_root = *state
+        .root
+        .budget
+        .spent_usd
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let lead_usd = *state
         .root
         .budget
@@ -105,7 +110,11 @@ pub async fn compute_total_spend(state: &DispatchState) -> SpendBreakdown {
     {
         let live = state.subleads.read().await;
         for layer in live.values() {
-            workers_subs += *layer.budget.spent_usd.lock().await;
+            workers_subs += *layer
+                .budget
+                .spent_usd
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             subleads_usd += *layer
                 .budget
                 .lead_spent_usd
@@ -116,7 +125,11 @@ pub async fn compute_total_spend(state: &DispatchState) -> SpendBreakdown {
     {
         let terminated = state.terminated_sublead_layers.read().await;
         for layer in terminated.iter() {
-            workers_subs += *layer.budget.spent_usd.lock().await;
+            workers_subs += *layer
+                .budget
+                .spent_usd
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             subleads_usd += *layer
                 .budget
                 .lead_spent_usd
@@ -134,18 +147,21 @@ pub async fn compute_total_spend(state: &DispatchState) -> SpendBreakdown {
 
 /// Synchronous variant of [`compute_total_spend`]. Used inside the
 /// usage observer, which runs from a non-async context inside the
-/// session stream loop. Uses `try_lock` on the tokio mutexes — if a
-/// `worker_status` MCP call happens to be reading worker spend at the
-/// same instant the contention is benign and the next observer fire
-/// gets a fresh reading.
+/// session stream loop. `spent_usd` and `lead_spent_usd` are
+/// `std::sync::Mutex<f64>` and acquired with a short blocking
+/// `.lock()` — critical sections are an f64 read away. The remaining
+/// `try_read()` on `state.subleads` is a tokio `RwLock` and falls
+/// back to a partial sum on contention with a concurrent
+/// `register_sublead` / `reconcile_terminated_sublead`; those writes
+/// are rare (one per sub-lead lifecycle event) so the next observer
+/// fire gets a fresh reading.
 fn compute_total_spend_blocking(state: &DispatchState) -> SpendBreakdown {
-    let workers_root = state
+    let workers_root = *state
         .root
         .budget
         .spent_usd
-        .try_lock()
-        .map(|g| *g)
-        .unwrap_or(0.0);
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let lead_usd = *state
         .root
         .budget
@@ -157,7 +173,11 @@ fn compute_total_spend_blocking(state: &DispatchState) -> SpendBreakdown {
     let mut subleads_usd = 0.0_f64;
     if let Ok(live) = state.subleads.try_read() {
         for layer in live.values() {
-            workers_subs += layer.budget.spent_usd.try_lock().map(|g| *g).unwrap_or(0.0);
+            workers_subs += *layer
+                .budget
+                .spent_usd
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             subleads_usd += *layer
                 .budget
                 .lead_spent_usd
@@ -167,7 +187,11 @@ fn compute_total_spend_blocking(state: &DispatchState) -> SpendBreakdown {
     }
     if let Ok(terminated) = state.terminated_sublead_layers.try_read() {
         for layer in terminated.iter() {
-            workers_subs += layer.budget.spent_usd.try_lock().map(|g| *g).unwrap_or(0.0);
+            workers_subs += *layer
+                .budget
+                .spent_usd
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             subleads_usd += *layer
                 .budget
                 .lead_spent_usd

--- a/crates/pitboss-cli/src/dispatch/layer.rs
+++ b/crates/pitboss-cli/src/dispatch/layer.rs
@@ -148,7 +148,16 @@ pub struct BudgetState {
     /// Total USD spent so far on completed workers in this layer.
     /// Lead and sub-lead token spend are accounted in `lead_spent_usd`;
     /// helpers that compute the total run spend sum across layers.
-    pub spent_usd: Mutex<f64>,
+    ///
+    /// Uses `std::sync::Mutex` rather than `tokio::sync::Mutex` because
+    /// `dispatch::budget_watch::compute_total_spend_blocking` (run from
+    /// the synchronous session-stream usage observer) needs to read it
+    /// without `try_lock` — previously, contention from a concurrent
+    /// `worker_status` MCP call would silently zero this contribution
+    /// and delay budget-abort by one or more assistant turns. Critical
+    /// sections are short (f64 read/write); no `.await` may cross the
+    /// guard.
+    pub spent_usd: std::sync::Mutex<f64>,
     /// USD reserved for in-flight workers at spawn time.
     pub reserved_usd: Mutex<f64>,
     /// Token spend (USD) attributed to *this layer's lead* (the root
@@ -173,7 +182,7 @@ impl BudgetState {
     /// and `abort_reason` is `None`.
     pub fn new() -> Self {
         Self {
-            spent_usd: Mutex::new(0.0),
+            spent_usd: std::sync::Mutex::new(0.0),
             reserved_usd: Mutex::new(0.0),
             lead_spent_usd: std::sync::Mutex::new(0.0),
             abort_reason: std::sync::Mutex::new(None),
@@ -605,7 +614,11 @@ impl LayerState {
 
     pub async fn budget_remaining(&self) -> Option<f64> {
         let budget = self.manifest.budget_usd?;
-        let spent = *self.budget.spent_usd.lock().await;
+        let spent = *self
+            .budget
+            .spent_usd
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         Some((budget - spent).max(0.0))
     }
 
@@ -659,7 +672,14 @@ mod tests {
         let (_dir, layer) = mk_layer();
         assert!(layer.workers.states.read().await.is_empty());
         assert!(layer.workers.cancels.read().await.is_empty());
-        assert_eq!(*layer.budget.spent_usd.lock().await, 0.0);
+        assert_eq!(
+            *layer
+                .budget
+                .spent_usd
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+            0.0
+        );
         assert_eq!(*layer.budget.reserved_usd.lock().await, 0.0);
     }
 

--- a/crates/pitboss-cli/src/dispatch/layer.rs
+++ b/crates/pitboss-cli/src/dispatch/layer.rs
@@ -76,6 +76,14 @@ pub struct WorkerRegistry {
     /// Map of task_id → worker state. Lead is also tracked here for convenience.
     pub states: RwLock<HashMap<String, WorkerState>>,
     /// Per-worker CancelToken, keyed by task_id.
+    ///
+    /// **All production inserts MUST go through
+    /// [`LayerState::register_worker_cancel`]** — direct `.write().await.insert(...)`
+    /// bypasses the eager `cascade_to` step that closes the post-register
+    /// cascade gap (#99). The per-sublead watcher
+    /// (`install_sublead_cancel_watcher`) is fire-once: a worker registered
+    /// after the watcher has already fired would otherwise miss the cancel
+    /// signal forever.
     pub cancels: RwLock<HashMap<String, CancelToken>>,
     /// Per-worker prompt preview (first 80 chars of the worker's prompt).
     pub prompts: RwLock<HashMap<String, String>>,

--- a/crates/pitboss-cli/src/dispatch/signals.rs
+++ b/crates/pitboss-cli/src/dispatch/signals.rs
@@ -425,11 +425,12 @@ mod tests {
         // Register two worker cancel tokens.
         let w1 = CancelToken::new();
         let w2 = CancelToken::new();
-        {
-            let mut cancels = sub_layer.workers.cancels.write().await;
-            cancels.insert("w1".into(), w1.clone());
-            cancels.insert("w2".into(), w2.clone());
-        }
+        sub_layer
+            .register_worker_cancel("w1".into(), w1.clone())
+            .await;
+        sub_layer
+            .register_worker_cancel("w2".into(), w2.clone())
+            .await;
 
         install_sublead_cancel_watcher(sub_layer.clone());
 
@@ -521,10 +522,9 @@ mod tests {
         ));
 
         let w1 = CancelToken::new();
-        {
-            let mut cancels = sub_layer.workers.cancels.write().await;
-            cancels.insert("w1".into(), w1.clone());
-        }
+        sub_layer
+            .register_worker_cancel("w1".into(), w1.clone())
+            .await;
 
         install_sublead_cancel_watcher(sub_layer.clone());
 
@@ -619,10 +619,9 @@ mod tests {
         ));
 
         let w1 = CancelToken::new();
-        {
-            let mut cancels = sub_layer.workers.cancels.write().await;
-            cancels.insert("w1".into(), w1.clone());
-        }
+        sub_layer
+            .register_worker_cancel("w1".into(), w1.clone())
+            .await;
 
         install_sublead_cancel_watcher(sub_layer.clone());
 

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -762,7 +762,11 @@ mod tests {
     async fn budget_remaining_reflects_spent() {
         let st = mk_state(Some(10.0), None);
         assert_eq!(st.root.budget_remaining().await, Some(10.0));
-        *st.root.budget.spent_usd.lock().await = 3.5;
+        *st.root
+            .budget
+            .spent_usd
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = 3.5;
         assert_eq!(st.root.budget_remaining().await, Some(6.5));
     }
 

--- a/crates/pitboss-cli/src/dispatch/sublead.rs
+++ b/crates/pitboss-cli/src/dispatch/sublead.rs
@@ -326,7 +326,12 @@ pub async fn spawn_sublead(
             // Fixes the TOCTOU described in #106: two independent lock
             // snapshots + an unlocked check allowed both callers to pass
             // the guard before either wrote, enabling budget over-commit.
-            let spent = *state.root.budget.spent_usd.lock().await;
+            let spent = *state
+                .root
+                .budget
+                .spent_usd
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             let mut reserved = state.root.budget.reserved_usd.lock().await;
             if spent + *reserved + amount > cap {
                 bail!(
@@ -907,7 +912,11 @@ async fn spawn_sublead_session(
         // sub-tree can occur between iterations because the sub-lead's
         // MCP session is closed while its subprocess is dead).
         if let Some(cost) = pitboss_core::prices::cost_usd(&model_bg, &total_token_usage) {
-            *sub_layer_bg.budget.spent_usd.lock().await += cost;
+            *sub_layer_bg
+                .budget
+                .spent_usd
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) += cost;
         }
 
         // Close the reprompt channel so further sends return errors.
@@ -1110,7 +1119,11 @@ pub async fn reconcile_terminated_sublead(
         .await
         .push(sub_layer.clone());
 
-    let actual_spend = *sub_layer.budget.spent_usd.lock().await;
+    let actual_spend = *sub_layer
+        .budget
+        .spent_usd
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let original_reservation_usd = sub_layer.original_reservation_usd.unwrap_or(0.0);
     let unspent = (original_reservation_usd - actual_spend).max(0.0);
 
@@ -1204,7 +1217,12 @@ pub async fn reconcile_terminated_sublead(
     }
     // Then record the actual spend
     {
-        let mut spent = state.root.budget.spent_usd.lock().await;
+        let mut spent = state
+            .root
+            .budget
+            .spent_usd
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         *spent += actual_spend;
     }
 

--- a/crates/pitboss-cli/src/mcp/tools/spawn.rs
+++ b/crates/pitboss-cli/src/mcp/tools/spawn.rs
@@ -214,7 +214,11 @@ pub async fn handle_spawn_worker(
         // inside the same critical section to keep the arithmetic on a
         // single consistent snapshot.
         let mut reserved_guard = target_layer.budget.reserved_usd.lock().await;
-        let spent = *target_layer.budget.spent_usd.lock().await;
+        let spent = *target_layer
+            .budget
+            .spent_usd
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let reserved = *reserved_guard;
         // (#253) Include the lead/sub-lead's own token spend in the
         // budget check — `budget_usd` is now the run-wide cap across
@@ -829,7 +833,11 @@ async fn run_worker(
 
     // Accumulate cost into the layer's spent_usd.
     if let Some(cost) = pitboss_core::prices::cost_usd(&model, &rec.token_usage) {
-        *layer.budget.spent_usd.lock().await += cost;
+        *layer
+            .budget
+            .spent_usd
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) += cost;
     }
 
     // Transition to Done + broadcast on the layer's done channel.

--- a/crates/pitboss-cli/src/mcp/tools/tests.rs
+++ b/crates/pitboss-cli/src/mcp/tools/tests.rs
@@ -458,7 +458,12 @@ async fn spawn_worker_refuses_when_max_workers_reached() {
 #[tokio::test]
 async fn spawn_worker_refuses_when_budget_exceeded() {
     let state = test_state().await; // budget_usd = 5.0
-    *state.root.budget.spent_usd.lock().await = 5.0; // at cap
+    *state
+        .root
+        .budget
+        .spent_usd
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = 5.0; // at cap
     let args = SpawnWorkerArgs {
         prompt: "p".into(),
         directory: None,
@@ -878,7 +883,12 @@ async fn spawn_worker_completes_and_updates_spent_usd_and_parent_task_id() {
 
     // Verify cost accumulation. claude-haiku-4-5: input $0.80/1M, output $4.00/1M.
     // 1000 input = $0.0008; 2000 output = $0.008; total = $0.0088.
-    let spent = *state.root.budget.spent_usd.lock().await;
+    let spent = *state
+        .root
+        .budget
+        .spent_usd
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     assert!(
         (spent - 0.0088).abs() < 1e-6,
         "expected spent_usd ≈ 0.0088, got {spent}"

--- a/crates/pitboss-cli/tests/e2e_sublead_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_sublead_flows.rs
@@ -158,7 +158,11 @@ async fn root_spawns_sublead_which_completes() {
     {
         let subleads = state.subleads.read().await;
         let sub_layer = subleads.get(&sublead_id).expect("sub-layer should exist");
-        *sub_layer.budget.spent_usd.lock().await = actual_spend;
+        *sub_layer
+            .budget
+            .spent_usd
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = actual_spend;
     }
 
     // Trigger reconciliation (mimics Event::Result terminal event).
@@ -177,7 +181,12 @@ async fn root_spawns_sublead_which_completes() {
         "root.budget.reserved_usd should be 0 after reconcile"
     );
     assert_eq!(
-        *state.root.budget.spent_usd.lock().await,
+        *state
+            .root
+            .budget
+            .spent_usd
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner),
         actual_spend,
         "root.budget.spent_usd should equal sub-lead actual spend"
     );
@@ -569,7 +578,12 @@ async fn budget_envelope_returns_to_root_pool() {
 
     // Record root's pre-spawn baseline.
     let pre_spawn_reserved = *state.root.budget.reserved_usd.lock().await;
-    let pre_spawn_spent = *state.root.budget.spent_usd.lock().await;
+    let pre_spawn_spent = *state
+        .root
+        .budget
+        .spent_usd
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
 
     // Root lead spawns sub-lead with $5 envelope.
     let req = SubleadSpawnRequest {
@@ -601,7 +615,11 @@ async fn budget_envelope_returns_to_root_pool() {
     {
         let subleads = state.subleads.read().await;
         let sub_layer = subleads.get(&sublead_id).expect("sub-layer must exist");
-        *sub_layer.budget.spent_usd.lock().await = actual_spend;
+        *sub_layer
+            .budget
+            .spent_usd
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = actual_spend;
     }
 
     // Reconcile (terminate the sub-lead).
@@ -623,7 +641,12 @@ async fn budget_envelope_returns_to_root_pool() {
         "root.budget.reserved_usd should return to pre-spawn value after reconcile"
     );
     assert_eq!(
-        *state.root.budget.spent_usd.lock().await,
+        *state
+            .root
+            .budget
+            .spent_usd
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner),
         pre_spawn_spent + actual_spend,
         "root.budget.spent_usd should increase by the sub-lead's actual spend"
     );

--- a/crates/pitboss-cli/tests/hierarchical_flows.rs
+++ b/crates/pitboss-cli/tests/hierarchical_flows.rs
@@ -108,7 +108,12 @@ async fn mcp_spawn_over_max_workers_returns_error() {
 #[tokio::test]
 async fn mcp_spawn_over_budget_returns_error() {
     let (_dir, state) = mk_state(); // budget_usd = 5.0
-    *state.root.budget.spent_usd.lock().await = 5.0;
+    *state
+        .root
+        .budget
+        .spent_usd
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = 5.0;
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
     let _server = McpServer::start(socket.clone(), state.clone())
         .await

--- a/crates/pitboss-cli/tests/sublead_flows.rs
+++ b/crates/pitboss-cli/tests/sublead_flows.rs
@@ -457,7 +457,11 @@ async fn unspent_sublead_envelope_returns_to_root_pool() {
     {
         let subleads = state.subleads.read().await;
         let sub_layer = subleads.get(&sublead_id).expect("sub-layer should exist");
-        *sub_layer.budget.spent_usd.lock().await = 2.0;
+        *sub_layer
+            .budget
+            .spent_usd
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = 2.0;
     }
 
     // Trigger reconciliation
@@ -472,7 +476,15 @@ async fn unspent_sublead_envelope_returns_to_root_pool() {
     // After: root's reserved_usd dropped by $5, spent_usd rose by $2,
     // releasing $3 to reservable pool.
     assert_eq!(*state.root.budget.reserved_usd.lock().await, 0.0);
-    assert_eq!(*state.root.budget.spent_usd.lock().await, 2.0);
+    assert_eq!(
+        *state
+            .root
+            .budget
+            .spent_usd
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner),
+        2.0
+    );
     // Verify sub-layer was removed during reconciliation
     assert!(
         state.subleads.read().await.get(&sublead_id).is_none(),
@@ -1116,7 +1128,11 @@ async fn wait_actor_returns_for_terminated_sublead() {
     {
         let subleads = state.subleads.read().await;
         let sub_layer = subleads.get(&sublead_id).expect("sub-layer should exist");
-        *sub_layer.budget.spent_usd.lock().await = 1.0;
+        *sub_layer
+            .budget
+            .spent_usd
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = 1.0;
     }
 
     // Reconcile (terminate the sub-lead).


### PR DESCRIPTION
## Summary

Two medium-severity audit findings, bundled per request. Distinct commits with conventional prefixes for git-cliff routing.

| Commit | Issue | Shape |
|---|---|---|
| \`docs(dispatch): pin the register_worker_cancel invariant on workers.cancels\` | #495 | Rustdoc + 3 test-site cleanups |
| \`fix(dispatch): switch BudgetState.spent_usd to std::sync::Mutex\` | #493 | Mutex type switch + 24 call sites updated |

### #495 (F-CONC-5)

The audit's framing: \`cascade_to\` is point-in-time and \`install_sublead_cancel_watcher\` is fire-once, so any worker registered after a cancel signal misses it unless the insertion path also calls \`cascade_to\`. \`LayerState::register_worker_cancel\` is the only insertion path that does this — direct \`.write().await.insert(...)\` silently breaks the contract.

**Fix:** rustdoc on \`WorkerRegistry.cancels\` naming the invariant + switch the three test sites in \`signals.rs\` that bypassed the helper. Test semantics unchanged (the inserts happen before any cancel signal, so the eager cascade was a no-op in those tests anyway — they were testing the watcher path).

### #493 (F-CONC-3)

\`compute_total_spend_blocking\` runs from the synchronous session-stream usage observer and used \`try_lock\` on \`spent_usd\`. Contention from a concurrent \`worker_status\` MCP call (or any other read-side caller) zeroed that contribution, delaying budget-breach abort by ≥1 assistant turn.

**Fix:** switch \`spent_usd\` from \`tokio::sync::Mutex\` to \`std::sync::Mutex\`, mirroring the existing \`lead_spent_usd\` treatment (which had the same audit-flagged shape and was fixed pre-audit). Critical sections are short f64 reads/writes; no \`.await\` crosses the guard. The blocking variant now reads the real value unconditionally.

The remaining \`try_read()\` on \`state.subleads\` is left as-is — it's a much narrower window (register/reconcile writes are per-lifecycle, not per-MCP-call). The updated docstring names it explicitly.

24 call sites updated to use the matching \`.lock().unwrap_or_else(std::sync::PoisonError::into_inner)\` pattern.

## Test plan

- [x] \`TMPDIR=/private/tmp/pb cargo test -p pitboss-cli --lib budget_watch\` — 4 passed
- [x] \`TMPDIR=/private/tmp/pb cargo test -p pitboss-cli --lib signals::\` — 5 passed
- [x] \`TMPDIR=/private/tmp/pb cargo test -p pitboss-cli\` — 900 passed (two parallel-test flakes observed: \`continue_worker_from_paused_transitions_running\` and \`e2e_lead_request_approval_round_trip\`; both pass in isolation and on Linux CI — known macOS-only artifact)
- [x] \`cargo lint\` — clean
- [x] \`cargo tidy\` — clean
- [ ] CI \`test + lint + fmt\` green (Linux ground truth)

Closes #495
Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)