### PR TITLE
fix(core): surface AssistantThinking + push AssistantUsage before empty-check

### DIFF
--- a/crates/pitboss-cli/src/attach.rs
+++ b/crates/pitboss-cli/src/attach.rs
@@ -327,6 +327,14 @@ fn format_single_event_capped(event: Event) -> Option<String> {
             let first = text.lines().find(|l| !l.trim().is_empty()).unwrap_or(&text);
             Some(format!("> {}", cap_with_marker(first, CAP_ASSISTANT_TEXT)))
         }
+        Event::AssistantThinking { thinking } => {
+            let first = thinking
+                .lines()
+                .find(|l| !l.trim().is_empty())
+                .unwrap_or(&thinking);
+            // `~` distinguishes draft reasoning from `>` assistant text.
+            Some(format!("~ {}", cap_with_marker(first, CAP_ASSISTANT_TEXT)))
+        }
         Event::AssistantToolUse {
             tool_name,
             input_summary,

--- a/crates/pitboss-core/src/parser/events.rs
+++ b/crates/pitboss-core/src/parser/events.rs
@@ -24,6 +24,15 @@ pub enum Event {
         tool_name: String,
         input_summary: String,
     },
+    /// Extended-thinking content block (`content[i].type == "thinking"`).
+    /// The reasoning text lives at `content[i].thinking` on the wire and is
+    /// surfaced here. The wire also carries a `signature` continuity token
+    /// (opaque base64) — we do not preserve it today, since pitboss has no
+    /// thinking-re-injection path on resume. Add a `signature` field here
+    /// if/when that capability lands. (#600)
+    AssistantThinking {
+        thinking: String,
+    },
     ToolResult {
         content_summary: String,
     },

--- a/crates/pitboss-core/src/parser/mod.rs
+++ b/crates/pitboss-core/src/parser/mod.rs
@@ -112,6 +112,14 @@ fn parse_assistant(value: &serde_json::Value, raw: &str) -> Result<Vec<Event>, P
                     input_summary,
                 });
             }
+            "thinking" => {
+                let thinking = block
+                    .get("thinking")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                events.push(Event::AssistantThinking { thinking });
+            }
             other => {
                 tracing::warn!(
                     block_type = %other,
@@ -121,16 +129,13 @@ fn parse_assistant(value: &serde_json::Value, raw: &str) -> Result<Vec<Event>, P
         }
     }
 
-    if events.is_empty() {
-        return Err(ParseError::malformed(
-            "assistant content had no text or tool_use block",
-            raw,
-        ));
-    }
     // Surface per-message usage when claude carries it on the wire so
     // the dispatcher can reconcile lead spend per-turn instead of
-    // only at terminal `Event::Result`. (#253) Optional: older builds
-    // and the fake-claude harness omit it, so absence is not an error.
+    // only at terminal `Event::Result`. (#253) Pushed BEFORE the empty
+    // check so a thinking-only turn — common with extended-thinking
+    // models — still surfaces its usage to the budget watcher. (#600)
+    // Older builds and the fake-claude harness omit `message.usage`,
+    // so absence is not an error.
     if let Some(usage_val) = value.get("message").and_then(|m| m.get("usage")) {
         let usage = TokenUsage {
             input: u64_field(usage_val, "input_tokens"),
@@ -139,6 +144,13 @@ fn parse_assistant(value: &serde_json::Value, raw: &str) -> Result<Vec<Event>, P
             cache_creation: u64_field(usage_val, "cache_creation_input_tokens"),
         };
         events.push(Event::AssistantUsage { usage });
+    }
+
+    if events.is_empty() {
+        return Err(ParseError::malformed(
+            "assistant content had no text, tool_use, or thinking block (and no message.usage)",
+            raw,
+        ));
     }
     Ok(events)
 }
@@ -344,6 +356,82 @@ mod tests {
         assert!(matches!(events[0], Event::AssistantText { .. }));
     }
 
