### PR TITLE
fix(dispatch): strip inherited sdk-ts under Path B

### DIFF
--- a/crates/pitboss-cli/src/dispatch/runner.rs
+++ b/crates/pitboss-cli/src/dispatch/runner.rs
@@ -63,6 +63,18 @@ pub fn apply_pitboss_env_defaults(
             // so claude's gate is active. Pitboss registers
             // `permission_prompt` MCP tool to intercept checks. Do NOT
             // set sdk-ts — that would bypass the gate we want to route.
+            //
+            // #608: also strip an *inherited* sdk-ts value. Operator env
+            // layers in BEFORE this helper, so a `CLAUDE_CODE_ENTRYPOINT=sdk-ts`
+            // left over from the operator shell (e.g. a prior Path A
+            // interactive run) or from a grandparent Path A pitboss
+            // process would silently disable claude's gate and defeat
+            // Path B's whole purpose. Only `sdk-ts` is the bypass shape;
+            // a deliberate operator override to e.g. `cli` for telemetry
+            // stays preserved.
+            if env.get("CLAUDE_CODE_ENTRYPOINT").map(String::as_str) == Some("sdk-ts") {
+                env.remove("CLAUDE_CODE_ENTRYPOINT");
+            }
         }
     }
 }
@@ -1461,6 +1473,50 @@ mod tests {
             env.get("CLAUDE_CODE_ENTRYPOINT"),
             Some(&"cli".to_string()),
             "operator-set value must not be overwritten"
+        );
+    }
+
+    /// #608 regression: under Path B, an inherited
+    /// `CLAUDE_CODE_ENTRYPOINT=sdk-ts` from the operator shell or a
+    /// grandparent Path A pitboss process must be stripped — leaving it
+    /// would silently disable claude's gate and defeat Path B's whole
+    /// "claude's permission gate stays active" invariant. The gap was
+    /// reachable on every run after #393 flipped the default routing to
+    /// Path B in v0.12.
+    #[test]
+    fn apply_pitboss_env_defaults_path_b_strips_inherited_sdk_ts() {
+        let mut env: HashMap<String, String> = HashMap::new();
+        env.insert("CLAUDE_CODE_ENTRYPOINT".to_string(), "sdk-ts".to_string());
+        apply_pitboss_env_defaults(
+            &mut env,
+            "test-run-id",
+            crate::manifest::schema::PermissionRouting::PathB,
+        );
+        assert_ne!(
+            env.get("CLAUDE_CODE_ENTRYPOINT").map(String::as_str),
+            Some("sdk-ts"),
+            "Path B must not allow an inherited sdk-ts entrypoint to bypass claude's gate"
+        );
+    }
+
+    /// #608 corollary: the Path B strip is surgical — it only removes
+    /// the `sdk-ts` bypass shape. A deliberate operator override to a
+    /// non-bypass value (e.g. `cli` for telemetry, mirroring the
+    /// Path A `apply_pitboss_env_defaults_honors_operator_override`
+    /// precedent) must pass through unchanged.
+    #[test]
+    fn apply_pitboss_env_defaults_path_b_preserves_non_sdk_ts_override() {
+        let mut env: HashMap<String, String> = HashMap::new();
+        env.insert("CLAUDE_CODE_ENTRYPOINT".to_string(), "cli".to_string());
+        apply_pitboss_env_defaults(
+            &mut env,
+            "test-run-id",
+            crate::manifest::schema::PermissionRouting::PathB,
+        );
+        assert_eq!(
+            env.get("CLAUDE_CODE_ENTRYPOINT"),
+            Some(&"cli".to_string()),
+            "Path B must preserve a non-sdk-ts operator override"
         );
     }
 


### PR DESCRIPTION
## Summary

- Closes #608.
- Under Path B (default since #393 / v0.12), `apply_pitboss_env_defaults` now strips an inherited `CLAUDE_CODE_ENTRYPOINT=sdk-ts` from the spawned-subprocess env. Previously the Path B arm was a no-op, so an `sdk-ts` value leaked from the operator shell (or a grandparent Path A pitboss process) silently disabled claude's permission gate — undetectable from outside the subprocess, no event, no log line. The manifest's `permission_routing = "path_b"` setting was silently violated.
- The strip is surgical: only the `sdk-ts` bypass shape is removed. A deliberate operator override to a non-bypass value (e.g. `cli` for telemetry) passes through unchanged, mirroring the Path A `apply_pitboss_env_defaults_honors_operator_override` precedent.
- Applies transitively to subleads via `compose_sublead_env` (which routes through the helper), so a lead-inherited or grandparent-leaked `sdk-ts` is stripped before reaching any sublead.

## Test plan

- [x] `cargo test -p pitboss-cli --lib apply_pitboss_env_defaults` — 6 tests pass (4 existing + 2 new regression tests):
  - `apply_pitboss_env_defaults_path_b_strips_inherited_sdk_ts` — proves the gate-bypass case is closed.
  - `apply_pitboss_env_defaults_path_b_preserves_non_sdk_ts_override` — proves the strip is surgical and doesn't clobber an operator's intentional `cli` (or other) override.
- [x] `cargo test -p pitboss-cli --lib env_composition_tests` — all 4 sublead env-composition tests still green (the transitive `compose_sublead_env` callers).
- [x] `cargo lint` — clean.
- [x] `cargo tidy` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)