### PR TITLE
fix(web): redact ?token= query param from request trace logs

### DIFF
--- a/crates/pitboss-web/src/api/mod.rs
+++ b/crates/pitboss-web/src/api/mod.rs
@@ -2,13 +2,14 @@
 
 use axum::{
     extract::{Query, State},
-    http::{HeaderMap, StatusCode},
+    http::{HeaderMap, HeaderValue, StatusCode},
     middleware::{self, Next},
     response::Response,
     routing::{get, post},
     Router,
 };
 use serde::Deserialize;
+use tower_http::{set_header::SetResponseHeaderLayer, trace::TraceLayer};
 
 use crate::{assets, state::AppState};
 
@@ -51,7 +52,64 @@ pub fn router(state: AppState) -> Router {
     Router::new()
         .nest("/api", api)
         .fallback(assets::handler)
-        .layer(tower_http::trace::TraceLayer::new_for_http())
+        // #608-sibling: redact `?token=...` from the request-span URI so
+        // bearer tokens delivered via the query-param fallback (SSE
+        // `EventSource`, manifest download links) don't appear verbatim
+        // in stderr/tracing logs. `TraceLayer` wraps the outer router
+        // — it fires before `require_token` runs — so the URI must be
+        // scrubbed at span-creation time. The default `DefaultMakeSpan`
+        // records `uri = %request.uri()`, which captures the full query.
+        .layer(
+            TraceLayer::new_for_http().make_span_with(|request: &axum::http::Request<_>| {
+                tracing::info_span!(
+                    "request",
+                    method = %request.method(),
+                    uri = %redact_uri_for_tracing(request.uri()),
+                    version = ?request.version(),
+                )
+            }),
+        )
+        // Defense-in-depth for the same `?token=` surface: `Referrer-Policy:
+        // no-referrer` prevents the SSE/manifest-download URLs (and their
+        // embedded token) from leaking via the `Referer` header on any
+        // cross-origin navigation the page triggers. Applied globally —
+        // pitboss-web is an operator tool, not a content site, so we
+        // never need to send a Referer.
+        .layer(SetResponseHeaderLayer::overriding(
+            axum::http::header::REFERRER_POLICY,
+            HeaderValue::from_static("no-referrer"),
+        ))
+}
+
+/// Format a request URI for inclusion in a tracing span, redacting the
+/// `token` query parameter so bearer tokens don't leak into logs.
+///
+/// The SPA falls back to `?token=<bearer>` on the SSE endpoint (because
+/// the browser `EventSource` API can't set Authorization headers) and
+/// for manifest-download navigations. Both paths route through
+/// `TraceLayer`'s span before `require_token` runs — auth-stripping
+/// inside middleware would be too late, the span is already populated.
+/// Redacting at span-construction time covers every consumer in one
+/// place keyed on the parameter name rather than the route.
+fn redact_uri_for_tracing(uri: &axum::http::Uri) -> String {
+    let Some(query) = uri.query() else {
+        return uri.to_string();
+    };
+    if !query.contains("token=") {
+        return uri.to_string();
+    }
+    let redacted = query
+        .split('&')
+        .map(|pair| {
+            if pair.starts_with("token=") {
+                "token=REDACTED"
+            } else {
+                pair
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("&");
+    format!("{}?{}", uri.path(), redacted)
 }
 
 #[derive(Debug, Deserialize)]
@@ -90,4 +148,89 @@ async fn require_token(
         return Ok(next.run(request).await);
     }
     Err(StatusCode::UNAUTHORIZED)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::redact_uri_for_tracing;
+    use axum::http::Uri;
+
+    #[test]
+    fn redacts_token_only_query_param() {
+        let uri: Uri = "/api/runs/abc/events?token=supersecret".parse().unwrap();
+        assert_eq!(
+            redact_uri_for_tracing(&uri),
+            "/api/runs/abc/events?token=REDACTED"
+        );
+    }
+
+    #[test]
+    fn redacts_token_when_first_of_multiple_params() {
+        let uri: Uri = "/api/manifests/foo?token=secret&format=toml"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            redact_uri_for_tracing(&uri),
+            "/api/manifests/foo?token=REDACTED&format=toml"
+        );
+    }
+
+    #[test]
+    fn redacts_token_when_not_first_param() {
+        let uri: Uri = "/api/manifests/foo?format=toml&token=secret"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            redact_uri_for_tracing(&uri),
+            "/api/manifests/foo?format=toml&token=REDACTED"
+        );
+    }
+
+    #[test]
+    fn leaves_query_alone_when_no_token() {
+        let uri: Uri = "/api/runs?status=running&since=2026-05-01".parse().unwrap();
+        assert_eq!(
+            redact_uri_for_tracing(&uri),
+            "/api/runs?status=running&since=2026-05-01"
+        );
+    }
+
+    #[test]
+    fn leaves_path_only_uris_alone() {
+        let uri: Uri = "/api/runs".parse().unwrap();
+        assert_eq!(redact_uri_for_tracing(&uri), "/api/runs");
+    }
+
+    #[test]
+    fn redacts_empty_token_value() {
+        // Defensive: a malformed/empty `token=` shouldn't bypass redaction
+        // just because the value happens to be empty.
+        let uri: Uri = "/api/runs?token=".parse().unwrap();
+        assert_eq!(redact_uri_for_tracing(&uri), "/api/runs?token=REDACTED");
+    }
+
+    #[test]
+    fn does_not_redact_unrelated_param_starting_with_token_substr() {
+        // `tokenize` is not `token` — must not be redacted, otherwise an
+        // operator's query for a search field gets clobbered. Exact-prefix
+        // match on `token=` enforces this.
+        let uri: Uri = "/api/insights?tokenize=true&q=foo".parse().unwrap();
+        assert_eq!(
+            redact_uri_for_tracing(&uri),
+            "/api/insights?tokenize=true&q=foo"
+        );
+    }
+
+    #[test]
+    fn redacts_token_with_url_safe_chars_in_value() {
+        // Bearer tokens often contain `-`, `_`, `.`, base64 padding etc.
+        // Redaction must not depend on the value shape.
+        let uri: Uri = "/api/runs/abc/events?token=eyJhbGciOiJIUzI1NiJ9.payload.sig"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            redact_uri_for_tracing(&uri),
+            "/api/runs/abc/events?token=REDACTED"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Closes #610.
- `TraceLayer::new_for_http()` with the default `DefaultMakeSpan` records the full request URI (path + query) in every request span, and the SPA's `?token=<bearer>` fallback (used by SSE `EventSource` and manifest-download navigations because neither can set the `Authorization` header) was therefore being captured verbatim in stderr. Log aggregators silently collected the bearer token in any non-loopback + `--token` deployment — the only configuration where bearer-token protection matters at all.
- Replace the default `make_span_with` with a closure that calls a new `redact_uri_for_tracing` helper. The helper splits the query on `&`, replaces any `token=...` segment with `token=REDACTED`, and rejoins. Keying off the param name (`token`), not the route, covers both `?token=` consumers (SSE + manifest-download) with one change — and would cover any future consumer too.
- Also set `Referrer-Policy: no-referrer` globally via `SetResponseHeaderLayer::overriding` (defense-in-depth for the same query-param surface — the SSE/manifest-download URLs can otherwise leak via the `Referer` header on any cross-origin navigation). pitboss-web is an operator tool, never a content site, so `no-referrer` is unconditionally correct; `overriding` is intentional so the policy can't be downgraded by a future handler.
- `TraceLayer` wraps the outer router and fires *before* `require_token` runs, so the URI has to be scrubbed at span-creation time — middleware-based scrubbing would be too late. This was flagged by one of the two cross-validation reviewers.

## Validation

Independent two-reviewer cross-validation via `feature-dev:code-reviewer` before any code was written. Both agents reached CONFIRMED on all 5 sub-claims (default `TraceLayer` behavior, SPA actually constructs `?token=`, subscriber filter emits these to stderr, no existing mitigation, no `Referrer-Policy` header on SSE). Both independently identified `exportManifestUrl` as a second `?token=` consumer the original audit narrative missed — confirming both that the bug is real AND that the redaction-by-param-name fix shape is what's needed (single-route fixes would have missed the manifest case).

## Test plan

- [x] `cargo test -p pitboss-web --bin pitboss-web api::tests` — 8 new unit tests pass (`redacts_token_only_query_param`, `redacts_token_when_first_of_multiple_params`, `redacts_token_when_not_first_param`, `leaves_query_alone_when_no_token`, `leaves_path_only_uris_alone`, `redacts_empty_token_value`, `does_not_redact_unrelated_param_starting_with_token_substr`, `redacts_token_with_url_safe_chars_in_value`).
- [x] `cargo test -p pitboss-web --features pitboss-core/test-support` — full suite green, no regressions.
- [x] `cargo lint` — clean.
- [x] `cargo tidy` — clean.
- [x] **End-to-end smoke** against a live binary at `127.0.0.1:8765` with `--token testsupersecret`:
  - 8/8 trace-log writes redacted (`on_request` + `on_response` events both fire under the span, and both inherit the redaction).
  - Plain, first-param, last-param, and mixed-param URIs all redact correctly.
  - Header-path `Authorization: Bearer ...` requests are unaffected (the token is not in the URI; the trace log shows the bare path).
  - `Referrer-Policy: no-referrer` confirmed on every response via `curl -D -`.

## Known limitation (separate finding)

The smoke run surfaced one remaining `testsupersecret` occurrence in stderr — the startup banner `auth required: Authorization: Bearer <token>` at `main.rs`. This is a distinct, lower-severity issue (once-at-startup vs. per-request) and not in scope for this PR. Will file as a follow-up under the same `audit-2026-05-24-code-to-docs` cohort label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)