### PR TITLE
feat(core,fake-claude): emit result/usage/rate_limit so tests can exercise the full pipeline

### DIFF
--- a/crates/pitboss-cli/src/dispatch/budget_watch.rs
+++ b/crates/pitboss-cli/src/dispatch/budget_watch.rs
@@ -492,4 +492,63 @@ mod tests {
             "baseline after one iteration should be $0.90, got {after}"
         );
     }
+
+    /// End-to-end pipeline test (F-TEST-3): FakeSpawner emits stream-json
+    /// `assistant_usage` lines whose cumulative cost exceeds `budget_usd`,
+    /// the parser surfaces `AssistantUsage`, the usage observer prices it,
+    /// and the layer's cancel token terminates mid-stream — all without
+    /// hand-calling `obs(usage)`. Closes the audit's "no integration test
+    /// exercises the full pipeline from stream-json output through
+    /// budget-trip to cancel" gap.
+    #[tokio::test]
+    async fn fakespawner_overspend_trips_cancel_through_full_pipeline() {
+        use pitboss_core::process::fake::{FakeScript, FakeSpawner};
+        use pitboss_core::process::{ProcessSpawner, SpawnCmd};
+        use pitboss_core::session::SessionHandle;
+        use std::time::Duration;
+
+        // Tight $0.50 cap; one Opus turn at 50k input + 50k output prices to
+        // $0.75 + $3.75 = $4.50, well past the cap.
+        let (_dir, state) = mk_state_with_caps(Some(0.50), None);
+        let layer = state.root.clone();
+        let baseline = LeadSpendBaseline::new();
+
+        let script = FakeScript::new()
+            .stdout_line(r#"{"type":"system","subtype":"init","session_id":"sess-trip"}"#)
+            .assistant_usage("burning tokens", usage(50_000, 50_000))
+            .result_event("sess-trip", usage(50_000, 50_000))
+            .exit_code(0);
+        let spawner: Arc<dyn ProcessSpawner> = Arc::new(FakeSpawner::new(script));
+        let cmd = SpawnCmd {
+            program: std::path::PathBuf::from("fake-claude"),
+            args: vec![],
+            cwd: std::path::PathBuf::from("/tmp"),
+            env: std::collections::HashMap::new(),
+        };
+        let observer = build_lead_usage_observer(
+            layer.clone(),
+            Arc::clone(&state),
+            "claude-opus-4-7".into(),
+            "lead".into(),
+            Arc::clone(&baseline),
+            state.root.manifest.budget_usd,
+            state.root.manifest.lead_budget_usd,
+        );
+        let handle = SessionHandle::new("lead", spawner, cmd).with_usage_observer(observer);
+        let cancel = layer.cancel.clone();
+        let _outcome = handle
+            .run_to_completion(cancel, Duration::from_millis(100))
+            .await;
+
+        assert!(
+            layer.cancel.is_terminated(),
+            "cancel token should be terminated after parser-driven budget trip"
+        );
+        let reason = layer.budget.abort_reason.lock().unwrap().clone();
+        let msg = reason.expect("abort reason should be stamped");
+        assert!(
+            msg.contains("budget_usd"),
+            "abort reason should name the cap: {msg}"
+        );
+    }
 }

--- a/crates/pitboss-core/src/process/fake.rs
+++ b/crates/pitboss-core/src/process/fake.rs
@@ -49,6 +49,70 @@ impl FakeScript {
         self
     }
 
