### PR TITLE
docs(core): document FakeSpawner signal-path coverage limitation

### DIFF
--- a/crates/pitboss-core/src/process/fake.rs
+++ b/crates/pitboss-core/src/process/fake.rs
@@ -130,6 +130,29 @@ impl FakeScript {
     }
 }
 
+/// In-process spawner used by tests to play back a scripted child
+/// process without touching the OS.
+///
+/// **Signal-path coverage is intentionally limited.** Every [`FakeChild`]
+/// reports `pid: 1` and routes `terminate()` / `kill()` through an
+/// internal `oneshot` channel rather than real `kill(2)` syscalls. That
+/// means tests using `FakeSpawner` exercise the dispatcher's
+/// kill-then-resume control flow, but they do **not** exercise:
+///
+/// - The `dispatch/signals.rs` `SIGSTOP` / `SIGCONT` freeze/thaw path
+///   (which signals the child's process group via the real pid).
+/// - Process-group teardown via `kill(-pgid, …)` from
+///   [`crate::process::tokio::TokioChild`].
+/// - `/proc/<pid>/status` state inspection on Linux (used by
+///   `freeze_then_resume_flips_proc_state`).
+///
+/// The real-process signal tests in `pitboss-cli::dispatch::signals` are
+/// `#[cfg(target_os = "linux")]`-gated, so **Linux CI is the ground
+/// truth for signal coverage**. macOS local runs and the macOS CI matrix
+/// intentionally skip those tests; making `FakeSpawner` mint a real pid
+/// would invite tests that pretend to cover the signal path but actually
+/// don't (the kernel won't deliver signals to a pid we didn't spawn).
+/// See issue #540 (F-TEST-6) for the audit finding.
 #[derive(Clone)]
 pub struct FakeSpawner {
     script: FakeScript,
@@ -260,6 +283,9 @@ impl ProcessSpawner for FakeSpawner {
             exit_rx: Some(exit_rx),
             cached_exit_code: None,
             kill_tx: Some(kill_tx),
+            // Deliberately bogus — see the `FakeSpawner` doc comment.
+            // Tests that need real signal-path coverage must run under
+            // `TokioSpawner` on Linux CI, not `FakeSpawner`.
             pid: 1,
         }))
     }


### PR DESCRIPTION
## Summary

- `FakeSpawner` hardcodes `pid: 1` and routes `terminate()`/`kill()` through a oneshot channel rather than real signals — by design, since the kernel won't deliver signals to a pid the test didn't spawn.
- Add a doc comment to the struct enumerating exactly what is *not* covered (`SIGSTOP`/`SIGCONT` freeze, `kill(-pgid, …)` process-group teardown, `/proc/<pid>/status` inspection) so contributors don't add tests that look like they exercise the signal path but actually don't.
- Add a brief in-place comment at the `pid: 1` site pointing back to the struct doc.

Per the issue's own recommendation: *"Accept this as a known limitation. Document that macOS CI is not the ground truth for signal tests."*

## Validation

- Pre-PR: re-validated #540 — `pid: 1` confirmed at `fake.rs:263`, signal tests in `dispatch/signals.rs` still `#[cfg(target_os = "linux")]`-gated.
- `cargo check -p pitboss-core --features test-support` — clean.

## Test plan

- [x] CI: `cargo lint` clean
- [x] CI: `cargo tidy` clean
- [x] CI: workspace test suite still passes (no code paths changed)

Closes #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)