### PR TITLE
chore(deps): bump git2 to 0.21.0 + adapt worktree manager to new API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -702,7 +702,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -970,15 +970,14 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
  "libgit2-sys",
  "log",
- "url",
 ]
 
 [[package]]
@@ -1464,9 +1463,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.4+1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
 dependencies = [
  "cc",
  "libc",
@@ -1708,7 +1707,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2615,7 +2614,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3075,7 +3074,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3889,7 +3888,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ serde_json         = "1"
 toml               = "1.1"
 uuid               = { version = "1", features = ["v7","serde"] }
 chrono             = { version = "0.4", features = ["serde"] }
-git2               = { version = "0.20", default-features = false, features = ["vendored-libgit2"] }
+git2               = { version = "0.21", default-features = false, features = ["vendored-libgit2"] }
 thiserror          = "2"
 anyhow             = "1"
 tracing            = "0.1"

--- a/crates/pitboss-core/src/worktree/manager.rs
+++ b/crates/pitboss-core/src/worktree/manager.rs
@@ -73,7 +73,11 @@ impl WorktreeManager {
             // `ref: refs/heads/<branch>`; read it directly. Falls back to
             // the Repository::open path only on read/parse failure so
             // detached-HEAD or symbolic-ref forms still classify.
-            for wt_name in repo.worktrees()?.iter().flatten() {
+            // git2 0.21 widened StringArray::iter() to yield
+            // `Result<Option<&str>, Error>` (was `Option<&str>`); collapse
+            // both layers so callees still see a plain `&str`. Entries that
+            // fail UTF-8 conversion or are absent are skipped.
+            for wt_name in repo.worktrees()?.iter().flatten().flatten() {
                 let wt = repo.find_worktree(wt_name)?;
                 let checked_out = head_branch_for_worktree(repo_root, wt_name)
                     .or_else(|| head_branch_via_open(wt.path()));
@@ -187,7 +191,7 @@ fn head_branch_via_open(wt_path: &Path) -> Option<String> {
     wt_repo
         .head()
         .ok()
-        .and_then(|h| h.shorthand().map(str::to_string))
+        .and_then(|h| h.shorthand().ok().map(str::to_string))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Bumps `git2` from 0.20.4 to 0.21.0 (carries the dependabot commit from #559).
- Adapts `pitboss-core::worktree::manager` to the two API tightenings in 0.21:
  - `StringArray::iter()` now yields `Result<Option<&str>, Error>` (was `Option<&str>`) — double `.flatten()` recovers the `&str`.
  - `Reference::shorthand()` now returns `Result<&str, Error>` (was `Option<&str>`) — chain `.ok()` before `.map(str::to_string)`.

Behaviour is identical: non-UTF-8 / missing entries were already skipped under the 0.20 semantics.

Supersedes #559 (which only contained the bump and could not pass CI due to the API breaks).

## Test plan

- [x] `cargo lint` (clippy pedantic + `-D warnings`)
- [x] `cargo test -p pitboss-core --features test-support worktree::` — all 11 worktree tests pass, including `prepare_rejects_branch_already_checked_out_in_another_worktree` (exercises the iterator path)
- [x] `TMPDIR=/private/tmp/pb cargo test --workspace --features pitboss-core/test-support` (full suite passes; one pre-existing parallel-test flake on `e2e_lead_request_approval_round_trip` confirmed unrelated by isolated rerun)

Closes #559.

🤖 Generated with [Claude Code](https://claude.com/claude-code)