+    /// Emit a stream-json `assistant` message line whose `content` carries
+    /// one `text` block and whose `message.usage` matches `usage`. This is
+    /// what triggers [`crate::parser::Event::AssistantUsage`] in the
+    /// parser (#253), letting callers exercise the per-turn usage path.
+    pub fn assistant_usage(mut self, text: &str, usage: crate::parser::TokenUsage) -> Self {
+        let line = serde_json::json!({
+            "type": "assistant",
+            "message": {
+                "content": [{ "type": "text", "text": text }],
+                "usage": {
+                    "input_tokens": usage.input,
+                    "output_tokens": usage.output,
+                    "cache_read_input_tokens": usage.cache_read,
+                    "cache_creation_input_tokens": usage.cache_creation,
+                }
+            }
+        });
+        self.actions.push(Action::StdoutLine(line.to_string()));
+        self
+    }
+
+    /// Emit a terminal stream-json `result` line so callers can drive the
+    /// budget-watch finalization path. `session_id` is required by real
+    /// claude; pass any unique string for tests.
+    pub fn result_event(mut self, session_id: &str, usage: crate::parser::TokenUsage) -> Self {
+        let line = serde_json::json!({
+            "type": "result",
+            "subtype": "success",
+            "session_id": session_id,
+            "result": "done",
+            "usage": {
+                "input_tokens": usage.input,
+                "output_tokens": usage.output,
+                "cache_read_input_tokens": usage.cache_read,
+                "cache_creation_input_tokens": usage.cache_creation,
+            }
+        });
+        self.actions.push(Action::StdoutLine(line.to_string()));
+        self
+    }
+
+    /// Emit a stream-json `rate_limit_event` line. `resets_at` is a Unix
+    /// epoch-seconds timestamp.
+    pub fn rate_limit_event(
+        mut self,
+        status: &str,
+        rate_limit_type: Option<&str>,
+        resets_at: Option<u64>,
+    ) -> Self {
+        let mut info = serde_json::json!({ "status": status });
+        if let Some(kind) = rate_limit_type {
+            info["rateLimitType"] = serde_json::Value::String(kind.to_string());
+        }
+        if let Some(ts) = resets_at {
+            info["resetsAt"] = serde_json::Value::from(ts);
+        }
+        let line = serde_json::json!({
+            "type": "rate_limit_event",
+            "rate_limit_info": info,
+        });
+        self.actions.push(Action::StdoutLine(line.to_string()));
+        self
+    }
+
     pub fn exit_code(mut self, code: i32) -> Self {
         self.exit_code = code;
         self
@@ -213,4 +277,84 @@ fn exit_status_from_code(code: i32) -> ExitStatus {
 fn exit_status_from_code(code: i32) -> ExitStatus {
     use std::os::windows::process::ExitStatusExt;
     ExitStatus::from_raw(code as u32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::{parse_line_all, Event, TokenUsage};
+
+    fn emitted_lines(script: &FakeScript) -> Vec<String> {
+        script
+            .actions
+            .iter()
+            .filter_map(|a| match a {
+                Action::StdoutLine(s) => Some(s.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn assistant_usage_helper_emits_a_parseable_assistant_with_usage() {
+        let usage = TokenUsage {
+            input: 100,
+            output: 200,
+            cache_read: 50,
+            cache_creation: 25,
+        };
+        let script = FakeScript::new().assistant_usage("hello", usage);
+        let line = emitted_lines(&script).pop().expect("one line");
+        let events = parse_line_all(line.as_bytes()).expect("parse");
+        // Expect AssistantText + AssistantUsage in order.
+        assert!(matches!(events[0], Event::AssistantText { .. }));
+        match &events[1] {
+            Event::AssistantUsage { usage: u } => assert_eq!(*u, usage),
+            other => panic!("expected AssistantUsage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn result_event_helper_emits_a_parseable_result_line() {
+        let usage = TokenUsage {
+            input: 1,
+            output: 2,
+            cache_read: 3,
+            cache_creation: 4,
+        };
+        let script = FakeScript::new().result_event("sess_xyz", usage);
+        let line = emitted_lines(&script).pop().expect("one line");
+        let events = parse_line_all(line.as_bytes()).expect("parse");
+        match &events[0] {
+            Event::Result {
+                session_id,
+                usage: u,
+                ..
+            } => {
+                assert_eq!(session_id, "sess_xyz");
+                assert_eq!(*u, usage);
+            }
+            other => panic!("expected Result, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rate_limit_event_helper_emits_a_parseable_rate_limit_line() {
+        let script =
+            FakeScript::new().rate_limit_event("rejected", Some("five_hour"), Some(1_776_402_000));
+        let line = emitted_lines(&script).pop().expect("one line");
+        let events = parse_line_all(line.as_bytes()).expect("parse");
+        match &events[0] {
+            Event::RateLimit {
+                status,
+                rate_limit_type,
+                resets_at,
+            } => {
+                assert_eq!(status, "rejected");
+                assert_eq!(rate_limit_type.as_deref(), Some("five_hour"));
+                assert_eq!(*resets_at, Some(1_776_402_000));
+            }
+            other => panic!("expected RateLimit, got {other:?}"),
+        }
+    }
 }

--- a/tests-support/fake-claude/src/main.rs
+++ b/tests-support/fake-claude/src/main.rs
@@ -6,6 +6,17 @@
 //!   {"sleep_ms": N}   — sleeps for N milliseconds
 //!   {"tool_use": {"name": "...", "input": {...}}}
 //!       — emits a stream-json assistant tool_use event on stdout
+//!   {"usage": {"text": "...", "input": N, "output": N,
+//!              "cache_read": N, "cache_creation": N}}
+//!       — emits an assistant message with `message.usage` so the parser
+//!         surfaces Event::AssistantUsage (#253). Per-turn budget watch.
+//!   {"result": {"session_id": "...", "subtype": "...", "text": "...",
+//!               "usage": {"input_tokens": N, ...}}}
+//!       — emits the terminal stream-json result line (drives the
+//!         budget-watch finalization path and SessionOutcome).
+//!   {"rate_limit_event": {"status": "...", "rate_limit_type": "...",
+//!                          "resets_at": N}}
+//!       — emits a rate_limit_event line.
 //!   {"mcp_call": {"name": "...", "args": {...}, "bind": "...", "allow_err": bool}}
 //!       — issues an MCP tool call (requires PITBOSS_FAKE_MCP_SOCKET).
 //!

--- a/tests-support/fake-claude/src/script.rs
+++ b/tests-support/fake-claude/src/script.rs
@@ -2,9 +2,11 @@
 //!
 //! Reads a JSONL script line-by-line from a `BufRead`, executing each
 //! action in order. Existing action types (stdout/stderr/sleep_ms/
-//! tool_use) preserve their pre-v0.4.1 behavior exactly. The new
-//! `mcp_call` action issues a real MCP tool call through an optionally-
-//! provided client.
+//! tool_use/mcp_call) preserve their prior behavior exactly. The
+//! `usage`, `result`, and `rate_limit_event` actions added for #539
+//! emit the corresponding stream-json wire shapes so integration tests
+//! can exercise the budget_watch / SessionOutcome paths that those
+//! events drive.
 
 #![allow(dead_code)]
 
@@ -69,6 +71,75 @@ pub async fn execute_script<R: BufRead>(reader: R, mut client: Option<McpClient>
                         "input": tu.get("input").cloned().unwrap_or(Value::Null),
                     }]
                 }
+            });
+            let mut out = stdout.lock();
+            writeln!(out, "{}", serde_json::to_string(&wrapper)?)?;
+            out.flush()?;
+        } else if let Some(u) = action.get("usage") {
+            // Emit an assistant message whose `message.usage` triggers
+            // Event::AssistantUsage in the parser (#253). The `text` block
+            // mirrors `tool_use` above: real claude always carries a content
+            // block alongside the usage snapshot.
+            let text = u.get("text").and_then(|v| v.as_str()).unwrap_or("");
+            let wrapper = serde_json::json!({
+                "type": "assistant",
+                "message": {
+                    "content": [{ "type": "text", "text": text }],
+                    "usage": {
+                        "input_tokens": u.get("input").and_then(|v| v.as_u64()).unwrap_or(0),
+                        "output_tokens": u.get("output").and_then(|v| v.as_u64()).unwrap_or(0),
+                        "cache_read_input_tokens":
+                            u.get("cache_read").and_then(|v| v.as_u64()).unwrap_or(0),
+                        "cache_creation_input_tokens":
+                            u.get("cache_creation").and_then(|v| v.as_u64()).unwrap_or(0),
+                    }
+                }
+            });
+            let mut out = stdout.lock();
+            writeln!(out, "{}", serde_json::to_string(&wrapper)?)?;
+            out.flush()?;
+        } else if let Some(r) = action.get("result") {
+            // Emit the terminal stream-json result line so tests can drive
+            // the budget-watch finalization path and SessionOutcome's
+            // session_id / token_usage fallback (#475 / #549).
+            let session_id = r
+                .get("session_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("sess-fake");
+            let subtype = r
+                .get("subtype")
+                .and_then(|v| v.as_str())
+                .unwrap_or("success");
+            let result_text = r.get("text").and_then(|v| v.as_str()).unwrap_or("done");
+            let usage = r
+                .get("usage")
+                .cloned()
+                .unwrap_or_else(|| serde_json::json!({ "input_tokens": 0, "output_tokens": 0 }));
+            let wrapper = serde_json::json!({
+                "type": "result",
+                "subtype": subtype,
+                "session_id": session_id,
+                "result": result_text,
+                "usage": usage,
+            });
+            let mut out = stdout.lock();
+            writeln!(out, "{}", serde_json::to_string(&wrapper)?)?;
+            out.flush()?;
+        } else if let Some(rl) = action.get("rate_limit_event") {
+            let status = rl
+                .get("status")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
+            let mut info = serde_json::json!({ "status": status });
+            if let Some(kind) = rl.get("rate_limit_type").and_then(|v| v.as_str()) {
+                info["rateLimitType"] = Value::String(kind.to_string());
+            }
+            if let Some(ts) = rl.get("resets_at").and_then(|v| v.as_u64()) {
+                info["resetsAt"] = Value::from(ts);
+            }
+            let wrapper = serde_json::json!({
+                "type": "rate_limit_event",
+                "rate_limit_info": info,
             });
             let mut out = stdout.lock();
             writeln!(out, "{}", serde_json::to_string(&wrapper)?)?;


### PR DESCRIPTION
## Summary

Two audit findings about test scaffolding gaps that prevented integration tests from exercising the parser → AssistantUsage / Result / RateLimit pathways end-to-end. Bundled as v0.17.0 release-prep work.

| Commit | Issue | What |
|---|---|---|
| \`feat(core): add result/usage/rate_limit emitters to FakeScript\` | #537 | New FakeScript helpers + full-pipeline integration test |
| \`feat(fake-claude): add usage/result/rate_limit_event script actions\` | #539 | Three new JSONL action types in fake-claude |

### Why \`feat\` and not \`test\`

git-cliff is configured to **skip \`^test\` commits** from the CHANGELOG (cliff.toml \`commit_parsers\`). These two commits close medium-severity audit issues and add net-new capability to test scaffolding — \`feat\` routes them into v0.17.0's "Added" section so the closure is documented.

### #537 — FakeScript emitters (pitboss-core)

\`FakeScript\` previously only had \`StdoutLine\` / \`StderrLine\` / \`Sleep\`. Three composable helpers added:

- \`assistant_usage(text, usage)\` — emits an assistant message with \`message.usage\` (drives \`Event::AssistantUsage\`)
- \`result_event(session_id, usage)\` — emits the terminal \`result\` line
- \`rate_limit_event(status, kind, resets_at)\` — emits \`rate_limit_event\`

Plus three inline unit tests verifying each helper round-trips through \`parse_line_all\` to the expected variant.

**Headline test (audit-requested):** \`fakespawner_overspend_trips_cancel_through_full_pipeline\` in \`budget_watch.rs\` drives a real \`SessionHandle\` + \`UsageObserver\` against a \`FakeSpawner\` whose script emits ~$4.50 of Opus tokens under a $0.50 cap. Asserts the layer's cancel terminates mid-stream and \`abort_reason\` names \`budget_usd\`. Closes the audit's specific gap: *"no integration test exercises the full pipeline from stream-json output through budget-trip to cancel."*

### #539 — fake-claude action types

Mirrors the FakeScript helpers in the external \`fake-claude\` binary so dispatcher-level integration tests (which shell out to \`fake-claude\` instead of using the in-process \`FakeSpawner\`) can also exercise the same paths. New JSONL action shapes:

- \`{"usage": {"text": "...", "input": N, "output": N, ...}}\`
- \`{"result": {"session_id": "...", "subtype": "...", "usage": {...}}}\`
- \`{"rate_limit_event": {"status": "...", "rate_limit_type": "...", "resets_at": N}}\`

Module-level docs in \`main.rs\` and \`script.rs\` updated.

## Test plan

- [x] \`cargo test -p pitboss-core --features test-support process::fake::tests\` — 3 new round-trip tests pass
- [x] \`TMPDIR=/private/tmp/pb cargo test -p pitboss-cli --lib budget_watch::\` — 5/5 pass including new full-pipeline test
- [x] \`TMPDIR=/private/tmp/pb cargo test -p pitboss-cli --lib\` — **901/901** (count went up by 1 from the new test)
- [x] \`cargo build -p fake-claude\` — clean
- [x] \`cargo lint\` — clean
- [x] \`cargo tidy\` — clean
- [x] \`TMPDIR=/private/tmp/pb cargo test -p pitboss-core --features test-support\` — 245/246 (one expected macOS-only flake: \`process::tokio_impl::tests::terminate_after_exit_is_ok\` / \`BinaryNotFound /bin/true\`; documented in workspace CLAUDE.md, Linux CI is ground truth)
- [ ] CI \`test + lint + fmt\` green

Closes #537
Closes #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)