### PR TITLE
feat(fake-claude): add tool_result action for full tool-cycle coverage

### DIFF
--- a/tests-support/fake-claude/src/main.rs
+++ b/tests-support/fake-claude/src/main.rs
@@ -6,6 +6,12 @@
 //!   {"sleep_ms": N}   — sleeps for N milliseconds
 //!   {"tool_use": {"name": "...", "input": {...}}}
 //!       — emits a stream-json assistant tool_use event on stdout
+//!   {"tool_result": {"tool_use_id": "...", "content": "..." | [...],
+//!                    "is_error": bool}}
+//!       — emits the `user`-turn wrapper that real claude sends after
+//!         each tool_use. Pair with a prior `tool_use` action to exercise
+//!         the full assistant→tool_use→user→tool_result cycle through
+//!         the dispatcher's parser pipeline (#541).
 //!   {"usage": {"text": "...", "input": N, "output": N,
 //!              "cache_read": N, "cache_creation": N}}
 //!       — emits an assistant message with `message.usage` so the parser

--- a/tests-support/fake-claude/src/script.rs
+++ b/tests-support/fake-claude/src/script.rs
@@ -6,7 +6,10 @@
 //! `usage`, `result`, and `rate_limit_event` actions added for #539
 //! emit the corresponding stream-json wire shapes so integration tests
 //! can exercise the budget_watch / SessionOutcome paths that those
-//! events drive.
+//! events drive. The `tool_result` action added for #541 emits the
+//! `user`-turn wrapper that real claude sends after every `tool_use`,
+//! letting tests cover the full assistant→tool_use→user→tool_result
+//! cycle through the dispatcher's stream-json pipeline.
 
 #![allow(dead_code)]
 
@@ -70,6 +73,43 @@ pub async fn execute_script<R: BufRead>(reader: R, mut client: Option<McpClient>
                         "name": tu.get("name").and_then(|n| n.as_str()).unwrap_or(""),
                         "input": tu.get("input").cloned().unwrap_or(Value::Null),
                     }]
+                }
+            });
+            let mut out = stdout.lock();
+            writeln!(out, "{}", serde_json::to_string(&wrapper)?)?;
+            out.flush()?;
+        } else if let Some(tr) = action.get("tool_result") {
+            // Emit the user-turn wrapper that real claude sends after every
+            // tool_use. Pair this with a prior `tool_use` action to exercise
+            // the full assistant→tool_use→user→tool_result cycle through
+            // the dispatcher's stream-json pipeline (parse_user /
+            // Event::ToolResult). See issue #541.
+            //
+            // `content` accepts either a plain string (rendered as
+            // `{"content":"..."}`) or any JSON value (passed through —
+            // real claude uses an array of `{type, text}` blocks).
+            let tool_use_id = tr
+                .get("tool_use_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let content = tr.get("content").cloned().unwrap_or(Value::Null);
+            let is_error = tr
+                .get("is_error")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            let mut block = serde_json::json!({
+                "type": "tool_result",
+                "tool_use_id": tool_use_id,
+                "content": content,
+            });
+            if is_error {
+                block["is_error"] = Value::Bool(true);
+            }
+            let wrapper = serde_json::json!({
+                "type": "user",
+                "message": {
+                    "content": [block]
                 }
             });
             let mut out = stdout.lock();


### PR DESCRIPTION
## Summary

- fake-claude's `tool_use` action emits the assistant-side wrapper, but real claude always follows it with a `user`-turn wrapper carrying the `tool_result`. Without an equivalent action, integration tests can't exercise the dispatcher's full stdout pipeline for the cycle — `parse_user` / `Event::ToolResult` is only covered by parser unit tests.
- Adds `{"tool_result": {"tool_use_id": "...", "content": ..., "is_error": bool}}` matching the wire shape claude emits.
- `content` accepts either a plain string or any JSON value (real claude uses an array of `{type, text}` blocks).
- Updates module docs in `main.rs` and `script.rs` to list the new action.

Follows the same enable-the-action shape as PR for #539 (the prior `usage`/`result`/`rate_limit_event` additions). Integration tests can now pair `tool_use` with `tool_result` to exercise the full cycle.

## Validation

- Pre-PR: re-validated #541 — `tool_use` handler emits only the assistant block; no `user`-turn equivalent exists.
- `cargo build -p fake-claude` — clean.
- `cargo lint`, `cargo tidy` — clean.

## Test plan

- [ ] CI: workspace lint/tidy/test still pass
- [ ] CI: existing fake-claude-driven tests still pass (the new action is opt-in)

Closes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)