### PR TITLE
refactor(cli): call McpServer::shutdown() explicitly in 40 test sites

### DIFF
--- a/crates/pitboss-cli/tests/cancel_cascade_flows.rs
+++ b/crates/pitboss-cli/tests/cancel_cascade_flows.rs
@@ -95,7 +95,7 @@ async fn yield_for_cascade_watcher() {
 async fn sublead_spawned_after_root_drain_inherits_drain() {
     let (_dir, state) = mk_state();
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -122,6 +122,7 @@ async fn sublead_spawned_after_root_drain_inherits_drain() {
         sub_layer.cancel.is_draining(),
         "sub-lead spawned post-drain must inherit drain via the eager cascade"
     );
+    server.shutdown().await;
 }
 
 /// Sub-lead spawned **after** `state.root.cancel.terminate()` must
@@ -132,7 +133,7 @@ async fn sublead_spawned_after_root_drain_inherits_drain() {
 async fn sublead_spawned_after_root_terminate_inherits_terminate() {
     let (_dir, state) = mk_state();
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -159,6 +160,7 @@ async fn sublead_spawned_after_root_terminate_inherits_terminate() {
         sub_layer.cancel.is_terminated(),
         "sub-lead spawned post-terminate must inherit terminate via the eager cascade"
     );
+    server.shutdown().await;
 }
 
 /// Worker registered in a **drained sub-tree** (root still healthy) must
@@ -170,7 +172,7 @@ async fn sublead_spawned_after_root_terminate_inherits_terminate() {
 async fn worker_spawned_in_subtree_after_subtree_drain_inherits_drain() {
     let (_dir, state) = mk_state();
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -212,6 +214,7 @@ async fn worker_spawned_in_subtree_after_subtree_drain_inherits_drain() {
         tok.is_draining(),
         "worker spawned in drained sub-tree must inherit drain via the eager cascade"
     );
+    server.shutdown().await;
 }
 
 /// Production-behavior pin: terminating a sub-tree reaps the sub-lead.
@@ -226,7 +229,7 @@ async fn worker_spawned_in_subtree_after_subtree_drain_inherits_drain() {
 async fn worker_spawn_after_subtree_terminate_fails_with_unknown_sublead() {
     let (_dir, state) = mk_state();
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -262,4 +265,5 @@ async fn worker_spawn_after_subtree_terminate_fails_with_unknown_sublead() {
         msg.contains("unknown sublead_id"),
         "expected reaping to make the sub-lead unknown; got: {msg}"
     );
+    server.shutdown().await;
 }

--- a/crates/pitboss-cli/tests/dogfood_fake_flows.rs
+++ b/crates/pitboss-cli/tests/dogfood_fake_flows.rs
@@ -250,7 +250,7 @@ async fn dogfood_isolation_strict_tree() {
 
     let (_dir, state) = mk_state_with_subleads();
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -420,6 +420,7 @@ async fn dogfood_isolation_strict_tree() {
     )
     .await
     .unwrap();
+    server.shutdown().await;
 }
 
 // ── Spotlight #03: kill-cascade-drain ────────────────────────────────────────
@@ -460,7 +461,7 @@ async fn dogfood_kill_cascade_drain() {
 
     let (_dir, state) = mk_state_with_subleads();
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -587,6 +588,7 @@ async fn dogfood_kill_cascade_drain() {
         state.root.cancel.is_draining(),
         "root cancel should be draining after operator cancel"
     );
+    server.shutdown().await;
 }
 
 #[tokio::test]
@@ -599,7 +601,7 @@ async fn dogfood_run_lease_contention() {
 
     let (_dir, state) = mk_state_with_subleads();
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -713,6 +715,7 @@ async fn dogfood_run_lease_contention() {
         acq3_resp["holder"], s2_id,
         "S2 acquire should list S2 as holder (not S1)"
     );
+    server.shutdown().await;
 }
 
 #[tokio::test]
@@ -732,7 +735,7 @@ async fn dogfood_policy_auto_filter() {
 
     let (_dir, state) = mk_state_with_subleads();
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -910,6 +913,7 @@ async fn dogfood_policy_auto_filter() {
 
     // Clean up the hanging plan approval.
     plan_req_handle.abort();
+    server.shutdown().await;
 }
 
 // ── Spotlight #06: Envelope cap rejection ──────────────────────────────────────
@@ -1012,7 +1016,7 @@ async fn dogfood_envelope_cap_rejection() {
     };
 
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -1108,4 +1112,5 @@ async fn dogfood_envelope_cap_rejection() {
     }
 
     eprintln!("Spotlight #06 passed: cap enforcement clean rejection + successful retry");
+    server.shutdown().await;
 }

--- a/crates/pitboss-cli/tests/e2e_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_flows.rs
@@ -177,7 +177,7 @@ async fn e2e_lead_spawns_worker_via_real_subprocess() {
 
     // Start the MCP server so fake-claude's mcp_call can land somewhere.
     let sock = socket_path_for_run(run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(sock.clone(), state.clone()).await.unwrap();
+    let server = McpServer::start(sock.clone(), state.clone()).await.unwrap();
 
     // Write the script. spawn_worker returns {task_id: "worker-..."},
     // stored under "w1"; wait_for_worker then consumes $w1.task_id.
@@ -240,6 +240,7 @@ async fn e2e_lead_spawns_worker_via_real_subprocess() {
 
     // Explicit cleanup: cancel the run token so any stray tasks exit.
     state.root.cancel.terminate();
+    server.shutdown().await;
 }
 
 #[tokio::test]
@@ -250,7 +251,7 @@ async fn e2e_lead_spawns_three_workers_and_waits_for_any() {
     let (run_id, state) = mk_state(dir.path(), ApprovalPolicy::Block);
 
     let sock = socket_path_for_run(run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(sock.clone(), state.clone()).await.unwrap();
+    let server = McpServer::start(sock.clone(), state.clone()).await.unwrap();
 
     // Three spawn_workers then one wait_for_any. Workers complete quickly
     // under the FakeSpawner so wait_for_any resolves once the first exits.
@@ -303,6 +304,7 @@ async fn e2e_lead_spawns_three_workers_and_waits_for_any() {
     );
 
     state.root.cancel.terminate();
+    server.shutdown().await;
 }
 
 #[tokio::test]
@@ -387,7 +389,7 @@ async fn e2e_lead_cancels_worker_mid_flight() {
     ));
 
     let sock = socket_path_for_run(run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(sock.clone(), state.clone()).await.unwrap();
+    let server = McpServer::start(sock.clone(), state.clone()).await.unwrap();
 
     // spawn_worker (worker hangs), sleep for slot fill, cancel_worker, list.
     let script = dir.path().join("script.jsonl");
@@ -439,6 +441,7 @@ async fn e2e_lead_cancels_worker_mid_flight() {
     }
 
     state.root.cancel.terminate();
+    server.shutdown().await;
 }
 
 #[tokio::test]
@@ -674,7 +677,7 @@ async fn e2e_lead_reprompts_running_worker() {
     ));
 
     let sock = socket_path_for_run(run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(sock.clone(), state.clone()).await.unwrap();
+    let server = McpServer::start(sock.clone(), state.clone()).await.unwrap();
 
     // Spawn a worker, sleep for init+result to land (session_id captured),
     // reprompt it.
@@ -732,6 +735,7 @@ async fn e2e_lead_reprompts_running_worker() {
     assert_eq!(counters.reprompt_count, 1);
 
     state.root.cancel.terminate();
+    server.shutdown().await;
 }
 
 #[tokio::test]
@@ -1008,7 +1012,7 @@ async fn e2e_lead_through_mcp_bridge_injects_meta() {
     let (run_id, state) = mk_state(dir.path(), ApprovalPolicy::Block);
 
     let sock = socket_path_for_run(run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(sock.clone(), state.clone()).await.unwrap();
+    let server = McpServer::start(sock.clone(), state.clone()).await.unwrap();
 
     // Lead script: init, kv_set on /shared/bridge_probe, result.
     // kv_set carries `_meta` as a required field — the bridge's job is
@@ -1065,6 +1069,7 @@ async fn e2e_lead_through_mcp_bridge_injects_meta() {
     );
 
     state.root.cancel.terminate();
+    server.shutdown().await;
 }
 
 /// Test-only ProcessSpawner that rewrites each spawn to run fake-claude
@@ -1204,7 +1209,7 @@ async fn e2e_freeze_pause_and_continue_real_subprocess_worker() {
     ));
 
     let mcp_sock = socket_path_for_run(run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(mcp_sock.clone(), state.clone())
+    let server = McpServer::start(mcp_sock.clone(), state.clone())
         .await
         .unwrap();
 
@@ -1257,4 +1262,5 @@ async fn e2e_freeze_pause_and_continue_real_subprocess_worker() {
     tokio::time::sleep(Duration::from_millis(200)).await;
     state.root.cancel.terminate();
     tokio::time::sleep(Duration::from_millis(200)).await;
+    server.shutdown().await;
 }

--- a/crates/pitboss-cli/tests/e2e_sublead_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_sublead_flows.rs
@@ -331,7 +331,7 @@ async fn run_global_lease_serializes_two_subleads() {
     let (run_id, state) = mk_state_hold_workers(dir.path());
 
     let socket = socket_path_for_run(run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -414,6 +414,7 @@ async fn run_global_lease_serializes_two_subleads() {
     );
 
     state.root.cancel.terminate();
+    server.shutdown().await;
 }
 
 // ── Test 4: Reject-with-reason reaches sub-lead session ──────────────────────

--- a/crates/pitboss-cli/tests/e2e_sublead_flows.rs
+++ b/crates/pitboss-cli/tests/e2e_sublead_flows.rs
@@ -440,7 +440,7 @@ async fn reject_with_reason_reaches_sublead_session() {
         .unwrap();
 
     let mcp_sock = socket_path_for_run(run_id, &state.root.manifest.run_dir);
-    let _mcp_server = McpServer::start(mcp_sock.clone(), state.clone())
+    let mcp_server = McpServer::start(mcp_sock.clone(), state.clone())
         .await
         .unwrap();
 
@@ -558,6 +558,7 @@ async fn reject_with_reason_reaches_sublead_session() {
     );
 
     state.root.cancel.terminate();
+    mcp_server.shutdown().await;
 }
 
 // ── Test 5: Budget envelope returns to root pool ──────────────────────────────
@@ -795,7 +796,7 @@ async fn sublead_session_spawns_runs_and_reconciles() {
     // written. The sub-lead subprocess doesn't need to connect — fake-claude
     // only reads PITBOSS_FAKE_MCP_SOCKET when that env var is set.
     let socket = socket_path_for_run(run_id, dir.path());
-    let _mcp = McpServer::start(socket.clone(), state.clone())
+    let mcp = McpServer::start(socket.clone(), state.clone())
         .await
         .expect("start MCP server");
 
@@ -893,4 +894,5 @@ async fn sublead_session_spawns_runs_and_reconciles() {
     );
 
     state.root.cancel.terminate();
+    mcp.shutdown().await;
 }

--- a/crates/pitboss-cli/tests/hierarchical_flows.rs
+++ b/crates/pitboss-cli/tests/hierarchical_flows.rs
@@ -29,7 +29,7 @@ fn mk_state() -> (TempDir, Arc<DispatchState>) {
 async fn mcp_spawn_and_list_round_trip() {
     let (_dir, state) = mk_state();
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -57,13 +57,14 @@ async fn mcp_spawn_and_list_round_trip() {
     assert_eq!(list[0]["task_id"].as_str().unwrap(), task_id);
 
     client.close().await.unwrap();
+    server.shutdown().await;
 }
 
 #[tokio::test]
 async fn mcp_spawn_over_max_workers_returns_error() {
     let (_dir, state) = mk_state(); // max_workers = 4
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
     let token = mint_root_token(&state).await;
@@ -103,6 +104,7 @@ async fn mcp_spawn_over_max_workers_returns_error() {
     }
 
     client.close().await.unwrap();
+    server.shutdown().await;
 }
 
 #[tokio::test]
@@ -115,7 +117,7 @@ async fn mcp_spawn_over_budget_returns_error() {
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner) = 5.0;
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
     let token = mint_root_token(&state).await;
@@ -144,6 +146,7 @@ async fn mcp_spawn_over_budget_returns_error() {
     }
 
     client.close().await.unwrap();
+    server.shutdown().await;
 }
 
 #[tokio::test]
@@ -151,7 +154,7 @@ async fn mcp_spawn_while_draining_returns_error() {
     let (_dir, state) = mk_state();
     state.root.cancel.drain();
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
     let token = mint_root_token(&state).await;
@@ -180,6 +183,7 @@ async fn mcp_spawn_while_draining_returns_error() {
     }
 
     client.close().await.unwrap();
+    server.shutdown().await;
 }
 
 // Task 26 of the v0.3 plan left a placeholder here; the full
@@ -196,7 +200,7 @@ async fn wait_actor_alias_resolves_worker_id() {
 
     let (_dir, state) = mk_state();
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -261,6 +265,7 @@ async fn wait_actor_alias_resolves_worker_id() {
     assert!(result.is_ok(), "wait_actor should accept worker actor_ids");
 
     client.close().await.unwrap();
+    server.shutdown().await;
 }
 
 #[test]
@@ -296,10 +301,10 @@ async fn concurrent_runs_isolate_sockets_and_tokens() {
         "concurrent runs must derive distinct socket paths from their UUIDv7 run_ids"
     );
 
-    let _server_a = McpServer::start(socket_a.clone(), state_a.clone())
+    let server_a = McpServer::start(socket_a.clone(), state_a.clone())
         .await
         .unwrap();
-    let _server_b = McpServer::start(socket_b.clone(), state_b.clone())
+    let server_b = McpServer::start(socket_b.clone(), state_b.clone())
         .await
         .unwrap();
 
@@ -330,4 +335,6 @@ async fn concurrent_runs_isolate_sockets_and_tokens() {
         "expected 'invalid actor token' rejection, got: {msg}"
     );
     let _ = client_cross.close().await;
+    server_a.shutdown().await;
+    server_b.shutdown().await;
 }

--- a/crates/pitboss-cli/tests/shared_store_flows.rs
+++ b/crates/pitboss-cli/tests/shared_store_flows.rs
@@ -496,7 +496,7 @@ async fn lease_released_when_mcp_connection_drops() {
     ));
 
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -549,6 +549,7 @@ async fn lease_released_when_mcp_connection_drops() {
         "lease should be free after session A dropped: {acq_b}"
     );
     client_b.close().await.unwrap();
+    server.shutdown().await;
 }
 
 /// End-to-end test of the per-connection run-global-lease cleanup hook.
@@ -652,7 +653,7 @@ async fn run_global_lease_released_when_mcp_connection_drops() {
     ));
 
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -705,4 +706,5 @@ async fn run_global_lease_released_when_mcp_connection_drops() {
         "run-global lease should be free after session A dropped: {acq_b}"
     );
     client_b.close().await.unwrap();
+    server.shutdown().await;
 }

--- a/crates/pitboss-cli/tests/sublead_flows.rs
+++ b/crates/pitboss-cli/tests/sublead_flows.rs
@@ -87,7 +87,7 @@ async fn sublead_kv_writes_isolated_from_root() {
 
     let (_dir, state) = mk_state_with_subleads();
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -135,6 +135,7 @@ async fn sublead_kv_writes_isolated_from_root() {
         !sub_read["entry"].is_null(),
         "sub-lead should be able to read its own write; got: {sub_read}"
     );
+    server.shutdown().await;
 }
 
 /// Strict peer-visibility: within any layer, `/peer/<X>/*` is readable only
@@ -154,7 +155,7 @@ async fn sublead_workers_cannot_read_sibling_peer_slots() {
 
     let (_dir, state) = mk_state_with_subleads();
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -186,6 +187,7 @@ async fn sublead_workers_cannot_read_sibling_peer_slots() {
         err_msg.contains("strict peer visibility") || err_msg.contains("forbidden"),
         "error should mention peer visibility; got: {err_msg}"
     );
+    server.shutdown().await;
 }
 
 #[tokio::test]
@@ -194,7 +196,7 @@ async fn sublead_workers_cannot_wait_on_sibling_peer_slots() {
 
     let (_dir, state) = mk_state_with_subleads();
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -219,13 +221,14 @@ async fn sublead_workers_cannot_wait_on_sibling_peer_slots() {
         err_msg.contains("strict peer visibility") || err_msg.contains("forbidden"),
         "error should mention peer visibility; got: {err_msg}"
     );
+    server.shutdown().await;
 }
 
 #[tokio::test]
 async fn spawn_sublead_tool_is_exposed_to_root() {
     let (_dir, state) = mk_state_with_subleads();
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -235,6 +238,7 @@ async fn spawn_sublead_tool_is_exposed_to_root() {
         tools.iter().any(|t| t.name == "spawn_sublead"),
         "spawn_sublead should be in the root lead's MCP toolset"
     );
+    server.shutdown().await;
 }
 
 /// Mirror of `spawn_sublead_tool_is_exposed_to_root`: when the manifest
@@ -255,7 +259,7 @@ async fn spawn_sublead_tool_is_exposed_to_root() {
 async fn spawn_sublead_tool_hidden_when_allow_subleads_false() {
     let (_dir, state) = mk_state_without_subleads();
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -271,6 +275,7 @@ async fn spawn_sublead_tool_hidden_when_allow_subleads_false() {
         "list_tools must hide every ROOT_ONLY_TOOLS entry when \
          allow_subleads = false; leaks: {leaks:?}"
     );
+    server.shutdown().await;
 }
 
 #[tokio::test]
@@ -279,7 +284,7 @@ async fn spawn_sublead_creates_isolated_layer() {
 
     let (_dir, state) = mk_state_with_subleads();
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -327,6 +332,7 @@ async fn spawn_sublead_creates_isolated_layer() {
 
     // Root's reservation should reflect the sub-lead's envelope.
     assert_eq!(*state.root.budget.reserved_usd.lock().await, 5.0);
+    server.shutdown().await;
 }
 
 #[tokio::test]
@@ -335,7 +341,7 @@ async fn root_cancel_cascades_to_sublead_workers() {
 
     let (_dir, state) = mk_state_with_subleads();
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -388,6 +394,7 @@ async fn root_cancel_cascades_to_sublead_workers() {
         tok.is_draining(),
         "sub-tree worker should be cancelled by root cascade"
     );
+    server.shutdown().await;
 }
 
 #[tokio::test]
@@ -396,7 +403,7 @@ async fn sublead_cannot_call_spawn_sublead() {
 
     let (_dir, state) = mk_state_with_subleads();
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -420,6 +427,7 @@ async fn sublead_cannot_call_spawn_sublead() {
         err_msg.contains("depth-2") || err_msg.contains("only available to the root lead"),
         "error message should mention depth-2 invariant, got: {err_msg}"
     );
+    server.shutdown().await;
 }
 
 #[tokio::test]
@@ -498,7 +506,7 @@ async fn run_lease_blocks_cross_subtree_acquisition() {
 
     let (_dir, state) = mk_state_with_subleads();
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -563,6 +571,7 @@ async fn run_lease_blocks_cross_subtree_acquisition() {
         )
         .await;
     assert!(acq3.is_ok(), "s2 should acquire after s1 releases");
+    server.shutdown().await;
 }
 
 #[tokio::test]
@@ -688,7 +697,7 @@ async fn policy_auto_approves_sublead_actor() {
 
     let (_dir, state) = mk_state_with_subleads();
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -756,6 +765,7 @@ async fn policy_auto_approves_sublead_actor() {
         "policy short-circuit must not enqueue approval; queue has {} items",
         queue.len()
     );
+    server.shutdown().await;
 }
 
 // ── Task 4.1: Rich approval record fields ────────────────────────────────────
@@ -878,7 +888,7 @@ async fn kill_worker_with_reason_reprompts_parent_sublead() {
 
     let (_dir, state) = mk_state_with_subleads();
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -969,6 +979,7 @@ async fn kill_worker_with_reason_reprompts_parent_sublead() {
         "reprompt should include reason; got: {}",
         received[0]
     );
+    server.shutdown().await;
 }
 
 // ── Task 5.1: Manifest schema for allow_subleads and caps ─────────────────────
@@ -1022,7 +1033,7 @@ async fn spawn_sublead_rejected_when_over_max_sublead_budget() {
     let (_dir, state) = mk_state_with_sublead_budget_cap(3.0);
 
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
     let mut root = connect_actor(&state, &socket, "root", "root_lead").await;
@@ -1039,6 +1050,7 @@ async fn spawn_sublead_rejected_when_over_max_sublead_budget() {
         err.contains("exceeds per-sublead cap"),
         "error should mention the cap; got: {err}"
     );
+    server.shutdown().await;
 }
 
 /// `resolve_envelope` enforces the `max_total_workers` cap by summing root
@@ -1308,7 +1320,7 @@ async fn sublead_spawn_worker_registers_in_sub_tree_layer() {
 
     let (_dir, state) = mk_state_with_subleads();
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -1366,6 +1378,7 @@ async fn sublead_spawn_worker_registers_in_sub_tree_layer() {
         Some(sublead_id.as_str()),
         "worker_layer_index must point to sublead_id; got: {indexed_layer:?}"
     );
+    server.shutdown().await;
 }
 
 /// A worker actor (with `_meta.actor_role = "worker"`) calls `spawn_worker`.
@@ -1376,7 +1389,7 @@ async fn worker_cannot_spawn_worker() {
 
     let (_dir, state) = mk_state_with_subleads();
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -1395,6 +1408,7 @@ async fn worker_cannot_spawn_worker() {
         err_msg.contains("depth-2") || err_msg.contains("not available to workers"),
         "error should mention the depth-2 cap; got: {err_msg}"
     );
+    server.shutdown().await;
 }
 
 /// Calling `spawn_worker` WITHOUT `_meta` (the v0.5 backward-compat path)
@@ -1454,7 +1468,7 @@ async fn kill_with_reason_delivers_synthetic_reprompt_to_running_lead() {
 
     let (_dir, state) = mk_state_with_subleads();
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -1537,6 +1551,7 @@ async fn kill_with_reason_delivers_synthetic_reprompt_to_running_lead() {
         msg.contains("[SYSTEM]"),
         "reprompt message should use [SYSTEM] prefix; got: {msg}"
     );
+    server.shutdown().await;
 }
 
 /// When the parent lead has already terminated (workers map entry is Done),
@@ -1549,7 +1564,7 @@ async fn kill_with_reason_skips_delivery_when_lead_already_terminated() {
 
     let (_dir, state) = mk_state_with_subleads();
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -1652,6 +1667,7 @@ async fn kill_with_reason_skips_delivery_when_lead_already_terminated() {
 
     // No assertion on result — the point is no panic, no hang.
     let _ = result;
+    server.shutdown().await;
 }
 
 /// Sub-lead (with its own $5 envelope) spawns a worker. The spend reservation
@@ -1750,7 +1766,7 @@ async fn kill_with_reason_delivers_to_root_lead() {
 
     let (_dir, state) = mk_state_with_subleads();
     let socket = socket_path_for_run(state.root.run_id, &state.root.manifest.run_dir);
-    let _server = McpServer::start(socket.clone(), state.clone())
+    let server = McpServer::start(socket.clone(), state.clone())
         .await
         .unwrap();
 
@@ -1807,6 +1823,7 @@ async fn kill_with_reason_delivers_to_root_lead() {
         msg.contains("[SYSTEM]"),
         "reprompt message should use [SYSTEM] prefix; got: {msg}"
     );
+    server.shutdown().await;
 }
 
 /// v0.5 back-compat regression: when no kill-with-reason events are issued,


### PR DESCRIPTION
## Summary

- `McpServer::shutdown()` awaits per-connection cleanup (`release_all_for_actor`) before returning; the sync `Drop` impl cannot.
- Every integration test was constructing the server as `let _server = McpServer::start(...).await.unwrap()` and relying on `Drop`, leaving detached cleanup tasks racing test teardown. The race comment at `crates/pitboss-cli/src/mcp/server.rs:1612-1618` documents the symptom: flaky lease-state assertions in follow-up readers.
- Convert every site to `let server = ...` and add a trailing `server.shutdown().await;` so per-connection cleanup is observably complete before the test function returns.
- 40 sites across 7 files; no test logic changed.

## Validation

- Pre-PR: re-validated #535 — race comment confirmed at the cited lines; `shutdown()` exists and is the recommended path; 40 inline `let _server = McpServer::start` sites confirmed across 7 test files.
- Full `cargo test -p pitboss-cli --features pitboss-core/test-support` passes locally (TMPDIR=/private/tmp/pb).
- `cargo lint`, `cargo tidy` — clean.
- Multi-server test `concurrent_runs_isolate_sockets_and_tokens` (hierarchical_flows.rs) handled separately with both `server_a.shutdown().await` and `server_b.shutdown().await`.

## Test plan

- [ ] CI: full workspace test suite passes on linux + macOS
- [ ] CI: `cargo lint` clean
- [ ] No new flakes observed across the touched test files

Closes #535

🤖 Generated with [Claude Code](https://claude.com/claude-code)