+    // ── Extended-thinking blocks (#600) ────────────────────────────────
+
+    #[test]
+    fn parses_assistant_thinking_block() {
+        let line = br#"{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"reasoning...","signature":"sig-opaque"}]}}"#;
+        let ev = parse_line(line).unwrap();
+        assert_eq!(
+            ev,
+            Event::AssistantThinking {
+                thinking: "reasoning...".into()
+            }
+        );
+    }
+
+    #[test]
+    fn thinking_only_turn_still_emits_assistant_usage() {
+        // Regression for #600: real claude (haiku-4-5 etc.) emits turns
+        // that contain ONLY a thinking block alongside `message.usage`.
+        // Pre-fix the parser's empty-events check fired before the usage
+        // push, dropping the entire line — including the usage update
+        // the budget watcher needs for live enforcement. Fix reorders
+        // usage push above the empty-check.
+        let line = br#"{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"hmm"}],"usage":{"input_tokens":5,"output_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}"#;
+        let events = parse_line_all(line).unwrap();
+        assert_eq!(events.len(), 2);
+        assert!(matches!(events[0], Event::AssistantThinking { .. }));
+        match &events[1] {
+            Event::AssistantUsage { usage } => {
+                assert_eq!(usage.input, 5);
+                assert_eq!(usage.output, 1);
+            }
+            other => panic!("expected AssistantUsage second, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mixed_thinking_and_text_emits_all_three_events() {
+        let line = br#"{"type":"assistant","message":{"content":[
+            {"type":"thinking","thinking":"plan"},
+            {"type":"text","text":"answer"}
+        ],"usage":{"input_tokens":1,"output_tokens":2}}}"#;
+        let events = parse_line_all(line).unwrap();
+        assert_eq!(events.len(), 3);
+        assert!(matches!(events[0], Event::AssistantThinking { .. }));
+        assert!(matches!(events[1], Event::AssistantText { .. }));
+        assert!(matches!(events[2], Event::AssistantUsage { .. }));
+    }
+
+    #[test]
+    fn unknown_block_only_turn_still_surfaces_usage() {
+        // A turn whose only content is a future/unknown block type — but
+        // which carries `message.usage` — must still emit AssistantUsage
+        // so budget enforcement stays accurate even when the parser's
+        // type coverage lags behind claude wire format. (#600)
+        let line = br#"{"type":"assistant","message":{"content":[{"type":"future_block","payload":"x"}],"usage":{"input_tokens":7,"output_tokens":3}}}"#;
+        let events = parse_line_all(line).unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            Event::AssistantUsage { usage } => {
+                assert_eq!(usage.input, 7);
+                assert_eq!(usage.output, 3);
+            }
+            other => panic!("expected AssistantUsage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fully_empty_assistant_turn_still_malformed() {
+        // No recognized blocks AND no usage → still Malformed. Preserves
+        // the "something is genuinely wrong with this line" signal even
+        // after the #600 reorder.
+        let line = br#"{"type":"assistant","message":{"content":[{"type":"future_block"}]}}"#;
+        let err = parse_line_all(line).unwrap_err();
+        assert!(matches!(err, ParseError::Malformed { .. }));
+    }
+
     #[test]
     fn parses_user_tool_result_string() {
         let line = br#"{"type":"user","message":{"content":[{"type":"tool_result","content":"file written"}]}}"#;
@@ -513,19 +601,22 @@ mod tests {
     #[tracing_test::traced_test]
     #[test]
     fn unknown_assistant_content_block_type_emits_drift_warn() {
-        // Claude could add a new content block (e.g. "thinking" / "image"
-        // / something else entirely) inside an assistant message. The
-        // parser silently dropped these pre-#542 — now they surface as
-        // a drift warn so operators see the addition in tracing output.
+        // Claude could add a new content block ("redacted_thinking",
+        // "image", etc.) inside an assistant message. The parser
+        // silently dropped these pre-#542 — now they surface as a
+        // drift warn so operators see the addition in tracing output.
+        // `future_unknown_block` is a stable stand-in for the next
+        // unknown type; using a real-but-currently-unmapped type
+        // would couple this test to the parser's coverage roadmap.
         let line = br#"{"type":"assistant","message":{"content":[
             {"type":"text","text":"hello"},
-            {"type":"thinking","content":"reasoning"}
+            {"type":"future_unknown_block","payload":"x"}
         ]}}"#;
         let _ = parse_line_all(line).unwrap();
         assert!(logs_contain(
             "parser drift: unrecognized assistant content-block"
         ));
-        assert!(logs_contain("thinking"));
+        assert!(logs_contain("future_unknown_block"));
     }
 
     #[tracing_test::traced_test]

--- a/crates/pitboss-tui/src/watcher.rs
+++ b/crates/pitboss-tui/src/watcher.rs
@@ -828,6 +828,15 @@ fn format_single_event(event: Event) -> Option<String> {
             let capped = cap_with_marker(first_line, CAP_ASSISTANT_TEXT);
             Some(format!("> {capped}"))
         }
