### PR TITLE
refactor(dispatch): F-CONC audit batch (5 concurrency findings)

### DIFF
--- a/crates/pitboss-cli/src/control/server.rs
+++ b/crates/pitboss-cli/src/control/server.rs
@@ -654,6 +654,14 @@ async fn serve_connection(
                     }
                 } else {
                     let reply = dispatch_op(&state, op).await;
+                    // F-CONC-11 #490: broadcasting op replies to every
+                    // subscriber (including the SPA's SSE bridge) is
+                    // intentional — see the PR-Q routing block above for
+                    // the design rationale and the `OpUnknownState` /
+                    // current-state-leak analysis. Audit re-validation
+                    // confirmed `current_state` is the same coarse enum
+                    // already published via `WorkerStatus`, so the
+                    // "subscriber visibility" surface is not a leak.
                     state
                         .root
                         .broadcast_control_event(EventEnvelope {

--- a/crates/pitboss-cli/src/dispatch/layer.rs
+++ b/crates/pitboss-cli/src/dispatch/layer.rs
@@ -109,12 +109,22 @@ pub struct WorkerRegistry {
 }
 
 impl WorkerRegistry {
-    /// Construct an empty registry with a fresh 64-slot `done_tx` channel.
-    /// The capacity matches the pre-split `LayerState::new` default; the
-    /// channel is mostly there for `wait_for_worker` consumers and a
+    /// Construct an empty registry with a fresh 1024-slot `done_tx` channel.
+    /// The channel is mostly there for `wait_for_worker` consumers and a
     /// `Lagged` receiver re-syncs from the `states` map.
+    ///
+    /// **Capacity (F-CONC-12 #491):** sized to absorb a mass-cancel storm
+    /// across a fully-saturated depth-2 tree (root + N sub-leads, each
+    /// with their own worker pool) without the slowest `wait_for_*`
+    /// subscriber lagging into the recovery rescan. The `Lagged` →
+    /// `refresh_in_flight_from_maps` path in
+    /// `hierarchical.rs::await_workers_drained` remains correct and is
+    /// kept as belt-and-braces, not the expected fast path. The pre-F-CONC-12
+    /// capacity of 64 matched the historical single-layer default, but
+    /// post depth-2 every root subscriber sees every worker's completion
+    /// across the whole tree.
     pub fn new() -> Self {
-        let (done_tx, _) = broadcast::channel(64);
+        let (done_tx, _) = broadcast::channel(1024);
         Self {
             states: RwLock::new(HashMap::new()),
             cancels: RwLock::new(HashMap::new()),

--- a/crates/pitboss-cli/src/dispatch/signals.rs
+++ b/crates/pitboss-cli/src/dispatch/signals.rs
@@ -68,6 +68,12 @@ fn send_group_signal(pid: u32, sig: libc::c_int, name: &'static str) -> Result<(
 ///   2nd SIGINT within window → terminate
 /// After the window, re-armed: a single later SIGINT is treated as a fresh first.
 ///
+/// **Drain-mode auto-escalation (opt-in, F-CONC-7 #497):** set the env
+/// var `PITBOSS_CTRLC_DRAIN_ESCALATE_SECS=<n>` (positive integer seconds)
+/// to make the watcher escalate to terminate after `n` seconds of drain
+/// without a second Ctrl-C. Default behaviour (env unset / unparseable /
+/// zero) is to remain in drain mode indefinitely.
+///
 /// **Idempotent.** Calling more than once in the same process is a no-op
 /// after the first install — pitboss has two callsites today (flat-mode
 /// and hierarchical entry points) and a future third callsite would
@@ -102,12 +108,59 @@ pub fn install_ctrl_c_watcher(cancel: CancelToken) {
                     return;
                 }
                 _ => {
-                    tracing::info!("drain window expired; continuing in drain mode");
-                    // Loop again: if another Ctrl-C arrives later, start a new window.
+                    // F-CONC-7 #497: optionally auto-escalate to terminate
+                    // after a configurable drain-mode timeout, so operators
+                    // who walk away after a single Ctrl-C don't leave the
+                    // run hanging behind a stuck worker. Opt-in via env var
+                    // to preserve the "drain forever" default behaviour.
+                    if let Some(escalate_after) = drain_escalate_timeout() {
+                        tracing::warn!(
+                            "drain window expired; auto-escalating to terminate in {:?} \
+                             (PITBOSS_CTRLC_DRAIN_ESCALATE_SECS) unless another Ctrl-C arrives",
+                            escalate_after,
+                        );
+                        tokio::select! {
+                            () = tokio::time::sleep(escalate_after) => {
+                                cancel.terminate_with_reason(
+                                    pitboss_core::store::TerminateReason::OperatorCtrlC,
+                                );
+                                tracing::warn!(
+                                    "drain-mode timeout reached — terminating subprocesses",
+                                );
+                                return;
+                            }
+                            res = tokio::signal::ctrl_c() => {
+                                if res.is_ok() {
+                                    cancel.terminate_with_reason(
+                                        pitboss_core::store::TerminateReason::OperatorCtrlC,
+                                    );
+                                    tracing::warn!(
+                                        "received Ctrl-C during drain-mode timeout — terminating",
+                                    );
+                                }
+                                return;
+                            }
+                        }
+                    } else {
+                        tracing::info!("drain window expired; continuing in drain mode");
+                        // Loop again: if another Ctrl-C arrives later, start a new window.
+                    }
                 }
             }
         }
     });
+}
+
+/// Read the optional drain-mode auto-escalation timeout from
+/// `PITBOSS_CTRLC_DRAIN_ESCALATE_SECS`. Returns `None` if the env var is
+/// unset, empty, or unparseable as a positive integer — keeping the
+/// pre-F-CONC-7 "drain forever" semantics as the default.
+fn drain_escalate_timeout() -> Option<Duration> {
+    std::env::var("PITBOSS_CTRLC_DRAIN_ESCALATE_SECS")
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .filter(|n| *n > 0)
+        .map(Duration::from_secs)
 }
 
 // ── Kill-with-reason cascade (Task 4.5) ─────────────────────────────────────
@@ -306,6 +359,7 @@ pub fn install_cascade_cancel_watcher(state: Arc<DispatchState>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn freeze_rejects_pid_zero() {
@@ -317,6 +371,45 @@ mod tests {
     fn resume_rejects_pid_zero() {
         let err = resume_stopped(0).unwrap_err();
         assert!(err.to_string().contains("pid is 0"));
+    }
+
+    /// F-CONC-7 #497: the opt-in drain-mode auto-escalation timeout
+    /// returns `None` when the env var is unset (preserving the
+    /// pre-fix "drain forever" default) and `Some(_)` only for a
+    /// positive integer.
+    #[test]
+    #[serial(env)]
+    fn drain_escalate_timeout_is_opt_in() {
+        // SAFETY: `#[serial(env)]` serializes against other env-touching
+        // tests so we don't race readers in tracing/reqwest/locale init.
+        let key = "PITBOSS_CTRLC_DRAIN_ESCALATE_SECS";
+        std::env::remove_var(key);
+        assert_eq!(drain_escalate_timeout(), None, "unset → no escalation");
+
+        std::env::set_var(key, "");
+        assert_eq!(drain_escalate_timeout(), None, "empty → no escalation");
+
+        std::env::set_var(key, "0");
+        assert_eq!(drain_escalate_timeout(), None, "zero → no escalation");
+
+        std::env::set_var(key, "not-a-number");
+        assert_eq!(
+            drain_escalate_timeout(),
+            None,
+            "unparseable → no escalation"
+        );
+
+        std::env::set_var(key, "300");
+        assert_eq!(drain_escalate_timeout(), Some(Duration::from_secs(300)));
+
+        std::env::set_var(key, "  60  ");
+        assert_eq!(
+            drain_escalate_timeout(),
+            Some(Duration::from_secs(60)),
+            "surrounding whitespace tolerated"
+        );
+
+        std::env::remove_var(key);
     }
 
     /// End-to-end: spawn a sleeping child, SIGSTOP it, confirm

--- a/crates/pitboss-cli/src/dispatch/signals.rs
+++ b/crates/pitboss-cli/src/dispatch/signals.rs
@@ -172,6 +172,15 @@ pub async fn cancel_actor_with_reason(
 /// under a held `state.subleads` read lock — O(N) per cancel call,
 /// blocking new sublead registration. The `worker_layer_index` lookup
 /// mirrors `resolve_layer_for_caller`'s routing for KV ops (#150 audit).
+///
+/// **Lock-acquisition order (project invariant):** `state.subleads` →
+/// `state.worker_layer_index` → `sub_layer.workers.cancels`. Every
+/// callsite that holds any pair of these locks acquires them in this
+/// order. Inverting it under a `subleads.write()` would deadlock; today
+/// no such path exists because every `subleads.write()` callsite uses a
+/// single-statement guard (`register_sublead`, `reconcile_terminated_sublead`).
+/// Mirror of the convention documented in `hierarchical.rs::await_workers_drained`.
+/// (F-CONC-4 #494)
 async fn cancel_and_find_parent(
     state: &Arc<DispatchState>,
     target: &str,

--- a/crates/pitboss-cli/src/dispatch/state.rs
+++ b/crates/pitboss-cli/src/dispatch/state.rs
@@ -566,6 +566,32 @@ impl DispatchState {
     /// `dispatch/sublead.rs:340-383` so the watcher install + eager
     /// cascade can never drift out of order.  Pinned by the integration
     /// tests in `tests/cancel_cascade_flows.rs`.
+    ///
+    /// **Step order is load-bearing — do not reorder (F-CONC-8 #498):**
+    ///
+    /// - `insert` MUST happen before `cascade_to`. The cascade-watcher
+    ///   installed by `install_cascade_cancel_watcher` walks
+    ///   `cascade_to_subleads`, which reads `self.subleads`; if the
+    ///   sublead were not yet inserted, a concurrent root-cancel could
+    ///   miss this sub-layer and the eager `cascade_to` at step 3 would
+    ///   be the only signal that ever reaches it.
+    /// - `install_sublead_cancel_watcher` MUST happen before the eager
+    ///   `cascade_to`. The per-sub-layer watcher is fire-once on the
+    ///   sub-layer's own `CancelToken`; if `cascade_to` runs first and
+    ///   already toggles drain/terminate, the watcher started afterwards
+    ///   still observes the canceled state and fans out to workers as
+    ///   intended (the watcher's `select!` over `await_drain`/`await_terminate`
+    ///   resolves immediately for an already-canceled token). The
+    ///   ordering exists so the watcher is *registered* on the canonical
+    ///   pre-cancel state for the (more common) non-canceled path.
+    ///
+    /// Between steps 1 and 3 there is a benign window where a concurrent
+    /// root cancellation's `cascade_to_subleads` walk could fire and
+    /// no-op (root not yet canceled when walked) — the eager `cascade_to`
+    /// at step 3 closes this window. The sublead subprocess is not
+    /// launched until after `register_sublead` returns
+    /// (`dispatch/sublead.rs::spawn_sublead_session`), so no worker
+    /// observes the transient state.
     pub async fn register_sublead(&self, sublead_id: String, sub_layer: Arc<LayerState>) {
         self.subleads
             .write()


### PR DESCRIPTION
## Summary

Bundles the five open `F-CONC-*` concurrency-audit findings into a single PR. Each finding was independently re-validated by a multi-agent review team against current code (post the F-ARCH batch merge) before any edits landed.

| Issue | Finding | Verdict | Action |
|---|---|---|---|
| #494 | F-CONC-4: triple-lock in `cancel_and_find_parent` | CONFIRMED, no deadlock today | Document the lock-acquisition order as a project invariant |
| #497 | F-CONC-7: Ctrl-C watcher loops indefinitely in drain | CONFIRMED | Add opt-in `PITBOSS_CTRLC_DRAIN_ESCALATE_SECS` env var |
| #498 | F-CONC-8: race window in `register_sublead` | CONFIRMED ordering — **proposed reorder would CAUSE a bug** | Document why the current step order is load-bearing |
| #490 | F-CONC-11: op-reply broadcast visible to all clients | CONFIRMED, intentional | Annotate the broadcast site (complements existing PR-Q routing block) |
| #491 | F-CONC-12: `done_tx` `Lagged` triggers nested-lock rescan | CONFIRMED, low severity | Bump broadcast capacity 64 → 1024 |

Three commits routed by `cliff.toml`:
- `docs(dispatch,control)` — covers #494, #498, #490 (skipped from CHANGELOG)
- `feat(dispatch)` — covers #497 (Added)
- `perf(dispatch)` — covers #491 (Changed)

## Notable findings from validation

**F-CONC-8 turned out to be the most valuable validation.** The audit's "no action needed" verdict was right, but the audit also flirted with a reorder (cascade → insert → install_watcher). Tracing `install_cascade_cancel_watcher` showed that reorder would actually *introduce* a bug: that watcher is fire-once on root cancel, so the eager `cascade_to` at step 3 is what closes the post-watcher-fired window for late-registered subleads. The doc-comment now spells out *why* the current order is load-bearing so a future refactorer doesn't try the "obvious" cleanup.

**F-CONC-7 is opt-in for back-compat safety.** Default behaviour is unchanged (loop forever in drain mode). Operators who want auto-cleanup set `PITBOSS_CTRLC_DRAIN_ESCALATE_SECS=<n>`. A unit test pins the env-parsing contract.

**F-CONC-11 is documentation-only.** Validation confirmed `OpUnknownState.current_state` only carries the coarse string enum already published via `WorkerStatus` — there is no leak. The existing PR-Q routing block at `server.rs:619-635` is the design rationale; the new inline comment marks the broadcast site so a reader at that line knows the visibility is intentional, not a bug.

**F-CONC-12 capacity bump from 64 → 1024.** Pre-depth-2 the channel served a single layer; post depth-2 the root subscriber sees completions across the whole tree. ~8 KiB additional memory per `WorkerRegistry`, well within budget. The `Lagged` → `refresh_in_flight_from_maps` recovery path remains in place as belt-and-braces.

## Test plan

- [x] `cargo lint` clean (workspace clippy `-D warnings`)
- [x] `cargo tidy` clean (fmt --check)
- [x] `cargo test -p pitboss-cli --test cancel_cascade_flows` — 4/4 pass (pins #498 invariants)
- [x] `cargo test -p pitboss-cli --test control_flows` — 20/20 pass (incl. `op_replies_broadcast_to_subscribers` which pins #490 behaviour)
- [x] `cargo test -p pitboss-cli --test sublead_flows` — 34/34 pass
- [x] `cargo test -p pitboss-cli --test hierarchical_flows` — 7/7 pass
- [x] New `#[serial(env)]` unit test `drain_escalate_timeout_is_opt_in` pins the F-CONC-7 env-parsing contract

## What's NOT in this PR

The `register_sublead` "race window" (#498) is not closed by code change because closing it would require introducing the bug the audit reviewer flagged. The window is benign (sublead subprocess hasn't launched yet); the documentation makes that explicit so future maintainers don't trade it for the worse failure mode.

Closes #490
Closes #491
Closes #494
Closes #497
Closes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)