### PR TITLE
fix(web): don't print bearer token to stderr at startup

### DIFF
--- a/crates/pitboss-web/src/main.rs
+++ b/crates/pitboss-web/src/main.rs
@@ -179,8 +179,14 @@ async fn run_serve(args: ServeArgs) -> Result<()> {
     if !pid_path.as_os_str().is_empty() {
         eprintln!("pidfile: {}", pid_path.display());
     }
-    if let Some(t) = &args.token {
-        eprintln!("auth required: Authorization: Bearer {}", t);
+    // #612: never print the token itself. The operator who passed
+    // `--token` already knows the value; printing it persists the
+    // secret in any aggregator that captures startup stderr (systemd
+    // journal, docker logs, k8s log collection). To verify the token
+    // loaded, `curl --fail` against any endpoint without the header
+    // returns 401 — a stronger check than visual confirmation.
+    if args.token.is_some() {
+        eprintln!("auth required: Bearer token configured");
     } else {
         eprintln!("no auth (loopback only)");
     }


### PR DESCRIPTION
## Summary

- Closes #612.
- The startup banner at `crates/pitboss-web/src/main.rs:182-183` printed `--token` verbatim to stderr. Operators running pitboss-web as a long-lived service capture stderr persistently (systemd journals, docker logs, k8s log collection), so the secret landed in any log aggregator that watches the binary.
- Replace `eprintln!("auth required: Authorization: Bearer {}", t)` with a token-presence acknowledgement: `auth required: Bearer token configured`. The operator who set `--token` already knows the value; `curl --fail` against any endpoint without the header returns 401, which is a stronger check than visual confirmation.
- Lower-volume sibling of the trace-layer leak closed in #611 (one line per process start vs. one line per request); same threat shape, same `audit-2026-05-24-code-to-docs` cohort.

## Test plan

- [x] `cargo build -p pitboss-web` — clean.
- [x] `cargo lint` — clean.
- [x] `cargo tidy` — clean.
- [x] **End-to-end smoke** against a live binary at `127.0.0.1:8765` with `--token testsupersecret`:
  - Banner now reads `auth required: Bearer token configured` (no token value).
  - Zero `testsupersecret` occurrences in stderr (down from 1 pre-fix).
  - **Cross-fix verification**: #611's trace-layer redaction still active (4 `token=REDACTED` occurrences from the probe requests confirm the prior fix is unaffected).
- No unit tests added — the change is a single `eprintln!` rewrite of a string literal; the meaningful verification is the end-to-end smoke (which the prior `eprintln!` would have passed under any unit test of its own).

🤖 Generated with [Claude Code](https://claude.com/claude-code)