+        Event::AssistantThinking { thinking } => {
+            let first_line = thinking
+                .lines()
+                .find(|l| !l.trim().is_empty())
+                .unwrap_or(&thinking);
+            let capped = cap_with_marker(first_line, CAP_ASSISTANT_TEXT);
+            // `~` prefix distinguishes draft reasoning from `>` final text.
+            Some(format!("~ {capped}"))
+        }
         Event::AssistantToolUse {
             tool_name,
             input_summary,


### PR DESCRIPTION
## Summary

Real Claude CLI emits \`{"type":"thinking",...}\` content blocks inside assistant messages when extended thinking is active. Pre-PR the parser dropped them silently — and **worse**, on thinking-ONLY turns it also dropped the per-turn \`AssistantUsage\` event by hitting an empty-events early-return *before* the usage push.

| Issue | Effect | Severity |
|---|---|---|
| Thinking content dropped | Operators can't see agent reasoning in events.jsonl / attach / TUI / SPA | observability |
| AssistantUsage lost on thinking-only turns | Mid-run budget watcher view stale; worst-case budget trip one turn late | budget-adjacent |

**Surfaced by:** v0.17.0 validation run \`019e4acd-5f88-7c53-872f-5484d565682b\` on 2026-05-21. 31 drift warns (\`block_type=thinking\`) in 68 s of runtime; 3 of the lead's 10 assistant turns were thinking-only. The #599 drift detector working exactly as designed on its first live run after merge.

## Changes (4 files, +131 / -14)

1. **\`Event::AssistantThinking { thinking: String }\`** added to \`parser::events\` alongside \`AssistantText\` and \`AssistantToolUse\`. \`signature\` dropped (no current consumer; add later if interleaved-thinking re-injection on resume is ever supported).
2. **\`parse_assistant\` reorder**: \`AssistantUsage\` push moved BEFORE the empty-events check, so a thinking-only or unknown-only turn that carries \`message.usage\` still surfaces it to \`budget_watch.rs\`'s live observer.
3. **\`pitboss-cli/src/attach.rs\`** and **\`pitboss-tui/src/watcher.rs\`** format \`AssistantThinking\` with \`~\` prefix (vs \`>\` for final text), so operators visually distinguish reasoning from output.
4. **TS mirror**: \`pitboss-web/spa/src/lib/stream-json.ts\` already declared \`kind: 'thinking'\` and had a parser arm — the Rust side just never emitted matching events. No SPA change needed.

## Tests

Five new parser tests in \`pitboss-core\`:

| Test | Asserts |
|---|---|
| \`parses_assistant_thinking_block\` | \`thinking\` arm emits \`AssistantThinking\` |
| \`thinking_only_turn_still_emits_assistant_usage\` | **The core regression**: thinking-only + usage → both events emitted |
| \`mixed_thinking_and_text_emits_all_three_events\` | Three events in order: thinking, text, usage |
| \`unknown_block_only_turn_still_surfaces_usage\` | Forward-compat: future unknown block + usage → AssistantUsage still emitted |
| \`fully_empty_assistant_turn_still_malformed\` | Preserves \"truly broken line\" error signal |

Existing \`unknown_assistant_content_block_type_emits_drift_warn\` updated to use \`future_unknown_block\` as the synthetic unknown (was \`thinking\`, which is now a real type).

## Test plan

- [x] \`cargo test -p pitboss-core --features test-support parser::\` — 29 passed (5 new)
- [x] \`TMPDIR=/private/tmp/pb cargo test -p pitboss-cli --lib\` — 901/901, no regressions
- [x] \`cargo test -p pitboss-tui --features pitboss-core/test-support\` — 0/0 (integration tests; lib has none)
- [x] \`cd crates/pitboss-web/spa && npm run check\` — 0 errors / 0 warnings
- [x] \`cargo lint\` — clean
- [x] \`cargo tidy\` — clean
- [ ] CI \`test + lint + fmt\` green
- [ ] Manual validation: re-run \`pb_manifests/v0.17.0-validation.toml\` with \`emit_event_stream = true\`; verify zero \`block_type=thinking\` drift warns and \`AssistantUsage\` lands on every assistant turn

Closes #600

🤖 Generated with [Claude Code](https://claude.com/claude-code)